### PR TITLE
Update about page, logo in admin bar

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -32,20 +32,38 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 		</h2>
 
 		<div class="changelog point-releases">
-			<h3><?php _e( 'Maintenance and Security Releases' ); ?></h3>
+			<h3><?php _e( 'ClassicPress' ); ?></h3>
+
+			<?php
+			echo "<p>\n";
+			_e( '<strong>We began a fork of WordPress</strong> named ClassicPress.' );
+			print ' ';
+			_e( 'The initial version will be based on the WordPress 4.9 branch.' );
+			echo "</p><p>\n";
+			/* translators: 1: ClassicPress GitHub URL, 2: ClassicPress website URL */
+			printf(
+				__( 'To see how you can help, take a look at <a href="%s">our GitHub repository</a> and <a href="%s">the official ClassicPress website</a>!' ),
+				'https://github.com/ClassicPress/ClassicPress',
+				'https://www.classicpress.net'
+			);
+			echo "</p>\n";
+			?>
+
+			<h3><?php _e( 'WordPress Maintenance and Security Releases' ); ?></h3>
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bugs.',
 						46
 					),
 					'4.9.8',
 					number_format_i18n( 46 )
 				);
-
+				?>
+				<?php
 				printf(
 					/* translators: %s: Codex URL */
 					__( 'For more information, see <a href="%s">the release notes</a>.' ),
@@ -56,10 +74,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
 						17
 					),
 					'4.9.7',
@@ -74,10 +92,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bugs.',
 						18
 					),
 					'4.9.6',
@@ -92,10 +110,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
 						28
 					),
 					'4.9.5',
@@ -110,10 +128,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bugs.',
 						1
 					),
 					'4.9.4',
@@ -128,10 +146,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed %2$s bugs.',
 						34
 					),
 					'4.9.3',
@@ -146,10 +164,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
 						22
 					),
 					'4.9.2',
@@ -164,10 +182,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: ClassicPress version number, 2: plural number of bugs. */
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
 					_n(
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
-						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bug.',
+						'<strong>WordPress version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
 						11
 					),
 					'4.9.1',

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -14,7 +14,7 @@ wp_enqueue_script( 'underscore' );
 /* translators: Page title of the About ClassicPress page in the admin. */
 $title = _x( 'About', 'page title' );
 
-$display_version = get_bloginfo( 'classicpress_display_version' );
+$display_version = classicpress_version();
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 ?>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -14,14 +14,14 @@ wp_enqueue_script( 'underscore' );
 /* translators: Page title of the About ClassicPress page in the admin. */
 $title = _x( 'About', 'page title' );
 
-list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
+$display_version = get_bloginfo( 'classicpress_display_version' );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 ?>
 	<div class="wrap about-wrap full-width-layout">
 		<h1><?php printf( __( 'Welcome to ClassicPress&nbsp;%s' ), $display_version ); ?></h1>
 
-		<p class="about-text"><?php printf( __( 'Thank you for updating to the latest version! ClassicPress %s will smooth your design workflow and keep you safe from coding errors.' ), $display_version ); ?></p>
+		<p class="about-text"><?php printf( __( 'Thank you for trying ClassicPress! We are under heavy development while we prepare for an initial release.' ), $display_version ); ?></p>
 		<div class="wp-badge"><?php printf( __( 'Version %s' ), $display_version ); ?></div>
 
 		<h2 class="nav-tab-wrapper wp-clearfix">

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -12,7 +12,7 @@ require_once( dirname( __FILE__ ) . '/includes/credits.php' );
 
 $title = __( 'Credits' );
 
-$display_version = get_bloginfo( 'classicpress_display_version' );
+$display_version = classicpress_version();
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 ?>

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -12,7 +12,7 @@ require_once( dirname( __FILE__ ) . '/includes/credits.php' );
 
 $title = __( 'Credits' );
 
-list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
+$display_version = get_bloginfo( 'classicpress_display_version' );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 ?>
@@ -20,7 +20,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 
 <h1><?php printf( __( 'Welcome to ClassicPress %s' ), $display_version ); ?></h1>
 
-<p class="about-text"><?php printf( __( 'Thank you for updating to the latest version! ClassicPress %s will smooth your design workflow and keep you safe from coding errors.' ), $display_version ); ?></p>
+<p class="about-text"><?php printf( __( 'Thank you for trying ClassicPress! We are under heavy development while we prepare for an initial release.' ), $display_version ); ?></p>
 
 <div class="wp-badge"><?php printf( __( 'Version %s' ), $display_version ); ?></div>
 

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -11,7 +11,7 @@ require_once( dirname( __FILE__ ) . '/admin.php' );
 
 $title = __( 'Freedoms' );
 
-list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
+$display_version = get_bloginfo( 'classicpress_display_version' );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 
@@ -22,7 +22,7 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 
 <h1><?php printf( __( 'Welcome to ClassicPress %s' ), $display_version ); ?></h1>
 
-<p class="about-text"><?php printf( __( 'Thank you for updating to the latest version! ClassicPress %s will smooth your design workflow and keep you safe from coding errors.' ), $display_version ); ?></p>
+<p class="about-text"><?php printf( __( 'Thank you for trying ClassicPress! We are under heavy development while we prepare for an initial release.' ), $display_version ); ?></p>
 
 <div class="wp-badge"><?php printf( __( 'Version %s' ), $display_version ); ?></div>
 

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -11,7 +11,7 @@ require_once( dirname( __FILE__ ) . '/admin.php' );
 
 $title = __( 'Freedoms' );
 
-$display_version = get_bloginfo( 'classicpress_display_version' );
+$display_version = classicpress_version();
 
 include( ABSPATH . 'wp-admin/admin-header.php' );
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -120,7 +120,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		'id'    => 'wp-logo',
 		'title' => (
 			'<img class="cp-logo" src="' . $cp_logo_src . '" />'
-			. '<span class="screen-reader-text">' . __( 'About WordPress' ) . '</span>'
+			. '<span class="screen-reader-text">' . __( 'About ClassicPress' ) . '</span>'
 		),
 		'href'  => $about_url,
 	);

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -115,9 +115,13 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		$about_url = false;
 	}
 
+	$cp_logo_src = includes_url( 'images/classicpress-logo-dashicon-style.svg' );
 	$wp_logo_menu_args = array(
 		'id'    => 'wp-logo',
-		'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . __( 'About WordPress' ) . '</span>',
+		'title' => (
+			'<img class="cp-logo" src="' . $cp_logo_src . '" />'
+			. '<span class="screen-reader-text">' . __( 'About WordPress' ) . '</span>'
+		),
 		'href'  => $about_url,
 	);
 

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -476,22 +476,17 @@ html:lang(he-il) .rtl #wpadminbar *  {
 }
 
 /**
- * WP Logo
+ * ClassicPress Logo
  */
-#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
-	width: 15px;
-	height: 20px;
-	margin-right: 0;
-	padding: 6px 0 5px;
+#wpadminbar #wp-admin-bar-wp-logo > .ab-item .cp-logo {
+	width: 18px;
+	height: 18px;
+	margin: 7px 2px 6px 1px;
+	vertical-align: top;
 }
 
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item {
 	padding: 0 7px;
-}
-
-#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
-	content: "\f120";
-	top: 2px;
 }
 
 /*
@@ -856,22 +851,11 @@ html:lang(he-il) .rtl #wpadminbar *  {
 		display: none;
 	}
 
-	/* WP logo */
-	#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
-		padding: 0;
-	}
-
-	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
-		padding: 0;
-		width: 52px;
-		height: 46px;
-		text-align: center;
-		vertical-align: top;
-	}
-
-	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
-		font: 28px/1 dashicons !important;
-		top: -3px;
+	/* ClassicPress logo */
+	#wpadminbar #wp-admin-bar-wp-logo > .ab-item .cp-logo {
+		padding: 3px 4px 3px 5px;
+		width: 26px;
+		height: 26px;
 	}
 
 	#wpadminbar .ab-icon,

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -696,6 +696,11 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			global $wp_version;
 			$output = $wp_version;
 			break;
+		case 'classicpress_version':
+		case 'classicpress_display_version': // May be different in the future.
+			global $cp_version;
+			$output = $cp_version;
+			break;
 		case 'language':
 			/* translators: Translate this to the correct language tag for your locale,
 			 * see https://www.w3.org/International/articles/language-tags/ for reference.

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -696,11 +696,6 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			global $wp_version;
 			$output = $wp_version;
 			break;
-		case 'classicpress_version':
-		case 'classicpress_display_version': // May be different in the future.
-			global $cp_version;
-			$output = $cp_version;
-			break;
 		case 'language':
 			/* translators: Translate this to the correct language tag for your locale,
 			 * see https://www.w3.org/International/articles/language-tags/ for reference.

--- a/src/wp-includes/images/classicpress-logo-dashicon-style.svg
+++ b/src/wp-includes/images/classicpress-logo-dashicon-style.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg16"
+   version="1.1"
+   viewBox="0 0 138.5 138.5">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>icon-blue</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20" />
+  <title
+     id="title2">icon-blue</title>
+  <path
+     id="circle4"
+     d="M 69.25 0 A 69.25 69.25 0 0 0 0 69.25 A 69.25 69.25 0 0 0 69.25 138.5 A 69.25 69.25 0 0 0 138.5 69.25 A 69.25 69.25 0 0 0 69.25 0 z M 122.58398 37.386719 A 1.85 1.85 0 0 1 124.14062 38.240234 L 124.14062 38.210938 A 1.85 1.85 0 0 1 124.25 40.070312 L 109.31055 69.939453 A 1.86 1.86 0 0 1 107.94922 70.939453 L 94.460938 73.289062 L 100.67969 74.849609 A 1.85 1.85 0 0 1 101.86914 75.769531 A 1.9 1.9 0 0 1 101.99023 77.279297 C 99.640238 83.929297 76.319219 104.58008 62.199219 104.58008 A 10.65 10.65 0 0 1 53.447266 100.6582 C 48.245822 108.49824 43.449148 116.96435 38.310547 126.05078 A 1.85 1.85 0 0 1 36.679688 127 L 36.679688 127.01953 A 1.87 1.87 0 0 1 35.060547 124.24023 C 51.380547 95.360238 64.280469 72.560234 97.480469 56.240234 A 1.87 1.87 0 0 1 97.732422 56.123047 A 1.8649464 1.8649464 0 0 0 95.859375 52.910156 C 74.269375 63.510156 61.089844 76.670078 50.089844 92.330078 C 47.229844 76.930078 60.959375 64.58 61.609375 64 A 1.86 1.86 0 0 1 64.509766 64.570312 L 65.759766 67.050781 C 66.469766 63.860781 67.520859 60.249375 68.880859 58.609375 C 71.220859 55.809375 82.210625 49.940547 84.390625 48.810547 A 1.83 1.83 0 0 1 86.570312 49.140625 L 88.480469 51.039062 L 91.050781 45.890625 A 2 2 0 0 1 92.050781 44.970703 C 92.830781 44.690703 111.12047 37.990625 122.48047 37.390625 A 1.85 1.85 0 0 1 122.58398 37.386719 z "
+     style="fill:#f0f5fa;fill-opacity:0.60000002" />
+  <path
+     id="path6"
+     style="fill:#fff;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.97px"
+     transform="translate(-374.17 -273.06)"
+     d="M410.85,398.21" />
+  <path
+     id="path8"
+     style="fill:#fff;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.97px"
+     transform="translate(-374.17 -273.06)"
+     d="M410.85,398.21" />
+  <path
+     id="path12"
+     style="fill:#fff;stroke:#fff;stroke-linecap:round;stroke-linejoin:round;stroke-width:0.97px"
+     transform="translate(-374.17 -273.06)"
+     d="M407.12,396.35" />
+</svg>

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -7,12 +7,28 @@
 $cp_version = '1.0.0-alpha';
 
 /**
+ * Return the ClassicPress version string.
+ *
+ * `function_exists( 'classicpress_version' )` is the recommended way for
+ * plugins and themes to determine whether they are running under ClassicPress.
+ *
+ * @return string The ClassicPress version string.
+ */
+if ( ! function_exists( 'classicpress_version' ) ) {
+    function classicpress_version() {
+        global $cp_version;
+        return $cp_version;
+    }
+}
+
+/**
  * The WordPress version string
  *
- * This is still used internally for various core and plugin functions.  The
- * ClassicPress version is stored in a separate variable.
+ * This is still used internally for various core and plugin functions, and to
+ * keep compatibility checks working as intended.  The ClassicPress version is
+ * stored separately.
  *
- * @see $cp_version
+ * @see classicpress_version()
  *
  * @global string $wp_version
  */

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -1,6 +1,18 @@
 <?php
 /**
+ * The ClassicPress version string
+ *
+ * @global string $cp_version
+ */
+$cp_version = '1.0.0-alpha';
+
+/**
  * The WordPress version string
+ *
+ * This is still used internally for various core and plugin functions.  The
+ * ClassicPress version is stored in a separate variable.
+ *
+ * @see $cp_version
  *
  * @global string $wp_version
  */


### PR DESCRIPTION
The intent of this PR is to get us to a place where we can show screenshots of our work in progress.  The PR does the following:

- Add a new `$cp_version` global variable.  There are lots of places in the code where `$wp_version` is used to compare and enable/disable various features, so it will be easiest to introduce our own version variable.
- Show the ClassicPress version instead of the WordPress version in the admin dashboard's About section, and begin updating the About page content accordingly.
- Replace the WP logo in the admin bar with an SVG of the ClassicPress logo.  This is a bit different than how it worked previously, since this logo in WP uses [an icon font](https://github.com/WordPress/dashicons).

Screenshots:

## Installation screen

![classicpress-install](https://user-images.githubusercontent.com/227022/45112310-eb49b400-b10c-11e8-86ab-637776d0f118.png)

## About page

![2018-09-05t12 59 11-05 00](https://user-images.githubusercontent.com/227022/45112341-f7357600-b10c-11e8-88f3-4b8f85a45fae.png)

## Editor

![2018-09-05t12 58 29-05 00](https://user-images.githubusercontent.com/227022/45112363-00264780-b10d-11e8-8073-f38ebf235649.png)

## Front-end

![2018-09-05t13 02 30-05 00](https://user-images.githubusercontent.com/227022/45112375-04eafb80-b10d-11e8-9568-2a2fc2d97410.png)
