### PR TITLE
remove grunt-patch-wordpress

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "grunt-jsdoc": "^2.1.0",
     "grunt-jsvalidate": "~0.2.2",
     "grunt-legacy-util": "^0.2.0",
-    "grunt-patch-wordpress": "~0.4.2",
     "grunt-postcss": "~0.7.1",
     "grunt-replace": "~1.0.1",
     "grunt-rtlcss": "~2.0.1",


### PR DESCRIPTION
no need to apply a patch for WP from the command line