### PR TITLE
Remove Gutenberg callout from About page

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -316,29 +316,6 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			</div>
 		</div>
 
-		<div class="inline-svg">
-			<picture>
-				<source media="(max-width: 500px)" srcset="<?php echo 'https://s.w.org/images/core/4.9/gutenberg-mobile.svg'; ?>">
-				<img src="https://s.w.org/images/core/4.9/gutenberg.svg" alt="">
-			</picture>
-		</div>
-
-		<div class="feature-section">
-			<h2>
-				<?php
-					printf(
-						/* translators: %s: handshake emoji */
-						__( 'Lend a Hand with Gutenberg %s' ),
-						'&#x1F91D'
-					);
-				?>
-			</h2>
-			<p><?php printf(
-				__( 'ClassicPress is working on a new way to create and control your content and we&#8217;d love to have your help. Interested in being an <a href="%s">early tester</a> or getting involved with the Gutenberg project? <a href="%s">Contribute on GitHub</a>.' ),
-				__( 'https://wordpress.org/plugins/gutenberg/' ),
-				'https://github.com/ClassicPress/gutenberg' ); ?></p>
-		</div>
-
 		<hr />
 
 		<div class="changelog">


### PR DESCRIPTION
This PR removes the Gutenberg section from the bottom of the About page:

> ![2018-09-04t21 41 20-05 00](https://user-images.githubusercontent.com/227022/45068045-4b981180-b08b-11e8-8789-03d50f912add.png)

I noticed this code while reviewing #23.