### PR TITLE
Rename: Update all `@ deprecated` annotations

### DIFF
--- a/src/wp-admin/admin-functions.php
+++ b/src/wp-admin/admin-functions.php
@@ -4,7 +4,7 @@
  *
  * This file is deprecated, use 'wp-admin/includes/admin.php' instead.
  *
- * @deprecated 2.5.0
+ * @deprecated WP-2.5.0
  * @package ClassicPress
  * @subpackage Administration
  */

--- a/src/wp-admin/custom-background.php
+++ b/src/wp-admin/custom-background.php
@@ -514,7 +514,7 @@ if ( current_theme_supports( 'custom-background', 'default-color' ) )
 	/**
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 *
 	 * @param array $form_fields
 	 * @return array $form_fields
@@ -526,7 +526,7 @@ if ( current_theme_supports( 'custom-background', 'default-color' ) )
 	/**
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 *
 	 * @param array $tabs
 	 * @return array $tabs
@@ -538,7 +538,7 @@ if ( current_theme_supports( 'custom-background', 'default-color' ) )
 	/**
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 */
 	public function wp_set_background_image() {
 		if ( ! current_user_can('edit_theme_options') || ! isset( $_POST['attachment_id'] ) ) exit;

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -290,7 +290,7 @@ if ( post_type_supports($post_type, 'custom-fields') )
  * Fires in the middle of built-in meta box registration.
  *
  * @since WP-2.1.0
- * @deprecated 3.7.0 Use 'add_meta_boxes' instead.
+ * @deprecated WP-3.7.0 Use 'add_meta_boxes' instead.
  *
  * @param WP_Post $post Post object.
  */

--- a/src/wp-admin/edit-tag-form.php
+++ b/src/wp-admin/edit-tag-form.php
@@ -17,7 +17,7 @@ if ( 'category' == $taxonomy ) {
  	 * Fires before the Edit Category form.
 	 *
 	 * @since WP-2.1.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_pre_edit_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_edit_form instead.
 	 *
 	 * @param object $tag Current category term object.
 	 */
@@ -27,7 +27,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires before the Edit Link Category form.
 	 *
 	 * @since WP-2.3.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_pre_edit_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_edit_form instead.
 	 *
 	 * @param object $tag Current link category term object.
 	 */
@@ -37,7 +37,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires before the Edit Tag form.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_pre_edit_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_edit_form instead.
 	 *
 	 * @param object $tag Current tag term object.
 	 */
@@ -183,7 +183,7 @@ do_action( "{$taxonomy}_term_edit_form_top", $tag, $taxonomy );
 			 * Fires after the Edit Category form fields are displayed.
 			 *
 			 * @since WP-2.9.0
-			 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+			 * @deprecated WP-3.0.0 Use {$taxonomy}_edit_form_fields instead.
 			 *
 			 * @param object $tag Current category term object.
 			 */
@@ -193,7 +193,7 @@ do_action( "{$taxonomy}_term_edit_form_top", $tag, $taxonomy );
 			 * Fires after the Edit Link Category form fields are displayed.
 			 *
 			 * @since WP-2.9.0
-			 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+			 * @deprecated WP-3.0.0 Use {$taxonomy}_edit_form_fields instead.
 			 *
 			 * @param object $tag Current link category term object.
 			 */
@@ -203,7 +203,7 @@ do_action( "{$taxonomy}_term_edit_form_top", $tag, $taxonomy );
 			 * Fires after the Edit Tag form fields are displayed.
 			 *
 			 * @since WP-2.9.0
-			 * @deprecated 3.0.0 Use {$taxonomy}_edit_form_fields instead.
+			 * @deprecated WP-3.0.0 Use {$taxonomy}_edit_form_fields instead.
 			 *
 			 * @param object $tag Current tag term object.
 			 */
@@ -236,7 +236,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires at the end of the Edit Term form.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_edit_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_edit_form instead.
 	 *
 	 * @param object $tag Current taxonomy term object.
 	 */

--- a/src/wp-admin/edit-tags.php
+++ b/src/wp-admin/edit-tags.php
@@ -330,7 +330,7 @@ if ( current_user_can($tax->cap->edit_terms) ) {
  		 * Fires before the Add Category form.
 		 *
 		 * @since WP-2.1.0
-		 * @deprecated 3.0.0 Use {$taxonomy}_pre_add_form instead.
+		 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_add_form instead.
 		 *
 		 * @param object $arg Optional arguments cast to an object.
 		 */
@@ -340,7 +340,7 @@ if ( current_user_can($tax->cap->edit_terms) ) {
 		 * Fires before the link category form.
 		 *
 		 * @since WP-2.3.0
-		 * @deprecated 3.0.0 Use {$taxonomy}_pre_add_form instead.
+		 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_add_form instead.
 		 *
 		 * @param object $arg Optional arguments cast to an object.
 		 */
@@ -350,7 +350,7 @@ if ( current_user_can($tax->cap->edit_terms) ) {
 		 * Fires before the Add Tag form.
 		 *
 		 * @since WP-2.5.0
-		 * @deprecated 3.0.0 Use {$taxonomy}_pre_add_form instead.
+		 * @deprecated WP-3.0.0 Use {$taxonomy}_pre_add_form instead.
 		 *
 		 * @param string $taxonomy The taxonomy slug.
 		 */
@@ -481,7 +481,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires at the end of the Edit Category form.
 	 *
 	 * @since WP-2.1.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_add_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_add_form instead.
 	 *
 	 * @param object $arg Optional arguments cast to an object.
 	 */
@@ -491,7 +491,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires at the end of the Edit Link form.
 	 *
 	 * @since WP-2.3.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_add_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_add_form instead.
 	 *
 	 * @param object $arg Optional arguments cast to an object.
 	 */
@@ -501,7 +501,7 @@ if ( 'category' == $taxonomy ) {
 	 * Fires at the end of the Add Tag form.
 	 *
 	 * @since WP-2.7.0
-	 * @deprecated 3.0.0 Use {$taxonomy}_add_form instead.
+	 * @deprecated WP-3.0.0 Use {$taxonomy}_add_form instead.
 	 *
 	 * @param string $taxonomy The taxonomy slug.
 	 */

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2309,7 +2309,7 @@ function wp_ajax_time_format() {
  * Ajax handler for saving posts from the fullscreen editor.
  *
  * @since WP-3.1.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  */
 function wp_ajax_wp_fullscreen_save_post() {
 	$post_id = isset( $_POST['post_ID'] ) ? (int) $_POST['post_ID'] : 0;

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -439,7 +439,7 @@ class WP_Community_Events {
 	 * Logs responses to Events API requests.
 	 *
 	 * @since WP-4.8.0
-	 * @deprecated 4.9.0 Use a plugin instead. See #41217 for an example.
+	 * @deprecated WP-4.9.0 Use a plugin instead. See #41217 for an example.
 	 *
 	 * @param string $message A description of what occurred.
 	 * @param array  $details Details that provide more context for the

--- a/src/wp-admin/includes/class-wp-filesystem-base.php
+++ b/src/wp-admin/includes/class-wp-filesystem-base.php
@@ -115,7 +115,7 @@ class WP_Filesystem_Base {
 	 * Locate a folder on the remote filesystem.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 2.7.0 use WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir() instead.
+	 * @deprecated WP-2.7.0 use WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir() instead.
 	 * @see WP_Filesystem::abspath()
 	 * @see WP_Filesystem::wp_content_dir()
 	 * @see WP_Filesystem::wp_plugins_dir()
@@ -137,7 +137,7 @@ class WP_Filesystem_Base {
 	 * Locate a folder on the remote filesystem.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 2.7.0 use WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir() methods instead.
+	 * @deprecated WP-2.7.0 use WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir() methods instead.
 	 * @see WP_Filesystem::abspath()
 	 * @see WP_Filesystem::wp_content_dir()
 	 * @see WP_Filesystem::wp_plugins_dir()

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -60,7 +60,7 @@ final class WP_Screen {
 	 * Deprecated. Use in_admin() instead.
 	 *
 	 * @since WP-3.3.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 * @var bool
 	 */
 	public $is_network;
@@ -71,7 +71,7 @@ final class WP_Screen {
 	 * Deprecated. Use in_admin() instead.
 	 *
 	 * @since WP-3.3.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 * @var bool
 	 */
 	public $is_user;
@@ -714,7 +714,7 @@ final class WP_Screen {
 		 * Filters the legacy contextual help list.
 		 *
 		 * @since WP-2.7.0
-		 * @deprecated 3.3.0 Use get_current_screen()->add_help_tab() or
+		 * @deprecated WP-3.3.0 Use get_current_screen()->add_help_tab() or
 		 *                   get_current_screen()->remove_help_tab() instead.
 		 *
 		 * @param array     $old_compat_help Old contextual help.
@@ -728,7 +728,7 @@ final class WP_Screen {
 		 * Filters the legacy contextual help text.
 		 *
 		 * @since WP-2.7.0
-		 * @deprecated 3.3.0 Use get_current_screen()->add_help_tab() or
+		 * @deprecated WP-3.3.0 Use get_current_screen()->add_help_tab() or
 		 *                   get_current_screen()->remove_help_tab() instead.
 		 *
 		 * @param string    $old_help  Help text that appears on the screen.
@@ -745,7 +745,7 @@ final class WP_Screen {
 			 * Filters the default legacy contextual help text.
 			 *
 			 * @since WP-2.8.0
-			 * @deprecated 3.3.0 Use get_current_screen()->add_help_tab() or
+			 * @deprecated WP-3.3.0 Use get_current_screen()->add_help_tab() or
 			 *                   get_current_screen()->remove_help_tab() instead.
 			 *
 			 * @param string $old_help_default Default contextual help text.

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -89,7 +89,7 @@ class WP_Terms_List_Table extends WP_List_Table {
 			 * Filters the number of terms displayed per page for the Tags list table.
 			 *
 			 * @since WP-2.7.0
-			 * @deprecated 2.8.0 Use edit_tags_per_page instead.
+			 * @deprecated WP-2.8.0 Use edit_tags_per_page instead.
 			 *
 			 * @param int $tags_per_page Number of tags to be displayed. Default 20.
 			 */
@@ -466,7 +466,7 @@ class WP_Terms_List_Table extends WP_List_Table {
 		 * Filters the action links displayed for each term in the Tags list table.
 		 *
 		 * @since WP-2.8.0
-		 * @deprecated 3.0.0 Use {$taxonomy}_row_actions instead.
+		 * @deprecated WP-3.0.0 Use {$taxonomy}_row_actions instead.
 		 *
 		 * @param array  $actions An array of action links to be displayed. Default
 		 *                        'Edit', 'Quick Edit', 'Delete', and 'View'.

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -14,7 +14,7 @@
 
 /**
  * @since WP-2.1.0
- * @deprecated 2.1.0 Use wp_editor()
+ * @deprecated WP-2.1.0 Use wp_editor()
  * @see wp_editor()
  */
 function tinymce_include() {
@@ -27,7 +27,7 @@ function tinymce_include() {
  * Unused Admin function.
  *
  * @since WP-2.0.0
- * @deprecated 2.5.0
+ * @deprecated WP-2.5.0
  *
  */
 function documentation_link() {
@@ -38,7 +38,7 @@ function documentation_link() {
  * Calculates the new dimensions for a downsampled image.
  *
  * @since WP-2.0.0
- * @deprecated 3.0.0 Use wp_constrain_dimensions()
+ * @deprecated WP-3.0.0 Use wp_constrain_dimensions()
  * @see wp_constrain_dimensions()
  *
  * @param int $width Current width of the image
@@ -56,7 +56,7 @@ function wp_shrink_dimensions( $width, $height, $wmax = 128, $hmax = 96 ) {
  * Calculated the new dimensions for a downsampled image.
  *
  * @since WP-2.0.0
- * @deprecated 3.5.0 Use wp_constrain_dimensions()
+ * @deprecated WP-3.5.0 Use wp_constrain_dimensions()
  * @see wp_constrain_dimensions()
  *
  * @param int $width Current width of the image
@@ -72,7 +72,7 @@ function get_udims( $width, $height ) {
  * Legacy function used to generate the categories checklist control.
  *
  * @since WP-0.71
- * @deprecated 2.6.0 Use wp_category_checklist()
+ * @deprecated WP-2.6.0 Use wp_category_checklist()
  * @see wp_category_checklist()
  *
  * @param int $default       Unused.
@@ -89,7 +89,7 @@ function dropdown_categories( $default = 0, $parent = 0, $popular_ids = array() 
  * Legacy function used to generate a link categories checklist control.
  *
  * @since WP-2.1.0
- * @deprecated 2.6.0 Use wp_link_category_checklist()
+ * @deprecated WP-2.6.0 Use wp_link_category_checklist()
  * @see wp_link_category_checklist()
  *
  * @param int $default Unused.
@@ -104,7 +104,7 @@ function dropdown_link_categories( $default = 0 ) {
  * Get the real filesystem path to a file to edit within the admin.
  *
  * @since WP-1.5.0
- * @deprecated 2.9.0
+ * @deprecated WP-2.9.0
  * @uses WP_CONTENT_DIR Full filesystem path to the wp-content directory.
  *
  * @param string $file Filesystem path relative to the wp-content directory.
@@ -120,7 +120,7 @@ function get_real_file_to_edit( $file ) {
  * Legacy function used for generating a categories drop-down control.
  *
  * @since WP-1.2.0
- * @deprecated 3.0.0 Use wp_dropdown_categories()
+ * @deprecated WP-3.0.0 Use wp_dropdown_categories()
  * @see wp_dropdown_categories()
  *
  * @param int $currentcat    Optional. ID of the current category. Default 0.
@@ -156,7 +156,7 @@ function wp_dropdown_cats( $currentcat = 0, $currentparent = 0, $parent = 0, $le
  * Register a setting and its sanitization callback
  *
  * @since WP-2.7.0
- * @deprecated 3.0.0 Use register_setting()
+ * @deprecated WP-3.0.0 Use register_setting()
  * @see register_setting()
  *
  * @param string $option_group A settings group name. Should correspond to a whitelisted option key name.
@@ -173,7 +173,7 @@ function add_option_update_handler( $option_group, $option_name, $sanitize_callb
  * Unregister a setting
  *
  * @since WP-2.7.0
- * @deprecated 3.0.0 Use unregister_setting()
+ * @deprecated WP-3.0.0 Use unregister_setting()
  * @see unregister_setting()
  *
  * @param string $option_group
@@ -189,7 +189,7 @@ function remove_option_update_handler( $option_group, $option_name, $sanitize_ca
  * Determines the language to use for CodePress syntax highlighting.
  *
  * @since WP-2.8.0
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * @param string $filename
 **/
@@ -201,7 +201,7 @@ function codepress_get_lang( $filename ) {
  * Adds JavaScript required to make CodePress work on the theme/plugin editors.
  *
  * @since WP-2.8.0
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
 **/
 function codepress_footer_js() {
 	_deprecated_function( __FUNCTION__, '3.0.0' );
@@ -211,7 +211,7 @@ function codepress_footer_js() {
  * Determine whether to use CodePress.
  *
  * @since WP-2.8.0
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
 **/
 function use_codepress() {
 	_deprecated_function( __FUNCTION__, '3.0.0' );
@@ -220,7 +220,7 @@ function use_codepress() {
 /**
  * Get all user IDs.
  *
- * @deprecated 3.1.0 Use get_users()
+ * @deprecated WP-3.1.0 Use get_users()
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
@@ -241,7 +241,7 @@ function get_author_user_ids() {
 /**
  * Gets author users who can edit posts.
  *
- * @deprecated 3.1.0 Use get_users()
+ * @deprecated WP-3.1.0 Use get_users()
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
@@ -268,7 +268,7 @@ function get_editable_authors( $user_id ) {
 /**
  * Gets the IDs of any users who can edit posts.
  *
- * @deprecated 3.1.0 Use get_users()
+ * @deprecated WP-3.1.0 Use get_users()
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
@@ -307,7 +307,7 @@ function get_editable_user_ids( $user_id, $exclude_zeros = true, $post_type = 'p
 /**
  * Gets all users who are not authors.
  *
- * @deprecated 3.1.0 Use get_users()
+ * @deprecated WP-3.1.0 Use get_users()
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  */
@@ -329,7 +329,7 @@ if ( ! class_exists( 'WP_User_Search', false ) ) :
  * ClassicPress User Search class.
  *
  * @since WP-2.1.0
- * @deprecated 3.1.0 Use WP_User_Query
+ * @deprecated WP-3.1.0 Use WP_User_Query
  */
 class WP_User_Search {
 
@@ -669,7 +669,7 @@ endif;
  * Retrieves editable posts from other users.
  *
  * @since WP-2.3.0
- * @deprecated 3.1.0 Use get_posts()
+ * @deprecated WP-3.1.0 Use get_posts()
  * @see get_posts()
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
@@ -706,7 +706,7 @@ function get_others_unpublished_posts( $user_id, $type = 'any' ) {
 /**
  * Retrieve drafts from other users.
  *
- * @deprecated 3.1.0 Use get_posts()
+ * @deprecated WP-3.1.0 Use get_posts()
  * @see get_posts()
  *
  * @param int $user_id User ID.
@@ -721,7 +721,7 @@ function get_others_drafts($user_id) {
 /**
  * Retrieve pending review posts from other users.
  *
- * @deprecated 3.1.0 Use get_posts()
+ * @deprecated WP-3.1.0 Use get_posts()
  * @see get_posts()
  *
  * @param int $user_id User ID.
@@ -737,7 +737,7 @@ function get_others_pending($user_id) {
  * Output the QuickPress dashboard widget.
  *
  * @since WP-3.0.0
- * @deprecated 3.2.0 Use wp_dashboard_quick_press()
+ * @deprecated WP-3.2.0 Use wp_dashboard_quick_press()
  * @see wp_dashboard_quick_press()
  */
 function wp_dashboard_quick_press_output() {
@@ -749,7 +749,7 @@ function wp_dashboard_quick_press_output() {
  * Outputs the TinyMCE editor.
  *
  * @since WP-2.7.0
- * @deprecated 3.3.0 Use wp_editor()
+ * @deprecated WP-3.3.0 Use wp_editor()
  * @see wp_editor()
  *
  * @staticvar int $num
@@ -777,7 +777,7 @@ function wp_tiny_mce( $teeny = false, $settings = false ) {
 /**
  * Preloads TinyMCE dialogs.
  *
- * @deprecated 3.3.0 Use wp_editor()
+ * @deprecated WP-3.3.0 Use wp_editor()
  * @see wp_editor()
  */
 function wp_preload_dialogs() {
@@ -787,7 +787,7 @@ function wp_preload_dialogs() {
 /**
  * Prints TinyMCE editor JS.
  *
- * @deprecated 3.3.0 Use wp_editor()
+ * @deprecated WP-3.3.0 Use wp_editor()
  * @see wp_editor()
  */
 function wp_print_editor_js() {
@@ -797,7 +797,7 @@ function wp_print_editor_js() {
 /**
  * Handles quicktags.
  *
- * @deprecated 3.3.0 Use wp_editor()
+ * @deprecated WP-3.3.0 Use wp_editor()
  * @see wp_editor()
  */
 function wp_quicktags() {
@@ -808,7 +808,7 @@ function wp_quicktags() {
  * Returns the screen layout options.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0 WP_Screen::render_screen_layout()
+ * @deprecated WP-3.3.0 WP_Screen::render_screen_layout()
  * @see WP_Screen::render_screen_layout()
  */
 function screen_layout( $screen ) {
@@ -828,7 +828,7 @@ function screen_layout( $screen ) {
  * Returns the screen's per-page options.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0 Use WP_Screen::render_per_page_options()
+ * @deprecated WP-3.3.0 Use WP_Screen::render_per_page_options()
  * @see WP_Screen::render_per_page_options()
  */
 function screen_options( $screen ) {
@@ -848,7 +848,7 @@ function screen_options( $screen ) {
  * Renders the screen's help.
  *
  * @since WP-2.7.0
- * @deprecated 3.3.0 Use WP_Screen::render_screen_meta()
+ * @deprecated WP-3.3.0 Use WP_Screen::render_screen_meta()
  * @see WP_Screen::render_screen_meta()
  */
 function screen_meta( $screen ) {
@@ -860,7 +860,7 @@ function screen_meta( $screen ) {
  * Favorite actions were deprecated in version 3.2. Use the admin bar instead.
  *
  * @since WP-2.7.0
- * @deprecated 3.2.0 Use WP_Admin_Bar
+ * @deprecated WP-3.2.0 Use WP_Admin_Bar
  * @see WP_Admin_Bar
  */
 function favorite_actions() {
@@ -870,7 +870,7 @@ function favorite_actions() {
 /**
  * Handles uploading an image.
  *
- * @deprecated 3.3.0 Use wp_media_upload_handler()
+ * @deprecated WP-3.3.0 Use wp_media_upload_handler()
  * @see wp_media_upload_handler()
  *
  * @return null|string
@@ -883,7 +883,7 @@ function media_upload_image() {
 /**
  * Handles uploading an audio file.
  *
- * @deprecated 3.3.0 Use wp_media_upload_handler()
+ * @deprecated WP-3.3.0 Use wp_media_upload_handler()
  * @see wp_media_upload_handler()
  *
  * @return null|string
@@ -896,7 +896,7 @@ function media_upload_audio() {
 /**
  * Handles uploading a video file.
  *
- * @deprecated 3.3.0 Use wp_media_upload_handler()
+ * @deprecated WP-3.3.0 Use wp_media_upload_handler()
  * @see wp_media_upload_handler()
  *
  * @return null|string
@@ -909,7 +909,7 @@ function media_upload_video() {
 /**
  * Handles uploading a generic file.
  *
- * @deprecated 3.3.0 Use wp_media_upload_handler()
+ * @deprecated WP-3.3.0 Use wp_media_upload_handler()
  * @see wp_media_upload_handler()
  *
  * @return null|string
@@ -922,7 +922,7 @@ function media_upload_file() {
 /**
  * Handles retrieving the insert-from-URL form for an image.
  *
- * @deprecated 3.3.0 Use wp_media_insert_url_form()
+ * @deprecated WP-3.3.0 Use wp_media_insert_url_form()
  * @see wp_media_insert_url_form()
  *
  * @return string
@@ -935,7 +935,7 @@ function type_url_form_image() {
 /**
  * Handles retrieving the insert-from-URL form for an audio file.
  *
- * @deprecated 3.3.0 Use wp_media_insert_url_form()
+ * @deprecated WP-3.3.0 Use wp_media_insert_url_form()
  * @see wp_media_insert_url_form()
  *
  * @return string
@@ -948,7 +948,7 @@ function type_url_form_audio() {
 /**
  * Handles retrieving the insert-from-URL form for a video file.
  *
- * @deprecated 3.3.0 Use wp_media_insert_url_form()
+ * @deprecated WP-3.3.0 Use wp_media_insert_url_form()
  * @see wp_media_insert_url_form()
  *
  * @return string
@@ -961,7 +961,7 @@ function type_url_form_video() {
 /**
  * Handles retrieving the insert-from-URL form for a generic file.
  *
- * @deprecated 3.3.0 Use wp_media_insert_url_form()
+ * @deprecated WP-3.3.0 Use wp_media_insert_url_form()
  * @see wp_media_insert_url_form()
  *
  * @return string
@@ -977,7 +977,7 @@ function type_url_form_file() {
  * Creates an 'Overview' help tab.
  *
  * @since WP-2.7.0
- * @deprecated 3.3.0 Use WP_Screen::add_help_tab()
+ * @deprecated WP-3.3.0 Use WP_Screen::add_help_tab()
  * @see WP_Screen::add_help_tab()
  *
  * @param string    $screen The handle for the screen to add help to. This is usually the hook name returned by the add_*_page() functions.
@@ -996,7 +996,7 @@ function add_contextual_help( $screen, $help ) {
  * Get the allowed themes for the current site.
  *
  * @since WP-3.0.0
- * @deprecated 3.4.0 Use wp_get_themes()
+ * @deprecated WP-3.4.0 Use wp_get_themes()
  * @see wp_get_themes()
  *
  * @return array $themes Array of allowed themes.
@@ -1018,7 +1018,7 @@ function get_allowed_themes() {
  * Retrieves a list of broken themes.
  *
  * @since WP-1.5.0
- * @deprecated 3.4.0 Use wp_get_themes()
+ * @deprecated WP-3.4.0 Use wp_get_themes()
  * @see wp_get_themes()
  *
  * @return array
@@ -1043,7 +1043,7 @@ function get_broken_themes() {
  * Retrieves information on the current active theme.
  *
  * @since WP-2.0.0
- * @deprecated 3.4.0 Use wp_get_theme()
+ * @deprecated WP-3.4.0 Use wp_get_theme()
  * @see wp_get_theme()
  *
  * @return WP_Theme
@@ -1059,7 +1059,7 @@ function current_theme_info() {
  *
  * Now it is deprecated and stubbed.
  *
- * @deprecated 3.5.0
+ * @deprecated WP-3.5.0
  */
 function _insert_into_post_button( $type ) {
 	_deprecated_function( __FUNCTION__, '3.5.0' );
@@ -1070,7 +1070,7 @@ function _insert_into_post_button( $type ) {
  *
  * Now it is deprecated and stubbed.
  *
- * @deprecated 3.5.0
+ * @deprecated WP-3.5.0
  */
 function _media_button($title, $icon, $type, $id) {
 	_deprecated_function( __FUNCTION__, '3.5.0' );
@@ -1080,7 +1080,7 @@ function _media_button($title, $icon, $type, $id) {
  * Gets an existing post and format it for editing.
  *
  * @since WP-2.0.0
- * @deprecated 3.5.0 Use get_post()
+ * @deprecated WP-3.5.0 Use get_post()
  * @see get_post()
  *
  * @param int $id
@@ -1096,7 +1096,7 @@ function get_post_to_edit( $id ) {
  * Gets the default page information to use.
  *
  * @since WP-2.5.0
- * @deprecated 3.5.0 Use get_default_post_to_edit()
+ * @deprecated WP-3.5.0 Use get_default_post_to_edit()
  * @see get_default_post_to_edit()
  *
  * @return WP_Post Post object containing all the default post data as attributes
@@ -1113,7 +1113,7 @@ function get_default_page_to_edit() {
  * This was once used to create a thumbnail from an Image given a maximum side size.
  *
  * @since WP-1.2.0
- * @deprecated 3.5.0 Use image_resize()
+ * @deprecated WP-3.5.0 Use image_resize()
  * @see image_resize()
  *
  * @param mixed $file Filename of the original image, Or attachment id.
@@ -1132,7 +1132,7 @@ function wp_create_thumbnail( $file, $max_side, $deprecated = '' ) {
  * Deprecated in favor of a 'Manage Locations' tab added to nav menus management screen.
  *
  * @since WP-3.0.0
- * @deprecated 3.6.0
+ * @deprecated WP-3.6.0
  */
 function wp_nav_menu_locations_meta_box() {
 	_deprecated_function( __FUNCTION__, '3.6.0' );
@@ -1145,7 +1145,7 @@ function wp_nav_menu_locations_meta_box() {
  * and calling the 'upgrade' method.
  *
  * @since WP-2.7.0
- * @deprecated 3.7.0 Use Core_Upgrader
+ * @deprecated WP-3.7.0 Use Core_Upgrader
  * @see Core_Upgrader
  */
 function wp_update_core($current, $feedback = '') {
@@ -1168,7 +1168,7 @@ function wp_update_core($current, $feedback = '') {
  * Unused since 2.8.0.
  *
  * @since WP-2.5.0
- * @deprecated 3.7.0 Use Plugin_Upgrader
+ * @deprecated WP-3.7.0 Use Plugin_Upgrader
  * @see Plugin_Upgrader
  */
 function wp_update_plugin($plugin, $feedback = '') {
@@ -1190,7 +1190,7 @@ function wp_update_plugin($plugin, $feedback = '') {
  * Unused since 2.8.0.
  *
  * @since WP-2.7.0
- * @deprecated 3.7.0 Use Theme_Upgrader
+ * @deprecated WP-3.7.0 Use Theme_Upgrader
  * @see Theme_Upgrader
  */
 function wp_update_theme($theme, $feedback = '') {
@@ -1208,7 +1208,7 @@ function wp_update_theme($theme, $feedback = '') {
  * This was once used to display attachment links. Now it is deprecated and stubbed.
  *
  * @since WP-2.0.0
- * @deprecated 3.7.0
+ * @deprecated WP-3.7.0
  *
  * @param int|bool $id
  */
@@ -1220,7 +1220,7 @@ function the_attachment_links( $id = false ) {
  * Displays a screen icon.
  *
  * @since WP-2.7.0
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function screen_icon() {
 	_deprecated_function( __FUNCTION__, '3.8.0' );
@@ -1231,7 +1231,7 @@ function screen_icon() {
  * Retrieves the screen icon (no longer used in 3.8+).
  *
  * @since WP-3.2.0
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  *
  * @return string An HTML comment explaining that icons are no longer used.
  */
@@ -1244,14 +1244,14 @@ function get_screen_icon() {
  * Deprecated dashboard widget controls.
  *
  * @since WP-2.5.0
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_incoming_links_output() {}
 
 /**
  * Deprecated dashboard secondary output.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_secondary_output() {}
 
@@ -1259,49 +1259,49 @@ function wp_dashboard_secondary_output() {}
  * Deprecated dashboard widget controls.
  *
  * @since WP-2.7.0
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_incoming_links() {}
 
 /**
  * Deprecated dashboard incoming links control.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_incoming_links_control() {}
 
 /**
  * Deprecated dashboard plugins control.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_plugins() {}
 
 /**
  * Deprecated dashboard primary control.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_primary_control() {}
 
 /**
  * Deprecated dashboard recent comments control.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_recent_comments_control() {}
 
 /**
  * Deprecated dashboard secondary section.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_secondary() {}
 
 /**
  * Deprecated dashboard secondary control.
  *
- * @deprecated 3.8.0
+ * @deprecated WP-3.8.0
  */
 function wp_dashboard_secondary_control() {}
 
@@ -1309,7 +1309,7 @@ function wp_dashboard_secondary_control() {}
  * Display plugins text for the ClassicPress news widget.
  *
  * @since WP-2.5.0
- * @deprecated 4.8.0
+ * @deprecated WP-4.8.0
  *
  * @param string $rss  The RSS feed URL.
  * @param array  $args Array of arguments for this RSS feed.
@@ -1391,7 +1391,7 @@ function wp_dashboard_plugins_output( $rss, $args = array() ) {
  * This was once used to move child posts to a new parent.
  *
  * @since WP-2.3.0
- * @deprecated 3.9.0
+ * @deprecated WP-3.9.0
  * @access private
  *
  * @param int $old_ID
@@ -1412,7 +1412,7 @@ function _relocate_children( $old_ID, $new_ID ) {
  *
  * @since WP-2.7.0
  *
- * @deprecated 4.5.0 Use add_menu_page()
+ * @deprecated WP-4.5.0 Use add_menu_page()
  * @see add_menu_page()
  * @global int $_wp_last_object_menu
  *
@@ -1445,7 +1445,7 @@ function add_object_page( $page_title, $menu_title, $capability, $menu_slug, $fu
  *
  * @since WP-2.7.0
  *
- * @deprecated 4.5.0 Use add_menu_page()
+ * @deprecated WP-4.5.0 Use add_menu_page()
  * @see add_menu_page()
  * @global int $_wp_last_utility_menu
  *
@@ -1475,7 +1475,7 @@ function add_utility_page( $page_title, $menu_title, $capability, $menu_slug, $f
  * Replaced with wp_page_reload_on_back_button_js() that also fixes this problem.
  *
  * @since WP-4.0.0
- * @deprecated 4.6.0
+ * @deprecated WP-4.6.0
  *
  * @link https://core.trac.wordpress.org/ticket/35852
  *
@@ -1496,7 +1496,7 @@ function post_form_autocomplete_off() {
  * Display JavaScript on the page.
  *
  * @since WP-3.5.0
- * @deprecated 4.9.0
+ * @deprecated WP-4.9.0
  */
 function options_permalink_add_js() {
 	?>

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -261,7 +261,7 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
 		 * Filters the GD image resource to be streamed to the browser.
 		 *
 		 * @since WP-2.9.0
-		 * @deprecated 3.5.0 Use image_editor_save_pre instead.
+		 * @deprecated WP-3.5.0 Use image_editor_save_pre instead.
 		 *
 		 * @param resource $image         Image resource to be streamed.
 		 * @param int      $attachment_id The attachment post ID.
@@ -332,7 +332,7 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 		 * returning that value instead.
 		 *
 		 * @since WP-2.9.0
-		 * @deprecated 3.5.0 Use wp_save_image_editor_file instead.
+		 * @deprecated WP-3.5.0 Use wp_save_image_editor_file instead.
 		 *
 		 * @param mixed           $override  Value to return instead of saving. Default null.
 		 * @param string          $filename  Name of the file to be saved.
@@ -379,7 +379,7 @@ function _image_get_preview_ratio($w, $h) {
  * Returns an image resource. Internal use only.
  *
  * @since WP-2.9.0
- * @deprecated 3.5.0 Use WP_Image_Editor::rotate()
+ * @deprecated WP-3.5.0 Use WP_Image_Editor::rotate()
  * @see WP_Image_Editor::rotate()
  *
  * @ignore
@@ -403,7 +403,7 @@ function _rotate_image_resource($img, $angle) {
  * Flips an image resource. Internal use only.
  *
  * @since WP-2.9.0
- * @deprecated 3.5.0 Use WP_Image_Editor::flip()
+ * @deprecated WP-3.5.0 Use WP_Image_Editor::flip()
  * @see WP_Image_Editor::flip()
  *
  * @ignore
@@ -531,7 +531,7 @@ function image_edit_apply_changes( $image, $changes ) {
 		 * Filters the GD image resource before applying changes to the image.
 		 *
 		 * @since WP-2.9.0
-		 * @deprecated 3.5.0 Use wp_image_editor_before_change instead.
+		 * @deprecated WP-3.5.0 Use wp_image_editor_before_change instead.
 		 *
 		 * @param resource $image   GD image resource.
  		 * @param array    $changes Array of change operations.

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -582,7 +582,7 @@ function media_buttons($editor_id = 'content') {
 	 * Use {@see 'media_buttons'} action instead.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 3.5.0 Use {@see 'media_buttons'} action instead.
+	 * @deprecated WP-3.5.0 Use {@see 'media_buttons'} action instead.
 	 *
 	 * @param string $string Media buttons context. Default empty.
 	 */

--- a/src/wp-admin/includes/ms-deprecated.php
+++ b/src/wp-admin/includes/ms-deprecated.php
@@ -13,7 +13,7 @@
 /**
  * Outputs the WPMU menu.
  *
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  */
 function wpmu_menu() {
 	_deprecated_function(__FUNCTION__, '3.0.0' );
@@ -23,7 +23,7 @@ function wpmu_menu() {
 /**
  * Determines if the available space defined by the admin has been exceeded by the user.
  *
- * @deprecated 3.0.0 Use is_upload_space_available()
+ * @deprecated WP-3.0.0 Use is_upload_space_available()
  * @see is_upload_space_available()
  */
 function wpmu_checkAvailableSpace() {
@@ -36,7 +36,7 @@ function wpmu_checkAvailableSpace() {
 /**
  * WPMU options.
  *
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  */
 function mu_options( $options ) {
 	_deprecated_function(__FUNCTION__, '3.0.0' );
@@ -46,7 +46,7 @@ function mu_options( $options ) {
 /**
  * Deprecated functionality for activating a network-only plugin.
  *
- * @deprecated 3.0.0 Use activate_plugin()
+ * @deprecated WP-3.0.0 Use activate_plugin()
  * @see activate_plugin()
  */
 function activate_sitewide_plugin() {
@@ -57,7 +57,7 @@ function activate_sitewide_plugin() {
 /**
  * Deprecated functionality for deactivating a network-only plugin.
  *
- * @deprecated 3.0.0 Use deactivate_plugin()
+ * @deprecated WP-3.0.0 Use deactivate_plugin()
  * @see deactivate_plugin()
  */
 function deactivate_sitewide_plugin( $plugin = false ) {
@@ -67,7 +67,7 @@ function deactivate_sitewide_plugin( $plugin = false ) {
 /**
  * Deprecated functionality for determining if the current plugin is network-only.
  *
- * @deprecated 3.0.0 Use is_network_only_plugin()
+ * @deprecated WP-3.0.0 Use is_network_only_plugin()
  * @see is_network_only_plugin()
  */
 function is_wpmu_sitewide_plugin( $file ) {
@@ -78,7 +78,7 @@ function is_wpmu_sitewide_plugin( $file ) {
 /**
  * Deprecated functionality for getting themes network-enabled themes.
  *
- * @deprecated 3.4.0 Use WP_Theme::get_allowed_on_network()
+ * @deprecated WP-3.4.0 Use WP_Theme::get_allowed_on_network()
  * @see WP_Theme::get_allowed_on_network()
  */
 function get_site_allowed_themes() {
@@ -89,7 +89,7 @@ function get_site_allowed_themes() {
 /**
  * Deprecated functionality for getting themes allowed on a specific site.
  *
- * @deprecated 3.4.0 Use WP_Theme::get_allowed_on_site()
+ * @deprecated WP-3.4.0 Use WP_Theme::get_allowed_on_site()
  * @see WP_Theme::get_allowed_on_site()
  */
 function wpmu_get_blog_allowedthemes( $blog_id = 0 ) {
@@ -100,6 +100,6 @@ function wpmu_get_blog_allowedthemes( $blog_id = 0 ) {
 /**
  * Deprecated functionality for determining whether a file is deprecated.
  *
- * @deprecated 3.5.0
+ * @deprecated WP-3.5.0
  */
 function ms_deprecated_blogs_file() {}

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -153,7 +153,7 @@ function install_themes_upload() {
 /**
  * Prints a theme on the Install Themes pages.
  *
- * @deprecated 3.4.0
+ * @deprecated WP-3.4.0
  *
  * @global WP_Theme_Install_List_Table $wp_list_table
  *

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -3928,7 +3928,7 @@
 		},
 
 		/**
-		 * @deprecated 4.1.0 Use this.onChangeActive() instead.
+		 * @deprecated WP-4.1.0 Use this.onChangeActive() instead.
 		 */
 		toggle: function ( active ) {
 			return this.onChangeActive( active, this.defaultActiveArguments );

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -3029,14 +3029,14 @@
 	 *
 	 * @constructor
 	 * @augments wp.customize.Control
-	 * @deprecated 4.9.0 This class is no longer used due to new menu creation UX.
+	 * @deprecated WP-4.9.0 This class is no longer used due to new menu creation UX.
 	 */
 	api.Menus.NewMenuControl = api.Control.extend({
 
 		/**
 		 * Initialize.
 		 *
-		 * @deprecated 4.9.0
+		 * @deprecated WP-4.9.0
 		 */
 		initialize: function() {
 			if ( 'undefined' !== typeof console && console.warn ) {
@@ -3048,7 +3048,7 @@
 		/**
 		 * Set up the control.
 		 *
-		 * @deprecated 4.9.0
+		 * @deprecated WP-4.9.0
 		 */
 		ready: function() {
 			this._bindHandlers();
@@ -3073,7 +3073,7 @@
 		/**
 		 * Create the new menu with the name supplied.
 		 *
-		 * @deprecated 4.9.0
+		 * @deprecated WP-4.9.0
 		 */
 		submit: function() {
 

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -1331,7 +1331,7 @@
 		/**
 		 * Expand the widget form control
 		 *
-		 * @deprecated 4.1.0 Use this.expand() instead.
+		 * @deprecated WP-4.1.0 Use this.expand() instead.
 		 */
 		expandForm: function() {
 			this.expand();
@@ -1348,7 +1348,7 @@
 		/**
 		 * Collapse the widget form control
 		 *
-		 * @deprecated 4.1.0 Use this.collapse() instead.
+		 * @deprecated WP-4.1.0 Use this.collapse() instead.
 		 */
 		collapseForm: function() {
 			this.collapse();

--- a/src/wp-admin/upgrade-functions.php
+++ b/src/wp-admin/upgrade-functions.php
@@ -3,7 +3,7 @@
  * ClassicPress Upgrade Functions. Old file, must not be used. Include
  * wp-admin/includes/upgrade.php instead.
  *
- * @deprecated 2.5.0
+ * @deprecated WP-2.5.0
  * @package ClassicPress
  * @subpackage Administration
  */

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -258,7 +258,7 @@ function wp_cache_add_non_persistent_groups( $groups ) {
  * high.
  *
  * @since WP-2.6.0
- * @deprecated 3.5.0 WP_Object_Cache::reset()
+ * @deprecated WP-3.5.0 WP_Object_Cache::reset()
  * @see WP_Object_Cache::reset()
  *
  * @global WP_Object_Cache $wp_object_cache Object cache global instance.
@@ -606,7 +606,7 @@ class WP_Object_Cache {
 	 *
 	 * @since WP-3.0.0
 	 *
-	 * @deprecated 3.5.0 Use switch_to_blog()
+	 * @deprecated WP-3.5.0 Use switch_to_blog()
 	 * @see switch_to_blog()
 	 */
 	public function reset() {

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -345,7 +345,7 @@ function map_meta_cap( $cap, $user_id ) {
 				 *
 				 * @since WP-4.6.0 As `auth_post_{$post_type}_meta_{$meta_key}`.
 				 * @since WP-4.7.0
-				 * @deprecated 4.9.8 Use `auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}`
+				 * @deprecated WP-4.9.8 Use `auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}`
 				 *
 				 * @param bool     $allowed   Whether the user can add the object meta. Default false.
 				 * @param string   $meta_key  The meta key.

--- a/src/wp-includes/class-http.php
+++ b/src/wp-includes/class-http.php
@@ -859,7 +859,7 @@ class WP_Http {
 	/**
 	 * Used as a wrapper for PHP's parse_url() function that handles edgecases in < PHP 5.4.7.
 	 *
-	 * @deprecated 4.4.0 Use wp_parse_url()
+	 * @deprecated WP-4.4.0 Use wp_parse_url()
 	 * @see wp_parse_url()
 	 *
 	 * @param string $url The URL to parse.

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -556,7 +556,7 @@ class WP_Admin_Bar {
 	 * Renders toolbar items recursively.
 	 *
 	 * @since WP-3.1.0
-	 * @deprecated 3.3.0 Use WP_Admin_Bar::_render_item() or WP_Admin_bar::render() instead.
+	 * @deprecated WP-3.3.0 Use WP_Admin_Bar::_render_item() or WP_Admin_bar::render() instead.
 	 * @see WP_Admin_Bar::_render_item()
 	 * @see WP_Admin_Bar::render()
 	 *

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -774,7 +774,7 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-location
  * release, the require_once() here will be removed and _deprecated_file() will be called if file is
  * required at all.
  *
- * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
+ * @deprecated WP-4.9.0 This file is no longer used due to new menu creation UX.
  */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -480,7 +480,7 @@ final class WP_Customize_Manager {
 	 * Return the Ajax wp_die() handler if it's a customized request.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 *
 	 * @return callable Die handler.
 	 */
@@ -943,7 +943,7 @@ final class WP_Customize_Manager {
 	 * Instead, the JS will sniff out the location header.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 *
 	 * @param int $status Status.
 	 * @return int
@@ -1935,7 +1935,7 @@ final class WP_Customize_Manager {
 	 * preview, since it causes the jQuery Ajax to fail. Send 200 instead.
 	 *
 	 * @since WP-4.0.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 */
 	public function customize_preview_override_404_status() {
 		_deprecated_function( __METHOD__, '4.7.0' );
@@ -1945,7 +1945,7 @@ final class WP_Customize_Manager {
 	 * Print base element for preview frame.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 */
 	public function customize_preview_base() {
 		_deprecated_function( __METHOD__, '4.7.0' );
@@ -1955,7 +1955,7 @@ final class WP_Customize_Manager {
 	 * Print a workaround to handle HTML5 tags in IE < 9.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0 Customizer no longer supports IE8, so all supported browsers recognize HTML5.
+	 * @deprecated WP-4.7.0 Customizer no longer supports IE8, so all supported browsers recognize HTML5.
 	 */
 	public function customize_preview_html5() {
 		_deprecated_function( __FUNCTION__, '4.7.0' );
@@ -2148,7 +2148,7 @@ final class WP_Customize_Manager {
 	 * Prints a signature so we can ensure the Customizer was properly executed.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 */
 	public function customize_preview_signature() {
 		_deprecated_function( __METHOD__, '4.7.0' );
@@ -2158,7 +2158,7 @@ final class WP_Customize_Manager {
 	 * Removes the signature in case we experience a case where the Customizer was not properly executed.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0
+	 * @deprecated WP-4.7.0
 	 *
 	 * @param mixed $return Value passed through for {@see 'wp_die_handler'} filter.
 	 * @return mixed Value passed through for {@see 'wp_die_handler'} filter.
@@ -4226,7 +4226,7 @@ final class WP_Customize_Manager {
 	 * Helper function to compare two objects by priority, ensuring sort stability via instance_number.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.7.0 Use wp_list_sort()
+	 * @deprecated WP-4.7.0 Use wp_list_sort()
 	 *
 	 * @param WP_Customize_Panel|WP_Customize_Section|WP_Customize_Control $a Object A.
 	 * @param WP_Customize_Panel|WP_Customize_Section|WP_Customize_Control $b Object B.

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -393,6 +393,6 @@ require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.
  * release, the require_once() here will be removed and _deprecated_file() will be called if file is
  * required at all.
  *
- * @deprecated 4.9.0 This file is no longer used due to new menu creation UX.
+ * @deprecated WP-4.9.0 This file is no longer used due to new menu creation UX.
  */
 require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' );

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -696,7 +696,7 @@ class WP_Customize_Setting {
 	 * Deprecated method.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.4.0 Deprecated in favor of update() method.
+	 * @deprecated WP-4.4.0 Deprecated in favor of update() method.
 	 */
 	protected function _update_theme_mod() {
 		_deprecated_function( __METHOD__, '4.4.0', __CLASS__ . '::update()' );
@@ -706,7 +706,7 @@ class WP_Customize_Setting {
 	 * Deprecated method.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.4.0 Deprecated in favor of update() method.
+	 * @deprecated WP-4.4.0 Deprecated in favor of update() method.
 	 */
 	protected function _update_option() {
 		_deprecated_function( __METHOD__, '4.4.0', __CLASS__ . '::update()' );

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1985,7 +1985,7 @@ final class WP_Customize_Widgets {
 	 * See the {@see 'customize_dynamic_setting_args'} filter.
 	 *
 	 * @since WP-3.9.0
-	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
+	 * @deprecated WP-4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function setup_widget_addition_previews() {
 		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
@@ -1997,7 +1997,7 @@ final class WP_Customize_Widgets {
 	 * See the {@see 'customize_dynamic_setting_args'} filter.
 	 *
 	 * @since WP-3.9.0
-	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
+	 * @deprecated WP-4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function prepreview_added_sidebars_widgets() {
 		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
@@ -2009,7 +2009,7 @@ final class WP_Customize_Widgets {
 	 * See the {@see 'customize_dynamic_setting_args'} filter.
 	 *
 	 * @since WP-3.9.0
-	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
+	 * @deprecated WP-4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function prepreview_added_widget_instance() {
 		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
@@ -2021,7 +2021,7 @@ final class WP_Customize_Widgets {
 	 * See the {@see 'customize_dynamic_setting_args'} filter.
 	 *
 	 * @since WP-3.9.0
-	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
+	 * @deprecated WP-4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function remove_prepreview_filters() {
 		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -1579,7 +1579,7 @@ final class _WP_Editors {
 	 * Outputs the HTML for distraction-free writing mode.
 	 *
 	 * @since WP-3.2.0
-	 * @deprecated 4.3.0
+	 * @deprecated WP-4.3.0
 	 *
 	 * @static
 	 */

--- a/src/wp-includes/class-wp-http-streams.php
+++ b/src/wp-includes/class-wp-http-streams.php
@@ -425,7 +425,7 @@ class WP_Http_Streams {
  * @see WP_HTTP::request
  *
  * @since WP-2.7.0
- * @deprecated 3.7.0 Please use WP_HTTP::request() directly
+ * @deprecated WP-3.7.0 Please use WP_HTTP::request() directly
  */
 class WP_HTTP_Fsockopen extends WP_HTTP_Streams {
 	// For backward compatibility for users who are using the class directly.

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3591,7 +3591,7 @@ class WP_Query {
 	 * Whether the current URL is within the comments popup window.
 	 *
 	 * @since WP-3.1.0
-	 * @deprecated 4.5.0
+	 * @deprecated WP-4.5.0
 	 *
 	 * @return bool
 	 */
@@ -4066,7 +4066,7 @@ class WP_Query {
 	 * Lazyload term meta for posts in the loop.
 	 *
 	 * @since WP-4.4.0
-	 * @deprecated 4.5.0 See wp_queue_posts_for_term_meta_lazyload().
+	 * @deprecated WP-4.5.0 See wp_queue_posts_for_term_meta_lazyload().
 	 *
 	 * @param mixed $check
 	 * @param int   $term_id
@@ -4081,7 +4081,7 @@ class WP_Query {
 	 * Lazyload comment meta for comments in the loop.
 	 *
 	 * @since WP-4.4.0
-	 * @deprecated 4.5.0 See wp_queue_comments_for_comment_meta_lazyload().
+	 * @deprecated WP-4.5.0 See wp_queue_comments_for_comment_meta_lazyload().
 	 *
 	 * @param mixed $check
 	 * @param int   $comment_id

--- a/src/wp-includes/class-wp-rewrite.php
+++ b/src/wp-includes/class-wp-rewrite.php
@@ -1371,7 +1371,7 @@ class WP_Rewrite {
 				 * Filters rewrite rules used specifically for Tags.
 				 *
 				 * @since WP-2.3.0
-				 * @deprecated 3.1.0 Use 'post_tag_rewrite_rules' instead
+				 * @deprecated WP-3.1.0 Use 'post_tag_rewrite_rules' instead
 				 *
 				 * @param array $rules The rewrite rules generated for tags.
 				 */
@@ -1515,7 +1515,7 @@ class WP_Rewrite {
 		 * Filters the list of rewrite rules formatted for output to an .htaccess file.
 		 *
 		 * @since WP-1.5.0
-		 * @deprecated 1.5.0 Use the mod_rewrite_rules filter instead.
+		 * @deprecated WP-1.5.0 Use the mod_rewrite_rules filter instead.
 		 *
 		 * @param string $rules mod_rewrite Rewrite rules formatted for .htaccess.
 		 */

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -114,7 +114,7 @@ class WP_Roles {
 	 * be used and the role option will not be updated or used.
 	 *
 	 * @since WP-2.1.0
-	 * @deprecated 4.9.0 Use WP_Roles::for_site()
+	 * @deprecated WP-4.9.0 Use WP_Roles::for_site()
 	 */
 	protected function _init() {
 		_deprecated_function( __METHOD__, '4.9.0', 'WP_Roles::for_site()' );
@@ -129,7 +129,7 @@ class WP_Roles {
 	 * after switching wpdb to a new site ID.
 	 *
 	 * @since WP-3.5.0
-	 * @deprecated 4.7.0 Use WP_Roles::for_site()
+	 * @deprecated WP-4.7.0 Use WP_Roles::for_site()
 	 */
 	public function reinit() {
 		_deprecated_function( __METHOD__, '4.7.0', 'WP_Roles::for_site()' );

--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -441,7 +441,7 @@ class WP_User {
 	 * used.
 	 *
 	 * @since WP-2.1.0
-	 * @deprecated 4.9.0 Use WP_User::for_site()
+	 * @deprecated WP-4.9.0 Use WP_User::for_site()
 	 *
 	 * @global wpdb $wpdb ClassicPress database abstraction object.
 	 *
@@ -774,7 +774,7 @@ class WP_User {
 	 * Set the site to operate on. Defaults to the current site.
 	 *
 	 * @since WP-3.0.0
-	 * @deprecated 4.9.0 Use WP_User::for_site()
+	 * @deprecated WP-4.9.0 Use WP_User::for_site()
 	 *
 	 * @global wpdb $wpdb ClassicPress database abstraction object.
 	 *

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -301,7 +301,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Check user's credentials. Deprecated.
 	 *
 	 * @since WP-1.5.0
-	 * @deprecated 2.8.0 Use wp_xmlrpc_server::login()
+	 * @deprecated WP-2.8.0 Use wp_xmlrpc_server::login()
 	 * @see wp_xmlrpc_server::login()
 	 *
 	 * @param string $username User's username.
@@ -4649,7 +4649,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Deprecated.
 	 *
 	 * @since WP-1.5.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 *
 	 * @param array $args Unused.
 	 * @return IXR_Error Error object.
@@ -4662,7 +4662,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	 * Deprecated.
 	 *
 	 * @since WP-1.5.0
-	 * @deprecated 3.5.0
+	 * @deprecated WP-3.5.0
 	 *
 	 * @param array $args Unused.
 	 * @return IXR_Error Error object.

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -528,7 +528,7 @@ class WP {
 			 * Filters the query string before parsing.
 			 *
 			 * @since WP-1.5.0
-			 * @deprecated 2.1.0 Use 'query_vars' or 'request' filters instead.
+			 * @deprecated WP-2.1.0 Use 'query_vars' or 'request' filters instead.
 			 *
 			 * @param string $query_string The query string to modify.
 			 */

--- a/src/wp-includes/class.wp-dependencies.php
+++ b/src/wp-includes/class.wp-dependencies.php
@@ -70,7 +70,7 @@ class WP_Dependencies {
 	 * A handle group to enqueue.
 	 *
 	 * @since WP-2.8.0
-	 * @deprecated 4.5.0
+	 * @deprecated WP-4.5.0
 	 * @var int
 	 */
 	public $group = 0;

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -62,7 +62,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * Holds a string which contains script handles and their version.
 	 *
 	 * @since WP-2.8.0
-	 * @deprecated 3.4.0
+	 * @deprecated WP-3.4.0
 	 * @var string
 	 */
 	public $concat_version = '';
@@ -171,7 +171,7 @@ class WP_Scripts extends WP_Dependencies {
 	 *
 	 * @since WP-2.1.0
 	 * @since WP-2.8.0 Added the `$echo` parameter.
-	 * @deprecated 3.3.0
+	 * @deprecated WP-3.3.0
 	 *
 	 * @see print_extra_script()
 	 *

--- a/src/wp-includes/class.wp-styles.php
+++ b/src/wp-includes/class.wp-styles.php
@@ -62,7 +62,7 @@ class WP_Styles extends WP_Dependencies {
 	 * Holds a string which contains style handles and their version.
 	 *
 	 * @since WP-2.8.0
-	 * @deprecated 3.4.0
+	 * @deprecated WP-3.4.0
 	 * @var string
 	 */
 	public $concat_version = '';

--- a/src/wp-includes/customize/class-wp-customize-image-control.php
+++ b/src/wp-includes/customize/class-wp-customize-image-control.php
@@ -20,13 +20,13 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 
 	/**
 	 * @since WP-3.4.2
-	 * @deprecated 4.1.0
+	 * @deprecated WP-4.1.0
 	 */
 	public function prepare_control() {}
 
 	/**
 	 * @since WP-3.4.0
-	 * @deprecated 4.1.0
+	 * @deprecated WP-4.1.0
 	 *
 	 * @param string $id
 	 * @param string $label
@@ -38,7 +38,7 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 
 	/**
 	 * @since WP-3.4.0
-	 * @deprecated 4.1.0
+	 * @deprecated WP-4.1.0
 	 *
 	 * @param string $id
 	 */
@@ -48,7 +48,7 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 
 	/**
 	 * @since WP-3.4.0
-	 * @deprecated 4.1.0
+	 * @deprecated WP-4.1.0
 	 *
 	 * @param string $url
 	 * @param string $thumbnail_url

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
@@ -301,7 +301,7 @@ class WP_Customize_Nav_Menu_Setting extends WP_Customize_Setting {
 	 * This is a workaround for a lack of closures.
 	 *
 	 * @since WP-4.3.0
-	 * @deprecated 4.7.0 Use wp_list_sort()
+	 * @deprecated WP-4.7.0 Use wp_list_sort()
 	 *
 	 * @param object $menu1
 	 * @param object $menu2

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -47,7 +47,7 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	 * Link title attribute added as it's a relatively advanced concept for new users.
 	 *
 	 * @since WP-4.3.0
-	 * @deprecated 4.5.0 Deprecated in favor of wp_nav_menu_manage_columns().
+	 * @deprecated WP-4.5.0 Deprecated in favor of wp_nav_menu_manage_columns().
 	 */
 	public function wp_nav_menu_manage_columns() {
 		_deprecated_function( __METHOD__, '4.5.0', 'wp_nav_menu_manage_columns' );

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -5,14 +5,14 @@
  * @package ClassicPress
  * @subpackage Customize
  * @since WP-4.4.0
- * @deprecated 4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
+ * @deprecated WP-4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
  */
 
 /**
  * Customize control class for new menus.
  *
  * @since WP-4.3.0
- * @deprecated 4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
+ * @deprecated WP-4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
  *
  * @see WP_Customize_Control
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -5,14 +5,14 @@
  * @package ClassicPress
  * @subpackage Customize
  * @since WP-4.4.0
- * @deprecated 4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
+ * @deprecated WP-4.9.0 This file is no longer used as of the menu creation UX introduced in #40104.
  */
 
 /**
  * Customize Menu Section Class
  *
  * @since WP-4.3.0
- * @deprecated 4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
+ * @deprecated WP-4.9.0 This class is no longer used as of the menu creation UX introduced in #40104.
  *
  * @see WP_Customize_Section
  */

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -296,7 +296,7 @@ function wp_ssl_constants() {
 
 	/**
 	 * @since WP-2.6.0
-	 * @deprecated 4.0.0
+	 * @deprecated WP-4.0.0
 	 */
 	if ( defined( 'FORCE_SSL_LOGIN' ) && FORCE_SSL_LOGIN ) {
 		force_ssl_admin( true );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -16,7 +16,7 @@
  * Retrieves all post data for a given post.
  *
  * @since WP-0.71
- * @deprecated 1.5.1 Use get_post()
+ * @deprecated WP-1.5.1 Use get_post()
  * @see get_post()
  *
  * @param int $postid Post ID.
@@ -56,7 +56,7 @@ function get_postdata($postid) {
  * @link https://codex.wordpress.org/The_Loop
  *
  * @since WP-1.0.1
- * @deprecated 1.5.0
+ * @deprecated WP-1.5.0
  */
 function start_wp() {
 	global $wp_query;
@@ -73,7 +73,7 @@ function start_wp() {
  * Returns or prints a category ID.
  *
  * @since WP-0.71
- * @deprecated 0.71 Use get_the_category()
+ * @deprecated WP-0.71 Use get_the_category()
  * @see get_the_category()
  *
  * @param bool $echo Optional. Whether to echo the output. Default true.
@@ -96,7 +96,7 @@ function the_category_ID($echo = true) {
  * Prints a category with optional text before and after.
  *
  * @since WP-0.71
- * @deprecated 0.71 Use get_the_category_by_ID()
+ * @deprecated WP-0.71 Use get_the_category_by_ID()
  * @see get_the_category_by_ID()
  *
  * @param string $before Optional. Text to display before the category. Default empty.
@@ -122,7 +122,7 @@ function the_category_head( $before = '', $after = '' ) {
  * Prints a link to the previous post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use previous_post_link()
+ * @deprecated WP-2.0.0 Use previous_post_link()
  * @see previous_post_link()
  *
  * @param string $format
@@ -158,7 +158,7 @@ function previous_post($format='%', $previous='previous post: ', $title='yes', $
  * Prints link to the next post.
  *
  * @since WP-0.71
- * @deprecated 2.0.0 Use next_post_link()
+ * @deprecated WP-2.0.0 Use next_post_link()
  * @see next_post_link()
  *
  * @param string $format
@@ -193,7 +193,7 @@ function next_post($format='%', $next='next post: ', $title='yes', $in_same_cat=
  * Whether user can create a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -212,7 +212,7 @@ function user_can_create_post($user_id, $blog_id = 1, $category_id = 'None') {
  * Whether user can create a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -231,7 +231,7 @@ function user_can_create_draft($user_id, $blog_id = 1, $category_id = 'None') {
  * Whether user can edit a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -259,7 +259,7 @@ function user_can_edit_post($user_id, $post_id, $blog_id = 1) {
  * Whether user can delete a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -278,7 +278,7 @@ function user_can_delete_post($user_id, $post_id, $blog_id = 1) {
  * Whether user can set new posts' dates.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -297,7 +297,7 @@ function user_can_set_post_date($user_id, $blog_id = 1, $category_id = 'None') {
  * Whether user can delete a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -316,7 +316,7 @@ function user_can_edit_post_date($user_id, $post_id, $blog_id = 1) {
  * Whether user can delete a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -335,7 +335,7 @@ function user_can_edit_post_comments($user_id, $post_id, $blog_id = 1) {
  * Whether user can delete a post.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -354,7 +354,7 @@ function user_can_delete_post_comments($user_id, $post_id, $blog_id = 1) {
  * Can user can edit other user.
  *
  * @since WP-1.5.0
- * @deprecated 2.0.0 Use current_user_can()
+ * @deprecated WP-2.0.0 Use current_user_can()
  * @see current_user_can()
  *
  * @param int $user_id
@@ -376,7 +376,7 @@ function user_can_edit_user($user_id, $other_user) {
  * Gets the links associated with category $cat_name.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param string $cat_name Optional. The category name to use. If no match is found uses all.
@@ -409,7 +409,7 @@ function get_linksbyname($cat_name = "noname", $before = '', $after = '<br />', 
  * Gets the links associated with the named category.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use wp_list_bookmarks()
+ * @deprecated WP-2.1.0 Use wp_list_bookmarks()
  * @see wp_list_bookmarks()
  *
  * @param string $category The category to use.
@@ -444,7 +444,7 @@ function wp_get_linksbyname($category, $args = '') {
  *     }
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param string $cat_name The category name to use. If no match is found uses all.
@@ -494,7 +494,7 @@ function get_linkobjectsbyname($cat_name = "noname" , $orderby = 'name', $limit 
  * - link_notes
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param int $category The category to use. If no category supplied uses all
@@ -521,7 +521,7 @@ function get_linkobjects($category = 0, $orderby = 'name', $limit = 0) {
  * Gets the links associated with category 'cat_name' and display rating stars/chars.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param string $cat_name The category name to use. If no match is found uses all
@@ -548,7 +548,7 @@ function get_linksbyname_withrating($cat_name = "noname", $before = '', $after =
  * Gets the links associated with category n and display rating stars/chars.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param int $category The category to use. If no category supplied uses all
@@ -575,7 +575,7 @@ function get_links_withrating($category = -1, $before = '', $after = '<br />', $
  * Gets the auto_toggle setting.
  *
  * @since WP-0.71
- * @deprecated 2.1.0
+ * @deprecated WP-2.1.0
  *
  * @param int $id The category to get. If no category supplied uses 0
  * @return int Only returns 0.
@@ -589,7 +589,7 @@ function get_autotoggle($id = 0) {
  * Lists categories.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use wp_list_categories()
+ * @deprecated WP-2.1.0 Use wp_list_categories()
  * @see wp_list_categories()
  *
  * @param int $optionall
@@ -626,7 +626,7 @@ function list_cats($optionall = 1, $all = 'All', $sort_column = 'ID', $sort_orde
  * Lists categories.
  *
  * @since WP-1.2.0
- * @deprecated 2.1.0 Use wp_list_categories()
+ * @deprecated WP-2.1.0 Use wp_list_categories()
  * @see wp_list_categories()
  *
  * @param string|array $args
@@ -659,7 +659,7 @@ function wp_list_cats($args = '') {
  * Deprecated method for generating a drop-down of categories.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use wp_dropdown_categories()
+ * @deprecated WP-2.1.0 Use wp_dropdown_categories()
  * @see wp_dropdown_categories()
  *
  * @param int $optionall
@@ -697,7 +697,7 @@ function dropdown_cats($optionall = 1, $all = 'All', $orderby = 'ID', $order = '
  * Lists authors.
  *
  * @since WP-1.2.0
- * @deprecated 2.1.0 Use wp_list_authors()
+ * @deprecated WP-2.1.0 Use wp_list_authors()
  * @see wp_list_authors()
  *
  * @param bool $optioncount
@@ -719,7 +719,7 @@ function list_authors($optioncount = false, $exclude_admin = true, $show_fullnam
  * Retrieves a list of post categories.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use wp_get_post_categories()
+ * @deprecated WP-2.1.0 Use wp_get_post_categories()
  * @see wp_get_post_categories()
  *
  * @param int $blogid Not Used
@@ -735,7 +735,7 @@ function wp_get_post_cats($blogid = '1', $post_ID = 0) {
  * Sets the categories that the post id belongs to.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0
+ * @deprecated WP-2.1.0
  * @deprecated Use wp_set_post_categories()
  * @see wp_set_post_categories()
  *
@@ -753,7 +753,7 @@ function wp_set_post_cats($blogid = '1', $post_ID = 0, $post_categories = array(
  * Retrieves a list of archives.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use wp_get_archives()
+ * @deprecated WP-2.1.0 Use wp_get_archives()
  * @see wp_get_archives()
  *
  * @param string $type
@@ -774,7 +774,7 @@ function get_archives($type='', $limit='', $format='html', $before = '', $after 
  * Returns or Prints link to the author's posts.
  *
  * @since WP-1.2.0
- * @deprecated 2.1.0 Use get_author_posts_url()
+ * @deprecated WP-2.1.0 Use get_author_posts_url()
  * @see get_author_posts_url()
  *
  * @param bool $echo
@@ -796,7 +796,7 @@ function get_author_link($echo, $author_id, $author_nicename = '') {
  * Print list of pages based on arguments.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use wp_link_pages()
+ * @deprecated WP-2.1.0 Use wp_link_pages()
  * @see wp_link_pages()
  *
  * @param string $before
@@ -820,7 +820,7 @@ function link_pages($before='<br />', $after='<br />', $next_or_number='number',
  * Get value based on option.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_option()
+ * @deprecated WP-2.1.0 Use get_option()
  * @see get_option()
  *
  * @param string $option
@@ -836,7 +836,7 @@ function get_settings($option) {
  * Print the permalink of the current post in the loop.
  *
  * @since WP-0.71
- * @deprecated 1.2.0 Use the_permalink()
+ * @deprecated WP-1.2.0 Use the_permalink()
  * @see the_permalink()
  */
 function permalink_link() {
@@ -848,7 +848,7 @@ function permalink_link() {
  * Print the permalink to the RSS feed.
  *
  * @since WP-0.71
- * @deprecated 2.3.0 Use the_permalink_rss()
+ * @deprecated WP-2.3.0 Use the_permalink_rss()
  * @see the_permalink_rss()
  *
  * @param string $deprecated
@@ -862,7 +862,7 @@ function permalink_single_rss($deprecated = '') {
  * Gets the links associated with category.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use wp_list_bookmarks()
+ * @deprecated WP-2.1.0 Use wp_list_bookmarks()
  * @see wp_list_bookmarks()
  *
  * @param string $args a query string
@@ -901,7 +901,7 @@ function wp_get_links($args = '') {
  * Gets the links associated with category by id.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_bookmarks()
+ * @deprecated WP-2.1.0 Use get_bookmarks()
  * @see get_bookmarks()
  *
  * @param int $category The category to use. If no category supplied uses all
@@ -1009,7 +1009,7 @@ function get_links($category = -1, $before = '', $after = '<br />', $between = '
  * $wpdb->linkcategories and output it as a nested HTML unordered list.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use wp_list_bookmarks()
+ * @deprecated WP-2.1.0 Use wp_list_bookmarks()
  * @see wp_list_bookmarks()
  *
  * @param string $order Sort link categories by 'name' or 'id'
@@ -1051,7 +1051,7 @@ function get_links_list($order = 'name') {
  * Show the link to the links popup and the number of links.
  *
  * @since WP-0.71
- * @deprecated 2.1.0
+ * @deprecated WP-2.1.0
  *
  * @param string $text the text of the link
  * @param int $width the width of the popup window
@@ -1067,7 +1067,7 @@ function links_popup_script($text = 'Links', $width=400, $height=400, $file='lin
  * Legacy function that retrieved the value of a link's link_rating field.
  *
  * @since WP-1.0.1
- * @deprecated 2.1.0 Use sanitize_bookmark_field()
+ * @deprecated WP-2.1.0 Use sanitize_bookmark_field()
  * @see sanitize_bookmark_field()
  *
  * @param object $link Link object.
@@ -1082,7 +1082,7 @@ function get_linkrating( $link ) {
  * Gets the name of category by id.
  *
  * @since WP-0.71
- * @deprecated 2.1.0 Use get_category()
+ * @deprecated WP-2.1.0 Use get_category()
  * @see get_category()
  *
  * @param int $id The category to get. If no category supplied uses 0
@@ -1111,7 +1111,7 @@ function get_linkcatname($id = 0) {
  * Print RSS comment feed link.
  *
  * @since WP-1.0.1
- * @deprecated 2.5.0 Use post_comments_feed_link()
+ * @deprecated WP-2.5.0 Use post_comments_feed_link()
  * @see post_comments_feed_link()
  *
  * @param string $link_text
@@ -1125,7 +1125,7 @@ function comments_rss_link($link_text = 'Comments RSS') {
  * Print/Return link to category RSS2 feed.
  *
  * @since WP-1.2.0
- * @deprecated 2.5.0 Use get_category_feed_link()
+ * @deprecated WP-2.5.0 Use get_category_feed_link()
  * @see get_category_feed_link()
  *
  * @param bool $echo
@@ -1146,7 +1146,7 @@ function get_category_rss_link($echo = false, $cat_ID = 1) {
  * Print/Return link to author RSS feed.
  *
  * @since WP-1.2.0
- * @deprecated 2.5.0 Use get_author_feed_link()
+ * @deprecated WP-2.5.0 Use get_author_feed_link()
  * @see get_author_feed_link()
  *
  * @param bool $echo
@@ -1166,7 +1166,7 @@ function get_author_rss_link($echo = false, $author_id = 1) {
  * Return link to the post RSS feed.
  *
  * @since WP-1.5.0
- * @deprecated 2.2.0 Use get_post_comments_feed_link()
+ * @deprecated WP-2.2.0 Use get_post_comments_feed_link()
  * @see get_post_comments_feed_link()
  *
  * @return string
@@ -1180,7 +1180,7 @@ function comments_rss() {
  * An alias of wp_create_user().
  *
  * @since WP-2.0.0
- * @deprecated 2.0.0 Use wp_create_user()
+ * @deprecated WP-2.0.0 Use wp_create_user()
  * @see wp_create_user()
  *
  * @param string $username The user's username.
@@ -1196,7 +1196,7 @@ function create_user($username, $password, $email) {
 /**
  * Unused function.
  *
- * @deprecated 2.5.0
+ * @deprecated WP-2.5.0
  */
 function gzip_compression() {
 	_deprecated_function( __FUNCTION__, '2.5.0' );
@@ -1207,7 +1207,7 @@ function gzip_compression() {
  * Retrieve an array of comment data about comment $comment_ID.
  *
  * @since WP-0.71
- * @deprecated 2.7.0 Use get_comment()
+ * @deprecated WP-2.7.0 Use get_comment()
  * @see get_comment()
  *
  * @param int $comment_ID The ID of the comment
@@ -1224,7 +1224,7 @@ function get_commentdata( $comment_ID, $no_cache = 0, $include_unapproved = fals
  * Retrieve the category name by the category ID.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use get_cat_name()
+ * @deprecated WP-2.8.0 Use get_cat_name()
  * @see get_cat_name()
  *
  * @param int $cat_ID Category ID
@@ -1239,7 +1239,7 @@ function get_catname( $cat_ID ) {
  * Retrieve category children list separated before and after the term IDs.
  *
  * @since WP-1.2.0
- * @deprecated 2.8.0 Use get_term_children()
+ * @deprecated WP-2.8.0 Use get_term_children()
  * @see get_term_children()
  *
  * @param int $id Category ID to retrieve children.
@@ -1276,7 +1276,7 @@ function get_category_children( $id, $before = '/', $after = '', $visited = arra
  * Retrieves all category IDs.
  *
  * @since WP-2.0.0
- * @deprecated 4.0.0 Use get_terms()
+ * @deprecated WP-4.0.0 Use get_terms()
  * @see get_terms()
  *
  * @link https://codex.wordpress.org/Function_Reference/get_all_category_ids
@@ -1298,7 +1298,7 @@ function get_all_category_ids() {
  * Retrieve the description of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's description.
@@ -1312,7 +1312,7 @@ function get_the_author_description() {
  * Display the description of the author of the current post.
  *
  * @since WP-1.0.0
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_description() {
@@ -1324,7 +1324,7 @@ function the_author_description() {
  * Retrieve the login name of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's login name (username).
@@ -1338,7 +1338,7 @@ function get_the_author_login() {
  * Display the login name of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_login() {
@@ -1350,7 +1350,7 @@ function the_author_login() {
  * Retrieve the first name of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's first name.
@@ -1364,7 +1364,7 @@ function get_the_author_firstname() {
  * Display the first name of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_firstname() {
@@ -1376,7 +1376,7 @@ function the_author_firstname() {
  * Retrieve the last name of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's last name.
@@ -1390,7 +1390,7 @@ function get_the_author_lastname() {
  * Display the last name of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_lastname() {
@@ -1402,7 +1402,7 @@ function the_author_lastname() {
  * Retrieve the nickname of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's nickname.
@@ -1416,7 +1416,7 @@ function get_the_author_nickname() {
  * Display the nickname of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_nickname() {
@@ -1428,7 +1428,7 @@ function the_author_nickname() {
  * Retrieve the email of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's username.
@@ -1442,7 +1442,7 @@ function get_the_author_email() {
  * Display the email of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_email() {
@@ -1454,7 +1454,7 @@ function the_author_email() {
  * Retrieve the ICQ number of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's ICQ number.
@@ -1468,7 +1468,7 @@ function get_the_author_icq() {
  * Display the ICQ number of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_icq() {
@@ -1480,7 +1480,7 @@ function the_author_icq() {
  * Retrieve the Yahoo! IM name of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's Yahoo! IM name.
@@ -1494,7 +1494,7 @@ function get_the_author_yim() {
  * Display the Yahoo! IM name of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_yim() {
@@ -1506,7 +1506,7 @@ function the_author_yim() {
  * Retrieve the MSN address of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's MSN address.
@@ -1520,7 +1520,7 @@ function get_the_author_msn() {
  * Display the MSN address of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_msn() {
@@ -1532,7 +1532,7 @@ function the_author_msn() {
  * Retrieve the AIM address of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The author's AIM address.
@@ -1546,7 +1546,7 @@ function get_the_author_aim() {
  * Display the AIM address of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta('aim')
+ * @deprecated WP-2.8.0 Use the_author_meta('aim')
  * @see the_author_meta()
  */
 function the_author_aim() {
@@ -1558,7 +1558,7 @@ function the_author_aim() {
  * Retrieve the specified author's preferred display name.
  *
  * @since WP-1.0.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @param int $auth_id The ID of the author.
@@ -1573,7 +1573,7 @@ function get_author_name( $auth_id = false ) {
  * Retrieve the URL to the home page of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string The URL to the author's page.
@@ -1587,7 +1587,7 @@ function get_the_author_url() {
  * Display the URL to the home page of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_url() {
@@ -1599,7 +1599,7 @@ function the_author_url() {
  * Retrieve the ID of the author of the current post.
  *
  * @since WP-1.5.0
- * @deprecated 2.8.0 Use get_the_author_meta()
+ * @deprecated WP-2.8.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @return string|int The author's ID.
@@ -1613,7 +1613,7 @@ function get_the_author_ID() {
  * Display the ID of the author of the current post.
  *
  * @since WP-0.71
- * @deprecated 2.8.0 Use the_author_meta()
+ * @deprecated WP-2.8.0 Use the_author_meta()
  * @see the_author_meta()
  */
 function the_author_ID() {
@@ -1640,7 +1640,7 @@ function the_author_ID() {
  *
  * @since WP-0.71
  *
- * @deprecated 2.9.0 Use the_content_feed()
+ * @deprecated WP-2.9.0 Use the_content_feed()
  * @see the_content_feed()
  *
  * @param string $more_link_text Optional. Text to display when more content is available but not displayed.
@@ -1698,7 +1698,7 @@ function the_content_rss($more_link_text='(more...)', $stripteaser=0, $more_file
  * them at the bottom of the content with numbers.
  *
  * @since WP-0.71
- * @deprecated 2.9.0
+ * @deprecated WP-2.9.0
  *
  * @param string $content Content to get links
  * @return string HTML stripped out of content with links at the bottom.
@@ -1735,7 +1735,7 @@ function make_url_footnote( $content ) {
  * everything is returned.
  *
  * @since WP-2.2.0
- * @deprecated 2.9.0 Use _x()
+ * @deprecated WP-2.9.0 Use _x()
  * @see _x()
  *
  * @param string $text Text to translate
@@ -1752,7 +1752,7 @@ function _c( $text, $domain = 'default' ) {
  * contains a context after its last vertical bar.
  *
  * @since WP-2.5.0
- * @deprecated 3.0.0 Use _x()
+ * @deprecated WP-3.0.0 Use _x()
  * @see _x()
  *
  * @param string $text Text to translate
@@ -1770,7 +1770,7 @@ function translate_with_context( $text, $domain = 'default' ) {
  * Strips everything from the translation after the last bar.
  *
  * @since WP-2.7.0
- * @deprecated 3.0.0 Use _nx()
+ * @deprecated WP-3.0.0 Use _nx()
  * @see _nx()
  *
  * @param string $single The text to be used if the number is singular.
@@ -1789,7 +1789,7 @@ function _nc( $single, $plural, $number, $domain = 'default' ) {
  * Retrieve the plural or single form based on the amount.
  *
  * @since WP-1.2.0
- * @deprecated 2.8.0 Use _n()
+ * @deprecated WP-2.8.0 Use _n()
  * @see _n()
  */
 function __ngettext() {
@@ -1802,7 +1802,7 @@ function __ngettext() {
  * Register plural strings in POT file, but don't translate them.
  *
  * @since WP-2.5.0
- * @deprecated 2.8.0 Use _n_noop()
+ * @deprecated WP-2.8.0 Use _n_noop()
  * @see _n_noop()
  */
 function __ngettext_noop() {
@@ -1816,7 +1816,7 @@ function __ngettext_noop() {
  * Retrieve all autoload options, or all options if no autoloaded ones exist.
  *
  * @since WP-1.0.0
- * @deprecated 3.0.0 Use wp_load_alloptions())
+ * @deprecated WP-3.0.0 Use wp_load_alloptions())
  * @see wp_load_alloptions()
  *
  * @return array List of all options.
@@ -1830,7 +1830,7 @@ function get_alloptions() {
  * Retrieve HTML content of attachment image with link.
  *
  * @since WP-2.0.0
- * @deprecated 2.5.0 Use wp_get_attachment_link()
+ * @deprecated WP-2.5.0 Use wp_get_attachment_link()
  * @see wp_get_attachment_link()
  *
  * @param int $id Optional. Post ID.
@@ -1860,7 +1860,7 @@ function get_the_attachment_link($id = 0, $fullsize = false, $max_dims = false, 
  * Retrieve icon URL and Path.
  *
  * @since WP-2.1.0
- * @deprecated 2.5.0 Use wp_get_attachment_image_src()
+ * @deprecated WP-2.5.0 Use wp_get_attachment_image_src()
  * @see wp_get_attachment_image_src()
  *
  * @param int $id Optional. Post ID.
@@ -1901,7 +1901,7 @@ function get_attachment_icon_src( $id = 0, $fullsize = false ) {
  * Retrieve HTML content of icon attachment image element.
  *
  * @since WP-2.0.0
- * @deprecated 2.5.0 Use wp_get_attachment_image()
+ * @deprecated WP-2.5.0 Use wp_get_attachment_image()
  * @see wp_get_attachment_image()
  *
  * @param int $id Optional. Post ID.
@@ -1957,7 +1957,7 @@ function get_attachment_icon( $id = 0, $fullsize = false, $max_dims = false ) {
  * Retrieve HTML content of image element.
  *
  * @since WP-2.0.0
- * @deprecated 2.5.0 Use wp_get_attachment_image()
+ * @deprecated WP-2.5.0 Use wp_get_attachment_image()
  * @see wp_get_attachment_image()
  *
  * @param int $id Optional. Post ID.
@@ -1983,7 +1983,7 @@ function get_attachment_innerHTML($id = 0, $fullsize = false, $max_dims = false)
  * Retrieves bookmark data based on ID.
  *
  * @since WP-2.0.0
- * @deprecated 2.1.0 Use get_bookmark()
+ * @deprecated WP-2.1.0 Use get_bookmark()
  * @see get_bookmark()
  *
  * @param int    $bookmark_id ID of link
@@ -2002,7 +2002,7 @@ function get_link( $bookmark_id, $output = OBJECT, $filter = 'raw' ) {
  * Performs esc_url() for database or redirect usage.
  *
  * @since WP-2.3.1
- * @deprecated 2.8.0 Use esc_url_raw()
+ * @deprecated WP-2.8.0 Use esc_url_raw()
  * @see esc_url_raw()
  *
  * @param string $url The URL to be cleaned.
@@ -2022,7 +2022,7 @@ function sanitize_url( $url, $protocols = null ) {
  * is applied to the returned cleaned URL.
  *
  * @since WP-1.2.0
- * @deprecated 3.0.0 Use esc_url()
+ * @deprecated WP-3.0.0 Use esc_url()
  * @see esc_url()
  *
  * @param string $url The URL to be cleaned.
@@ -2044,7 +2044,7 @@ function clean_url( $url, $protocols = null, $context = 'display' ) {
  * The filter {@see 'js_escape'} is also applied by esc_js().
  *
  * @since WP-2.0.4
- * @deprecated 2.8.0 Use esc_js()
+ * @deprecated WP-2.8.0 Use esc_js()
  * @see esc_js()
  *
  * @param string $text The text to be escaped.
@@ -2058,7 +2058,7 @@ function js_escape( $text ) {
 /**
  * Legacy escaping for HTML blocks.
  *
- * @deprecated 2.8.0 Use esc_html()
+ * @deprecated WP-2.8.0 Use esc_html()
  * @see esc_html()
  *
  * @param string       $string        String to escape.
@@ -2081,7 +2081,7 @@ function wp_specialchars( $string, $quote_style = ENT_NOQUOTES, $charset = false
  * Escaping for HTML attributes.
  *
  * @since WP-2.0.6
- * @deprecated 2.8.0 Use esc_attr()
+ * @deprecated WP-2.8.0 Use esc_attr()
  * @see esc_attr()
  *
  * @param string $text
@@ -2103,7 +2103,7 @@ function attribute_escape( $text ) {
  * compatibility is complete.
  *
  * @since WP-2.2.0
- * @deprecated 2.8.0 Use wp_register_sidebar_widget()
+ * @deprecated WP-2.8.0 Use wp_register_sidebar_widget()
  * @see wp_register_sidebar_widget()
  *
  * @param string|int $name            Widget ID.
@@ -2137,7 +2137,7 @@ function register_sidebar_widget($name, $output_callback, $classname = '') {
  * Serves as an alias of wp_unregister_sidebar_widget().
  *
  * @since WP-2.2.0
- * @deprecated 2.8.0 Use wp_unregister_sidebar_widget()
+ * @deprecated WP-2.8.0 Use wp_unregister_sidebar_widget()
  * @see wp_unregister_sidebar_widget()
  *
  * @param int|string $id Widget ID.
@@ -2158,7 +2158,7 @@ function unregister_sidebar_widget($id) {
  * been compiled.
  *
  * @since WP-2.2.0
- * @deprecated 2.8.0 Use wp_register_widget_control()
+ * @deprecated WP-2.8.0 Use wp_register_widget_control()
  * @see wp_register_widget_control()
  *
  * @param int|string $name Sidebar ID.
@@ -2194,7 +2194,7 @@ function register_widget_control($name, $control_callback, $width = '', $height 
  * Alias of wp_unregister_widget_control().
  *
  * @since WP-2.2.0
- * @deprecated 2.8.0 Use wp_unregister_widget_control()
+ * @deprecated WP-2.8.0 Use wp_unregister_widget_control()
  * @see wp_unregister_widget_control()
  *
  * @param int|string $id Widget ID.
@@ -2208,7 +2208,7 @@ function unregister_widget_control($id) {
  * Remove user meta data.
  *
  * @since WP-2.0.0
- * @deprecated 3.0.0 Use delete_user_meta()
+ * @deprecated WP-3.0.0 Use delete_user_meta()
  * @see delete_user_meta()
  *
  * @param int $user_id User ID.
@@ -2255,7 +2255,7 @@ function delete_usermeta( $user_id, $meta_key, $meta_value = '' ) {
  * than one metadata value, then it will be list of metadata values.
  *
  * @since WP-2.0.0
- * @deprecated 3.0.0 Use get_user_meta()
+ * @deprecated WP-3.0.0 Use get_user_meta()
  * @see get_user_meta()
  *
  * @param int $user_id User ID
@@ -2307,7 +2307,7 @@ function get_usermeta( $user_id, $meta_key = '' ) {
  * Will remove the metadata, if the meta value is empty.
  *
  * @since WP-2.0.0
- * @deprecated 3.0.0 Use update_user_meta()
+ * @deprecated WP-3.0.0 Use update_user_meta()
  * @see update_user_meta()
  *
  * @param int $user_id User ID
@@ -2361,7 +2361,7 @@ function update_usermeta( $user_id, $meta_key, $meta_value ) {
  * multisite feature.
  *
  * @since WP-2.2.0
- * @deprecated 3.1.0 Use get_users()
+ * @deprecated WP-3.1.0 Use get_users()
  * @see get_users()
  *
  * @global wpdb $wpdb    ClassicPress database abstraction object.
@@ -2385,7 +2385,7 @@ function get_users_of_blog( $id = '' ) {
  * Enable/disable automatic general feed link outputting.
  *
  * @since WP-2.8.0
- * @deprecated 3.0.0 Use add_theme_support()
+ * @deprecated WP-3.0.0 Use add_theme_support()
  * @see add_theme_support()
  *
  * @param bool $add Optional, default is true. Add or remove links. Defaults to true.
@@ -2403,7 +2403,7 @@ function automatic_feed_links( $add = true ) {
  * Retrieve user data based on field.
  *
  * @since WP-1.5.0
- * @deprecated 3.0.0 Use get_the_author_meta()
+ * @deprecated WP-3.0.0 Use get_the_author_meta()
  * @see get_the_author_meta()
  *
  * @param string    $field User meta field.
@@ -2423,7 +2423,7 @@ function get_profile( $field, $user = false ) {
  * Retrieves the number of posts a user has written.
  *
  * @since WP-0.71
- * @deprecated 3.0.0 Use count_user_posts()
+ * @deprecated WP-3.0.0 Use count_user_posts()
  * @see count_user_posts()
  *
  * @param int $userid User to count posts for.
@@ -2439,7 +2439,7 @@ function get_usernumposts( $userid ) {
  *
  * @since WP-2.8.0
  * @access private
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * @param array $matches Single Match
  * @return string An HTML entity
@@ -2454,7 +2454,7 @@ function funky_javascript_callback($matches) {
  * Converts unicode characters to HTML numbered entities.
  *
  * @since WP-1.5.0
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * @global $is_macIE
  * @global $is_winIE
@@ -2479,7 +2479,7 @@ function funky_javascript_fix($text) {
  * Checks that the taxonomy name exists.
  *
  * @since WP-2.3.0
- * @deprecated 3.0.0 Use taxonomy_exists()
+ * @deprecated WP-3.0.0 Use taxonomy_exists()
  * @see taxonomy_exists()
  *
  * @param string $taxonomy Name of taxonomy object
@@ -2494,7 +2494,7 @@ function is_taxonomy( $taxonomy ) {
  * Check if Term exists.
  *
  * @since WP-2.3.0
- * @deprecated 3.0.0 Use term_exists()
+ * @deprecated WP-3.0.0 Use term_exists()
  * @see term_exists()
  *
  * @param int|string $term The term to check
@@ -2513,7 +2513,7 @@ function is_term( $term, $taxonomy = '', $parent = 0 ) {
  * Use global $plugin_page and/or get_plugin_page_hookname() hooks.
  *
  * @since WP-1.5.0
- * @deprecated 3.1.0
+ * @deprecated WP-3.1.0
  *
  * @global $plugin_page
  *
@@ -2538,7 +2538,7 @@ function is_plugin_page() {
  * for updating the category cache.
  *
  * @since WP-1.5.0
- * @deprecated 3.1.0
+ * @deprecated WP-3.1.0
  *
  * @return bool Always return True
  */
@@ -2552,7 +2552,7 @@ function update_category_cache() {
  * Check for PHP timezone support
  *
  * @since WP-2.9.0
- * @deprecated 3.2.0
+ * @deprecated WP-3.2.0
  *
  * @return bool
  */
@@ -2566,7 +2566,7 @@ function wp_timezone_supported() {
  * Displays an editor: TinyMCE, HTML, or both.
  *
  * @since WP-2.1.0
- * @deprecated 3.3.0 Use wp_editor()
+ * @deprecated WP-3.3.0 Use wp_editor()
  * @see wp_editor()
  *
  * @param string $content       Textarea content.
@@ -2586,7 +2586,7 @@ function the_editor($content, $id = 'content', $prev_id = 'title', $media_button
  * Perform the query to get the $metavalues array(s) needed by _fill_user and _fill_many_users
  *
  * @since WP-3.0.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param array $ids User ID numbers list.
  * @return array of arrays. The array is indexed by user_id, containing $metavalues object arrays.
@@ -2619,7 +2619,7 @@ function get_user_metavalues($ids) {
  * If the context is 'raw', then the user object or array will get minimal santization of the int fields.
  *
  * @since WP-2.3.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param object|array $user The User Object or Array
  * @param string $context Optional, default is 'display'. How to sanitize user fields.
@@ -2656,7 +2656,7 @@ function sanitize_user_object($user, $context = 'display') {
  * Can either be start or end post relational link.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param string $title Optional. Link title format.
  * @param bool $in_same_cat Optional. Whether link should be in a same category.
@@ -2696,7 +2696,7 @@ function get_boundary_post_rel_link($title = '%title', $in_same_cat = false, $ex
  * Display relational link for the first post.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param string $title Optional. Link title format.
  * @param bool $in_same_cat Optional. Whether link should be in a same category.
@@ -2712,7 +2712,7 @@ function start_post_rel_link($title = '%title', $in_same_cat = false, $excluded_
  * Get site index relational link.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @return string
  */
@@ -2727,7 +2727,7 @@ function get_index_rel_link() {
  * Display relational link for the site index.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  */
 function index_rel_link() {
 	_deprecated_function( __FUNCTION__, '3.3.0' );
@@ -2739,7 +2739,7 @@ function index_rel_link() {
  * Get parent post relational link.
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param string $title Optional. Link title format. Default '%title'.
  * @return string
@@ -2770,7 +2770,7 @@ function get_parent_post_rel_link( $title = '%title' ) {
  * Display relational link for parent item
  *
  * @since WP-2.8.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param string $title Optional. Link title format. Default '%title'.
  */
@@ -2784,7 +2784,7 @@ function parent_post_rel_link( $title = '%title' ) {
  * Add the "Dashboard"/"Visit Site" menu.
  *
  * @since WP-3.2.0
- * @deprecated 3.3.0
+ * @deprecated WP-3.3.0
  *
  * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
  */
@@ -2807,7 +2807,7 @@ function wp_admin_bar_dashboard_view_site_menu( $wp_admin_bar ) {
  * Checks if the current user belong to a given site.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.3.0 Use is_user_member_of_blog()
+ * @deprecated WP-3.3.0 Use is_user_member_of_blog()
  * @see is_user_member_of_blog()
  *
  * @param int $blog_id Site ID
@@ -2823,7 +2823,7 @@ function is_blog_user( $blog_id = 0 ) {
  * Open the file handle for debugging.
  *
  * @since WP-0.71
- * @deprecated 3.4.0 Use error_log()
+ * @deprecated WP-3.4.0 Use error_log()
  * @see error_log()
  *
  * @link https://secure.php.net/manual/en/function.error-log.php
@@ -2841,7 +2841,7 @@ function debug_fopen( $filename, $mode ) {
  * Write contents to the file used for debugging.
  *
  * @since WP-0.71
- * @deprecated 3.4.0 Use error_log()
+ * @deprecated WP-3.4.0 Use error_log()
  * @see error_log()
  *
  * @link https://secure.php.net/manual/en/function.error-log.php
@@ -2859,7 +2859,7 @@ function debug_fwrite( $fp, $string ) {
  * Close the debugging file handle.
  *
  * @since WP-0.71
- * @deprecated 3.4.0 Use error_log()
+ * @deprecated WP-3.4.0 Use error_log()
  * @see error_log()
  *
  * @link https://secure.php.net/manual/en/function.error-log.php
@@ -2878,7 +2878,7 @@ function debug_fclose( $fp ) {
  * broken, if it is missing style.css; index.php is optional.
  *
  * @since WP-1.5.0
- * @deprecated 3.4.0 Use wp_get_themes()
+ * @deprecated WP-3.4.0 Use wp_get_themes()
  * @see wp_get_themes()
  *
  * @return array Theme list with theme data.
@@ -2908,7 +2908,7 @@ function get_themes() {
  * Retrieve theme data.
  *
  * @since WP-1.5.0
- * @deprecated 3.4.0 Use wp_get_theme()
+ * @deprecated WP-3.4.0 Use wp_get_theme()
  * @see wp_get_theme()
  *
  * @param string $theme Theme name.
@@ -2927,7 +2927,7 @@ function get_theme( $theme ) {
  * Retrieve current theme name.
  *
  * @since WP-1.5.0
- * @deprecated 3.4.0 Use wp_get_theme()
+ * @deprecated WP-3.4.0 Use wp_get_theme()
  * @see wp_get_theme()
  *
  * @return string
@@ -2948,7 +2948,7 @@ function get_current_theme() {
  * converted into paragraphs or line-breaks.
  *
  * @since WP-1.2.0
- * @deprecated 3.4.0
+ * @deprecated WP-3.4.0
  *
  * @param array|string $matches The array or string
  * @return string The pre block without paragraph/line-break conversion.
@@ -2973,7 +2973,7 @@ function clean_pre($matches) {
  * Add callbacks for image header display.
  *
  * @since WP-2.1.0
- * @deprecated 3.4.0 Use add_theme_support()
+ * @deprecated WP-3.4.0 Use add_theme_support()
  * @see add_theme_support()
  *
  * @param callable $wp_head_callback Call on the {@see 'wp_head'} action.
@@ -2995,7 +2995,7 @@ function add_custom_image_header( $wp_head_callback, $admin_head_callback, $admi
  * Remove image header support.
  *
  * @since WP-3.1.0
- * @deprecated 3.4.0 Use remove_theme_support()
+ * @deprecated WP-3.4.0 Use remove_theme_support()
  * @see remove_theme_support()
  *
  * @return null|bool Whether support was removed.
@@ -3009,7 +3009,7 @@ function remove_custom_image_header() {
  * Add callbacks for background image display.
  *
  * @since WP-3.0.0
- * @deprecated 3.4.0 Use add_theme_support()
+ * @deprecated WP-3.4.0 Use add_theme_support()
  * @see add_theme_support()
  *
  * @param callable $wp_head_callback Call on the {@see 'wp_head'} action.
@@ -3032,7 +3032,7 @@ function add_custom_background( $wp_head_callback = '', $admin_head_callback = '
  * Remove custom background support.
  *
  * @since WP-3.1.0
- * @deprecated 3.4.0 Use add_custom_background()
+ * @deprecated WP-3.4.0 Use add_custom_background()
  * @see add_custom_background()
  *
  * @return null|bool Whether support was removed.
@@ -3046,7 +3046,7 @@ function remove_custom_background() {
  * Retrieve theme data from parsed theme file.
  *
  * @since WP-1.5.0
- * @deprecated 3.4.0 Use wp_get_theme()
+ * @deprecated WP-3.4.0 Use wp_get_theme()
  * @see wp_get_theme()
  *
  * @param string $theme_file Theme file path.
@@ -3084,7 +3084,7 @@ function get_theme_data( $theme_file ) {
  * @see update_post_cache() Posts and pages are the same, alias is intentional
  *
  * @since WP-1.5.1
- * @deprecated 3.4.0 Use update_post_cache()
+ * @deprecated WP-3.4.0 Use update_post_cache()
  * @see update_post_cache()
  *
  * @param array $pages list of page objects
@@ -3102,7 +3102,7 @@ function update_page_cache( &$pages ) {
  * associated with 'all_page_ids' and 'get_pages'.
  *
  * @since WP-2.0.0
- * @deprecated 3.4.0 Use clean_post_cache
+ * @deprecated WP-3.4.0 Use clean_post_cache
  * @see clean_post_cache()
  *
  * @param int $id Page ID to clean
@@ -3119,7 +3119,7 @@ function clean_page_cache( $id ) {
  * Deprecated in 3.4.1 and 3.5.0. Backported to 3.3.3.
  *
  * @since WP-2.0.4
- * @deprecated 3.4.1 Use wp_nonce_ays()
+ * @deprecated WP-3.4.1 Use wp_nonce_ays()
  * @see wp_nonce_ays()
  *
  * @param string $action Nonce action.
@@ -3134,7 +3134,7 @@ function wp_explain_nonce( $action ) {
  * Display "sticky" CSS class, if a post is sticky.
  *
  * @since WP-2.7.0
- * @deprecated 3.5.0 Use post_class()
+ * @deprecated WP-3.5.0 Use post_class()
  * @see post_class()
  *
  * @param int $post_id An optional post ID.
@@ -3152,7 +3152,7 @@ function sticky_class( $post_id = null ) {
  * property with get_post_ancestors().
  *
  * @since WP-2.3.4
- * @deprecated 3.5.0 Use get_post_ancestors()
+ * @deprecated WP-3.5.0 Use get_post_ancestors()
  * @see get_post_ancestors()
  *
  * @param WP_Post $post Post object, passed by reference (unused).
@@ -3165,7 +3165,7 @@ function _get_post_ancestors( &$post ) {
  * Load an image from a string, if PHP supports it.
  *
  * @since WP-2.1.0
- * @deprecated 3.5.0 Use wp_get_image_editor()
+ * @deprecated WP-3.5.0 Use wp_get_image_editor()
  * @see wp_get_image_editor()
  *
  * @param string $file Filename of the image to load.
@@ -3210,7 +3210,7 @@ function wp_load_image( $file ) {
  * downgraded, not actual defects), but of your PHP version.
  *
  * @since WP-2.5.0
- * @deprecated 3.5.0 Use wp_get_image_editor()
+ * @deprecated WP-3.5.0 Use wp_get_image_editor()
  * @see wp_get_image_editor()
  *
  * @param string $file Image file path.
@@ -3250,7 +3250,7 @@ function image_resize( $file, $max_w, $max_h, $crop = false, $suffix = null, $de
  * property or key.
  *
  * @since WP-1.0.0
- * @deprecated 3.5.0 Use get_post()
+ * @deprecated WP-3.5.0 Use get_post()
  * @see get_post()
  *
  * @param int $postid Post ID.
@@ -3266,7 +3266,7 @@ function wp_get_single_post( $postid = 0, $mode = OBJECT ) {
  * Check that the user login name and password is correct.
  *
  * @since WP-0.71
- * @deprecated 3.5.0 Use wp_authenticate()
+ * @deprecated WP-3.5.0 Use wp_authenticate()
  * @see wp_authenticate()
  *
  * @param string $user_login User name.
@@ -3286,7 +3286,7 @@ function user_pass_ok($user_login, $user_pass) {
  * Callback formerly fired on the save_post hook. No longer needed.
  *
  * @since WP-2.3.0
- * @deprecated 3.5.0
+ * @deprecated WP-3.5.0
  */
 function _save_post_hook() {}
 
@@ -3294,7 +3294,7 @@ function _save_post_hook() {}
  * Check if the installed version of GD supports particular image type
  *
  * @since WP-2.9.0
- * @deprecated 3.5.0 Use wp_image_editor_supports()
+ * @deprecated WP-3.5.0 Use wp_image_editor_supports()
  * @see wp_image_editor_supports()
  *
  * @param string $mime_type
@@ -3329,7 +3329,7 @@ function gd_edit_image_support($mime_type) {
  * Converts an integer byte value to a shorthand byte value.
  *
  * @since WP-2.3.0
- * @deprecated 3.6.0 Use size_format()
+ * @deprecated WP-3.6.0 Use size_format()
  * @see size_format()
  *
  * @param int $bytes An integer byte value.
@@ -3358,7 +3358,7 @@ function wp_convert_bytes_to_hr( $bytes ) {
  *
  * @since WP-2.9.0
  * @access private
- * @deprecated 3.7.0
+ * @deprecated WP-3.7.0
  *
  * @param string $t Search terms to "tidy", e.g. trim.
  * @return string Trimmed search terms.
@@ -3375,7 +3375,7 @@ function _search_terms_tidy( $t ) {
  * their ClassicPress installation.
  *
  * @since WP-2.1.0
- * @deprecated 3.9.0
+ * @deprecated WP-3.9.0
  *
  * @return bool Whether TinyMCE exists.
  */
@@ -3394,7 +3394,7 @@ function rich_edit_exists() {
  *
  * @since WP-2.7.0
  * @access private
- * @deprecated 3.9.0
+ * @deprecated WP-3.9.0
  *
  * @param int $count Number of topics.
  * @return int Number of topics.
@@ -3409,7 +3409,7 @@ function default_topic_count_text( $count ) {
  * Has not performed this function for many, many years. Use wpdb::prepare() instead.
  *
  * @since WP-0.71
- * @deprecated 3.9.0
+ * @deprecated WP-3.9.0
  *
  * @param string $content The text to format.
  * @return string The very same text.
@@ -3423,7 +3423,7 @@ function format_to_post( $content ) {
  * Formerly used to escape strings before searching the DB. It was poorly documented and never worked as described.
  *
  * @since WP-2.5.0
- * @deprecated 4.0.0 Use wpdb::esc_like()
+ * @deprecated WP-4.0.0 Use wpdb::esc_like()
  * @see wpdb::esc_like()
  *
  * @param string $text The text to be escaped.
@@ -3441,7 +3441,7 @@ function like_escape($text) {
  * the URL using https as the scheme.
  *
  * @since WP-2.5.0
- * @deprecated 4.0.0
+ * @deprecated WP-4.0.0
  *
  * @param string $url The URL to test.
  * @return bool Whether SSL access is available.
@@ -3468,7 +3468,7 @@ function url_is_accessable_via_ssl( $url ) {
  * query variables exist.
  *
  * @since WP-2.6.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  */
 function preview_theme() {
 	_deprecated_function( __FUNCTION__, '4.3.0' );
@@ -3478,7 +3478,7 @@ function preview_theme() {
  * Private function to modify the current template when previewing a theme
  *
  * @since WP-2.9.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  * @access private
  *
  * @return string
@@ -3492,7 +3492,7 @@ function _preview_theme_template_filter() {
  * Private function to modify the current stylesheet when previewing a theme
  *
  * @since WP-2.9.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  * @access private
  *
  * @return string
@@ -3506,7 +3506,7 @@ function _preview_theme_stylesheet_filter() {
  * Callback function for ob_start() to capture all links in the theme.
  *
  * @since WP-2.6.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  * @access private
  *
  * @param string $content
@@ -3523,7 +3523,7 @@ function preview_theme_ob_filter( $content ) {
  * Callback function for preg_replace_callback() to accept and filter matches.
  *
  * @since WP-2.6.0
- * @deprecated 4.3.0
+ * @deprecated WP-4.3.0
  * @access private
  *
  * @param array $matches
@@ -3541,7 +3541,7 @@ function preview_theme_ob_filter_callback( $matches ) {
  * be applied to an empty string.
  *
  * @since WP-2.0.0
- * @deprecated 4.3.0 Use format_for_editor()
+ * @deprecated WP-4.3.0 Use format_for_editor()
  * @see format_for_editor()
  *
  * @param string $text The text to be formatted.
@@ -3562,7 +3562,7 @@ function wp_richedit_pre($text) {
 		 * return after being formatted.
 		 *
 		 * @since WP-2.0.0
-		 * @deprecated 4.3.0
+		 * @deprecated WP-4.3.0
 		 *
 		 * @param string $output Text for the rich text editor.
 		 */
@@ -3584,7 +3584,7 @@ function wp_richedit_pre($text) {
  * {@see 'htmledit_pre'} filter is applied.
  *
  * @since WP-2.5.0
- * @deprecated 4.3.0 Use format_for_editor()
+ * @deprecated WP-4.3.0 Use format_for_editor()
  * @see format_for_editor()
  *
  * @param string $output The text to be formatted.
@@ -3600,7 +3600,7 @@ function wp_htmledit_pre($output) {
 	 * Filters the text before it is formatted for the HTML editor.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 4.3.0
+	 * @deprecated WP-4.3.0
 	 *
 	 * @param string $output The HTML-formatted text.
 	 */
@@ -3611,7 +3611,7 @@ function wp_htmledit_pre($output) {
  * Retrieve permalink from post ID.
  *
  * @since WP-1.0.0
- * @deprecated 4.4.0 Use get_permalink()
+ * @deprecated WP-4.4.0 Use get_permalink()
  * @see get_permalink()
  *
  * @param int|WP_Post $post_id Optional. Post ID or WP_Post object. Default is global $post.
@@ -3630,7 +3630,7 @@ function post_permalink( $post_id = 0 ) {
  * the file to that path.
  *
  * @since WP-2.5.0
- * @deprecated 4.4.0 Use WP_Http
+ * @deprecated WP-4.4.0 Use WP_Http
  * @see WP_Http
  *
  * @param string      $url       URL to fetch.
@@ -3687,7 +3687,7 @@ function wp_get_http( $url, $file_path = false, $red = 1 ) {
  * Whether SSL login should be forced.
  *
  * @since WP-2.6.0
- * @deprecated 4.4.0 Use force_ssl_admin()
+ * @deprecated WP-4.4.0 Use force_ssl_admin()
  * @see force_ssl_admin()
  *
  * @param string|bool $force Optional Whether to force SSL login. Default null.
@@ -3702,7 +3702,7 @@ function force_ssl_login( $force = null ) {
  * Retrieve path of comment popup template in current or parent template.
  *
  * @since WP-1.5.0
- * @deprecated 4.5.0
+ * @deprecated WP-4.5.0
  *
  * @return string Full path to comments popup template file.
  */
@@ -3716,7 +3716,7 @@ function get_comments_popup_template() {
  * Whether the current URL is within the comments popup window.
  *
  * @since WP-1.5.0
- * @deprecated 4.5.0
+ * @deprecated WP-4.5.0
  *
  * @return bool
  */
@@ -3730,7 +3730,7 @@ function is_comments_popup() {
  * Display the JS popup script to show a comment.
  *
  * @since WP-0.71
- * @deprecated 4.5.0
+ * @deprecated WP-4.5.0
  */
 function comments_popup_script() {
 	_deprecated_function( __FUNCTION__, '4.5.0' );
@@ -3740,7 +3740,7 @@ function comments_popup_script() {
  * Adds element attributes to open links in new windows.
  *
  * @since WP-0.71
- * @deprecated 4.5.0
+ * @deprecated WP-4.5.0
  *
  * @param string $text Content to replace links to open in a new window.
  * @return string Content that has filtered links.
@@ -3758,7 +3758,7 @@ function popuplinks( $text ) {
  * into embeds but that service has since been shut down.
  *
  * @since WP-2.9.0
- * @deprecated 4.6.0
+ * @deprecated WP-4.6.0
  *
  * @return string An empty string.
  */
@@ -3772,7 +3772,7 @@ function wp_embed_handler_googlevideo( $matches, $attr, $url, $rawattr ) {
  * Retrieve path of paged template in current or parent template.
  *
  * @since WP-1.5.0
- * @deprecated 4.7.0 The paged.php template is no longer part of the theme template hierarchy.
+ * @deprecated WP-4.7.0 The paged.php template is no longer part of the theme template hierarchy.
  *
  * @return string Full path to paged template file.
  */
@@ -3797,7 +3797,7 @@ function get_paged_template() {
  * input to the return.
  *
  * @since WP-1.0.0
- * @deprecated 4.7.0 Officially dropped security support for Netscape 4.
+ * @deprecated WP-4.7.0 Officially dropped security support for Netscape 4.
  *
  * @param string $string
  * @return string
@@ -3815,7 +3815,7 @@ function wp_kses_js_entities( $string ) {
  * used to sort any term object.
  *
  * @since WP-2.3.0
- * @deprecated 4.7.0 Use wp_list_sort()
+ * @deprecated WP-4.7.0 Use wp_list_sort()
  * @access private
  *
  * @param object $a
@@ -3840,7 +3840,7 @@ function _usort_terms_by_ID( $a, $b ) {
  * used to sort any term object.
  *
  * @since WP-2.3.0
- * @deprecated 4.7.0 Use wp_list_sort()
+ * @deprecated WP-4.7.0 Use wp_list_sort()
  * @access private
  *
  * @param object $a
@@ -3857,7 +3857,7 @@ function _usort_terms_by_name( $a, $b ) {
  * Sort menu items by the desired key.
  *
  * @since WP-3.0.0
- * @deprecated 4.7.0 Use wp_list_sort()
+ * @deprecated WP-4.7.0 Use wp_list_sort()
  * @access private
  *
  * @global string $_menu_item_sort_prop
@@ -3892,7 +3892,7 @@ function _sort_nav_menu_items( $a, $b ) {
  * Retrieves the Press This bookmarklet link.
  *
  * @since WP-2.6.0
- * @deprecated 4.9.0
+ * @deprecated WP-4.9.0
  *
  */
 function get_shortcut_link() {
@@ -3904,7 +3904,7 @@ function get_shortcut_link() {
 	 * Filters the Press This bookmarklet link.
 	 *
 	 * @since WP-2.6.0
-	 * @deprecated 4.9.0
+	 * @deprecated WP-4.9.0
 	 *
 	 * @param string $link The Press This bookmarklet link.
 	 */
@@ -3915,7 +3915,7 @@ function get_shortcut_link() {
 * Ajax handler for saving a post from Press This.
 *
 * @since WP-4.2.0
-* @deprecated 4.9.0
+* @deprecated WP-4.9.0
 */
 function wp_ajax_press_this_save_post() {
 	_deprecated_function( __FUNCTION__, '4.9.0' );
@@ -3932,7 +3932,7 @@ function wp_ajax_press_this_save_post() {
 * Ajax handler for creating new category from Press This.
 *
 * @since WP-4.2.0
-* @deprecated 4.9.0
+* @deprecated WP-4.9.0
 */
 function wp_ajax_press_this_add_category() {
 	_deprecated_function( __FUNCTION__, '4.9.0' );

--- a/src/wp-includes/embed-template.php
+++ b/src/wp-includes/embed-template.php
@@ -5,7 +5,7 @@
  * @package ClassicPress
  * @subpackage oEmbed
  * @since WP-4.4.0
- * @deprecated 4.5.0 Moved to wp-includes/theme-compat/embed.php
+ * @deprecated WP-4.5.0 Moved to wp-includes/theme-compat/embed.php
  */
 
 _deprecated_file( basename( __FILE__ ), '4.5.0', 'wp-includes/theme-compat/embed.php' );

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -685,7 +685,7 @@ function shutdown_action_hook() {
  * Copy an object.
  *
  * @since WP-2.7.0
- * @deprecated 3.2.0
+ * @deprecated WP-3.2.0
  *
  * @param object $object The object to clone.
  * @return object The cloned object.

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -238,7 +238,7 @@ function get_blog_details( $fields = null, $get_all = true ) {
 	 * Filters a blog's details.
 	 *
 	 * @since WP-MU (3.0.0)
-	 * @deprecated 4.7.0 Use site_details
+	 * @deprecated WP-4.7.0 Use site_details
 	 *
 	 * @param object $details The blog details.
 	 */
@@ -479,7 +479,7 @@ function clean_blog_cache( $blog ) {
 	 * Fires after the blog details cache is cleared.
 	 *
 	 * @since WP-3.4.0
-	 * @deprecated 4.9.0 Use clean_site_cache
+	 * @deprecated WP-4.9.0 Use clean_site_cache
 	 *
 	 * @param int $blog_id Blog ID.
 	 */

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -18,7 +18,7 @@
  * Dashboard blog functionality was removed in WordPress 3.1, replaced by the user admin.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.1.0 Use get_site()
+ * @deprecated WP-3.1.0 Use get_site()
  * @see get_site()
  *
  * @return WP_Site Current site object.
@@ -36,7 +36,7 @@ function get_dashboard_blog() {
  * Generates a random password.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use wp_generate_password()
+ * @deprecated WP-3.0.0 Use wp_generate_password()
  * @see wp_generate_password()
  *
  * @param int $len Optional. The length of password to generate. Default 8.
@@ -56,7 +56,7 @@ function generate_random_password( $len = 8 ) {
  * legacy function_exists() checks to determine if multisite is enabled.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use is_super_admin()
+ * @deprecated WP-3.0.0 Use is_super_admin()
  * @see is_super_admin()
  *
  * @param string $user_login Optional. Username for the user to check. Default empty.
@@ -83,7 +83,7 @@ if ( !function_exists( 'graceful_fail' ) ) :
  * Deprecated functionality to gracefully fail.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use wp_die()
+ * @deprecated WP-3.0.0 Use wp_die()
  * @see wp_die()
  */
 function graceful_fail( $message ) {
@@ -121,7 +121,7 @@ endif;
  * Deprecated functionality to retrieve user information.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use get_user_by()
+ * @deprecated WP-3.0.0 Use get_user_by()
  * @see get_user_by()
  *
  * @param string $username Username.
@@ -135,7 +135,7 @@ function get_user_details( $username ) {
  * Deprecated functionality to clear the global post cache.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use clean_post_cache()
+ * @deprecated WP-3.0.0 Use clean_post_cache()
  * @see clean_post_cache()
  *
  * @param int $post_id Post ID.
@@ -148,7 +148,7 @@ function clear_global_post_cache( $post_id ) {
  * Deprecated functionality to determin if the current site is the main site.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use is_main_site()
+ * @deprecated WP-3.0.0 Use is_main_site()
  * @see is_main_site()
  */
 function is_main_blog() {
@@ -160,7 +160,7 @@ function is_main_blog() {
  * Deprecated functionality to validate an email address.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use is_email()
+ * @deprecated WP-3.0.0 Use is_email()
  * @see is_email()
  *
  * @param string $email        Email address to verify.
@@ -176,7 +176,7 @@ function validate_email( $email, $check_domain = true) {
  * Deprecated functionality to retrieve a list of all sites.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0 Use wp_get_sites()
+ * @deprecated WP-3.0.0 Use wp_get_sites()
  * @see wp_get_sites()
  *
  * @param int    $start      Optional. Offset for retrieving the blog list. Default 0.
@@ -210,7 +210,7 @@ function get_blog_list( $start = 0, $num = 10, $deprecated = '' ) {
  * Deprecated functionality to retrieve a list of the most active sites.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * @param int  $num     Optional. Number of activate blogs to retrieve. Default 10.
  * @param bool $display Optional. Whether or not to display the most active blogs list. Default true.
@@ -262,7 +262,7 @@ function get_most_active_blogs( $num = 10, $display = true ) {
  * 6) $url
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.3.0 Use wp_redirect()
+ * @deprecated WP-3.3.0 Use wp_redirect()
  * @see wp_redirect()
  *
  * @param string $url Optional. Redirect URL. Default empty.
@@ -301,7 +301,7 @@ function wpmu_admin_do_redirect( $url = '' ) {
  * Adds an 'updated=true' argument to a URL.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.3.0 Use add_query_arg()
+ * @deprecated WP-3.3.0 Use add_query_arg()
  * @see add_query_arg()
  *
  * @param string $url Optional. Redirect URL. Default empty.
@@ -326,7 +326,7 @@ function wpmu_admin_redirect_add_updated_param( $url = '' ) {
  * and is simply returned as such.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.6.0 Use get_user_by()
+ * @deprecated WP-3.6.0 Use get_user_by()
  * @see get_user_by()
  *
  * @param string $string Either an email address or a login.
@@ -351,7 +351,7 @@ function get_user_id_from_string( $string ) {
  * Get a full blog URL, given a domain and a path.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 3.7.0
+ * @deprecated WP-3.7.0
  *
  * @param string $domain
  * @param string $path
@@ -380,7 +380,7 @@ function get_blogaddress_by_domain( $domain, $path ) {
  * Create an empty blog.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 4.4.0
+ * @deprecated WP-4.4.0
  *
  * @param string $domain       The new blog's domain.
  * @param string $path         The new blog's path.
@@ -416,7 +416,7 @@ function create_empty_blog( $domain, $path, $weblog_title, $site_id = 1 ) {
  * Get the admin for a domain/path combination.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 4.4.0
+ * @deprecated WP-4.4.0
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
@@ -451,7 +451,7 @@ function get_admin_users_for_domain( $domain = '', $path = '' ) {
  * Return an array of sites for a network or networks.
  *
  * @since WP-3.7.0
- * @deprecated 4.6.0 Use get_sites()
+ * @deprecated WP-4.6.0 Use get_sites()
  * @see get_sites()
  *
  * @param array $args {
@@ -524,7 +524,7 @@ function wp_get_sites( $args = array() ) {
  * Check whether a usermeta key has to do with the current blog.
  *
  * @since WP-MU (3.0.0)
- * @deprecated 4.9.0
+ * @deprecated WP-4.9.0
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -497,7 +497,7 @@ function ms_not_installed( $domain, $path ) {
  *
  * @access private
  * @since WP-3.0.0
- * @deprecated 3.9.0 Use get_current_site() instead.
+ * @deprecated WP-3.9.0 Use get_current_site() instead.
  *
  * @param object $current_site
  * @return object
@@ -515,7 +515,7 @@ function get_current_site_name( $current_site ) {
  *
  * @access private
  * @since WP-3.0.0
- * @deprecated 3.9.0
+ * @deprecated WP-3.9.0
  *
  * @global object $current_site
  *
@@ -531,7 +531,7 @@ function wpmu_current_site() {
  * Retrieve an object containing information about the requested network.
  *
  * @since WP-3.9.0
- * @deprecated 4.7.0 Use `get_network()`
+ * @deprecated WP-4.7.0 Use `get_network()`
  * @see get_network()
  *
  * @internal In 4.6.0, converted to use get_network()

--- a/src/wp-includes/pluggable-deprecated.php
+++ b/src/wp-includes/pluggable-deprecated.php
@@ -22,7 +22,7 @@ if ( !function_exists('set_current_user') ) :
  * Set $id to null and specify a name if you do not know a user's ID.
  *
  * @since WP-2.0.1
- * @deprecated 3.0.0 Use wp_set_current_user()
+ * @deprecated WP-3.0.0 Use wp_set_current_user()
  * @see wp_set_current_user()
  *
  * @param int|null $id User ID.
@@ -40,7 +40,7 @@ if ( !function_exists('get_currentuserinfo') ) :
  * Populate global variables with information about the currently logged in user.
  *
  * @since WP-0.71
- * @deprecated 4.5.0 Use wp_get_current_user()
+ * @deprecated WP-4.5.0 Use wp_get_current_user()
  * @see wp_get_current_user()
  *
  * @return bool|WP_User False on XMLRPC Request and invalid auth cookie, WP_User instance otherwise.
@@ -57,7 +57,7 @@ if ( !function_exists('get_userdatabylogin') ) :
  * Retrieve user info by login name.
  *
  * @since WP-0.71
- * @deprecated 3.3.0 Use get_user_by()
+ * @deprecated WP-3.3.0 Use get_user_by()
  * @see get_user_by()
  *
  * @param string $user_login User's username
@@ -74,7 +74,7 @@ if ( !function_exists('get_user_by_email') ) :
  * Retrieve user info by email.
  *
  * @since WP-2.5.0
- * @deprecated 3.3.0 Use get_user_by()
+ * @deprecated WP-3.3.0 Use get_user_by()
  * @see get_user_by()
  *
  * @param string $email User's email address
@@ -91,7 +91,7 @@ if ( !function_exists('wp_setcookie') ) :
  * Sets a cookie for a user who just logged in. This function is deprecated.
  *
  * @since WP-1.5.0
- * @deprecated 2.5.0 Use wp_set_auth_cookie()
+ * @deprecated WP-2.5.0 Use wp_set_auth_cookie()
  * @see wp_set_auth_cookie()
  *
  * @param string $username The user's username
@@ -115,7 +115,7 @@ if ( !function_exists('wp_clearcookie') ) :
  * Clears the authentication cookie, logging the user out. This function is deprecated.
  *
  * @since WP-1.5.0
- * @deprecated 2.5.0 Use wp_clear_auth_cookie()
+ * @deprecated WP-2.5.0 Use wp_clear_auth_cookie()
  * @see wp_clear_auth_cookie()
  */
 function wp_clearcookie() {
@@ -134,7 +134,7 @@ if ( !function_exists('wp_get_cookie_login') ):
  * used anywhere in ClassicPress. Also, plugins shouldn't use it either.
  *
  * @since WP-2.0.3
- * @deprecated 2.5.0
+ * @deprecated WP-2.5.0
  *
  * @return bool Always returns false
  */
@@ -158,7 +158,7 @@ if ( !function_exists('wp_login') ) :
  * failure can utilize it later.
  *
  * @since WP-1.2.2
- * @deprecated 2.5.0 Use wp_signon()
+ * @deprecated WP-2.5.0 Use wp_signon()
  * @see wp_signon()
  *
  * @global string $error Error when false is returned
@@ -191,7 +191,7 @@ endif;
  * It is kept here in case a plugin directly referred to the class.
  *
  * @since WP-2.2.0
- * @deprecated 3.5.0
+ * @deprecated WP-3.5.0
  *
  * @link https://wordpress.org/plugins/atom-publishing-protocol/
  */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4362,7 +4362,7 @@ function get_all_page_ids() {
  * Use get_post() instead of get_page().
  *
  * @since WP-1.5.1
- * @deprecated 3.5.0 Use get_post()
+ * @deprecated WP-3.5.0 Use get_post()
  *
  * @param mixed  $page   Page object or page ID. Passed by reference.
  * @param string $output Optional. The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which correspond to
@@ -5720,7 +5720,7 @@ function get_posts_by_author_sql( $post_type, $full = true, $post_author = null,
 		 * when generating SQL for getting posts by author.
 		 *
 		 * @since WP-2.2.0
-		 * @deprecated 3.2.0 The hook transitioned from "somewhat useless" to "totally useless".
+		 * @deprecated WP-3.2.0 The hook transitioned from "somewhat useless" to "totally useless".
 		 *
 		 * @param string $cap Capability.
 		 */
@@ -6116,7 +6116,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 		 * Fires when a post's status is transitioned from private to published.
 		 *
 		 * @since WP-1.5.0
-		 * @deprecated 2.3.0 Use 'private_to_publish' instead.
+		 * @deprecated WP-2.3.0 Use 'private_to_publish' instead.
 		 *
 		 * @param int $post_id Post ID.
 		 */

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -256,7 +256,7 @@ class WP_REST_Server {
 		 * Filters whether the REST API is enabled.
 		 *
 		 * @since WP-4.4.0
-		 * @deprecated 4.7.0 Use the rest_authentication_errors filter to restrict access to the API
+		 * @deprecated WP-4.7.0 Use the rest_authentication_errors filter to restrict access to the API
 		 *
 		 * @param bool $rest_enabled Whether the REST API is enabled. Default true.
 		 */

--- a/src/wp-includes/rss.php
+++ b/src/wp-includes/rss.php
@@ -10,7 +10,7 @@
  *
  * @package External
  * @subpackage MagpieRSS
- * @deprecated 3.0.0 Use SimplePie instead.
+ * @deprecated WP-3.0.0 Use SimplePie instead.
  */
 
 /**
@@ -22,7 +22,7 @@ _deprecated_file( basename( __FILE__ ), '3.0.0', WPINC . '/class-simplepie.php' 
  * Fires before MagpieRSS is loaded, to optionally replace it.
  *
  * @since WP-2.3.0
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  */
 do_action( 'load_feed_engine' );
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -4008,7 +4008,7 @@ function get_term_link( $term, $taxonomy = '' ) {
 		 * Filters the tag link.
 		 *
 		 * @since WP-2.3.0
-		 * @deprecated 2.5.0 Use 'term_link' instead.
+		 * @deprecated WP-2.5.0 Use 'term_link' instead.
 		 *
 		 * @param string $termlink Tag link URL.
 		 * @param int    $term_id  Term ID.
@@ -4020,7 +4020,7 @@ function get_term_link( $term, $taxonomy = '' ) {
 		 * Filters the category link.
 		 *
 		 * @since WP-1.5.0
-		 * @deprecated 2.5.0 Use 'term_link' instead.
+		 * @deprecated WP-2.5.0 Use 'term_link' instead.
 		 *
 		 * @param string $termlink Category link URL.
 		 * @param int    $term_id  Term ID.

--- a/src/wp-includes/theme-compat/comments.php
+++ b/src/wp-includes/theme-compat/comments.php
@@ -2,7 +2,7 @@
 /**
  * @package ClassicPress
  * @subpackage Theme_Compat
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * This file is here for backward compatibility with old themes and will be removed in a future version
  *

--- a/src/wp-includes/theme-compat/footer.php
+++ b/src/wp-includes/theme-compat/footer.php
@@ -2,7 +2,7 @@
 /**
  * @package ClassicPress
  * @subpackage Theme_Compat
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * This file is here for backward compatibility with old themes and will be removed in a future version
  */

--- a/src/wp-includes/theme-compat/header.php
+++ b/src/wp-includes/theme-compat/header.php
@@ -2,7 +2,7 @@
 /**
  * @package ClassicPress
  * @subpackage Theme_Compat
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * This file is here for backward compatibility with old themes and will be removed in a future version.
  */

--- a/src/wp-includes/theme-compat/sidebar.php
+++ b/src/wp-includes/theme-compat/sidebar.php
@@ -2,7 +2,7 @@
 /**
  * @package ClassicPress
  * @subpackage Theme_Compat
- * @deprecated 3.0.0
+ * @deprecated WP-3.0.0
  *
  * This file is here for backward compatibility with old themes and will be removed in a future version.
  */

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2138,7 +2138,7 @@ function get_password_reset_key( $user ) {
 	 * Use the {@see 'retrieve_password'} hook instead.
 	 *
 	 * @since WP-1.5.0
-	 * @deprecated 1.5.1 Misspelled. Use 'retrieve_password' hook instead.
+	 * @deprecated WP-1.5.1 Misspelled. Use 'retrieve_password' hook instead.
 	 *
 	 * @param string $user_login The user login name.
 	 */

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -166,7 +166,7 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 	 *
 	 * @since WP-2.8.0
 	 *
-	 * @deprecated 4.4.0 Fragment caching was removed in favor of split queries.
+	 * @deprecated WP-4.4.0 Fragment caching was removed in favor of split queries.
 	 */
 	public function flush_widget_cache() {
 		_deprecated_function( __METHOD__, '4.4.0' );

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1073,7 +1073,7 @@ class wpdb {
 	 * Use esc_sql() or wpdb::prepare() instead.
 	 *
 	 * @since WP-2.8.0
-	 * @deprecated 3.6.0 Use wpdb::prepare()
+	 * @deprecated WP-3.6.0 Use wpdb::prepare()
 	 * @see wpdb::prepare
 	 * @see esc_sql()
 	 *
@@ -1148,7 +1148,7 @@ class wpdb {
 	 * Use esc_sql() or wpdb::prepare() instead.
 	 *
 	 * @since WP-0.71
-	 * @deprecated 3.6.0 Use wpdb::prepare()
+	 * @deprecated WP-3.6.0 Use wpdb::prepare()
 	 * @see wpdb::prepare()
 	 * @see esc_sql()
 	 *
@@ -3320,7 +3320,7 @@ class wpdb {
 	 * Use `wpdb::has_cap( 'collation' )`.
 	 *
 	 * @since WP-2.5.0
-	 * @deprecated 3.5.0 Use wpdb::has_cap()
+	 * @deprecated WP-3.5.0 Use wpdb::has_cap()
 	 *
 	 * @return bool True if collation is supported, false if version does not
 	 */

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -404,7 +404,7 @@ function validate_another_blog_signup() {
 	 * Use the {@see 'add_signup_meta'} filter instead.
 	 *
 	 * @since WP-MU (3.0.0)
-	 * @deprecated 3.0.0 Use the {@see 'add_signup_meta'} filter instead.
+	 * @deprecated WP-3.0.0 Use the {@see 'add_signup_meta'} filter instead.
 	 *
 	 * @param array $blog_meta_defaults An array of default blog meta variables.
 	 */

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -88,7 +88,7 @@ exit;
 /**
  * logIO() - Writes logging info to a file.
  *
- * @deprecated 3.4.0 Use error_log()
+ * @deprecated WP-3.4.0 Use error_log()
  * @see error_log()
  *
  * @param string $io Whether input or output


### PR DESCRIPTION
These should reflect the WP version, not yet-to-be-released ClassicPress versions.

Automated refactoring using https://github.com/facebook/codemod:

```
codemod --extensions js,php --exclude-paths node_modules/ '@deprecated(\s+)(\d)' '@deprecated\1WP-\2'
```

Similar to #26.  I noticed this while reviewing #53.