### PR TITLE
Rename: Update more internal WP versions

### DIFF
--- a/src/wp-admin/admin-functions.php
+++ b/src/wp-admin/admin-functions.php
@@ -9,7 +9,7 @@
  * @subpackage Administration
  */
 
-_deprecated_file( basename(__FILE__), '2.5.0', 'wp-admin/includes/admin.php' );
+_deprecated_file( basename(__FILE__), 'WP-2.5.0', 'wp-admin/includes/admin.php' );
 
 /** ClassicPress Administration API: Includes all Administration functions. */
 require_once(ABSPATH . 'wp-admin/includes/admin.php');

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -446,7 +446,7 @@ class WP_Community_Events {
 	 *                        log entry.
 	 */
 	protected function maybe_log_events_response( $message, $details ) {
-		_deprecated_function( __METHOD__, '4.9.0' );
+		_deprecated_function( __METHOD__, 'WP-4.9.0' );
 
 		if ( ! WP_DEBUG_LOG ) {
 			return;

--- a/src/wp-admin/includes/class-wp-filesystem-base.php
+++ b/src/wp-admin/includes/class-wp-filesystem-base.php
@@ -128,7 +128,7 @@ class WP_Filesystem_Base {
 	 * @return string The location of the remote path.
 	 */
 	public function find_base_dir( $base = '.', $echo = false ) {
-		_deprecated_function(__FUNCTION__, '2.7.0', 'WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir()' );
+		_deprecated_function(__FUNCTION__, 'WP-2.7.0', 'WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir()' );
 		$this->verbose = $echo;
 		return $this->abspath();
 	}
@@ -149,7 +149,7 @@ class WP_Filesystem_Base {
 	 * @return string The location of the remote path.
 	 */
 	public function get_base_dir( $base = '.', $echo = false ) {
-		_deprecated_function(__FUNCTION__, '2.7.0', 'WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir()' );
+		_deprecated_function(__FUNCTION__, 'WP-2.7.0', 'WP_Filesystem::abspath() or WP_Filesystem::wp_*_dir()' );
 		$this->verbose = $echo;
 		return $this->abspath();
 	}

--- a/src/wp-admin/includes/class-wp-upgrader-skins.php
+++ b/src/wp-admin/includes/class-wp-upgrader-skins.php
@@ -7,7 +7,7 @@
  * @since WP-2.8.0
  */
 
-_deprecated_file( basename( __FILE__ ), '4.7.0', 'class-wp-upgrader.php' );
+_deprecated_file( basename( __FILE__ ), 'WP-4.7.0', 'class-wp-upgrader.php' );
 
 /** WP_Upgrader_Skin class */
 require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -18,7 +18,7 @@
  * @see wp_editor()
  */
 function tinymce_include() {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_editor()' );
 
 	wp_tiny_mce();
 }
@@ -31,7 +31,7 @@ function tinymce_include() {
  *
  */
 function documentation_link() {
-	_deprecated_function( __FUNCTION__, '2.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0' );
 }
 
 /**
@@ -48,7 +48,7 @@ function documentation_link() {
  * @return array Shrunk dimensions (width, height).
  */
 function wp_shrink_dimensions( $width, $height, $wmax = 128, $hmax = 96 ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_constrain_dimensions()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_constrain_dimensions()' );
 	return wp_constrain_dimensions( $width, $height, $wmax, $hmax );
 }
 
@@ -64,7 +64,7 @@ function wp_shrink_dimensions( $width, $height, $wmax = 128, $hmax = 96 ) {
  * @return array Shrunk dimensions (width, height).
  */
 function get_udims( $width, $height ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'wp_constrain_dimensions()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wp_constrain_dimensions()' );
 	return wp_constrain_dimensions( $width, $height, 128, 96 );
 }
 
@@ -80,7 +80,7 @@ function get_udims( $width, $height ) {
  * @param array $popular_ids Unused.
  */
 function dropdown_categories( $default = 0, $parent = 0, $popular_ids = array() ) {
-	_deprecated_function( __FUNCTION__, '2.6.0', 'wp_category_checklist()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.6.0', 'wp_category_checklist()' );
 	global $post_ID;
 	wp_category_checklist( $post_ID );
 }
@@ -95,7 +95,7 @@ function dropdown_categories( $default = 0, $parent = 0, $popular_ids = array() 
  * @param int $default Unused.
  */
 function dropdown_link_categories( $default = 0 ) {
-	_deprecated_function( __FUNCTION__, '2.6.0', 'wp_link_category_checklist()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.6.0', 'wp_link_category_checklist()' );
 	global $link_id;
 	wp_link_category_checklist( $link_id );
 }
@@ -111,7 +111,7 @@ function dropdown_link_categories( $default = 0 ) {
  * @return string Full filesystem path to edit.
  */
 function get_real_file_to_edit( $file ) {
-	_deprecated_function( __FUNCTION__, '2.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0' );
 
 	return WP_CONTENT_DIR . $file;
 }
@@ -131,7 +131,7 @@ function get_real_file_to_edit( $file ) {
  * @return bool|null False if no categories were found.
  */
 function wp_dropdown_cats( $currentcat = 0, $currentparent = 0, $parent = 0, $level = 0, $categories = 0 ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_dropdown_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_dropdown_categories()' );
 	if (!$categories )
 		$categories = get_categories( array('hide_empty' => 0) );
 
@@ -165,7 +165,7 @@ function wp_dropdown_cats( $currentcat = 0, $currentparent = 0, $parent = 0, $le
  * @param callable $sanitize_callback A callback function that sanitizes the option's value.
  */
 function add_option_update_handler( $option_group, $option_name, $sanitize_callback = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'register_setting()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'register_setting()' );
 	register_setting( $option_group, $option_name, $sanitize_callback );
 }
 
@@ -181,7 +181,7 @@ function add_option_update_handler( $option_group, $option_name, $sanitize_callb
  * @param callable $sanitize_callback
  */
 function remove_option_update_handler( $option_group, $option_name, $sanitize_callback = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'unregister_setting()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'unregister_setting()' );
 	unregister_setting( $option_group, $option_name, $sanitize_callback );
 }
 
@@ -194,7 +194,7 @@ function remove_option_update_handler( $option_group, $option_name, $sanitize_ca
  * @param string $filename
 **/
 function codepress_get_lang( $filename ) {
-	_deprecated_function( __FUNCTION__, '3.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0' );
 }
 
 /**
@@ -204,7 +204,7 @@ function codepress_get_lang( $filename ) {
  * @deprecated 3.0.0
 **/
 function codepress_footer_js() {
-	_deprecated_function( __FUNCTION__, '3.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0' );
 }
 
 /**
@@ -214,7 +214,7 @@ function codepress_footer_js() {
  * @deprecated 3.0.0
 **/
 function use_codepress() {
-	_deprecated_function( __FUNCTION__, '3.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0' );
 }
 
 /**
@@ -227,7 +227,7 @@ function use_codepress() {
  * @return array List of user IDs.
  */
 function get_author_user_ids() {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_users()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_users()' );
 
 	global $wpdb;
 	if ( !is_multisite() )
@@ -249,7 +249,7 @@ function get_author_user_ids() {
  * @return array|bool List of editable authors. False if no editable users.
  */
 function get_editable_authors( $user_id ) {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_users()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_users()' );
 
 	global $wpdb;
 
@@ -277,7 +277,7 @@ function get_editable_authors( $user_id ) {
  * @return array Array of editable user IDs, empty array otherwise.
  */
 function get_editable_user_ids( $user_id, $exclude_zeros = true, $post_type = 'post' ) {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_users()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_users()' );
 
 	global $wpdb;
 
@@ -312,7 +312,7 @@ function get_editable_user_ids( $user_id, $exclude_zeros = true, $post_type = 'p
  * @global wpdb $wpdb ClassicPress database abstraction object.
  */
 function get_nonauthor_user_ids() {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_users()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_users()' );
 
 	global $wpdb;
 
@@ -488,7 +488,7 @@ class WP_User_Search {
 	 * @return WP_User_Search
 	 */
 	function __construct( $search_term = '', $page = '', $role = '' ) {
-		_deprecated_function( __FUNCTION__, '3.1.0', 'WP_User_Query' );
+		_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'WP_User_Query' );
 
 		$this->search_term = wp_unslash( $search_term );
 		$this->raw_page = ( '' == $page ) ? false : (int) $page;
@@ -680,7 +680,7 @@ endif;
  * @return array List of posts from others.
  */
 function get_others_unpublished_posts( $user_id, $type = 'any' ) {
-	_deprecated_function( __FUNCTION__, '3.1.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0' );
 
 	global $wpdb;
 
@@ -713,7 +713,7 @@ function get_others_unpublished_posts( $user_id, $type = 'any' ) {
  * @return array List of drafts from other users.
  */
 function get_others_drafts($user_id) {
-	_deprecated_function( __FUNCTION__, '3.1.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0' );
 
 	return get_others_unpublished_posts($user_id, 'draft');
 }
@@ -728,7 +728,7 @@ function get_others_drafts($user_id) {
  * @return array List of posts with pending review post type from other users.
  */
 function get_others_pending($user_id) {
-	_deprecated_function( __FUNCTION__, '3.1.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0' );
 
 	return get_others_unpublished_posts($user_id, 'pending');
 }
@@ -741,7 +741,7 @@ function get_others_pending($user_id) {
  * @see wp_dashboard_quick_press()
  */
 function wp_dashboard_quick_press_output() {
-	_deprecated_function( __FUNCTION__, '3.2.0', 'wp_dashboard_quick_press()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.2.0', 'wp_dashboard_quick_press()' );
 	wp_dashboard_quick_press();
 }
 
@@ -755,7 +755,7 @@ function wp_dashboard_quick_press_output() {
  * @staticvar int $num
  */
 function wp_tiny_mce( $teeny = false, $settings = false ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_editor()' );
 
 	static $num = 1;
 
@@ -781,7 +781,7 @@ function wp_tiny_mce( $teeny = false, $settings = false ) {
  * @see wp_editor()
  */
 function wp_preload_dialogs() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_editor()' );
 }
 
 /**
@@ -791,7 +791,7 @@ function wp_preload_dialogs() {
  * @see wp_editor()
  */
 function wp_print_editor_js() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_editor()' );
 }
 
 /**
@@ -801,7 +801,7 @@ function wp_print_editor_js() {
  * @see wp_editor()
  */
 function wp_quicktags() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_editor()' );
 }
 
 /**
@@ -812,7 +812,7 @@ function wp_quicktags() {
  * @see WP_Screen::render_screen_layout()
  */
 function screen_layout( $screen ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', '$current_screen->render_screen_layout()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', '$current_screen->render_screen_layout()' );
 
 	$current_screen = get_current_screen();
 
@@ -832,7 +832,7 @@ function screen_layout( $screen ) {
  * @see WP_Screen::render_per_page_options()
  */
 function screen_options( $screen ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', '$current_screen->render_per_page_options()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', '$current_screen->render_per_page_options()' );
 
 	$current_screen = get_current_screen();
 
@@ -864,7 +864,7 @@ function screen_meta( $screen ) {
  * @see WP_Admin_Bar
  */
 function favorite_actions() {
-	_deprecated_function( __FUNCTION__, '3.2.0', 'WP_Admin_Bar' );
+	_deprecated_function( __FUNCTION__, 'WP-3.2.0', 'WP_Admin_Bar' );
 }
 
 /**
@@ -876,7 +876,7 @@ function favorite_actions() {
  * @return null|string
  */
 function media_upload_image() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_media_upload_handler()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_media_upload_handler()' );
 	return wp_media_upload_handler();
 }
 
@@ -889,7 +889,7 @@ function media_upload_image() {
  * @return null|string
  */
 function media_upload_audio() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_media_upload_handler()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_media_upload_handler()' );
 	return wp_media_upload_handler();
 }
 
@@ -902,7 +902,7 @@ function media_upload_audio() {
  * @return null|string
  */
 function media_upload_video() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_media_upload_handler()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_media_upload_handler()' );
 	return wp_media_upload_handler();
 }
 
@@ -915,7 +915,7 @@ function media_upload_video() {
  * @return null|string
  */
 function media_upload_file() {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_media_upload_handler()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_media_upload_handler()' );
 	return wp_media_upload_handler();
 }
 
@@ -928,7 +928,7 @@ function media_upload_file() {
  * @return string
  */
 function type_url_form_image() {
-	_deprecated_function( __FUNCTION__, '3.3.0', "wp_media_insert_url_form('image')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "wp_media_insert_url_form('image')" );
 	return wp_media_insert_url_form( 'image' );
 }
 
@@ -941,7 +941,7 @@ function type_url_form_image() {
  * @return string
  */
 function type_url_form_audio() {
-	_deprecated_function( __FUNCTION__, '3.3.0', "wp_media_insert_url_form('audio')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "wp_media_insert_url_form('audio')" );
 	return wp_media_insert_url_form( 'audio' );
 }
 
@@ -954,7 +954,7 @@ function type_url_form_audio() {
  * @return string
  */
 function type_url_form_video() {
-	_deprecated_function( __FUNCTION__, '3.3.0', "wp_media_insert_url_form('video')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "wp_media_insert_url_form('video')" );
 	return wp_media_insert_url_form( 'video' );
 }
 
@@ -967,7 +967,7 @@ function type_url_form_video() {
  * @return string
  */
 function type_url_form_file() {
-	_deprecated_function( __FUNCTION__, '3.3.0', "wp_media_insert_url_form('file')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "wp_media_insert_url_form('file')" );
 	return wp_media_insert_url_form( 'file' );
 }
 
@@ -984,7 +984,7 @@ function type_url_form_file() {
  * @param string    $help   The content of an 'Overview' help tab.
  */
 function add_contextual_help( $screen, $help ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'get_current_screen()->add_help_tab()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'get_current_screen()->add_help_tab()' );
 
 	if ( is_string( $screen ) )
 		$screen = convert_to_screen( $screen );
@@ -1002,7 +1002,7 @@ function add_contextual_help( $screen, $help ) {
  * @return array $themes Array of allowed themes.
  */
 function get_allowed_themes() {
-	_deprecated_function( __FUNCTION__, '3.4.0', "wp_get_themes( array( 'allowed' => true ) )" );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', "wp_get_themes( array( 'allowed' => true ) )" );
 
 	$themes = wp_get_themes( array( 'allowed' => true ) );
 
@@ -1024,7 +1024,7 @@ function get_allowed_themes() {
  * @return array
  */
 function get_broken_themes() {
-	_deprecated_function( __FUNCTION__, '3.4.0', "wp_get_themes( array( 'errors' => true )" );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', "wp_get_themes( array( 'errors' => true )" );
 
 	$themes = wp_get_themes( array( 'errors' => true ) );
 	$broken = array();
@@ -1049,7 +1049,7 @@ function get_broken_themes() {
  * @return WP_Theme
  */
 function current_theme_info() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'wp_get_theme()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'wp_get_theme()' );
 
 	return wp_get_theme();
 }
@@ -1062,7 +1062,7 @@ function current_theme_info() {
  * @deprecated 3.5.0
  */
 function _insert_into_post_button( $type ) {
-	_deprecated_function( __FUNCTION__, '3.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0' );
 }
 
 /**
@@ -1073,7 +1073,7 @@ function _insert_into_post_button( $type ) {
  * @deprecated 3.5.0
  */
 function _media_button($title, $icon, $type, $id) {
-	_deprecated_function( __FUNCTION__, '3.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0' );
 }
 
 /**
@@ -1087,7 +1087,7 @@ function _media_button($title, $icon, $type, $id) {
  * @return object
  */
 function get_post_to_edit( $id ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'get_post()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'get_post()' );
 
 	return get_post( $id, OBJECT, 'edit' );
 }
@@ -1102,7 +1102,7 @@ function get_post_to_edit( $id ) {
  * @return WP_Post Post object containing all the default post data as attributes
  */
 function get_default_page_to_edit() {
-	_deprecated_function( __FUNCTION__, '3.5.0', "get_default_post_to_edit( 'page' )" );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', "get_default_post_to_edit( 'page' )" );
 
 	$page = get_default_post_to_edit();
 	$page->post_type = 'page';
@@ -1122,7 +1122,7 @@ function get_default_page_to_edit() {
  * @return string Thumbnail path on success, Error string on failure.
  */
 function wp_create_thumbnail( $file, $max_side, $deprecated = '' ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'image_resize()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'image_resize()' );
 	return apply_filters( 'wp_create_thumbnail', image_resize( $file, $max_side, $max_side ) );
 }
 
@@ -1135,7 +1135,7 @@ function wp_create_thumbnail( $file, $max_side, $deprecated = '' ) {
  * @deprecated 3.6.0
  */
 function wp_nav_menu_locations_meta_box() {
-	_deprecated_function( __FUNCTION__, '3.6.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.6.0' );
 }
 
 /**
@@ -1149,7 +1149,7 @@ function wp_nav_menu_locations_meta_box() {
  * @see Core_Upgrader
  */
 function wp_update_core($current, $feedback = '') {
-	_deprecated_function( __FUNCTION__, '3.7.0', 'new Core_Upgrader();' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0', 'new Core_Upgrader();' );
 
 	if ( !empty($feedback) )
 		add_filter('update_feedback', $feedback);
@@ -1172,7 +1172,7 @@ function wp_update_core($current, $feedback = '') {
  * @see Plugin_Upgrader
  */
 function wp_update_plugin($plugin, $feedback = '') {
-	_deprecated_function( __FUNCTION__, '3.7.0', 'new Plugin_Upgrader();' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0', 'new Plugin_Upgrader();' );
 
 	if ( !empty($feedback) )
 		add_filter('update_feedback', $feedback);
@@ -1194,7 +1194,7 @@ function wp_update_plugin($plugin, $feedback = '') {
  * @see Theme_Upgrader
  */
 function wp_update_theme($theme, $feedback = '') {
-	_deprecated_function( __FUNCTION__, '3.7.0', 'new Theme_Upgrader();' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0', 'new Theme_Upgrader();' );
 
 	if ( !empty($feedback) )
 		add_filter('update_feedback', $feedback);
@@ -1213,7 +1213,7 @@ function wp_update_theme($theme, $feedback = '') {
  * @param int|bool $id
  */
 function the_attachment_links( $id = false ) {
-	_deprecated_function( __FUNCTION__, '3.7.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0' );
 }
 
 /**
@@ -1223,7 +1223,7 @@ function the_attachment_links( $id = false ) {
  * @deprecated 3.8.0
  */
 function screen_icon() {
-	_deprecated_function( __FUNCTION__, '3.8.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.8.0' );
 	echo get_screen_icon();
 }
 
@@ -1236,7 +1236,7 @@ function screen_icon() {
  * @return string An HTML comment explaining that icons are no longer used.
  */
 function get_screen_icon() {
-	_deprecated_function( __FUNCTION__, '3.8.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.8.0' );
 	return '<!-- Screen icons are no longer used as of WordPress 3.8. -->';
 }
 
@@ -1315,7 +1315,7 @@ function wp_dashboard_secondary_control() {}
  * @param array  $args Array of arguments for this RSS feed.
  */
 function wp_dashboard_plugins_output( $rss, $args = array() ) {
-	_deprecated_function( __FUNCTION__, '4.8.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.8.0' );
 
 	// Plugin feeds plus link to install them
 	$popular = fetch_feed( $args['url']['popular'] );
@@ -1398,7 +1398,7 @@ function wp_dashboard_plugins_output( $rss, $args = array() ) {
  * @param int $new_ID
  */
 function _relocate_children( $old_ID, $new_ID ) {
-	_deprecated_function( __FUNCTION__, '3.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.9.0' );
 }
 
 /**
@@ -1425,7 +1425,7 @@ function _relocate_children( $old_ID, $new_ID ) {
  * @return string The resulting page's hook_suffix.
  */
 function add_object_page( $page_title, $menu_title, $capability, $menu_slug, $function = '', $icon_url = '') {
-	_deprecated_function( __FUNCTION__, '4.5.0', 'add_menu_page()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0', 'add_menu_page()' );
 
 	global $_wp_last_object_menu;
 
@@ -1458,7 +1458,7 @@ function add_object_page( $page_title, $menu_title, $capability, $menu_slug, $fu
  * @return string The resulting page's hook_suffix.
  */
 function add_utility_page( $page_title, $menu_title, $capability, $menu_slug, $function = '', $icon_url = '') {
-	_deprecated_function( __FUNCTION__, '4.5.0', 'add_menu_page()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0', 'add_menu_page()' );
 
 	global $_wp_last_utility_menu;
 
@@ -1485,7 +1485,7 @@ function add_utility_page( $page_title, $menu_title, $capability, $menu_slug, $f
 function post_form_autocomplete_off() {
 	global $is_safari, $is_chrome;
 
-	_deprecated_function( __FUNCTION__, '4.6.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.6.0' );
 
 	if ( $is_safari || $is_chrome ) {
 		echo ' autocomplete="off"';

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -255,7 +255,7 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
 
 		return true;
 	} else {
-		_deprecated_argument( __FUNCTION__, '3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
 
 		/**
 		 * Filters the GD image resource to be streamed to the browser.
@@ -320,7 +320,7 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 
 		return $image->save( $filename, $mime_type );
 	} else {
-		_deprecated_argument( __FUNCTION__, '3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
 
 		/** This filter is documented in wp-admin/includes/image-edit.php */
 		$image = apply_filters( 'image_save_pre', $image, $post_id );
@@ -388,7 +388,7 @@ function _image_get_preview_ratio($w, $h) {
  * @return resource|false GD image resource, false otherwise.
  */
 function _rotate_image_resource($img, $angle) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'WP_Image_Editor::rotate()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'WP_Image_Editor::rotate()' );
 	if ( function_exists('imagerotate') ) {
 		$rotated = imagerotate($img, $angle, 0);
 		if ( is_resource($rotated) ) {
@@ -413,7 +413,7 @@ function _rotate_image_resource($img, $angle) {
  * @return resource (maybe) flipped image resource.
  */
 function _flip_image_resource($img, $horz, $vert) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'WP_Image_Editor::flip()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'WP_Image_Editor::flip()' );
 	$w = imagesx($img);
 	$h = imagesy($img);
 	$dst = wp_imagecreatetruecolor($w, $h);
@@ -466,7 +466,7 @@ function _crop_image_resource($img, $x, $y, $w, $h) {
  */
 function image_edit_apply_changes( $image, $changes ) {
 	if ( is_resource( $image ) )
-		_deprecated_argument( __FUNCTION__, '3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0', __( '$image needs to be an WP_Image_Editor object' ) );
 
 	if ( !is_array($changes) )
 		return $image;

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1070,7 +1070,7 @@ function xfn_check( $class, $value = '', $deprecated = '' ) {
 	global $link;
 
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.5.0' ); // Never implemented
+		_deprecated_argument( __FUNCTION__, 'WP-2.5.0' ); // Never implemented
 	}
 
 	$link_rel = isset( $link->link_rel ) ? $link->link_rel : ''; // In PHP 5.3: $link_rel = $link->link_rel ?: '';

--- a/src/wp-admin/includes/ms-deprecated.php
+++ b/src/wp-admin/includes/ms-deprecated.php
@@ -16,7 +16,7 @@
  * @deprecated 3.0.0
  */
 function wpmu_menu() {
-	_deprecated_function(__FUNCTION__, '3.0.0' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0' );
 	// Deprecated. See #11763.
 }
 
@@ -27,7 +27,7 @@ function wpmu_menu() {
  * @see is_upload_space_available()
  */
 function wpmu_checkAvailableSpace() {
-	_deprecated_function(__FUNCTION__, '3.0.0', 'is_upload_space_available()' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0', 'is_upload_space_available()' );
 
 	if ( !is_upload_space_available() )
 		wp_die( __('Sorry, you must delete files before you can upload any more.') );
@@ -39,7 +39,7 @@ function wpmu_checkAvailableSpace() {
  * @deprecated 3.0.0
  */
 function mu_options( $options ) {
-	_deprecated_function(__FUNCTION__, '3.0.0' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0' );
 	return $options;
 }
 
@@ -50,7 +50,7 @@ function mu_options( $options ) {
  * @see activate_plugin()
  */
 function activate_sitewide_plugin() {
-	_deprecated_function(__FUNCTION__, '3.0.0', 'activate_plugin()' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0', 'activate_plugin()' );
 	return false;
 }
 
@@ -61,7 +61,7 @@ function activate_sitewide_plugin() {
  * @see deactivate_plugin()
  */
 function deactivate_sitewide_plugin( $plugin = false ) {
-	_deprecated_function(__FUNCTION__, '3.0.0', 'deactivate_plugin()' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0', 'deactivate_plugin()' );
 }
 
 /**
@@ -71,7 +71,7 @@ function deactivate_sitewide_plugin( $plugin = false ) {
  * @see is_network_only_plugin()
  */
 function is_wpmu_sitewide_plugin( $file ) {
-	_deprecated_function(__FUNCTION__, '3.0.0', 'is_network_only_plugin()' );
+	_deprecated_function(__FUNCTION__, 'WP-3.0.0', 'is_network_only_plugin()' );
 	return is_network_only_plugin( $file );
 }
 
@@ -82,7 +82,7 @@ function is_wpmu_sitewide_plugin( $file ) {
  * @see WP_Theme::get_allowed_on_network()
  */
 function get_site_allowed_themes() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'WP_Theme::get_allowed_on_network()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'WP_Theme::get_allowed_on_network()' );
 	return array_map( 'intval', WP_Theme::get_allowed_on_network() );
 }
 
@@ -93,7 +93,7 @@ function get_site_allowed_themes() {
  * @see WP_Theme::get_allowed_on_site()
  */
 function wpmu_get_blog_allowedthemes( $blog_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'WP_Theme::get_allowed_on_site()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'WP_Theme::get_allowed_on_site()' );
 	return array_map( 'intval', WP_Theme::get_allowed_on_site( $blog_id ) );
 }
 

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -382,7 +382,7 @@ function update_user_status( $id, $pref, $value, $deprecated = null ) {
 	global $wpdb;
 
 	if ( null !== $deprecated )
-		_deprecated_argument( __FUNCTION__, '3.0.2' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.2' );
 
 	$wpdb->update( $wpdb->users, array( sanitize_key( $pref ) => $value ), array( 'ID' => $id ) );
 

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -86,7 +86,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 	// Site Wide Only is the old header for Network
 	if ( ! $plugin_data['Network'] && $plugin_data['_sitewide'] ) {
 		/* translators: 1: Site Wide Only: true, 2: Network: true */
-		_deprecated_argument( __FUNCTION__, '3.0.0', sprintf( __( 'The %1$s plugin header is deprecated. Use %2$s instead.' ), '<code>Site Wide Only: true</code>', '<code>Network: true</code>' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0', sprintf( __( 'The %1$s plugin header is deprecated. Use %2$s instead.' ), '<code>Site Wide Only: true</code>', '<code>Network: true</code>' ) );
 		$plugin_data['Network'] = $plugin_data['_sitewide'];
 	}
 	$plugin_data['Network'] = ( 'true' == strtolower( $plugin_data['Network'] ) );

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1926,7 +1926,7 @@ function wp_add_privacy_policy_content( $plugin_name, $policy_text ) {
 				__( 'The suggested privacy policy content should be added only in wp-admin by using the %s (or later) action.' ),
 				'<code>admin_init</code>'
 			),
-			'4.9.7'
+			'WP-4.9.7'
 		);
 		return;
 	} elseif ( ! doing_action( 'admin_init' ) && ! did_action( 'admin_init' ) ) {
@@ -1937,7 +1937,7 @@ function wp_add_privacy_policy_content( $plugin_name, $policy_text ) {
 				__( 'The suggested privacy policy content should be added by using the %s (or later) action. Please see the inline documentation.' ),
 				'<code>admin_init</code>'
 			),
-			'4.9.7'
+			'WP-4.9.7'
 		);
 		return;
 	}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2091,7 +2091,7 @@ function convert_to_screen( $hook_name ) {
 				'<code>add_meta_box()</code>',
 				'<code>add_meta_boxes</code>'
 			),
-			'3.3.0'
+			'WP-3.3.0'
 		);
 		return (object) array( 'id' => '_invalid', 'base' => '_are_belong_to_us' );
 	}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1232,7 +1232,7 @@ function add_settings_section($id, $title, $callback, $page) {
 	global $wp_settings_sections;
 
 	if ( 'misc' == $page ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: %s: misc */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'misc'
@@ -1242,7 +1242,7 @@ function add_settings_section($id, $title, $callback, $page) {
 	}
 
 	if ( 'privacy' == $page ) {
-		_deprecated_argument( __FUNCTION__, '3.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0',
 			/* translators: %s: privacy */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'privacy'
@@ -1293,7 +1293,7 @@ function add_settings_field($id, $title, $callback, $page, $section = 'default',
 	global $wp_settings_fields;
 
 	if ( 'misc' == $page ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: %s: misc */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'misc'
@@ -1303,7 +1303,7 @@ function add_settings_field($id, $title, $callback, $page, $section = 'default',
 	}
 
 	if ( 'privacy' == $page ) {
-		_deprecated_argument( __FUNCTION__, '3.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0',
 			/* translators: %s: privacy */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'privacy'

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -29,7 +29,7 @@ $theme_field_defaults = array( 'description' => true, 'sections' => false, 'test
  * @return array
  */
 function install_themes_feature_list() {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_theme_feature_list()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_theme_feature_list()' );
 
 	if ( !$cache = get_transient( 'wporg_theme_feature_list' ) )
 		set_transient( 'wporg_theme_feature_list', array(), 3 * HOUR_IN_SECONDS );
@@ -160,7 +160,7 @@ function install_themes_upload() {
  * @param object $theme
  */
 function display_theme( $theme ) {
-	_deprecated_function( __FUNCTION__, '3.4.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0' );
 	global $wp_list_table;
 	if ( ! isset( $wp_list_table ) ) {
 		$wp_list_table = _get_list_table('WP_Theme_Install_List_Table');

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -38,7 +38,7 @@ if ( !function_exists('wp_install') ) :
  */
 function wp_install( $blog_title, $user_name, $user_email, $public, $deprecated = '', $user_password = '', $language = '' ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.6.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.6.0' );
 
 	wp_check_mysql_version();
 	wp_cache_flush();

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -171,7 +171,7 @@ if ( ! empty( $languages ) || ! empty( $translations ) ) {
 					</p>
 					<?php
 				}
-				_deprecated_argument( 'define()', '4.0.0', sprintf( __( 'The %s constant in your %s file is no longer needed.' ), 'WPLANG', 'wp-config.php' ) );
+				_deprecated_argument( 'define()', 'WP-4.0.0', sprintf( __( 'The %s constant in your %s file is no longer needed.' ), 'WPLANG', 'wp-config.php' ) );
 			}
 			?>
 		</td>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -253,7 +253,7 @@ if ( 'update' == $action ) {
 
 		foreach ( $options as $option ) {
 			if ( $unregistered ) {
-				_deprecated_argument( 'options.php', '2.7.0',
+				_deprecated_argument( 'options.php', 'WP-2.7.0',
 					sprintf(
 						/* translators: %s: the option/setting */
 						__( 'The %s setting is unregistered. Unregistered settings are deprecated. See https://codex.wordpress.org/Settings_API' ),

--- a/src/wp-admin/upgrade-functions.php
+++ b/src/wp-admin/upgrade-functions.php
@@ -8,5 +8,5 @@
  * @subpackage Administration
  */
 
-_deprecated_file( basename(__FILE__), '2.5.0', 'wp-admin/includes/upgrade.php' );
+_deprecated_file( basename(__FILE__), 'WP-2.5.0', 'wp-admin/includes/upgrade.php' );
 require_once(ABSPATH . 'wp-admin/includes/upgrade.php');

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -24,7 +24,7 @@ function get_the_author($deprecated = '') {
 	global $authordata;
 
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.1.0' );
 
 	/**
 	 * Filters the display name of the current post's author.
@@ -57,11 +57,11 @@ function get_the_author($deprecated = '') {
  */
 function the_author( $deprecated = '', $deprecated_echo = true ) {
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.1.0' );
 	}
 
 	if ( true !== $deprecated_echo ) {
-		_deprecated_argument( __FUNCTION__, '1.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-1.5.0',
 			/* translators: %s: get_the_author() */
 			sprintf( __( 'Use %s instead if you do not want the value echoed.' ),
 				'<code>get_the_author()</code>'
@@ -315,7 +315,7 @@ function get_the_author_posts_link() {
  */
 function the_author_posts_link( $deprecated = '' ) {
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.1.0' );
 	}
 	echo get_the_author_posts_link();
 }

--- a/src/wp-includes/cache.php
+++ b/src/wp-includes/cache.php
@@ -264,7 +264,7 @@ function wp_cache_add_non_persistent_groups( $groups ) {
  * @global WP_Object_Cache $wp_object_cache Object cache global instance.
  */
 function wp_cache_reset() {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'WP_Object_Cache::reset()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'WP_Object_Cache::reset()' );
 
 	global $wp_object_cache;
 
@@ -610,7 +610,7 @@ class WP_Object_Cache {
 	 * @see switch_to_blog()
 	 */
 	public function reset() {
-		_deprecated_function( __FUNCTION__, '3.5.0', 'switch_to_blog()' );
+		_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'switch_to_blog()' );
 
 		// Clear out non-global caches since the blog ID has changed.
 		foreach ( array_keys( $this->cache ) as $group ) {

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -80,7 +80,7 @@ function map_meta_cap( $cap, $user_id ) {
 		$post_type = get_post_type_object( $post->post_type );
 		if ( ! $post_type ) {
 			/* translators: 1: post type, 2: capability name */
-			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), 'WP-4.4.0' );
 			$caps[] = 'edit_others_posts';
 			break;
 		}
@@ -150,7 +150,7 @@ function map_meta_cap( $cap, $user_id ) {
 		$post_type = get_post_type_object( $post->post_type );
 		if ( ! $post_type ) {
 			/* translators: 1: post type, 2: capability name */
-			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), 'WP-4.4.0' );
 			$caps[] = 'edit_others_posts';
 			break;
 		}
@@ -218,7 +218,7 @@ function map_meta_cap( $cap, $user_id ) {
 		$post_type = get_post_type_object( $post->post_type );
 		if ( ! $post_type ) {
 			/* translators: 1: post type, 2: capability name */
-			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), 'WP-4.4.0' );
 			$caps[] = 'edit_others_posts';
 			break;
 		}
@@ -255,7 +255,7 @@ function map_meta_cap( $cap, $user_id ) {
 		$post_type = get_post_type_object( $post->post_type );
 		if ( ! $post_type ) {
 			/* translators: 1: post type, 2: capability name */
-			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), 'WP-4.4.0' );
 			$caps[] = 'edit_others_posts';
 			break;
 		}

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -354,7 +354,7 @@ function map_meta_cap( $cap, $user_id ) {
 				 * @param string   $cap       Capability name.
 				 * @param string[] $caps      Array of the user's capabilities.
 				 */
-				$allowed = apply_filters_deprecated( "auth_{$object_type}_{$object_subtype}_meta_{$meta_key}", array( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ), '4.9.8', "auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}" );
+				$allowed = apply_filters_deprecated( "auth_{$object_type}_{$object_subtype}_meta_{$meta_key}", array( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ), 'WP-4.9.8', "auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}" );
 			}
 
 			if ( ! $allowed ) {

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -44,7 +44,7 @@ function get_category_link( $category ) {
 function get_category_parents( $id, $link = false, $separator = '/', $nicename = false, $deprecated = array() ) {
 
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '4.8.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-4.8.0' );
 	}
 
 	$format = $nicename ? 'slug' : 'name';
@@ -338,7 +338,7 @@ function wp_dropdown_categories( $args = '' ) {
 
 	// Back compat.
 	if ( isset( $args['type'] ) && 'link' == $args['type'] ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: 1: "type => link", 2: "taxonomy => link_category" */
 			sprintf( __( '%1$s is deprecated. Use %2$s instead.' ),
 				'<code>type => link</code>',

--- a/src/wp-includes/category.php
+++ b/src/wp-includes/category.php
@@ -41,7 +41,7 @@ function get_categories( $args = '' ) {
 
 	// Back compat
 	if ( isset($args['type']) && 'link' == $args['type'] ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: 1: "type => link", 2: "taxonomy => link_category" */
 			sprintf( __( '%1$s is deprecated. Use %2$s instead.' ),
 				'<code>type => link</code>',

--- a/src/wp-includes/class-feed.php
+++ b/src/wp-includes/class-feed.php
@@ -6,7 +6,7 @@
  * @subpackage Feed
  */
 
-_deprecated_file( basename( __FILE__ ), '4.7.0', 'fetch_feed()' );
+_deprecated_file( basename( __FILE__ ), 'WP-4.7.0', 'fetch_feed()' );
 
 if ( ! class_exists( 'SimplePie', false ) ) {
 	require_once( ABSPATH . WPINC . '/class-simplepie.php' );

--- a/src/wp-includes/class-http.php
+++ b/src/wp-includes/class-http.php
@@ -867,7 +867,7 @@ class WP_Http {
 	 *                    See parse_url()'s return values.
 	 */
 	protected static function parse_url( $url ) {
-		_deprecated_function( __METHOD__, '4.4.0', 'wp_parse_url()' );
+		_deprecated_function( __METHOD__, 'WP-4.4.0', 'wp_parse_url()' );
 		return wp_parse_url( $url );
 	}
 

--- a/src/wp-includes/class-snoopy.php
+++ b/src/wp-includes/class-snoopy.php
@@ -3,7 +3,7 @@
 /**
  * Deprecated. Use WP_HTTP (http.php) instead.
  */
-_deprecated_file( basename( __FILE__ ), '3.0.0', WPINC . '/http.php' );
+_deprecated_file( basename( __FILE__ ), 'WP-3.0.0', WPINC . '/http.php' );
 
 if ( ! class_exists( 'Snoopy', false ) ) :
 /*************************************************

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -27,7 +27,7 @@ class WP_Admin_Bar {
 				return is_ssl() ? 'https://' : 'http://';
 
 			case 'menu' :
-				_deprecated_argument( 'WP_Admin_Bar', '3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
+				_deprecated_argument( 'WP_Admin_Bar', 'WP-3.3.0', 'Modify admin bar nodes with WP_Admin_Bar::get_node(), WP_Admin_Bar::add_node(), and WP_Admin_Bar::remove_node(), not the <code>menu</code> property.' );
 				return array(); // Sorry, folks.
 		}
 	}
@@ -564,7 +564,7 @@ class WP_Admin_Bar {
 	 * @param object $node
 	 */
 	public function recursive_render( $id, $node ) {
-		_deprecated_function( __METHOD__, '3.3.0', 'WP_Admin_bar::render(), WP_Admin_Bar::_render_item()' );
+		_deprecated_function( __METHOD__, 'WP-3.3.0', 'WP_Admin_bar::render(), WP_Admin_Bar::_render_item()' );
 		$this->_render_item( $node );
 	}
 

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -125,7 +125,7 @@ class WP_Admin_Bar {
 			if ( empty( $args['title'] ) )
 				return;
 
-			_doing_it_wrong( __METHOD__, __( 'The menu ID should not be empty.' ), '3.3.0' );
+			_doing_it_wrong( __METHOD__, __( 'The menu ID should not be empty.' ), 'WP-3.3.0' );
 			// Deprecated: Generate an ID from the title.
 			$args['id'] = esc_attr( sanitize_title( trim( $args['title'] ) ) );
 		}

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -485,7 +485,7 @@ final class WP_Customize_Manager {
 	 * @return callable Die handler.
 	 */
 	public function wp_die_handler() {
-		_deprecated_function( __METHOD__, '4.7.0' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0' );
 
 		if ( $this->doing_ajax() || isset( $_POST['customized'] ) ) {
 			return '_ajax_wp_die_handler';
@@ -949,7 +949,7 @@ final class WP_Customize_Manager {
 	 * @return int
 	 */
 	public function wp_redirect_status( $status ) {
-		_deprecated_function( __FUNCTION__, '4.7.0' );
+		_deprecated_function( __FUNCTION__, 'WP-4.7.0' );
 
 		if ( $this->is_preview() && ! is_admin() ) {
 			return 200;
@@ -1938,7 +1938,7 @@ final class WP_Customize_Manager {
 	 * @deprecated 4.7.0
 	 */
 	public function customize_preview_override_404_status() {
-		_deprecated_function( __METHOD__, '4.7.0' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0' );
 	}
 
 	/**
@@ -1948,7 +1948,7 @@ final class WP_Customize_Manager {
 	 * @deprecated 4.7.0
 	 */
 	public function customize_preview_base() {
-		_deprecated_function( __METHOD__, '4.7.0' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0' );
 	}
 
 	/**
@@ -1958,7 +1958,7 @@ final class WP_Customize_Manager {
 	 * @deprecated 4.7.0 Customizer no longer supports IE8, so all supported browsers recognize HTML5.
 	 */
 	public function customize_preview_html5() {
-		_deprecated_function( __FUNCTION__, '4.7.0' );
+		_deprecated_function( __FUNCTION__, 'WP-4.7.0' );
 	}
 
 	/**
@@ -2151,7 +2151,7 @@ final class WP_Customize_Manager {
 	 * @deprecated 4.7.0
 	 */
 	public function customize_preview_signature() {
-		_deprecated_function( __METHOD__, '4.7.0' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0' );
 	}
 
 	/**
@@ -2164,7 +2164,7 @@ final class WP_Customize_Manager {
 	 * @return mixed Value passed through for {@see 'wp_die_handler'} filter.
 	 */
 	public function remove_preview_signature( $return = null ) {
-		_deprecated_function( __METHOD__, '4.7.0' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0' );
 
 		return $return;
 	}
@@ -4233,7 +4233,7 @@ final class WP_Customize_Manager {
 	 * @return int
 	 */
 	protected function _cmp_priority( $a, $b ) {
-		_deprecated_function( __METHOD__, '4.7.0', 'wp_list_sort' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0', 'wp_list_sort' );
 
 		if ( $a->priority === $b->priority ) {
 			return $a->instance_number - $b->instance_number;

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -3762,7 +3762,7 @@ final class WP_Customize_Manager {
 				'<a href="' . esc_url( 'https://developer.wordpress.org/reference/hooks/customize_loaded_components/' ) . '"><code>customize_loaded_components</code></a>'
 			);
 
-			_doing_it_wrong( __METHOD__, $message, '4.5.0' );
+			_doing_it_wrong( __METHOD__, $message, 'WP-4.5.0' );
 		}
 		unset( $this->panels[ $id ] );
 	}

--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -699,7 +699,7 @@ class WP_Customize_Setting {
 	 * @deprecated 4.4.0 Deprecated in favor of update() method.
 	 */
 	protected function _update_theme_mod() {
-		_deprecated_function( __METHOD__, '4.4.0', __CLASS__ . '::update()' );
+		_deprecated_function( __METHOD__, 'WP-4.4.0', __CLASS__ . '::update()' );
 	}
 
 	/**
@@ -709,7 +709,7 @@ class WP_Customize_Setting {
 	 * @deprecated 4.4.0 Deprecated in favor of update() method.
 	 */
 	protected function _update_option() {
-		_deprecated_function( __METHOD__, '4.4.0', __CLASS__ . '::update()' );
+		_deprecated_function( __METHOD__, 'WP-4.4.0', __CLASS__ . '::update()' );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -1988,7 +1988,7 @@ final class WP_Customize_Widgets {
 	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function setup_widget_addition_previews() {
-		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
+		_deprecated_function( __METHOD__, 'WP-4.2.0', 'customize_dynamic_setting_args' );
 	}
 
 	/**
@@ -2000,7 +2000,7 @@ final class WP_Customize_Widgets {
 	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function prepreview_added_sidebars_widgets() {
-		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
+		_deprecated_function( __METHOD__, 'WP-4.2.0', 'customize_dynamic_setting_args' );
 	}
 
 	/**
@@ -2012,7 +2012,7 @@ final class WP_Customize_Widgets {
 	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function prepreview_added_widget_instance() {
-		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
+		_deprecated_function( __METHOD__, 'WP-4.2.0', 'customize_dynamic_setting_args' );
 	}
 
 	/**
@@ -2024,6 +2024,6 @@ final class WP_Customize_Widgets {
 	 * @deprecated 4.2.0 Deprecated in favor of the {@see 'customize_dynamic_setting_args'} filter.
 	 */
 	public function remove_prepreview_filters() {
-		_deprecated_function( __METHOD__, '4.2.0', 'customize_dynamic_setting_args' );
+		_deprecated_function( __METHOD__, 'WP-4.2.0', 'customize_dynamic_setting_args' );
 	}
 }

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -103,7 +103,7 @@ final class _WP_Editors {
 		if ( self::$this_tinymce ) {
 			if ( false !== strpos( $editor_id, '[' ) ) {
 				self::$this_tinymce = false;
-				_deprecated_argument( 'wp_editor()', '3.9.0', 'TinyMCE editor IDs cannot have brackets.' );
+				_deprecated_argument( 'wp_editor()', 'WP-3.9.0', 'TinyMCE editor IDs cannot have brackets.' );
 			}
 		}
 
@@ -279,10 +279,10 @@ final class _WP_Editors {
 		// Back-compat for the `htmledit_pre` and `richedit_pre` filters
 		if ( 'html' === $default_editor && has_filter( 'htmledit_pre' ) ) {
 			/** This filter is documented in wp-includes/deprecated.php */
-			$content = apply_filters_deprecated( 'htmledit_pre', array( $content ), '4.3.0', 'format_for_editor' );
+			$content = apply_filters_deprecated( 'htmledit_pre', array( $content ), 'WP-4.3.0', 'format_for_editor' );
 		} elseif ( 'tinymce' === $default_editor && has_filter( 'richedit_pre' ) ) {
 			/** This filter is documented in wp-includes/deprecated.php */
-			$content = apply_filters_deprecated( 'richedit_pre', array( $content ), '4.3.0', 'format_for_editor' );
+			$content = apply_filters_deprecated( 'richedit_pre', array( $content ), 'WP-4.3.0', 'format_for_editor' );
 		}
 
 		if ( false !== stripos( $content, 'textarea' ) ) {
@@ -1584,7 +1584,7 @@ final class _WP_Editors {
 	 * @static
 	 */
 	public static function wp_fullscreen_html() {
-		_deprecated_function( __FUNCTION__, '4.3.0' );
+		_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1664,7 +1664,7 @@ class WP_Query {
 		$page = 1;
 
 		if ( isset( $q['caller_get_posts'] ) ) {
-			_deprecated_argument( 'WP_Query', '3.1.0',
+			_deprecated_argument( 'WP_Query', 'WP-3.1.0',
 				/* translators: 1: caller_get_posts, 2: ignore_sticky_posts */
 				sprintf( __( '%1$s is deprecated. Use %2$s instead.' ),
 					'<code>caller_get_posts</code>',
@@ -3596,7 +3596,7 @@ class WP_Query {
 	 * @return bool
 	 */
 	public function is_comments_popup() {
-		_deprecated_function( __FUNCTION__, '4.5.0' );
+		_deprecated_function( __FUNCTION__, 'WP-4.5.0' );
 
 		return false;
 	}
@@ -4073,7 +4073,7 @@ class WP_Query {
 	 * @return mixed
 	 */
 	public function lazyload_term_meta( $check, $term_id ) {
-		_deprecated_function( __METHOD__, '4.5.0' );
+		_deprecated_function( __METHOD__, 'WP-4.5.0' );
 		return $check;
 	}
 
@@ -4088,7 +4088,7 @@ class WP_Query {
 	 * @return mixed
 	 */
 	public function lazyload_comment_meta( $check, $comment_id ) {
-		_deprecated_function( __METHOD__, '4.5.0' );
+		_deprecated_function( __METHOD__, 'WP-4.5.0' );
 		return $check;
 	}
 }

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -117,7 +117,7 @@ class WP_Roles {
 	 * @deprecated 4.9.0 Use WP_Roles::for_site()
 	 */
 	protected function _init() {
-		_deprecated_function( __METHOD__, '4.9.0', 'WP_Roles::for_site()' );
+		_deprecated_function( __METHOD__, 'WP-4.9.0', 'WP_Roles::for_site()' );
 
 		$this->for_site();
 	}
@@ -132,7 +132,7 @@ class WP_Roles {
 	 * @deprecated 4.7.0 Use WP_Roles::for_site()
 	 */
 	public function reinit() {
-		_deprecated_function( __METHOD__, '4.7.0', 'WP_Roles::for_site()' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0', 'WP_Roles::for_site()' );
 
 		$this->for_site();
 	}

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -331,7 +331,7 @@ final class WP_Site {
 		}
 
 		/** This filter is documented in wp-includes/ms-blogs.php */
-		$details = apply_filters_deprecated( 'blog_details', array( $details ), '4.7.0', 'site_details' );
+		$details = apply_filters_deprecated( 'blog_details', array( $details ), 'WP-4.7.0', 'site_details' );
 
 		/**
 		 * Filters a site's extended properties.

--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -258,7 +258,7 @@ class WP_User {
 	 */
 	public function __isset( $key ) {
 		if ( 'id' == $key ) {
-			_deprecated_argument( 'WP_User->id', '2.1.0',
+			_deprecated_argument( 'WP_User->id', 'WP-2.1.0',
 				sprintf(
 					/* translators: %s: WP_User->ID */
 					__( 'Use %s instead.' ),
@@ -287,7 +287,7 @@ class WP_User {
 	 */
 	public function __get( $key ) {
 		if ( 'id' == $key ) {
-			_deprecated_argument( 'WP_User->id', '2.1.0',
+			_deprecated_argument( 'WP_User->id', 'WP-2.1.0',
 				sprintf(
 					/* translators: %s: WP_User->ID */
 					__( 'Use %s instead.' ),
@@ -325,7 +325,7 @@ class WP_User {
 	 */
 	public function __set( $key, $value ) {
 		if ( 'id' == $key ) {
-			_deprecated_argument( 'WP_User->id', '2.1.0',
+			_deprecated_argument( 'WP_User->id', 'WP-2.1.0',
 				sprintf(
 					/* translators: %s: WP_User->ID */
 					__( 'Use %s instead.' ),
@@ -348,7 +348,7 @@ class WP_User {
 	 */
 	public function __unset( $key ) {
 		if ( 'id' == $key ) {
-			_deprecated_argument( 'WP_User->id', '2.1.0',
+			_deprecated_argument( 'WP_User->id', 'WP-2.1.0',
 				sprintf(
 					/* translators: %s: WP_User->ID */
 					__( 'Use %s instead.' ),
@@ -450,7 +450,7 @@ class WP_User {
 	protected function _init_caps( $cap_key = '' ) {
 		global $wpdb;
 
-		_deprecated_function( __METHOD__, '4.9.0', 'WP_User::for_site()' );
+		_deprecated_function( __METHOD__, 'WP-4.9.0', 'WP_User::for_site()' );
 
 		if ( empty( $cap_key ) ) {
 			$this->cap_key = $wpdb->get_blog_prefix( $this->site_id ) . 'capabilities';
@@ -713,7 +713,7 @@ class WP_User {
 	 */
 	public function has_cap( $cap ) {
 		if ( is_numeric( $cap ) ) {
-			_deprecated_argument( __FUNCTION__, '2.0.0', __( 'Usage of user levels is deprecated. Use capabilities instead.' ) );
+			_deprecated_argument( __FUNCTION__, 'WP-2.0.0', __( 'Usage of user levels is deprecated. Use capabilities instead.' ) );
 			$cap = $this->translate_level_to_cap( $cap );
 		}
 
@@ -781,7 +781,7 @@ class WP_User {
 	 * @param int $blog_id Optional. Site ID, defaults to current site.
 	 */
 	public function for_blog( $blog_id = '' ) {
-		_deprecated_function( __METHOD__, '4.9.0', 'WP_User::for_site()' );
+		_deprecated_function( __METHOD__, 'WP-4.9.0', 'WP_User::for_site()' );
 
 		$this->for_site( $blog_id );
 	}

--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -38,7 +38,7 @@ class WP_Widget_Factory {
 	 * @since WP-2.8.0
 	 */
 	public function WP_Widget_Factory() {
-		_deprecated_constructor( 'WP_Widget_Factory', '4.2.0' );
+		_deprecated_constructor( 'WP_Widget_Factory', 'WP-4.2.0' );
 		self::__construct();
 	}
 

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -183,7 +183,7 @@ class WP_Widget {
 	 *                                information on accepted arguments. Default empty array.
 	 */
 	public function WP_Widget( $id_base, $name, $widget_options = array(), $control_options = array() ) {
-		_deprecated_constructor( 'WP_Widget', '4.3.0', get_class( $this ) );
+		_deprecated_constructor( 'WP_Widget', 'WP-4.3.0', get_class( $this ) );
 		WP_Widget::__construct( $id_base, $name, $widget_options, $control_options );
 	}
 

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -181,7 +181,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * @return bool|string|void Void if no data exists, extra scripts if `$echo` is true, true otherwise.
 	 */
 	public function print_scripts_l10n( $handle, $echo = true ) {
-		_deprecated_function( __FUNCTION__, '3.3.0', 'WP_Scripts::print_extra_script()' );
+		_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'WP_Scripts::print_extra_script()' );
 		return $this->print_extra_script( $handle, $echo );
 	}
 

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -823,9 +823,9 @@ function get_comments_link( $post_id = 0 ) {
  */
 function comments_link( $deprecated = '', $deprecated_2 = '' ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '0.72' );
+		_deprecated_argument( __FUNCTION__, 'WP-0.72' );
 	if ( !empty( $deprecated_2 ) )
-		_deprecated_argument( __FUNCTION__, '1.3.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-1.3.0' );
 	echo esc_url( get_comments_link() );
 }
 
@@ -871,7 +871,7 @@ function get_comments_number( $post_id = 0 ) {
  */
 function comments_number( $zero = false, $one = false, $more = false, $deprecated = '' ) {
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '1.3.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-1.3.0' );
 	}
 	echo get_comments_number_text( $zero, $one, $more );
 }
@@ -1133,7 +1133,7 @@ function get_trackback_url() {
  */
 function trackback_url( $deprecated_echo = true ) {
 	if ( true !== $deprecated_echo ) {
-		_deprecated_argument( __FUNCTION__, '2.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-2.5.0',
 			/* translators: %s: get_trackback_url() */
 			sprintf( __( 'Use %s instead if you do not want the value echoed.' ),
 				'<code>get_trackback_url()</code>'
@@ -1159,7 +1159,7 @@ function trackback_url( $deprecated_echo = true ) {
  */
 function trackback_rdf( $deprecated = '' ) {
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.5.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.5.0' );
 	}
 
 	if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && false !== stripos( $_SERVER['HTTP_USER_AGENT'], 'W3C_Validator' ) ) {

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2428,7 +2428,7 @@ function wp_update_comment_count_now($post_id) {
  */
 function discover_pingback_server_uri( $url, $deprecated = '' ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.7.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.7.0' );
 
 	$pingback_str_dquote = 'rel="pingback"';
 	$pingback_str_squote = 'rel=\'pingback\'';

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -202,7 +202,7 @@ function wp_clear_scheduled_hook( $hook, $args = array() ) {
 	// Backward compatibility
 	// Previously this function took the arguments as discrete vars rather than an array like the rest of the API
 	if ( !is_array($args) ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0', __('This argument has changed to an array to match the behavior of the other cron functions.') );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0', __('This argument has changed to an array to match the behavior of the other cron functions.') );
 		$args = array_slice( func_get_args(), 1 );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-image-control.php
+++ b/src/wp-includes/customize/class-wp-customize-image-control.php
@@ -33,7 +33,7 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 	 * @param mixed $callback
 	 */
 	public function add_tab( $id, $label, $callback ) {
-		_deprecated_function( __METHOD__, '4.1.0' );
+		_deprecated_function( __METHOD__, 'WP-4.1.0' );
     }
 
 	/**
@@ -43,7 +43,7 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 	 * @param string $id
 	 */
 	public function remove_tab( $id ) {
-		_deprecated_function( __METHOD__, '4.1.0' );
+		_deprecated_function( __METHOD__, 'WP-4.1.0' );
     }
 
 	/**
@@ -54,6 +54,6 @@ class WP_Customize_Image_Control extends WP_Customize_Upload_Control {
 	 * @param string $thumbnail_url
 	 */
 	public function print_tab_image( $url, $thumbnail_url = null ) {
-		_deprecated_function( __METHOD__, '4.1.0' );
+		_deprecated_function( __METHOD__, 'WP-4.1.0' );
     }
 }

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
@@ -310,7 +310,7 @@ class WP_Customize_Nav_Menu_Setting extends WP_Customize_Setting {
 	 * @see WP_Customize_Nav_Menu_Setting::filter_wp_get_nav_menus()
 	 */
 	protected function _sort_menus_by_orderby( $menu1, $menu2 ) {
-		_deprecated_function( __METHOD__, '4.7.0', 'wp_list_sort' );
+		_deprecated_function( __METHOD__, 'WP-4.7.0', 'wp_list_sort' );
 
 		$key = $this->_current_menus_sort_orderby;
 		return strcmp( $menu1->$key, $menu2->$key );

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -50,7 +50,7 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	 * @deprecated 4.5.0 Deprecated in favor of wp_nav_menu_manage_columns().
 	 */
 	public function wp_nav_menu_manage_columns() {
-		_deprecated_function( __METHOD__, '4.5.0', 'wp_nav_menu_manage_columns' );
+		_deprecated_function( __METHOD__, 'WP-4.5.0', 'wp_nav_menu_manage_columns' );
 		require_once ABSPATH . 'wp-admin/includes/nav-menu.php';
 		return wp_nav_menu_manage_columns();
 	}

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -36,7 +36,7 @@ class WP_Customize_New_Menu_Control extends WP_Customize_Control {
 	 * @param array                $args    Args.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php. See #42364.
+		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php. See #42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -38,7 +38,7 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 * @param array                $args    Section arguments.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), '4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php. See #42364.
+		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php. See #42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-partial.php
+++ b/src/wp-includes/customize/class-wp-customize-partial.php
@@ -204,7 +204,7 @@ class WP_Customize_Partial {
 			$ob_render = ob_get_clean();
 
 			if ( null !== $return_render && '' !== $ob_render ) {
-				_doing_it_wrong( __FUNCTION__, __( 'Partial render must echo the content or return the content string (or array), but not both.' ), '4.5.0' );
+				_doing_it_wrong( __FUNCTION__, __( 'Partial render must echo the content or return the content string (or array), but not both.' ), 'WP-4.5.0' );
 			}
 
 			/*

--- a/src/wp-includes/date.php
+++ b/src/wp-includes/date.php
@@ -407,7 +407,7 @@ class WP_Date_Query {
 						'<code>' . esc_html( $check['max'] ) . '</code>'
 					);
 
-					_doing_it_wrong( __CLASS__, $error, '4.1.0' );
+					_doing_it_wrong( __CLASS__, $error, 'WP-4.1.0' );
 
 					$valid = false;
 				}
@@ -457,7 +457,7 @@ class WP_Date_Query {
 		}
 
 		if ( ! empty( $day_month_year_error_msg ) ) {
-			_doing_it_wrong( __CLASS__, $day_month_year_error_msg, '4.1.0' );
+			_doing_it_wrong( __CLASS__, $day_month_year_error_msg, 'WP-4.1.0' );
 		}
 
 		return $valid;

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -23,7 +23,7 @@
  * @return array Post data.
  */
 function get_postdata($postid) {
-	_deprecated_function( __FUNCTION__, '1.5.1', 'get_post()' );
+	_deprecated_function( __FUNCTION__, 'WP-1.5.1', 'get_post()' );
 
 	$post = get_post($postid);
 
@@ -61,7 +61,7 @@ function get_postdata($postid) {
 function start_wp() {
 	global $wp_query;
 
-	_deprecated_function( __FUNCTION__, '1.5.0', __('new WordPress Loop') );
+	_deprecated_function( __FUNCTION__, 'WP-1.5.0', __('new WordPress Loop') );
 
 	// Since the old style loop is being used, advance the query iterator here.
 	$wp_query->next_post();
@@ -80,7 +80,7 @@ function start_wp() {
  * @return int Category ID.
  */
 function the_category_ID($echo = true) {
-	_deprecated_function( __FUNCTION__, '0.71', 'get_the_category()' );
+	_deprecated_function( __FUNCTION__, 'WP-0.71', 'get_the_category()' );
 
 	// Grab the first cat in the list.
 	$categories = get_the_category();
@@ -105,7 +105,7 @@ function the_category_ID($echo = true) {
 function the_category_head( $before = '', $after = '' ) {
 	global $currentcat, $previouscat;
 
-	_deprecated_function( __FUNCTION__, '0.71', 'get_the_category_by_ID()' );
+	_deprecated_function( __FUNCTION__, 'WP-0.71', 'get_the_category_by_ID()' );
 
 	// Grab the first cat in the list.
 	$categories = get_the_category();
@@ -134,7 +134,7 @@ function the_category_head( $before = '', $after = '' ) {
  */
 function previous_post($format='%', $previous='previous post: ', $title='yes', $in_same_cat='no', $limitprev=1, $excluded_categories='') {
 
-	_deprecated_function( __FUNCTION__, '2.0.0', 'previous_post_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'previous_post_link()' );
 
 	if ( empty($in_same_cat) || 'no' == $in_same_cat )
 		$in_same_cat = false;
@@ -169,7 +169,7 @@ function previous_post($format='%', $previous='previous post: ', $title='yes', $
  * @param string $excluded_categories
  */
 function next_post($format='%', $next='next post: ', $title='yes', $in_same_cat='no', $limitnext=1, $excluded_categories='') {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'next_post_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'next_post_link()' );
 
 	if ( empty($in_same_cat) || 'no' == $in_same_cat )
 		$in_same_cat = false;
@@ -202,7 +202,7 @@ function next_post($format='%', $next='next post: ', $title='yes', $in_same_cat=
  * @return bool
  */
 function user_can_create_post($user_id, $blog_id = 1, $category_id = 'None') {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$author_data = get_userdata($user_id);
 	return ($author_data->user_level > 1);
@@ -221,7 +221,7 @@ function user_can_create_post($user_id, $blog_id = 1, $category_id = 'None') {
  * @return bool
  */
 function user_can_create_draft($user_id, $blog_id = 1, $category_id = 'None') {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$author_data = get_userdata($user_id);
 	return ($author_data->user_level >= 1);
@@ -240,7 +240,7 @@ function user_can_create_draft($user_id, $blog_id = 1, $category_id = 'None') {
  * @return bool
  */
 function user_can_edit_post($user_id, $post_id, $blog_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$author_data = get_userdata($user_id);
 	$post = get_post($post_id);
@@ -268,7 +268,7 @@ function user_can_edit_post($user_id, $post_id, $blog_id = 1) {
  * @return bool
  */
 function user_can_delete_post($user_id, $post_id, $blog_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	// right now if one can edit, one can delete
 	return user_can_edit_post($user_id, $post_id, $blog_id);
@@ -287,7 +287,7 @@ function user_can_delete_post($user_id, $post_id, $blog_id = 1) {
  * @return bool
  */
 function user_can_set_post_date($user_id, $blog_id = 1, $category_id = 'None') {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$author_data = get_userdata($user_id);
 	return (($author_data->user_level > 4) && user_can_create_post($user_id, $blog_id, $category_id));
@@ -306,7 +306,7 @@ function user_can_set_post_date($user_id, $blog_id = 1, $category_id = 'None') {
  * @return bool returns true if $user_id can edit $post_id's date
  */
 function user_can_edit_post_date($user_id, $post_id, $blog_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$author_data = get_userdata($user_id);
 	return (($author_data->user_level > 4) && user_can_edit_post($user_id, $post_id, $blog_id));
@@ -325,7 +325,7 @@ function user_can_edit_post_date($user_id, $post_id, $blog_id = 1) {
  * @return bool returns true if $user_id can edit $post_id's comments
  */
 function user_can_edit_post_comments($user_id, $post_id, $blog_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	// right now if one can edit a post, one can edit comments made on it
 	return user_can_edit_post($user_id, $post_id, $blog_id);
@@ -344,7 +344,7 @@ function user_can_edit_post_comments($user_id, $post_id, $blog_id = 1) {
  * @return bool returns true if $user_id can delete $post_id's comments
  */
 function user_can_delete_post_comments($user_id, $post_id, $blog_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	// right now if one can edit comments, one can delete comments
 	return user_can_edit_post_comments($user_id, $post_id, $blog_id);
@@ -362,7 +362,7 @@ function user_can_delete_post_comments($user_id, $post_id, $blog_id = 1) {
  * @return bool
  */
 function user_can_edit_user($user_id, $other_user) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'current_user_can()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'current_user_can()' );
 
 	$user  = get_userdata($user_id);
 	$other = get_userdata($other_user);
@@ -395,7 +395,7 @@ function user_can_edit_user($user_id, $other_user) {
 function get_linksbyname($cat_name = "noname", $before = '', $after = '<br />', $between = " ", $show_images = true, $orderby = 'id',
 						 $show_description = true, $show_rating = false,
 						 $limit = -1, $show_updated = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	$cat_id = -1;
 	$cat = get_term_by('name', $cat_name, 'link_category');
@@ -417,7 +417,7 @@ function get_linksbyname($cat_name = "noname", $before = '', $after = '<br />', 
  * @return string|null
  */
 function wp_get_linksbyname($category, $args = '') {
-	_deprecated_function(__FUNCTION__, '2.1.0', 'wp_list_bookmarks()');
+	_deprecated_function(__FUNCTION__, 'WP-2.1.0', 'wp_list_bookmarks()');
 
 	$defaults = array(
 		'after' => '<br />',
@@ -455,7 +455,7 @@ function wp_get_linksbyname($category, $args = '') {
  * @return array
  */
 function get_linkobjectsbyname($cat_name = "noname" , $orderby = 'name', $limit = -1) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	$cat_id = -1;
 	$cat = get_term_by('name', $cat_name, 'link_category');
@@ -506,7 +506,7 @@ function get_linkobjectsbyname($cat_name = "noname" , $orderby = 'name', $limit 
  * @return array
  */
 function get_linkobjects($category = 0, $orderby = 'name', $limit = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	$links = get_bookmarks( array( 'category' => $category, 'orderby' => $orderby, 'limit' => $limit ) ) ;
 
@@ -539,7 +539,7 @@ function get_linkobjects($category = 0, $orderby = 'name', $limit = 0) {
  */
 function get_linksbyname_withrating($cat_name = "noname", $before = '', $after = '<br />', $between = " ",
 									$show_images = true, $orderby = 'id', $show_description = true, $limit = -1, $show_updated = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	get_linksbyname($cat_name, $before, $after, $between, $show_images, $orderby, $show_description, true, $limit, $show_updated);
 }
@@ -566,7 +566,7 @@ function get_linksbyname_withrating($cat_name = "noname", $before = '', $after =
  */
 function get_links_withrating($category = -1, $before = '', $after = '<br />', $between = " ", $show_images = true,
 							  $orderby = 'id', $show_description = true, $limit = -1, $show_updated = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	get_links($category, $before, $after, $between, $show_images, $orderby, $show_description, true, $limit, $show_updated);
 }
@@ -581,7 +581,7 @@ function get_links_withrating($category = -1, $before = '', $after = '<br />', $
  * @return int Only returns 0.
  */
 function get_autotoggle($id = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0' );
 	return 0;
 }
 
@@ -615,7 +615,7 @@ function get_autotoggle($id = 0) {
 function list_cats($optionall = 1, $all = 'All', $sort_column = 'ID', $sort_order = 'asc', $file = '', $list = true, $optiondates = 0,
 				   $optioncount = 0, $hide_empty = 1, $use_desc_for_title = 1, $children=false, $child_of=0, $categories=0,
 				   $recurse=0, $feed = '', $feed_image = '', $exclude = '', $hierarchical=false) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_list_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_list_categories()' );
 
 	$query = compact('optionall', 'all', 'sort_column', 'sort_order', 'file', 'list', 'optiondates', 'optioncount', 'hide_empty', 'use_desc_for_title', 'children',
 		'child_of', 'categories', 'recurse', 'feed', 'feed_image', 'exclude', 'hierarchical');
@@ -633,7 +633,7 @@ function list_cats($optionall = 1, $all = 'All', $sort_column = 'ID', $sort_orde
  * @return false|null|string
  */
 function wp_list_cats($args = '') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_list_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_list_categories()' );
 
 	$r = wp_parse_args( $args );
 
@@ -677,7 +677,7 @@ function wp_list_cats($args = '') {
 function dropdown_cats($optionall = 1, $all = 'All', $orderby = 'ID', $order = 'asc',
 		$show_last_update = 0, $show_count = 0, $hide_empty = 1, $optionnone = false,
 		$selected = 0, $exclude = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_dropdown_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_dropdown_categories()' );
 
 	$show_option_all = '';
 	if ( $optionall )
@@ -709,7 +709,7 @@ function dropdown_cats($optionall = 1, $all = 'All', $orderby = 'ID', $order = '
  * @return null|string
  */
 function list_authors($optioncount = false, $exclude_admin = true, $show_fullname = false, $hide_empty = true, $feed = '', $feed_image = '') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_list_authors()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_list_authors()' );
 
 	$args = compact('optioncount', 'exclude_admin', 'show_fullname', 'hide_empty', 'feed', 'feed_image');
 	return wp_list_authors($args);
@@ -727,7 +727,7 @@ function list_authors($optioncount = false, $exclude_admin = true, $show_fullnam
  * @return array
  */
 function wp_get_post_cats($blogid = '1', $post_ID = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_get_post_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_get_post_categories()' );
 	return wp_get_post_categories($post_ID);
 }
 
@@ -745,7 +745,7 @@ function wp_get_post_cats($blogid = '1', $post_ID = 0) {
  * @return bool|mixed
  */
 function wp_set_post_cats($blogid = '1', $post_ID = 0, $post_categories = array()) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_set_post_categories()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_set_post_categories()' );
 	return wp_set_post_categories($post_ID, $post_categories);
 }
 
@@ -765,7 +765,7 @@ function wp_set_post_cats($blogid = '1', $post_ID = 0, $post_categories = array(
  * @return string|null
  */
 function get_archives($type='', $limit='', $format='html', $before = '', $after = '', $show_post_count = false) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_get_archives()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_get_archives()' );
 	$args = compact('type', 'limit', 'format', 'before', 'after', 'show_post_count');
 	return wp_get_archives($args);
 }
@@ -783,7 +783,7 @@ function get_archives($type='', $limit='', $format='html', $before = '', $after 
  * @return string|null
  */
 function get_author_link($echo, $author_id, $author_nicename = '') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_author_posts_url()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_author_posts_url()' );
 
 	$link = get_author_posts_url($author_id, $author_nicename);
 
@@ -810,7 +810,7 @@ function get_author_link($echo, $author_id, $author_nicename = '') {
  */
 function link_pages($before='<br />', $after='<br />', $next_or_number='number', $nextpagelink='next page', $previouspagelink='previous page',
 					$pagelink='%', $more_file='') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_link_pages()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_link_pages()' );
 
 	$args = compact('before', 'after', 'next_or_number', 'nextpagelink', 'previouspagelink', 'pagelink', 'more_file');
 	return wp_link_pages($args);
@@ -827,7 +827,7 @@ function link_pages($before='<br />', $after='<br />', $next_or_number='number',
  * @return string
  */
 function get_settings($option) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_option()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_option()' );
 
 	return get_option($option);
 }
@@ -840,7 +840,7 @@ function get_settings($option) {
  * @see the_permalink()
  */
 function permalink_link() {
-	_deprecated_function( __FUNCTION__, '1.2.0', 'the_permalink()' );
+	_deprecated_function( __FUNCTION__, 'WP-1.2.0', 'the_permalink()' );
 	the_permalink();
 }
 
@@ -854,7 +854,7 @@ function permalink_link() {
  * @param string $deprecated
  */
 function permalink_single_rss($deprecated = '') {
-	_deprecated_function( __FUNCTION__, '2.3.0', 'the_permalink_rss()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.3.0', 'the_permalink_rss()' );
 	the_permalink_rss();
 }
 
@@ -869,7 +869,7 @@ function permalink_single_rss($deprecated = '') {
  * @return null|string
  */
 function wp_get_links($args = '') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_list_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_list_bookmarks()' );
 
 	if ( strpos( $args, '=' ) === false ) {
 		$cat_id = $args;
@@ -923,7 +923,7 @@ function wp_get_links($args = '') {
  */
 function get_links($category = -1, $before = '', $after = '<br />', $between = ' ', $show_images = true, $orderby = 'name',
 			$show_description = true, $show_rating = false, $limit = -1, $show_updated = 1, $echo = true) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmarks()' );
 
 	$order = 'ASC';
 	if ( substr($orderby, 0, 1) == '_' ) {
@@ -1015,7 +1015,7 @@ function get_links($category = -1, $before = '', $after = '<br />', $between = '
  * @param string $order Sort link categories by 'name' or 'id'
  */
 function get_links_list($order = 'name') {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'wp_list_bookmarks()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'wp_list_bookmarks()' );
 
 	$order = strtolower($order);
 
@@ -1060,7 +1060,7 @@ function get_links_list($order = 'name') {
  * @param bool $count the number of links in the db
  */
 function links_popup_script($text = 'Links', $width=400, $height=400, $file='links.all.php', $count = true) {
-	_deprecated_function( __FUNCTION__, '2.1.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0' );
 }
 
 /**
@@ -1074,7 +1074,7 @@ function links_popup_script($text = 'Links', $width=400, $height=400, $file='lin
  * @return mixed Value of the 'link_rating' field, false otherwise.
  */
 function get_linkrating( $link ) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'sanitize_bookmark_field()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'sanitize_bookmark_field()' );
 	return sanitize_bookmark_field('link_rating', $link->link_rating, $link->link_id, 'display');
 }
 
@@ -1089,7 +1089,7 @@ function get_linkrating( $link ) {
  * @return string
  */
 function get_linkcatname($id = 0) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_category()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_category()' );
 
 	$id = (int) $id;
 
@@ -1117,7 +1117,7 @@ function get_linkcatname($id = 0) {
  * @param string $link_text
  */
 function comments_rss_link($link_text = 'Comments RSS') {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'post_comments_feed_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'post_comments_feed_link()' );
 	post_comments_feed_link($link_text);
 }
 
@@ -1133,7 +1133,7 @@ function comments_rss_link($link_text = 'Comments RSS') {
  * @return string
  */
 function get_category_rss_link($echo = false, $cat_ID = 1) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'get_category_feed_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'get_category_feed_link()' );
 
 	$link = get_category_feed_link($cat_ID, 'rss2');
 
@@ -1154,7 +1154,7 @@ function get_category_rss_link($echo = false, $cat_ID = 1) {
  * @return string
  */
 function get_author_rss_link($echo = false, $author_id = 1) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'get_author_feed_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'get_author_feed_link()' );
 
 	$link = get_author_feed_link($author_id);
 	if ( $echo )
@@ -1172,7 +1172,7 @@ function get_author_rss_link($echo = false, $author_id = 1) {
  * @return string
  */
 function comments_rss() {
-	_deprecated_function( __FUNCTION__, '2.2.0', 'get_post_comments_feed_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.2.0', 'get_post_comments_feed_link()' );
 	return esc_url( get_post_comments_feed_link() );
 }
 
@@ -1189,7 +1189,7 @@ function comments_rss() {
  * @return int The new user's ID.
  */
 function create_user($username, $password, $email) {
-	_deprecated_function( __FUNCTION__, '2.0.0', 'wp_create_user()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.0.0', 'wp_create_user()' );
 	return wp_create_user($username, $password, $email);
 }
 
@@ -1199,7 +1199,7 @@ function create_user($username, $password, $email) {
  * @deprecated 2.5.0
  */
 function gzip_compression() {
-	_deprecated_function( __FUNCTION__, '2.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0' );
 	return false;
 }
 
@@ -1216,7 +1216,7 @@ function gzip_compression() {
  * @return array The comment data
  */
 function get_commentdata( $comment_ID, $no_cache = 0, $include_unapproved = false ) {
-	_deprecated_function( __FUNCTION__, '2.7.0', 'get_comment()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.7.0', 'get_comment()' );
 	return get_comment($comment_ID, ARRAY_A);
 }
 
@@ -1231,7 +1231,7 @@ function get_commentdata( $comment_ID, $no_cache = 0, $include_unapproved = fals
  * @return string category name
  */
 function get_catname( $cat_ID ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_cat_name()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_cat_name()' );
 	return get_cat_name( $cat_ID );
 }
 
@@ -1249,7 +1249,7 @@ function get_catname( $cat_ID ) {
  * @return string
  */
 function get_category_children( $id, $before = '/', $after = '', $visited = array() ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_term_children()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_term_children()' );
 	if ( 0 == $id )
 		return '';
 
@@ -1284,7 +1284,7 @@ function get_category_children( $id, $before = '/', $after = '', $visited = arra
  * @return object List of all of the category IDs.
  */
 function get_all_category_ids() {
-	_deprecated_function( __FUNCTION__, '4.0.0', 'get_terms()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.0.0', 'get_terms()' );
 
 	if ( ! $cat_ids = wp_cache_get( 'all_category_ids', 'category' ) ) {
 		$cat_ids = get_terms( 'category', array('fields' => 'ids', 'get' => 'all') );
@@ -1304,7 +1304,7 @@ function get_all_category_ids() {
  * @return string The author's description.
  */
 function get_the_author_description() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'description\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'description\')' );
 	return get_the_author_meta('description');
 }
 
@@ -1316,7 +1316,7 @@ function get_the_author_description() {
  * @see the_author_meta()
  */
 function the_author_description() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'description\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'description\')' );
 	the_author_meta('description');
 }
 
@@ -1330,7 +1330,7 @@ function the_author_description() {
  * @return string The author's login name (username).
  */
 function get_the_author_login() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'login\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'login\')' );
 	return get_the_author_meta('login');
 }
 
@@ -1342,7 +1342,7 @@ function get_the_author_login() {
  * @see the_author_meta()
  */
 function the_author_login() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'login\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'login\')' );
 	the_author_meta('login');
 }
 
@@ -1356,7 +1356,7 @@ function the_author_login() {
  * @return string The author's first name.
  */
 function get_the_author_firstname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'first_name\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'first_name\')' );
 	return get_the_author_meta('first_name');
 }
 
@@ -1368,7 +1368,7 @@ function get_the_author_firstname() {
  * @see the_author_meta()
  */
 function the_author_firstname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'first_name\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'first_name\')' );
 	the_author_meta('first_name');
 }
 
@@ -1382,7 +1382,7 @@ function the_author_firstname() {
  * @return string The author's last name.
  */
 function get_the_author_lastname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'last_name\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'last_name\')' );
 	return get_the_author_meta('last_name');
 }
 
@@ -1394,7 +1394,7 @@ function get_the_author_lastname() {
  * @see the_author_meta()
  */
 function the_author_lastname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'last_name\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'last_name\')' );
 	the_author_meta('last_name');
 }
 
@@ -1408,7 +1408,7 @@ function the_author_lastname() {
  * @return string The author's nickname.
  */
 function get_the_author_nickname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'nickname\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'nickname\')' );
 	return get_the_author_meta('nickname');
 }
 
@@ -1420,7 +1420,7 @@ function get_the_author_nickname() {
  * @see the_author_meta()
  */
 function the_author_nickname() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'nickname\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'nickname\')' );
 	the_author_meta('nickname');
 }
 
@@ -1434,7 +1434,7 @@ function the_author_nickname() {
  * @return string The author's username.
  */
 function get_the_author_email() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'email\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'email\')' );
 	return get_the_author_meta('email');
 }
 
@@ -1446,7 +1446,7 @@ function get_the_author_email() {
  * @see the_author_meta()
  */
 function the_author_email() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'email\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'email\')' );
 	the_author_meta('email');
 }
 
@@ -1460,7 +1460,7 @@ function the_author_email() {
  * @return string The author's ICQ number.
  */
 function get_the_author_icq() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'icq\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'icq\')' );
 	return get_the_author_meta('icq');
 }
 
@@ -1472,7 +1472,7 @@ function get_the_author_icq() {
  * @see the_author_meta()
  */
 function the_author_icq() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'icq\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'icq\')' );
 	the_author_meta('icq');
 }
 
@@ -1486,7 +1486,7 @@ function the_author_icq() {
  * @return string The author's Yahoo! IM name.
  */
 function get_the_author_yim() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'yim\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'yim\')' );
 	return get_the_author_meta('yim');
 }
 
@@ -1498,7 +1498,7 @@ function get_the_author_yim() {
  * @see the_author_meta()
  */
 function the_author_yim() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'yim\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'yim\')' );
 	the_author_meta('yim');
 }
 
@@ -1512,7 +1512,7 @@ function the_author_yim() {
  * @return string The author's MSN address.
  */
 function get_the_author_msn() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'msn\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'msn\')' );
 	return get_the_author_meta('msn');
 }
 
@@ -1524,7 +1524,7 @@ function get_the_author_msn() {
  * @see the_author_meta()
  */
 function the_author_msn() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'msn\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'msn\')' );
 	the_author_meta('msn');
 }
 
@@ -1538,7 +1538,7 @@ function the_author_msn() {
  * @return string The author's AIM address.
  */
 function get_the_author_aim() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'aim\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'aim\')' );
 	return get_the_author_meta('aim');
 }
 
@@ -1550,7 +1550,7 @@ function get_the_author_aim() {
  * @see the_author_meta()
  */
 function the_author_aim() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'aim\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'aim\')' );
 	the_author_meta('aim');
 }
 
@@ -1565,7 +1565,7 @@ function the_author_aim() {
  * @return string The author's display name.
  */
 function get_author_name( $auth_id = false ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'display_name\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'display_name\')' );
 	return get_the_author_meta('display_name', $auth_id);
 }
 
@@ -1579,7 +1579,7 @@ function get_author_name( $auth_id = false ) {
  * @return string The URL to the author's page.
  */
 function get_the_author_url() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'url\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'url\')' );
 	return get_the_author_meta('url');
 }
 
@@ -1591,7 +1591,7 @@ function get_the_author_url() {
  * @see the_author_meta()
  */
 function the_author_url() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'url\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'url\')' );
 	the_author_meta('url');
 }
 
@@ -1605,7 +1605,7 @@ function the_author_url() {
  * @return string|int The author's ID.
  */
 function get_the_author_ID() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'get_the_author_meta(\'ID\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'get_the_author_meta(\'ID\')' );
 	return get_the_author_meta('ID');
 }
 
@@ -1617,7 +1617,7 @@ function get_the_author_ID() {
  * @see the_author_meta()
  */
 function the_author_ID() {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'the_author_meta(\'ID\')' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'the_author_meta(\'ID\')' );
 	the_author_meta('ID');
 }
 
@@ -1650,7 +1650,7 @@ function the_author_ID() {
  * @param int $encode_html Optional. How to encode the content.
  */
 function the_content_rss($more_link_text='(more...)', $stripteaser=0, $more_file='', $cut = 0, $encode_html = 0) {
-	_deprecated_function( __FUNCTION__, '2.9.0', 'the_content_feed()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0', 'the_content_feed()' );
 	$content = get_the_content($more_link_text, $stripteaser);
 
 	/**
@@ -1704,7 +1704,7 @@ function the_content_rss($more_link_text='(more...)', $stripteaser=0, $more_file
  * @return string HTML stripped out of content with links at the bottom.
  */
 function make_url_footnote( $content ) {
-	_deprecated_function( __FUNCTION__, '2.9.0', '' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0', '' );
 	preg_match_all( '/<a(.+?)href=\"(.+?)\"(.*?)>(.+?)<\/a>/', $content, $matches );
 	$links_summary = "\n";
 	for ( $i = 0, $c = count( $matches[0] ); $i < $c; $i++ ) {
@@ -1743,7 +1743,7 @@ function make_url_footnote( $content ) {
  * @return string Translated context string without pipe
  */
 function _c( $text, $domain = 'default' ) {
-	_deprecated_function( __FUNCTION__, '2.9.0', '_x()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0', '_x()' );
 	return before_last_bar( translate( $text, $domain ) );
 }
 
@@ -1760,7 +1760,7 @@ function _c( $text, $domain = 'default' ) {
  * @return string Translated text
  */
 function translate_with_context( $text, $domain = 'default' ) {
-	_deprecated_function( __FUNCTION__, '2.9.0', '_x()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0', '_x()' );
 	return before_last_bar( translate( $text, $domain ) );
 }
 
@@ -1781,7 +1781,7 @@ function translate_with_context( $text, $domain = 'default' ) {
  * @return string The translated singular or plural form.
  */
 function _nc( $single, $plural, $number, $domain = 'default' ) {
-	_deprecated_function( __FUNCTION__, '2.9.0', '_nx()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.9.0', '_nx()' );
 	return before_last_bar( _n( $single, $plural, $number, $domain ) );
 }
 
@@ -1793,7 +1793,7 @@ function _nc( $single, $plural, $number, $domain = 'default' ) {
  * @see _n()
  */
 function __ngettext() {
-	_deprecated_function( __FUNCTION__, '2.8.0', '_n()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', '_n()' );
 	$args = func_get_args();
 	return call_user_func_array('_n', $args);
 }
@@ -1806,7 +1806,7 @@ function __ngettext() {
  * @see _n_noop()
  */
 function __ngettext_noop() {
-	_deprecated_function( __FUNCTION__, '2.8.0', '_n_noop()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', '_n_noop()' );
 	$args = func_get_args();
 	return call_user_func_array('_n_noop', $args);
 
@@ -1822,7 +1822,7 @@ function __ngettext_noop() {
  * @return array List of all options.
  */
 function get_alloptions() {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_load_alloptions()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_load_alloptions()' );
 	return wp_load_alloptions();
 }
 
@@ -1840,7 +1840,7 @@ function get_alloptions() {
  * @return string
  */
 function get_the_attachment_link($id = 0, $fullsize = false, $max_dims = false, $permalink = false) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_get_attachment_link()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_get_attachment_link()' );
 	$id = (int) $id;
 	$_post = get_post($id);
 
@@ -1868,7 +1868,7 @@ function get_the_attachment_link($id = 0, $fullsize = false, $max_dims = false, 
  * @return array Icon URL and full path to file, respectively.
  */
 function get_attachment_icon_src( $id = 0, $fullsize = false ) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_get_attachment_image_src()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_get_attachment_image_src()' );
 	$id = (int) $id;
 	if ( !$post = get_post($id) )
 		return false;
@@ -1910,7 +1910,7 @@ function get_attachment_icon_src( $id = 0, $fullsize = false ) {
  * @return false|string HTML content.
  */
 function get_attachment_icon( $id = 0, $fullsize = false, $max_dims = false ) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_get_attachment_image()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_get_attachment_image()' );
 	$id = (int) $id;
 	if ( !$post = get_post($id) )
 		return false;
@@ -1966,7 +1966,7 @@ function get_attachment_icon( $id = 0, $fullsize = false, $max_dims = false ) {
  * @return false|string
  */
 function get_attachment_innerHTML($id = 0, $fullsize = false, $max_dims = false) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_get_attachment_image()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_get_attachment_image()' );
 	$id = (int) $id;
 	if ( !$post = get_post($id) )
 		return false;
@@ -1994,7 +1994,7 @@ function get_attachment_innerHTML($id = 0, $fullsize = false, $max_dims = false)
  * @return object|array Bookmark object or array, depending on the type specified by `$output`.
  */
 function get_link( $bookmark_id, $output = OBJECT, $filter = 'raw' ) {
-	_deprecated_function( __FUNCTION__, '2.1.0', 'get_bookmark()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.1.0', 'get_bookmark()' );
 	return get_bookmark($bookmark_id, $output, $filter);
 }
 
@@ -2010,7 +2010,7 @@ function get_link( $bookmark_id, $output = OBJECT, $filter = 'raw' ) {
  * @return string The cleaned URL.
  */
 function sanitize_url( $url, $protocols = null ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'esc_url_raw()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'esc_url_raw()' );
 	return esc_url_raw( $url, $protocols );
 }
 
@@ -2032,9 +2032,9 @@ function sanitize_url( $url, $protocols = null ) {
  */
 function clean_url( $url, $protocols = null, $context = 'display' ) {
 	if ( $context == 'db' )
-		_deprecated_function( 'clean_url( $context = \'db\' )', '3.0.0', 'esc_url_raw()' );
+		_deprecated_function( 'clean_url( $context = \'db\' )', 'WP-3.0.0', 'esc_url_raw()' );
 	else
-		_deprecated_function( __FUNCTION__, '3.0.0', 'esc_url()' );
+		_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'esc_url()' );
 	return esc_url( $url, $protocols, $context );
 }
 
@@ -2051,7 +2051,7 @@ function clean_url( $url, $protocols = null, $context = 'display' ) {
  * @return string Escaped text.
  */
 function js_escape( $text ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'esc_js()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'esc_js()' );
 	return esc_js( $text );
 }
 
@@ -2068,7 +2068,7 @@ function js_escape( $text ) {
  * @return string Escaped `$string`.
  */
 function wp_specialchars( $string, $quote_style = ENT_NOQUOTES, $charset = false, $double_encode = false ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'esc_html()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'esc_html()' );
 	if ( func_num_args() > 1 ) { // Maintain back-compat for people passing additional arguments.
 		$args = func_get_args();
 		return call_user_func_array( '_wp_specialchars', $args );
@@ -2088,7 +2088,7 @@ function wp_specialchars( $string, $quote_style = ENT_NOQUOTES, $charset = false
  * @return string
  */
 function attribute_escape( $text ) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'esc_attr()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'esc_attr()' );
 	return esc_attr( $text );
 }
 
@@ -2112,7 +2112,7 @@ function attribute_escape( $text ) {
  * @param mixed      $params ,...     Widget parameters.
  */
 function register_sidebar_widget($name, $output_callback, $classname = '') {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'wp_register_sidebar_widget()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'wp_register_sidebar_widget()' );
 	// Compat
 	if ( is_array($name) ) {
 		if ( count($name) == 3 )
@@ -2143,7 +2143,7 @@ function register_sidebar_widget($name, $output_callback, $classname = '') {
  * @param int|string $id Widget ID.
  */
 function unregister_sidebar_widget($id) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'wp_unregister_sidebar_widget()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'wp_unregister_sidebar_widget()' );
 	return wp_unregister_sidebar_widget($id);
 }
 
@@ -2167,7 +2167,7 @@ function unregister_sidebar_widget($id) {
  * @param int $height Widget height.
  */
 function register_widget_control($name, $control_callback, $width = '', $height = '') {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'wp_register_widget_control()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'wp_register_widget_control()' );
 	// Compat
 	if ( is_array($name) ) {
 		if ( count($name) == 3 )
@@ -2200,7 +2200,7 @@ function register_widget_control($name, $control_callback, $width = '', $height 
  * @param int|string $id Widget ID.
  */
 function unregister_widget_control($id) {
-	_deprecated_function( __FUNCTION__, '2.8.0', 'wp_unregister_widget_control()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.8.0', 'wp_unregister_widget_control()' );
 	return wp_unregister_widget_control($id);
 }
 
@@ -2217,7 +2217,7 @@ function unregister_widget_control($id) {
  * @return bool True deletion completed and false if user_id is not a number.
  */
 function delete_usermeta( $user_id, $meta_key, $meta_value = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'delete_user_meta()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'delete_user_meta()' );
 	global $wpdb;
 	if ( !is_numeric( $user_id ) )
 		return false;
@@ -2263,7 +2263,7 @@ function delete_usermeta( $user_id, $meta_key, $meta_value = '' ) {
  * @return mixed
  */
 function get_usermeta( $user_id, $meta_key = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'get_user_meta()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'get_user_meta()' );
 	global $wpdb;
 	$user_id = (int) $user_id;
 
@@ -2316,7 +2316,7 @@ function get_usermeta( $user_id, $meta_key = '' ) {
  * @return bool True on successful update, false on failure.
  */
 function update_usermeta( $user_id, $meta_key, $meta_value ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'update_user_meta()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'update_user_meta()' );
 	global $wpdb;
 	if ( !is_numeric( $user_id ) )
 		return false;
@@ -2370,7 +2370,7 @@ function update_usermeta( $user_id, $meta_key, $meta_value ) {
  * @return array List of users that are part of that site ID
  */
 function get_users_of_blog( $id = '' ) {
-	_deprecated_function( __FUNCTION__, '3.1.0', 'get_users()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_users()' );
 
 	global $wpdb;
 	if ( empty( $id ) ) {
@@ -2391,7 +2391,7 @@ function get_users_of_blog( $id = '' ) {
  * @param bool $add Optional, default is true. Add or remove links. Defaults to true.
  */
 function automatic_feed_links( $add = true ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', "add_theme_support( 'automatic-feed-links' )" );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', "add_theme_support( 'automatic-feed-links' )" );
 
 	if ( $add )
 		add_theme_support( 'automatic-feed-links' );
@@ -2411,7 +2411,7 @@ function automatic_feed_links( $add = true ) {
  * @return string The author's field from the current author's DB object.
  */
 function get_profile( $field, $user = false ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'get_the_author_meta()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'get_the_author_meta()' );
 	if ( $user ) {
 		$user = get_user_by( 'login', $user );
 		$user = $user->ID;
@@ -2430,7 +2430,7 @@ function get_profile( $field, $user = false ) {
  * @return int Number of posts the given user has written.
  */
 function get_usernumposts( $userid ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'count_user_posts()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'count_user_posts()' );
 	return count_user_posts( $userid );
 }
 
@@ -2463,7 +2463,7 @@ function funky_javascript_callback($matches) {
  * @return string Fixed text.
  */
 function funky_javascript_fix($text) {
-	_deprecated_function( __FUNCTION__, '3.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0' );
 	// Fixes for browsers' JavaScript bugs.
 	global $is_macIE, $is_winIE;
 
@@ -2486,7 +2486,7 @@ function funky_javascript_fix($text) {
  * @return bool Whether the taxonomy exists.
  */
 function is_taxonomy( $taxonomy ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'taxonomy_exists()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'taxonomy_exists()' );
 	return taxonomy_exists( $taxonomy );
 }
 
@@ -2503,7 +2503,7 @@ function is_taxonomy( $taxonomy ) {
  * @return mixed Get the term id or Term Object, if exists.
  */
 function is_term( $term, $taxonomy = '', $parent = 0 ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'term_exists()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'term_exists()' );
 	return term_exists( $term, $taxonomy, $parent );
 }
 
@@ -2520,7 +2520,7 @@ function is_term( $term, $taxonomy = '', $parent = 0 ) {
  * @return bool
  */
 function is_plugin_page() {
-	_deprecated_function( __FUNCTION__, '3.1.0'  );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0'  );
 
 	global $plugin_page;
 
@@ -2543,7 +2543,7 @@ function is_plugin_page() {
  * @return bool Always return True
  */
 function update_category_cache() {
-	_deprecated_function( __FUNCTION__, '3.1.0'  );
+	_deprecated_function( __FUNCTION__, 'WP-3.1.0'  );
 
 	return true;
 }
@@ -2557,7 +2557,7 @@ function update_category_cache() {
  * @return bool
  */
 function wp_timezone_supported() {
-	_deprecated_function( __FUNCTION__, '3.2.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.2.0' );
 
 	return true;
 }
@@ -2577,7 +2577,7 @@ function wp_timezone_supported() {
  * @param bool   $extended      Optional. Unused.
  */
 function the_editor($content, $id = 'content', $prev_id = 'title', $media_buttons = true, $tab_index = 2, $extended = true) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_editor()' );
 
 	wp_editor( $content, $id, array( 'media_buttons' => $media_buttons ) );
 }
@@ -2592,7 +2592,7 @@ function the_editor($content, $id = 'content', $prev_id = 'title', $media_button
  * @return array of arrays. The array is indexed by user_id, containing $metavalues object arrays.
  */
 function get_user_metavalues($ids) {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	$objects = array();
 
@@ -2626,7 +2626,7 @@ function get_user_metavalues($ids) {
  * @return object|array The now sanitized User Object or Array (will be the same type as $user)
  */
 function sanitize_user_object($user, $context = 'display') {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	if ( is_object($user) ) {
 		if ( !isset($user->ID) )
@@ -2665,7 +2665,7 @@ function sanitize_user_object($user, $context = 'display') {
  * @return string
  */
 function get_boundary_post_rel_link($title = '%title', $in_same_cat = false, $excluded_categories = '', $start = true) {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	$posts = get_boundary_post($in_same_cat, $excluded_categories, $start);
 	// If there is no post stop.
@@ -2703,7 +2703,7 @@ function get_boundary_post_rel_link($title = '%title', $in_same_cat = false, $ex
  * @param string $excluded_categories Optional. Excluded categories IDs.
  */
 function start_post_rel_link($title = '%title', $in_same_cat = false, $excluded_categories = '') {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	echo get_boundary_post_rel_link($title, $in_same_cat, $excluded_categories, true);
 }
@@ -2717,7 +2717,7 @@ function start_post_rel_link($title = '%title', $in_same_cat = false, $excluded_
  * @return string
  */
 function get_index_rel_link() {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	$link = "<link rel='index' title='" . esc_attr( get_bloginfo( 'name', 'display' ) ) . "' href='" . esc_url( user_trailingslashit( get_bloginfo( 'url', 'display' ) ) ) . "' />\n";
 	return apply_filters( "index_rel_link", $link );
@@ -2730,7 +2730,7 @@ function get_index_rel_link() {
  * @deprecated 3.3.0
  */
 function index_rel_link() {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	echo get_index_rel_link();
 }
@@ -2745,7 +2745,7 @@ function index_rel_link() {
  * @return string
  */
 function get_parent_post_rel_link( $title = '%title' ) {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	if ( ! empty( $GLOBALS['post'] ) && ! empty( $GLOBALS['post']->post_parent ) )
 		$post = get_post($GLOBALS['post']->post_parent);
@@ -2775,7 +2775,7 @@ function get_parent_post_rel_link( $title = '%title' ) {
  * @param string $title Optional. Link title format. Default '%title'.
  */
 function parent_post_rel_link( $title = '%title' ) {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	echo get_parent_post_rel_link($title);
 }
@@ -2789,7 +2789,7 @@ function parent_post_rel_link( $title = '%title' ) {
  * @param WP_Admin_Bar $wp_admin_bar WP_Admin_Bar instance.
  */
 function wp_admin_bar_dashboard_view_site_menu( $wp_admin_bar ) {
-	_deprecated_function( __FUNCTION__, '3.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0' );
 
 	$user_id = get_current_user_id();
 
@@ -2814,7 +2814,7 @@ function wp_admin_bar_dashboard_view_site_menu( $wp_admin_bar ) {
  * @return bool True if the current users belong to $blog_id, false if not.
  */
 function is_blog_user( $blog_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'is_user_member_of_blog()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'is_user_member_of_blog()' );
 
 	return is_user_member_of_blog( get_current_user_id(), $blog_id );
 }
@@ -2833,7 +2833,7 @@ function is_blog_user( $blog_id = 0 ) {
  * @return false Always false.
  */
 function debug_fopen( $filename, $mode ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'error_log()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'error_log()' );
 	return false;
 }
 
@@ -2850,7 +2850,7 @@ function debug_fopen( $filename, $mode ) {
  * @param string $string Message to log.
  */
 function debug_fwrite( $fp, $string ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'error_log()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'error_log()' );
 	if ( ! empty( $GLOBALS['debug'] ) )
 		error_log( $string );
 }
@@ -2867,7 +2867,7 @@ function debug_fwrite( $fp, $string ) {
  * @param mixed $fp Unused.
  */
 function debug_fclose( $fp ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'error_log()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'error_log()' );
 }
 
 /**
@@ -2884,7 +2884,7 @@ function debug_fclose( $fp ) {
  * @return array Theme list with theme data.
  */
 function get_themes() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'wp_get_themes()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'wp_get_themes()' );
 
 	global $wp_themes;
 	if ( isset( $wp_themes ) )
@@ -2915,7 +2915,7 @@ function get_themes() {
  * @return array|null Null, if theme name does not exist. Theme data, if exists.
  */
 function get_theme( $theme ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'wp_get_theme( $stylesheet )' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'wp_get_theme( $stylesheet )' );
 
 	$themes = get_themes();
 	if ( is_array( $themes ) && array_key_exists( $theme, $themes ) )
@@ -2933,7 +2933,7 @@ function get_theme( $theme ) {
  * @return string
  */
 function get_current_theme() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'wp_get_theme()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'wp_get_theme()' );
 
 	if ( $theme = get_option( 'current_theme' ) )
 		return $theme;
@@ -2954,7 +2954,7 @@ function get_current_theme() {
  * @return string The pre block without paragraph/line-break conversion.
  */
 function clean_pre($matches) {
-	_deprecated_function( __FUNCTION__, '3.4.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0' );
 
 	if ( is_array($matches) )
 		$text = $matches[1] . $matches[2] . "</pre>";
@@ -2981,7 +2981,7 @@ function clean_pre($matches) {
  * @param callable $admin_preview_callback Output a custom header image div on the custom header administration screen. Optional.
  */
 function add_custom_image_header( $wp_head_callback, $admin_head_callback, $admin_preview_callback = '' ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'add_theme_support( \'custom-header\', $args )' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'add_theme_support( \'custom-header\', $args )' );
 	$args = array(
 		'wp-head-callback'    => $wp_head_callback,
 		'admin-head-callback' => $admin_head_callback,
@@ -3001,7 +3001,7 @@ function add_custom_image_header( $wp_head_callback, $admin_head_callback, $admi
  * @return null|bool Whether support was removed.
  */
 function remove_custom_image_header() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'remove_theme_support( \'custom-header\' )' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'remove_theme_support( \'custom-header\' )' );
 	return remove_theme_support( 'custom-header' );
 }
 
@@ -3017,7 +3017,7 @@ function remove_custom_image_header() {
  * @param callable $admin_preview_callback Output a custom background image div on the custom background administration screen. Optional.
  */
 function add_custom_background( $wp_head_callback = '', $admin_head_callback = '', $admin_preview_callback = '' ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'add_theme_support( \'custom-background\', $args )' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'add_theme_support( \'custom-background\', $args )' );
 	$args = array();
 	if ( $wp_head_callback )
 		$args['wp-head-callback'] = $wp_head_callback;
@@ -3038,7 +3038,7 @@ function add_custom_background( $wp_head_callback = '', $admin_head_callback = '
  * @return null|bool Whether support was removed.
  */
 function remove_custom_background() {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'remove_theme_support( \'custom-background\' )' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'remove_theme_support( \'custom-background\' )' );
 	return remove_theme_support( 'custom-background' );
 }
 
@@ -3053,7 +3053,7 @@ function remove_custom_background() {
  * @return array Theme data.
  */
 function get_theme_data( $theme_file ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'wp_get_theme()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'wp_get_theme()' );
 	$theme = new WP_Theme( basename( dirname( $theme_file ) ), dirname( dirname( $theme_file ) ) );
 
 	$theme_data = array(
@@ -3090,7 +3090,7 @@ function get_theme_data( $theme_file ) {
  * @param array $pages list of page objects
  */
 function update_page_cache( &$pages ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'update_post_cache()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'update_post_cache()' );
 
 	update_post_cache( $pages );
 }
@@ -3108,7 +3108,7 @@ function update_page_cache( &$pages ) {
  * @param int $id Page ID to clean
  */
 function clean_page_cache( $id ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'clean_post_cache()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'clean_post_cache()' );
 
 	clean_post_cache( $id );
 }
@@ -3126,7 +3126,7 @@ function clean_page_cache( $id ) {
  * @return string Are you sure message.
  */
 function wp_explain_nonce( $action ) {
-	_deprecated_function( __FUNCTION__, '3.4.1', 'wp_nonce_ays()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.1', 'wp_nonce_ays()' );
 	return __( 'Are you sure you want to do this?' );
 }
 
@@ -3140,7 +3140,7 @@ function wp_explain_nonce( $action ) {
  * @param int $post_id An optional post ID.
  */
 function sticky_class( $post_id = null ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'post_class()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'post_class()' );
 	if ( is_sticky( $post_id ) )
 		echo ' sticky';
 }
@@ -3158,7 +3158,7 @@ function sticky_class( $post_id = null ) {
  * @param WP_Post $post Post object, passed by reference (unused).
  */
 function _get_post_ancestors( &$post ) {
-	_deprecated_function( __FUNCTION__, '3.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0' );
 }
 
 /**
@@ -3172,7 +3172,7 @@ function _get_post_ancestors( &$post ) {
  * @return resource The resulting image resource on success, Error string on failure.
  */
 function wp_load_image( $file ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'wp_get_image_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wp_get_image_editor()' );
 
 	if ( is_numeric( $file ) )
 		$file = get_attached_file( $file );
@@ -3223,7 +3223,7 @@ function wp_load_image( $file ) {
  * @return mixed WP_Error on failure. String with new destination path.
  */
 function image_resize( $file, $max_w, $max_h, $crop = false, $suffix = null, $dest_path = null, $jpeg_quality = 90 ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'wp_get_image_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wp_get_image_editor()' );
 
 	$editor = wp_get_image_editor( $file );
 	if ( is_wp_error( $editor ) )
@@ -3258,7 +3258,7 @@ function image_resize( $file, $max_w, $max_h, $crop = false, $suffix = null, $de
  * @return WP_Post|null Post object or array holding post contents and information
  */
 function wp_get_single_post( $postid = 0, $mode = OBJECT ) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'get_post()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'get_post()' );
 	return get_post( $postid, $mode );
 }
 
@@ -3274,7 +3274,7 @@ function wp_get_single_post( $postid = 0, $mode = OBJECT ) {
  * @return bool False if does not authenticate, true if username and password authenticates.
  */
 function user_pass_ok($user_login, $user_pass) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'wp_authenticate()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wp_authenticate()' );
 	$user = wp_authenticate( $user_login, $user_pass );
 	if ( is_wp_error( $user ) )
 		return false;
@@ -3301,7 +3301,7 @@ function _save_post_hook() {}
  * @return bool
  */
 function gd_edit_image_support($mime_type) {
-	_deprecated_function( __FUNCTION__, '3.5.0', 'wp_image_editor_supports()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wp_image_editor_supports()' );
 
 	if ( function_exists('imagetypes') ) {
 		switch( $mime_type ) {
@@ -3336,7 +3336,7 @@ function gd_edit_image_support($mime_type) {
  * @return string A shorthand byte value.
  */
 function wp_convert_bytes_to_hr( $bytes ) {
-	_deprecated_function( __FUNCTION__, '3.6.0', 'size_format()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.6.0', 'size_format()' );
 
 	$units = array( 0 => 'B', 1 => 'KB', 2 => 'MB', 3 => 'GB', 4 => 'TB' );
 	$log   = log( $bytes, KB_IN_BYTES );
@@ -3364,7 +3364,7 @@ function wp_convert_bytes_to_hr( $bytes ) {
  * @return string Trimmed search terms.
  */
 function _search_terms_tidy( $t ) {
-	_deprecated_function( __FUNCTION__, '3.7.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0' );
 	return trim( $t, "\"'\n\r " );
 }
 
@@ -3381,7 +3381,7 @@ function _search_terms_tidy( $t ) {
  */
 function rich_edit_exists() {
 	global $wp_rich_edit_exists;
-	_deprecated_function( __FUNCTION__, '3.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.9.0' );
 
 	if ( ! isset( $wp_rich_edit_exists ) )
 		$wp_rich_edit_exists = file_exists( ABSPATH . WPINC . '/js/tinymce/tinymce.js' );
@@ -3415,7 +3415,7 @@ function default_topic_count_text( $count ) {
  * @return string The very same text.
  */
 function format_to_post( $content ) {
-	_deprecated_function( __FUNCTION__, '3.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.9.0' );
 	return $content;
 }
 
@@ -3430,7 +3430,7 @@ function format_to_post( $content ) {
  * @return string text, safe for inclusion in LIKE query.
  */
 function like_escape($text) {
-	_deprecated_function( __FUNCTION__, '4.0.0', 'wpdb::esc_like()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.0.0', 'wpdb::esc_like()' );
 	return str_replace( array( "%", "_" ), array( "\\%", "\\_" ), $text );
 }
 
@@ -3447,7 +3447,7 @@ function like_escape($text) {
  * @return bool Whether SSL access is available.
  */
 function url_is_accessable_via_ssl( $url ) {
-	_deprecated_function( __FUNCTION__, '4.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.0.0' );
 
 	$response = wp_remote_get( set_url_scheme( $url, 'https' ) );
 
@@ -3471,7 +3471,7 @@ function url_is_accessable_via_ssl( $url ) {
  * @deprecated 4.3.0
  */
 function preview_theme() {
-	_deprecated_function( __FUNCTION__, '4.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 }
 
 /**
@@ -3484,7 +3484,7 @@ function preview_theme() {
  * @return string
  */
 function _preview_theme_template_filter() {
-	_deprecated_function( __FUNCTION__, '4.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 	return '';
 }
 
@@ -3498,7 +3498,7 @@ function _preview_theme_template_filter() {
  * @return string
  */
 function _preview_theme_stylesheet_filter() {
-	_deprecated_function( __FUNCTION__, '4.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 	return '';
 }
 
@@ -3513,7 +3513,7 @@ function _preview_theme_stylesheet_filter() {
  * @return string
  */
 function preview_theme_ob_filter( $content ) {
-	_deprecated_function( __FUNCTION__, '4.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 	return $content;
 }
 
@@ -3530,7 +3530,7 @@ function preview_theme_ob_filter( $content ) {
  * @return string
  */
 function preview_theme_ob_filter_callback( $matches ) {
-	_deprecated_function( __FUNCTION__, '4.3.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0' );
 	return '';
 }
 
@@ -3548,7 +3548,7 @@ function preview_theme_ob_filter_callback( $matches ) {
  * @return string The formatted text after filter is applied.
  */
 function wp_richedit_pre($text) {
-	_deprecated_function( __FUNCTION__, '4.3.0', 'format_for_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0', 'format_for_editor()' );
 
 	if ( empty( $text ) ) {
 		/**
@@ -3591,7 +3591,7 @@ function wp_richedit_pre($text) {
  * @return string Formatted text after filter applied.
  */
 function wp_htmledit_pre($output) {
-	_deprecated_function( __FUNCTION__, '4.3.0', 'format_for_editor()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.3.0', 'format_for_editor()' );
 
 	if ( !empty($output) )
 		$output = htmlspecialchars($output, ENT_NOQUOTES, get_option( 'blog_charset' ) ); // convert only < > &
@@ -3618,7 +3618,7 @@ function wp_htmledit_pre($output) {
  * @return string|false
  */
 function post_permalink( $post_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '4.4.0', 'get_permalink()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.4.0', 'get_permalink()' );
 
 	return get_permalink( $post_id );
 }
@@ -3640,7 +3640,7 @@ function post_permalink( $post_id = 0 ) {
  * @return bool|string False on failure and string of headers if HEAD request.
  */
 function wp_get_http( $url, $file_path = false, $red = 1 ) {
-	_deprecated_function( __FUNCTION__, '4.4.0', 'WP_Http' );
+	_deprecated_function( __FUNCTION__, 'WP-4.4.0', 'WP_Http' );
 
 	@set_time_limit( 60 );
 
@@ -3694,7 +3694,7 @@ function wp_get_http( $url, $file_path = false, $red = 1 ) {
  * @return bool True if forced, false if not forced.
  */
 function force_ssl_login( $force = null ) {
-	_deprecated_function( __FUNCTION__, '4.4.0', 'force_ssl_admin()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.4.0', 'force_ssl_admin()' );
 	return force_ssl_admin( $force );
 }
 
@@ -3707,7 +3707,7 @@ function force_ssl_login( $force = null ) {
  * @return string Full path to comments popup template file.
  */
 function get_comments_popup_template() {
-	_deprecated_function( __FUNCTION__, '4.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0' );
 
 	return '';
 }
@@ -3721,7 +3721,7 @@ function get_comments_popup_template() {
  * @return bool
  */
 function is_comments_popup() {
-	_deprecated_function( __FUNCTION__, '4.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0' );
 
 	return false;
 }
@@ -3733,7 +3733,7 @@ function is_comments_popup() {
  * @deprecated 4.5.0
  */
 function comments_popup_script() {
-	_deprecated_function( __FUNCTION__, '4.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0' );
 }
 
 /**
@@ -3746,7 +3746,7 @@ function comments_popup_script() {
  * @return string Content that has filtered links.
  */
 function popuplinks( $text ) {
-	_deprecated_function( __FUNCTION__, '4.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0' );
 	$text = preg_replace('/<a (.+?)>/i', "<a $1 target='_blank' rel='external'>", $text);
 	return $text;
 }
@@ -3763,7 +3763,7 @@ function popuplinks( $text ) {
  * @return string An empty string.
  */
 function wp_embed_handler_googlevideo( $matches, $attr, $url, $rawattr ) {
-	_deprecated_function( __FUNCTION__, '4.6.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.6.0' );
 
 	return '';
 }
@@ -3777,7 +3777,7 @@ function wp_embed_handler_googlevideo( $matches, $attr, $url, $rawattr ) {
  * @return string Full path to paged template file.
  */
 function get_paged_template() {
-	_deprecated_function( __FUNCTION__, '4.7.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0' );
 
 	return get_query_template( 'paged' );
 }
@@ -3803,7 +3803,7 @@ function get_paged_template() {
  * @return string
  */
 function wp_kses_js_entities( $string ) {
-	_deprecated_function( __FUNCTION__, '4.7.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0' );
 
 	return preg_replace( '%&\s*\{[^}]*(\}\s*;?|$)%', '', $string );
 }
@@ -3823,7 +3823,7 @@ function wp_kses_js_entities( $string ) {
  * @return int
  */
 function _usort_terms_by_ID( $a, $b ) {
-	_deprecated_function( __FUNCTION__, '4.7.0', 'wp_list_sort()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0', 'wp_list_sort()' );
 
 	if ( $a->term_id > $b->term_id )
 		return 1;
@@ -3848,7 +3848,7 @@ function _usort_terms_by_ID( $a, $b ) {
  * @return int
  */
 function _usort_terms_by_name( $a, $b ) {
-	_deprecated_function( __FUNCTION__, '4.7.0', 'wp_list_sort()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0', 'wp_list_sort()' );
 
 	return strcmp( $a->name, $b->name );
 }
@@ -3869,7 +3869,7 @@ function _usort_terms_by_name( $a, $b ) {
 function _sort_nav_menu_items( $a, $b ) {
 	global $_menu_item_sort_prop;
 
-	_deprecated_function( __FUNCTION__, '4.7.0', 'wp_list_sort()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0', 'wp_list_sort()' );
 
 	if ( empty( $_menu_item_sort_prop ) )
 		return 0;
@@ -3896,7 +3896,7 @@ function _sort_nav_menu_items( $a, $b ) {
  *
  */
 function get_shortcut_link() {
-	_deprecated_function( __FUNCTION__, '4.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.9.0' );
 
 	$link = '';
 
@@ -3918,7 +3918,7 @@ function get_shortcut_link() {
 * @deprecated 4.9.0
 */
 function wp_ajax_press_this_save_post() {
-	_deprecated_function( __FUNCTION__, '4.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.9.0' );
 	if ( is_plugin_active( 'press-this/press-this-plugin.php' ) ) {
 		include( WP_PLUGIN_DIR . '/press-this/class-wp-press-this-plugin.php' );
 		$wp_press_this = new WP_Press_This_Plugin();
@@ -3935,7 +3935,7 @@ function wp_ajax_press_this_save_post() {
 * @deprecated 4.9.0
 */
 function wp_ajax_press_this_add_category() {
-	_deprecated_function( __FUNCTION__, '4.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.9.0' );
 	if ( is_plugin_active( 'press-this/press-this-plugin.php' ) ) {
 		include( WP_PLUGIN_DIR . '/press-this/class-wp-press-this-plugin.php' );
 		$wp_press_this = new WP_Press_This_Plugin();

--- a/src/wp-includes/embed-template.php
+++ b/src/wp-includes/embed-template.php
@@ -8,6 +8,6 @@
  * @deprecated 4.5.0 Moved to wp-includes/theme-compat/embed.php
  */
 
-_deprecated_file( basename( __FILE__ ), '4.5.0', 'wp-includes/theme-compat/embed.php' );
+_deprecated_file( basename( __FILE__ ), 'WP-4.5.0', 'wp-includes/theme-compat/embed.php' );
 
 include( ABSPATH . WPINC . '/theme-compat/embed.php' );

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -100,7 +100,7 @@ function get_default_feed() {
 function get_wp_title_rss( $deprecated = '&#8211;' ) {
 	if ( '&#8211;' !== $deprecated ) {
 		/* translators: %s: 'document_title_separator' filter name */
-		_deprecated_argument( __FUNCTION__, '4.4.0', sprintf( __( 'Use the %s filter instead.' ), '<code>document_title_separator</code>' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-4.4.0', sprintf( __( 'Use the %s filter instead.' ), '<code>document_title_separator</code>' ) );
 	}
 
 	/**
@@ -126,7 +126,7 @@ function get_wp_title_rss( $deprecated = '&#8211;' ) {
 function wp_title_rss( $deprecated = '&#8211;' ) {
 	if ( '&#8211;' !== $deprecated ) {
 		/* translators: %s: 'document_title_separator' filter name */
-		_deprecated_argument( __FUNCTION__, '4.4.0', sprintf( __( 'Use the %s filter instead.' ), '<code>document_title_separator</code>' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-4.4.0', sprintf( __( 'Use the %s filter instead.' ), '<code>document_title_separator</code>' ) );
 	}
 
 	/**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2103,7 +2103,7 @@ function sanitize_html_class( $class, $fallback = '' ) {
  */
 function convert_chars( $content, $deprecated = '' ) {
 	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '0.71' );
+		_deprecated_argument( __FUNCTION__, 'WP-0.71' );
 	}
 
 	if ( strpos( $content, '&' ) !== false ) {
@@ -2885,7 +2885,7 @@ function convert_smilies( $text ) {
  */
 function is_email( $email, $deprecated = false ) {
 	if ( ! empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '3.0.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0' );
 
 	// Test for the minimum length the email can be
 	if ( strlen( $email ) < 6 ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5739,7 +5739,7 @@ function wp_is_uuid( $uuid, $version = null ) {
 
 	if ( is_numeric( $version ) ) {
 		if ( 4 !== (int) $version ) {
-			_doing_it_wrong( __FUNCTION__, __( 'Only UUID V4 is supported at this time.' ), '4.9.0' );
+			_doing_it_wrong( __FUNCTION__, __( 'Only UUID V4 is supported at this time.' ), 'WP-4.9.0' );
 			return false;
 		}
 		$regex = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -643,7 +643,7 @@ function do_enclose( $content, $post_ID ) {
  */
 function wp_get_http_headers( $url, $deprecated = false ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.7.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.7.0' );
 
 	$response = wp_safe_remote_head( $url );
 
@@ -2143,7 +2143,7 @@ function wp_unique_filename( $dir, $filename, $unique_filename_callback = null )
  */
 function wp_upload_bits( $name, $deprecated, $bits, $time = null ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.0.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.0.0' );
 
 	if ( empty( $name ) )
 		return array( 'error' => __( 'Empty filename' ) );
@@ -4001,7 +4001,7 @@ function _deprecated_file( $file, $version, $replacement = null, $message = '' )
  * For example:
  *
  *     if ( ! empty( $deprecated ) ) {
- *         _deprecated_argument( __FUNCTION__, '3.0.0' );
+ *         _deprecated_argument( __FUNCTION__, 'WP-3.0.0' );
  *     }
  *
  *

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -231,7 +231,7 @@ function wp_deregister_script( $handle ) {
 				"<code>$handle</code>",
 				'<code>wp_enqueue_scripts</code>'
 			);
-			_doing_it_wrong( __FUNCTION__, $message, '3.6.0' );
+			_doing_it_wrong( __FUNCTION__, $message, 'WP-3.6.0' );
 			return;
 		}
 	}

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -44,7 +44,7 @@ function _wp_scripts_maybe_doing_it_wrong( $function ) {
 		'<code>wp_enqueue_scripts</code>',
 		'<code>admin_enqueue_scripts</code>',
 		'<code>login_enqueue_scripts</code>'
-	), '3.3.0' );
+	), 'WP-3.3.0' );
 }
 
 /**
@@ -113,7 +113,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
 			__( 'Do not pass %1$s tags to %2$s.' ),
 			'<code>&lt;script&gt;</code>',
 			'<code>wp_add_inline_script()</code>'
-		), '4.5.0' );
+		), 'WP-4.5.0' );
 		$data = trim( preg_replace( '#<script[^>]*>(.*)</script>#is', '$1', $data ) );
 	}
 

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -89,7 +89,7 @@ function wp_add_inline_style( $handle, $data ) {
 			__( 'Do not pass %1$s tags to %2$s.' ),
 			'<code>&lt;style&gt;</code>',
 			'<code>wp_add_inline_style()</code>'
-		), '3.7.0' );
+		), 'WP-3.7.0' );
 		$data = trim( preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $data ) );
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -635,7 +635,7 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 	switch( $show ) {
 		case 'home' : // DEPRECATED
 		case 'siteurl' : // DEPRECATED
-			_deprecated_argument( __FUNCTION__, '2.2.0', sprintf(
+			_deprecated_argument( __FUNCTION__, 'WP-2.2.0', sprintf(
 				/* translators: 1: 'siteurl'/'home' argument, 2: bloginfo() function name, 3: 'url' argument */
 				__( 'The %1$s option is deprecated for the family of %2$s functions. Use the %3$s option instead.' ),
 				'<code>' . $show . '</code>',
@@ -708,7 +708,7 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			}
 			break;
 		case 'text_direction':
-			_deprecated_argument( __FUNCTION__, '2.2.0', sprintf(
+			_deprecated_argument( __FUNCTION__, 'WP-2.2.0', sprintf(
 				/* translators: 1: 'text_direction' argument, 2: bloginfo() function name, 3: is_rtl() function name */
 				__( 'The %1$s option is deprecated for the family of %2$s functions. Use the %3$s function instead.' ),
 				'<code>' . $show . '</code>',

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1688,7 +1688,7 @@ function kses_init() {
  */
 function safecss_filter_attr( $css, $deprecated = '' ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.8.1' ); // Never implemented
+		_deprecated_argument( __FUNCTION__, 'WP-2.8.1' ); // Never implemented
 
 	$css = wp_kses_no_null($css);
 	$css = str_replace(array("\n","\r","\t"), '', $css);

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -723,7 +723,7 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
 	if ( false !== $plugin_rel_path ) {
 		$path = WP_PLUGIN_DIR . '/' . trim( $plugin_rel_path, '/' );
 	} elseif ( false !== $deprecated ) {
-		_deprecated_argument( __FUNCTION__, '2.7.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.7.0' );
 		$path = ABSPATH . trim( $deprecated, '/' );
 	} else {
 		$path = WP_PLUGIN_DIR;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1357,7 +1357,7 @@ function edit_post_link( $text = null, $before = '', $after = '', $id = 0, $clas
  */
 function get_delete_post_link( $id = 0, $deprecated = '', $force_delete = false ) {
 	if ( ! empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '3.0.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0' );
 
 	if ( !$post = get_post( $id ) )
 		return;
@@ -1604,7 +1604,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		if ( ! empty( $excluded_terms ) && ! is_array( $excluded_terms ) ) {
 			// back-compat, $excluded_terms used to be $excluded_terms with IDs separated by " and "
 			if ( false !== strpos( $excluded_terms, ' and ' ) ) {
-				_deprecated_argument( __FUNCTION__, '3.3.0', sprintf( __( 'Use commas instead of %s to separate excluded terms.' ), "'and'" ) );
+				_deprecated_argument( __FUNCTION__, 'WP-3.3.0', sprintf( __( 'Use commas instead of %s to separate excluded terms.' ), "'and'" ) );
 				$excluded_terms = explode( ' and ', $excluded_terms );
 			} else {
 				$excluded_terms = explode( ',', $excluded_terms );

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -599,7 +599,7 @@ function wp_get_active_and_valid_plugins() {
 
 	// Check for hacks file if the option is enabled
 	if ( get_option( 'hack_file' ) && file_exists( ABSPATH . 'my-hacks.php' ) ) {
-		_deprecated_file( 'my-hacks.php', '1.5.0' );
+		_deprecated_file( 'my-hacks.php', 'WP-1.5.0' );
 		array_unshift( $plugins, ABSPATH . 'my-hacks.php' );
 	}
 

--- a/src/wp-includes/locale.php
+++ b/src/wp-includes/locale.php
@@ -7,4 +7,4 @@
  * @since WP-1.2.0
  */
 
-_deprecated_file( basename( __FILE__ ), '4.7.0' );
+_deprecated_file( basename( __FILE__ ), 'WP-4.7.0' );

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -242,7 +242,7 @@ function get_blog_details( $fields = null, $get_all = true ) {
 	 *
 	 * @param object $details The blog details.
 	 */
-	$details = apply_filters_deprecated( 'blog_details', array( $details ), '4.7.0', 'site_details' );
+	$details = apply_filters_deprecated( 'blog_details', array( $details ), 'WP-4.7.0', 'site_details' );
 
 	wp_cache_set( $blog_id . $all, $details, 'blog-details' );
 
@@ -483,7 +483,7 @@ function clean_blog_cache( $blog ) {
 	 *
 	 * @param int $blog_id Blog ID.
 	 */
-	do_action_deprecated( 'refresh_blog_details', array( $blog_id ), '4.9.0', 'clean_site_cache' );
+	do_action_deprecated( 'refresh_blog_details', array( $blog_id ), 'WP-4.9.0', 'clean_site_cache' );
 }
 
 /**
@@ -763,7 +763,7 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
 	$id = (int) $id;
 
 	if ( null !== $deprecated  )
-		_deprecated_argument( __FUNCTION__, '3.1.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.1.0' );
 
 	if ( get_current_blog_id() == $id )
 		return update_option( $option, $value );
@@ -1008,7 +1008,7 @@ function update_blog_status( $blog_id, $pref, $value, $deprecated = null ) {
 	global $wpdb;
 
 	if ( null !== $deprecated  )
-		_deprecated_argument( __FUNCTION__, '3.1.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.1.0' );
 
 	if ( ! in_array( $pref, array( 'site_id', 'domain', 'path', 'registered', 'last_updated', 'public', 'archived', 'mature', 'spam', 'deleted', 'lang_id') ) )
 		return $value;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -1104,7 +1104,7 @@ function get_last_updated( $deprecated = '', $start = 0, $quantity = 40 ) {
 	global $wpdb;
 
 	if ( ! empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, 'MU' ); // never used
+		_deprecated_argument( __FUNCTION__, 'WP-MU' ); // never used
 
 	return $wpdb->get_results( $wpdb->prepare( "SELECT blog_id, domain, path FROM $wpdb->blogs WHERE site_id = %d AND public = '1' AND archived = '0' AND mature = '0' AND spam = '0' AND deleted = '0' AND last_updated != '0000-00-00 00:00:00' ORDER BY last_updated DESC limit %d, %d", get_current_network_id(), $start, $quantity ), ARRAY_A );
 }

--- a/src/wp-includes/ms-default-constants.php
+++ b/src/wp-includes/ms-default-constants.php
@@ -138,7 +138,7 @@ function ms_subdomain_constants() {
 		if ( $subdomain_error_warn ) {
 			trigger_error( __( '<strong>Conflicting values for the constants VHOST and SUBDOMAIN_INSTALL.</strong> The value of SUBDOMAIN_INSTALL will be assumed to be your subdomain configuration setting.' ) . ' ' . $vhost_deprecated, E_USER_WARNING );
 		} else {
-	 		_deprecated_argument( 'define()', '3.0.0', $vhost_deprecated );
+	 		_deprecated_argument( 'define()', 'WP-3.0.0', $vhost_deprecated );
 		}
 		return;
 	}

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -24,7 +24,7 @@
  * @return WP_Site Current site object.
  */
 function get_dashboard_blog() {
-    _deprecated_function( __FUNCTION__, '3.1.0', 'get_site()' );
+    _deprecated_function( __FUNCTION__, 'WP-3.1.0', 'get_site()' );
     if ( $blog = get_site_option( 'dashboard_blog' ) ) {
 	    return get_site( $blog );
     }
@@ -42,7 +42,7 @@ function get_dashboard_blog() {
  * @param int $len Optional. The length of password to generate. Default 8.
  */
 function generate_random_password( $len = 8 ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_generate_password()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_generate_password()' );
 	return wp_generate_password( $len );
 }
 
@@ -62,7 +62,7 @@ function generate_random_password( $len = 8 ) {
  * @param string $user_login Optional. Username for the user to check. Default empty.
  */
 function is_site_admin( $user_login = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'is_super_admin()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'is_super_admin()' );
 
 	if ( empty( $user_login ) ) {
 		$user_id = get_current_user_id();
@@ -87,7 +87,7 @@ if ( !function_exists( 'graceful_fail' ) ) :
  * @see wp_die()
  */
 function graceful_fail( $message ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_die()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_die()' );
 	$message = apply_filters( 'graceful_fail', $message );
 	$message_template = apply_filters( 'graceful_fail_template',
 '<!DOCTYPE html>
@@ -127,7 +127,7 @@ endif;
  * @param string $username Username.
  */
 function get_user_details( $username ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'get_user_by()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'get_user_by()' );
 	return get_user_by('login', $username);
 }
 
@@ -141,7 +141,7 @@ function get_user_details( $username ) {
  * @param int $post_id Post ID.
  */
 function clear_global_post_cache( $post_id ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'clean_post_cache()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'clean_post_cache()' );
 }
 
 /**
@@ -152,7 +152,7 @@ function clear_global_post_cache( $post_id ) {
  * @see is_main_site()
  */
 function is_main_blog() {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'is_main_site()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'is_main_site()' );
 	return is_main_site();
 }
 
@@ -168,7 +168,7 @@ function is_main_blog() {
  * @return string|bool Either false or the valid email address.
  */
 function validate_email( $email, $check_domain = true) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'is_email()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'is_email()' );
 	return is_email( $email, $check_domain );
 }
 
@@ -184,7 +184,7 @@ function validate_email( $email, $check_domain = true) {
  * @param string $deprecated Unused.
  */
 function get_blog_list( $start = 0, $num = 10, $deprecated = '' ) {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_get_sites()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_get_sites()' );
 
 	global $wpdb;
 	$blogs = $wpdb->get_results( $wpdb->prepare( "SELECT blog_id, domain, path FROM $wpdb->blogs WHERE site_id = %d AND public = '1' AND archived = '0' AND mature = '0' AND spam = '0' AND deleted = '0' ORDER BY registered DESC", get_current_network_id() ), ARRAY_A );
@@ -217,7 +217,7 @@ function get_blog_list( $start = 0, $num = 10, $deprecated = '' ) {
  * @return array List of "most active" sites.
  */
 function get_most_active_blogs( $num = 10, $display = true ) {
-	_deprecated_function( __FUNCTION__, '3.0.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0' );
 
 	$blogs = get_blog_list( 0, 'all', false ); // $blog_id -> $details
 	if ( is_array( $blogs ) ) {
@@ -268,7 +268,7 @@ function get_most_active_blogs( $num = 10, $display = true ) {
  * @param string $url Optional. Redirect URL. Default empty.
  */
 function wpmu_admin_do_redirect( $url = '' ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'wp_redirect()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'wp_redirect()' );
 
 	$ref = '';
 	if ( isset( $_GET['ref'] ) )
@@ -308,7 +308,7 @@ function wpmu_admin_do_redirect( $url = '' ) {
  * @return string
  */
 function wpmu_admin_redirect_add_updated_param( $url = '' ) {
-	_deprecated_function( __FUNCTION__, '3.3.0', 'add_query_arg()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', 'add_query_arg()' );
 
 	if ( strpos( $url, 'updated=true' ) === false ) {
 		if ( strpos( $url, '?' ) === false )
@@ -333,7 +333,7 @@ function wpmu_admin_redirect_add_updated_param( $url = '' ) {
  * @return int
  */
 function get_user_id_from_string( $string ) {
-	_deprecated_function( __FUNCTION__, '3.6.0', 'get_user_by()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.6.0', 'get_user_by()' );
 
 	if ( is_email( $string ) )
 		$user = get_user_by( 'email', $string );
@@ -358,7 +358,7 @@ function get_user_id_from_string( $string ) {
  * @return string
  */
 function get_blogaddress_by_domain( $domain, $path ) {
-	_deprecated_function( __FUNCTION__, '3.7.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.7.0' );
 
 	if ( is_subdomain_install() ) {
 		$url = "http://" . $domain.$path;
@@ -389,7 +389,7 @@ function get_blogaddress_by_domain( $domain, $path ) {
  * @return string|int The ID of the newly created blog
  */
 function create_empty_blog( $domain, $path, $weblog_title, $site_id = 1 ) {
-	_deprecated_function( __FUNCTION__, '4.4.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.4.0' );
 
 	if ( empty($path) )
 		$path = '/';
@@ -425,7 +425,7 @@ function create_empty_blog( $domain, $path, $weblog_title, $site_id = 1 ) {
  * @return array|false The network admins.
  */
 function get_admin_users_for_domain( $domain = '', $path = '' ) {
-	_deprecated_function( __FUNCTION__, '4.4.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.4.0' );
 
 	global $wpdb;
 
@@ -473,7 +473,7 @@ function get_admin_users_for_domain( $domain = '', $path = '' ) {
  *               values for whether the site is public, archived, mature, spam, and/or deleted.
  */
 function wp_get_sites( $args = array() ) {
-	_deprecated_function( __FUNCTION__, '4.6.0', 'get_sites()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.6.0', 'get_sites()' );
 
 	if ( wp_is_large_network() )
 		return array();
@@ -536,7 +536,7 @@ function wp_get_sites( $args = array() ) {
 function is_user_option_local( $key, $user_id = 0, $blog_id = 0 ) {
 	global $wpdb;
 
-	_deprecated_function( __FUNCTION__, '4.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-4.9.0' );
 
 	$current_user = wp_get_current_user();
 	if ( $blog_id == 0 ) {

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -503,7 +503,7 @@ function ms_not_installed( $domain, $path ) {
  * @return object
  */
 function get_current_site_name( $current_site ) {
-	_deprecated_function( __FUNCTION__, '3.9.0', 'get_current_site()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.9.0', 'get_current_site()' );
 	return $current_site;
 }
 
@@ -523,7 +523,7 @@ function get_current_site_name( $current_site ) {
  */
 function wpmu_current_site() {
 	global $current_site;
-	_deprecated_function( __FUNCTION__, '3.9.0' );
+	_deprecated_function( __FUNCTION__, 'WP-3.9.0' );
 	return $current_site;
 }
 
@@ -540,7 +540,7 @@ function wpmu_current_site() {
  * @return WP_Network|false Object containing network information if found, false if not.
  */
 function wp_get_network( $network ) {
-	_deprecated_function( __FUNCTION__, '4.7.0', 'get_network()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.7.0', 'get_network()' );
 
 	$network = get_network( $network );
 	if ( null === $network ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -440,7 +440,7 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' )
 	global $wpdb;
 
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.3.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.3.0' );
 
 	$option = trim($option);
 	if ( empty($option) )
@@ -2002,7 +2002,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 	}
 
 	if ( 'misc' == $option_group ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: %s: misc */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'misc'
@@ -2012,7 +2012,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 	}
 
 	if ( 'privacy' == $option_group ) {
-		_deprecated_argument( __FUNCTION__, '3.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0',
 			/* translators: %s: privacy */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'privacy'
@@ -2048,7 +2048,7 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 	global $new_whitelist_options, $wp_registered_settings;
 
 	if ( 'misc' == $option_group ) {
-		_deprecated_argument( __FUNCTION__, '3.0.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0',
 			/* translators: %s: misc */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'misc'
@@ -2058,7 +2058,7 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 	}
 
 	if ( 'privacy' == $option_group ) {
-		_deprecated_argument( __FUNCTION__, '3.5.0',
+		_deprecated_argument( __FUNCTION__, 'WP-3.5.0',
 			/* translators: %s: privacy */
 			sprintf( __( 'The "%s" options group has been removed. Use another settings group.' ),
 				'privacy'
@@ -2072,7 +2072,7 @@ function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
 		unset( $new_whitelist_options[ $option_group ][ $pos ] );
 	}
 	if ( '' !== $deprecated ) {
-		_deprecated_argument( __FUNCTION__, '4.7.0',
+		_deprecated_argument( __FUNCTION__, 'WP-4.7.0',
 			/* translators: 1: $sanitize_callback, 2: register_setting() */
 			sprintf( __( '%1$s is deprecated. The callback from %2$s is used instead.' ),
 				'<code>$sanitize_callback</code>',

--- a/src/wp-includes/pluggable-deprecated.php
+++ b/src/wp-includes/pluggable-deprecated.php
@@ -30,7 +30,7 @@ if ( !function_exists('set_current_user') ) :
  * @return WP_User returns wp_set_current_user()
  */
 function set_current_user($id, $name = '') {
-	_deprecated_function( __FUNCTION__, '3.0.0', 'wp_set_current_user()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.0.0', 'wp_set_current_user()' );
 	return wp_set_current_user($id, $name);
 }
 endif;
@@ -46,7 +46,7 @@ if ( !function_exists('get_currentuserinfo') ) :
  * @return bool|WP_User False on XMLRPC Request and invalid auth cookie, WP_User instance otherwise.
  */
 function get_currentuserinfo() {
-	_deprecated_function( __FUNCTION__, '4.5.0', 'wp_get_current_user()' );
+	_deprecated_function( __FUNCTION__, 'WP-4.5.0', 'wp_get_current_user()' );
 
 	return _wp_get_current_user();
 }
@@ -64,7 +64,7 @@ if ( !function_exists('get_userdatabylogin') ) :
  * @return bool|object False on failure, User DB row object
  */
 function get_userdatabylogin($user_login) {
-	_deprecated_function( __FUNCTION__, '3.3.0', "get_user_by('login')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "get_user_by('login')" );
 	return get_user_by('login', $user_login);
 }
 endif;
@@ -81,7 +81,7 @@ if ( !function_exists('get_user_by_email') ) :
  * @return bool|object False on failure, User DB row object
  */
 function get_user_by_email($email) {
-	_deprecated_function( __FUNCTION__, '3.3.0', "get_user_by('email')" );
+	_deprecated_function( __FUNCTION__, 'WP-3.3.0', "get_user_by('email')" );
 	return get_user_by('email', $email);
 }
 endif;
@@ -102,12 +102,12 @@ if ( !function_exists('wp_setcookie') ) :
  * @param bool $remember Optional. Remember that the user is logged in
  */
 function wp_setcookie($username, $password = '', $already_md5 = false, $home = '', $siteurl = '', $remember = false) {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_set_auth_cookie()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_set_auth_cookie()' );
 	$user = get_user_by('login', $username);
 	wp_set_auth_cookie($user->ID, $remember);
 }
 else :
-	_deprecated_function( 'wp_setcookie', '2.5.0', 'wp_set_auth_cookie()' );
+	_deprecated_function( 'wp_setcookie', 'WP-2.5.0', 'wp_set_auth_cookie()' );
 endif;
 
 if ( !function_exists('wp_clearcookie') ) :
@@ -119,11 +119,11 @@ if ( !function_exists('wp_clearcookie') ) :
  * @see wp_clear_auth_cookie()
  */
 function wp_clearcookie() {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_clear_auth_cookie()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_clear_auth_cookie()' );
 	wp_clear_auth_cookie();
 }
 else :
-	_deprecated_function( 'wp_clearcookie', '2.5.0', 'wp_clear_auth_cookie()' );
+	_deprecated_function( 'wp_clearcookie', 'WP-2.5.0', 'wp_clear_auth_cookie()' );
 endif;
 
 if ( !function_exists('wp_get_cookie_login') ):
@@ -139,11 +139,11 @@ if ( !function_exists('wp_get_cookie_login') ):
  * @return bool Always returns false
  */
 function wp_get_cookie_login() {
-	_deprecated_function( __FUNCTION__, '2.5.0' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0' );
 	return false;
 }
 else :
-	_deprecated_function( 'wp_get_cookie_login', '2.5.0' );
+	_deprecated_function( 'wp_get_cookie_login', 'WP-2.5.0' );
 endif;
 
 if ( !function_exists('wp_login') ) :
@@ -169,7 +169,7 @@ if ( !function_exists('wp_login') ) :
  * @return bool False on login failure, true on successful check
  */
 function wp_login($username, $password, $deprecated = '') {
-	_deprecated_function( __FUNCTION__, '2.5.0', 'wp_signon()' );
+	_deprecated_function( __FUNCTION__, 'WP-2.5.0', 'wp_signon()' );
 	global $error;
 
 	$user = wp_authenticate($username, $password);
@@ -181,7 +181,7 @@ function wp_login($username, $password, $deprecated = '') {
 	return false;
 }
 else :
-	_deprecated_function( 'wp_login', '2.5.0', 'wp_signon()' );
+	_deprecated_function( 'wp_login', 'WP-2.5.0', 'wp_signon()' );
 endif;
 
 /**
@@ -198,11 +198,11 @@ endif;
 if ( ! class_exists( 'wp_atom_server', false ) ) {
 	class wp_atom_server {
 		public function __call( $name, $arguments ) {
-			_deprecated_function( __CLASS__ . '::' . $name, '3.5.0', 'the Atom Publishing Protocol plugin' );
+			_deprecated_function( __CLASS__ . '::' . $name, 'WP-3.5.0', 'the Atom Publishing Protocol plugin' );
 		}
 
 		public static function __callStatic( $name, $arguments ) {
-			_deprecated_function( __CLASS__ . '::' . $name, '3.5.0', 'the Atom Publishing Protocol plugin' );
+			_deprecated_function( __CLASS__ . '::' . $name, 'WP-3.5.0', 'the Atom Publishing Protocol plugin' );
 		}
 	}
 }

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1385,7 +1385,7 @@ if ( ! function_exists('wp_notify_postauthor') ) :
  */
 function wp_notify_postauthor( $comment_id, $deprecated = null ) {
 	if ( null !== $deprecated ) {
-		_deprecated_argument( __FUNCTION__, '3.8.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.8.0' );
 	}
 
 	$comment = get_comment( $comment_id );
@@ -1814,7 +1814,7 @@ if ( !function_exists('wp_new_user_notification') ) :
  */
 function wp_new_user_notification( $user_id, $deprecated = null, $notify = '' ) {
 	if ( $deprecated !== null ) {
-		_deprecated_argument( __FUNCTION__, '4.3.1' );
+		_deprecated_argument( __FUNCTION__, 'WP-4.3.1' );
 	}
 
 	global $wpdb, $wp_hasher;

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1080,7 +1080,7 @@ if ( !function_exists('check_admin_referer') ) :
  */
 function check_admin_referer( $action = -1, $query_arg = '_wpnonce' ) {
 	if ( -1 == $action )
-		_doing_it_wrong( __FUNCTION__, __( 'You should specify a nonce action to be verified by using the first parameter.' ), '3.2.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'You should specify a nonce action to be verified by using the first parameter.' ), 'WP-3.2.0' );
 
 	$adminurl = strtolower(admin_url());
 	$referer = strtolower(wp_get_referer());
@@ -1123,7 +1123,7 @@ if ( !function_exists('check_ajax_referer') ) :
  */
 function check_ajax_referer( $action = -1, $query_arg = false, $die = true ) {
 	if ( -1 == $action ) {
-		_doing_it_wrong( __FUNCTION__, __( 'You should specify a nonce action to be verified by using the first parameter.' ), '4.7' );
+		_doing_it_wrong( __FUNCTION__, __( 'You should specify a nonce action to be verified by using the first parameter.' ), 'WP-4.7' );
 	}
 
 	$nonce = '';

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -582,7 +582,7 @@ function remove_all_actions($tag, $priority = false) {
  *     return apply_filters( 'wpdocs_filter', $value, $extra_arg );
  *
  *     // Deprecated.
- *     return apply_filters_deprecated( 'wpdocs_filter', array( $value, $extra_arg ), '4.9', 'wpdocs_new_filter' );
+ *     return apply_filters_deprecated( 'wpdocs_filter', array( $value, $extra_arg ), 'WP-4.9', 'wpdocs_new_filter' );
  *
  * @since WP-4.6.0
  *

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -807,7 +807,7 @@ function register_deactivation_hook($file, $function) {
  */
 function register_uninstall_hook( $file, $callback ) {
 	if ( is_array( $callback ) && is_object( $callback[0] ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Only a static class method or function can be used in an uninstall hook.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Only a static class method or function can be used in an uninstall hook.' ), 'WP-3.1.0' );
 		return;
 	}
 

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -373,7 +373,7 @@ function the_excerpt() {
  */
 function get_the_excerpt( $post = null ) {
 	if ( is_bool( $post ) ) {
-		_deprecated_argument( __FUNCTION__, '2.3.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.3.0' );
 	}
 
 	$post = get_post( $post );
@@ -1476,7 +1476,7 @@ function walk_page_dropdown_tree() {
  */
 function the_attachment_link( $id = 0, $fullsize = false, $deprecated = false, $permalink = false ) {
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '2.5.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.5.0' );
 
 	if ( $fullsize )
 		echo wp_get_attachment_link($id, 'full', $permalink);
@@ -1800,7 +1800,7 @@ function wp_list_post_revisions( $post_id = 0, $type = 'all' ) {
 	// $args array with (parent, format, right, left, type) deprecated since 3.6
 	if ( is_array( $type ) ) {
 		$type = ! empty( $type['type'] ) ? $type['type']  : $type;
-		_deprecated_argument( __FUNCTION__, '3.6.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.6.0' );
 	}
 
 	if ( ! $revisions = wp_get_post_revisions( $post->ID ) )

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1187,7 +1187,7 @@ function register_post_type( $post_type, $args = array() ) {
 	$post_type = sanitize_key( $post_type );
 
 	if ( empty( $post_type ) || strlen( $post_type ) > 20 ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Post type names must be between 1 and 20 characters in length.' ), '4.2.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Post type names must be between 1 and 20 characters in length.' ), 'WP-4.2.0' );
 		return new WP_Error( 'post_type_length_invalid', __( 'Post type names must be between 1 and 20 characters in length.' ) );
 	}
 
@@ -3509,7 +3509,7 @@ function wp_insert_post( $postarr, $wp_error = false ) {
 			$taxonomy_obj = get_taxonomy($taxonomy);
 			if ( ! $taxonomy_obj ) {
 				/* translators: %s: taxonomy name */
-				_doing_it_wrong( __FUNCTION__, sprintf( __( 'Invalid taxonomy: %s.' ), $taxonomy ), '4.4.0' );
+				_doing_it_wrong( __FUNCTION__, sprintf( __( 'Invalid taxonomy: %s.' ), $taxonomy ), 'WP-4.4.0' );
 				continue;
 			}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3043,7 +3043,7 @@ function wp_get_post_terms( $post_id = 0, $taxonomy = 'post_tag', $args = array(
 function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 
 	if ( is_numeric( $args ) ) {
-		_deprecated_argument( __FUNCTION__, '3.1.0', __( 'Passing an integer number of posts is deprecated. Pass an array of arguments instead.' ) );
+		_deprecated_argument( __FUNCTION__, 'WP-3.1.0', __( 'Passing an integer number of posts is deprecated. Pass an array of arguments instead.' ) );
 		$args = array( 'numberposts' => absint( $args ) );
 	}
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -150,7 +150,7 @@ function is_archive() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -171,7 +171,7 @@ function is_post_type_archive( $post_types = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -192,7 +192,7 @@ function is_attachment( $attachment = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -216,7 +216,7 @@ function is_author( $author = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -240,7 +240,7 @@ function is_category( $category = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -264,7 +264,7 @@ function is_tag( $tag = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -293,7 +293,7 @@ function is_tax( $taxonomy = '', $term = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -313,7 +313,7 @@ function is_date() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -333,7 +333,7 @@ function is_day() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -354,7 +354,7 @@ function is_feed( $feeds = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -374,7 +374,7 @@ function is_comment_feed() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -403,7 +403,7 @@ function is_front_page() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -432,7 +432,7 @@ function is_home() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -452,7 +452,7 @@ function is_month() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -479,7 +479,7 @@ function is_page( $page = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -499,7 +499,7 @@ function is_paged() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -519,7 +519,7 @@ function is_preview() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -539,7 +539,7 @@ function is_robots() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -559,7 +559,7 @@ function is_search() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -588,7 +588,7 @@ function is_single( $post = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -616,7 +616,7 @@ function is_singular( $post_types = '' ) {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -636,7 +636,7 @@ function is_time() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -656,7 +656,7 @@ function is_trackback() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -676,7 +676,7 @@ function is_year() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -696,7 +696,7 @@ function is_404() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -716,7 +716,7 @@ function is_embed() {
 	global $wp_query;
 
 	if ( ! isset( $wp_query ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), 'WP-3.1.0' );
 		return false;
 	}
 
@@ -742,7 +742,7 @@ function is_main_query() {
 			'<code>is_main_query()</code>',
 			__( 'https://codex.wordpress.org/Function_Reference/is_main_query' )
 		);
-		_doing_it_wrong( __FUNCTION__, $message, '3.7.0' );
+		_doing_it_wrong( __FUNCTION__, $message, 'WP-3.7.0' );
 	}
 
 	global $wp_query;

--- a/src/wp-includes/registration-functions.php
+++ b/src/wp-includes/registration-functions.php
@@ -4,4 +4,4 @@
  *
  * @package ClassicPress
  */
-_deprecated_file( basename(__FILE__), '2.1.0', null, __( 'This file no longer needs to be included.' ) );
+_deprecated_file( basename(__FILE__), 'WP-2.1.0', null, __( 'This file no longer needs to be included.' ) );

--- a/src/wp-includes/registration.php
+++ b/src/wp-includes/registration.php
@@ -4,4 +4,4 @@
  *
  * @package ClassicPress
  */
-_deprecated_file( basename(__FILE__), '3.1.0', null, __( 'This file no longer needs to be included.' ) );
+_deprecated_file( basename(__FILE__), 'WP-3.1.0', null, __( 'This file no longer needs to be included.' ) );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -34,10 +34,10 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 		 * and namespace indexes. If you really need to register a
 		 * non-namespaced route, call `WP_REST_Server::register_route` directly.
 		 */
-		_doing_it_wrong( 'register_rest_route', __( 'Routes must be namespaced with plugin or theme name and version.' ), '4.4.0' );
+		_doing_it_wrong( 'register_rest_route', __( 'Routes must be namespaced with plugin or theme name and version.' ), 'WP-4.4.0' );
 		return false;
 	} else if ( empty( $route ) ) {
-		_doing_it_wrong( 'register_rest_route', __( 'Route must be specified.' ), '4.4.0' );
+		_doing_it_wrong( 'register_rest_route', __( 'Route must be specified.' ), 'WP-4.4.0' );
 		return false;
 	}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -260,7 +260,7 @@ class WP_REST_Server {
 		 *
 		 * @param bool $rest_enabled Whether the REST API is enabled. Default true.
 		 */
-		apply_filters_deprecated( 'rest_enabled', array( true ), '4.7.0', 'rest_authentication_errors',
+		apply_filters_deprecated( 'rest_enabled', array( true ), 'WP-4.7.0', 'rest_authentication_errors',
 			__( 'The REST API can no longer be completely disabled, the rest_authentication_errors filter can be used to restrict access to the API, instead.' )
 		);
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -37,7 +37,7 @@ abstract class WP_REST_Controller {
 	 */
 	public function register_routes() {
 		/* translators: %s: register_routes() */
-		_doing_it_wrong( 'WP_REST_Controller::register_routes', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), '4.7' );
+		_doing_it_wrong( 'WP_REST_Controller::register_routes', sprintf( __( "Method '%s' must be overridden." ), __METHOD__ ), 'WP-4.7' );
 	}
 
 	/**

--- a/src/wp-includes/rss-functions.php
+++ b/src/wp-includes/rss-functions.php
@@ -5,5 +5,5 @@
  * @package ClassicPress
  */
 
-_deprecated_file( basename(__FILE__), '2.1.0', WPINC . '/rss.php' );
+_deprecated_file( basename(__FILE__), 'WP-2.1.0', WPINC . '/rss.php' );
 require_once( ABSPATH . WPINC . '/rss.php' );

--- a/src/wp-includes/rss.php
+++ b/src/wp-includes/rss.php
@@ -16,7 +16,7 @@
 /**
  * Deprecated. Use SimplePie (class-simplepie.php) instead.
  */
-_deprecated_file( basename( __FILE__ ), '3.0.0', WPINC . '/class-simplepie.php' );
+_deprecated_file( basename( __FILE__ ), 'WP-3.0.0', WPINC . '/class-simplepie.php' );
 
 /**
  * Fires before MagpieRSS is loaded, to optionally replace it.

--- a/src/wp-includes/session.php
+++ b/src/wp-includes/session.php
@@ -5,7 +5,7 @@
  * @since WP-4.0.0
  */
 
-_deprecated_file( basename( __FILE__ ), '4.7.0' );
+_deprecated_file( basename( __FILE__ ), 'WP-4.7.0' );
 
 require_once( ABSPATH . WPINC . '/class-wp-session-tokens.php' );
 require_once( ABSPATH . WPINC . '/class-wp-user-meta-session-tokens.php' );

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -65,14 +65,14 @@ function add_shortcode( $tag, $callback ) {
 
 	if ( '' == trim( $tag ) ) {
 		$message = __( 'Invalid shortcode name: Empty name given.' );
-		_doing_it_wrong( __FUNCTION__, $message, '4.4.0' );
+		_doing_it_wrong( __FUNCTION__, $message, 'WP-4.4.0' );
 		return;
 	}
 
 	if ( 0 !== preg_match( '@[<>&/\[\]\x00-\x20=]@', $tag ) ) {
 		/* translators: 1: shortcode name, 2: space separated list of reserved characters */
 		$message = sprintf( __( 'Invalid shortcode name: %1$s. Do not use spaces or reserved characters: %2$s' ), $tag, '& / < > [ ] =' );
-		_doing_it_wrong( __FUNCTION__, $message, '4.4.0' );
+		_doing_it_wrong( __FUNCTION__, $message, 'WP-4.4.0' );
 		return;
 	}
 
@@ -292,7 +292,7 @@ function do_shortcode_tag( $m ) {
 	if ( ! is_callable( $shortcode_tags[ $tag ] ) ) {
 		/* translators: %s: shortcode tag */
 		$message = sprintf( __( 'Attempting to parse a shortcode without a valid callback: %s' ), $tag );
-		_doing_it_wrong( __FUNCTION__, $message, '4.3.0' );
+		_doing_it_wrong( __FUNCTION__, $message, 'WP-4.3.0' );
 		return $m[0];
 	}
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -378,7 +378,7 @@ function register_taxonomy( $taxonomy, $object_type, $args = array() ) {
 	$args = wp_parse_args( $args );
 
 	if ( empty( $taxonomy ) || strlen( $taxonomy ) > 32 ) {
-		_doing_it_wrong( __FUNCTION__, __( 'Taxonomy names must be between 1 and 32 characters in length.' ), '4.2.0' );
+		_doing_it_wrong( __FUNCTION__, __( 'Taxonomy names must be between 1 and 32 characters in length.' ), 'WP-4.2.0' );
 		return new WP_Error( 'taxonomy_length_invalid', __( 'Taxonomy names must be between 1 and 32 characters in length.' ) );
 	}
 

--- a/src/wp-includes/theme-compat/comments.php
+++ b/src/wp-includes/theme-compat/comments.php
@@ -10,7 +10,7 @@
 _deprecated_file(
 	/* translators: %s: template name */
 	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
-	'3.0.0',
+	'WP-3.0.0',
 	null,
 	/* translators: %s: template name */
 	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )

--- a/src/wp-includes/theme-compat/footer.php
+++ b/src/wp-includes/theme-compat/footer.php
@@ -9,7 +9,7 @@
 _deprecated_file(
 	/* translators: %s: template name */
 	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
-	'3.0.0',
+	'WP-3.0.0',
 	null,
 	/* translators: %s: template name */
 	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )

--- a/src/wp-includes/theme-compat/header.php
+++ b/src/wp-includes/theme-compat/header.php
@@ -9,7 +9,7 @@
 _deprecated_file(
 	/* translators: %s: template name */
 	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
-	'3.0.0',
+	'WP-3.0.0',
 	null,
 	/* translators: %s: template name */
 	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )

--- a/src/wp-includes/theme-compat/sidebar.php
+++ b/src/wp-includes/theme-compat/sidebar.php
@@ -9,7 +9,7 @@
 _deprecated_file(
 	/* translators: %s: template name */
 	sprintf( __( 'Theme without %s' ), basename( __FILE__ ) ),
-	'3.0.0',
+	'WP-3.0.0',
 	null,
 	/* translators: %s: template name */
 	sprintf( __( 'Please include a %s template in your theme.' ), basename( __FILE__ ) )

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2259,7 +2259,7 @@ function add_theme_support( $feature ) {
 				// Build an array of types for back-compat.
 				$args = array( 0 => array( 'comment-list', 'comment-form', 'search-form' ) );
 			} elseif ( ! is_array( $args[0] ) ) {
-				_doing_it_wrong( "add_theme_support( 'html5' )", __( 'You need to pass an array of types.' ), '3.6.1' );
+				_doing_it_wrong( "add_theme_support( 'html5' )", __( 'You need to pass an array of types.' ), 'WP-3.6.1' );
 				return false;
 			}
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2416,7 +2416,7 @@ function add_theme_support( $feature ) {
 			if ( did_action( 'wp_loaded' ) ) {
 				/* translators: 1: Theme support 2: hook name */
 				_doing_it_wrong( "add_theme_support( 'title-tag' )", sprintf( __( 'Theme support for %1$s should be registered before the %2$s hook.' ),
-					'<code>title-tag</code>', '<code>wp_loaded</code>' ), '4.1.0' );
+					'<code>title-tag</code>', '<code>wp_loaded</code>' ), 'WP-4.1.0' );
 
 				return false;
 			}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -457,7 +457,7 @@ function get_user_option( $option, $user = 0, $deprecated = '' ) {
 	global $wpdb;
 
 	if ( !empty( $deprecated ) )
-		_deprecated_argument( __FUNCTION__, '3.0.0' );
+		_deprecated_argument( __FUNCTION__, 'WP-3.0.0' );
 
 	if ( empty( $user ) )
 		$user = get_current_user_id();

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -890,7 +890,7 @@ function is_active_sidebar( $index ) {
  */
 function wp_get_sidebars_widgets( $deprecated = true ) {
 	if ( $deprecated !== true )
-		_deprecated_argument( __FUNCTION__, '2.8.1' );
+		_deprecated_argument( __FUNCTION__, 'WP-2.8.1' );
 
 	global $_wp_sidebars_widgets, $sidebars_widgets;
 

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -259,7 +259,7 @@ function register_sidebar($args = array()) {
 
 	if ( $id_is_empty ) {
 		/* translators: 1: the id argument, 2: sidebar name, 3: recommended id value */
-		_doing_it_wrong( __FUNCTION__, sprintf( __( 'No %1$s was set in the arguments array for the "%2$s" sidebar. Defaulting to "%3$s". Manually set the %1$s to "%3$s" to silence this notice and keep existing sidebar content.' ), '<code>id</code>', $sidebar['name'], $sidebar['id'] ), '4.2.0' );
+		_doing_it_wrong( __FUNCTION__, sprintf( __( 'No %1$s was set in the arguments array for the "%2$s" sidebar. Defaulting to "%3$s". Manually set the %1$s to "%3$s" to silence this notice and keep existing sidebar content.' ), '<code>id</code>', $sidebar['name'], $sidebar['id'] ), 'WP-4.2.0' );
 	}
 
 	$wp_registered_sidebars[$sidebar['id']] = $sidebar;
@@ -1051,7 +1051,7 @@ function the_widget( $widget, $instance = array(), $args = array() ) {
 
 	if ( ! isset( $wp_widget_factory->widgets[ $widget ] ) ) {
 		/* translators: %s: register_widget() */
-		_doing_it_wrong( __FUNCTION__, sprintf( __( 'Widgets need to be registered using %s, before they can be displayed.' ), '<code>register_widget()</code>' ), '4.9.0' );
+		_doing_it_wrong( __FUNCTION__, sprintf( __( 'Widgets need to be registered using %s, before they can be displayed.' ), '<code>register_widget()</code>' ), 'WP-4.9.0' );
 		return;
 	}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -169,6 +169,6 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 	 * @deprecated 4.4.0 Fragment caching was removed in favor of split queries.
 	 */
 	public function flush_widget_cache() {
-		_deprecated_function( __METHOD__, '4.4.0' );
+		_deprecated_function( __METHOD__, 'WP-4.4.0' );
 	}
 }

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1082,7 +1082,7 @@ class wpdb {
 	 */
 	function _weak_escape( $string ) {
 		if ( func_num_args() === 1 && function_exists( '_deprecated_function' ) )
-			_deprecated_function( __METHOD__, '3.6.0', 'wpdb::prepare() or esc_sql()' );
+			_deprecated_function( __METHOD__, 'WP-3.6.0', 'wpdb::prepare() or esc_sql()' );
 		return addslashes( $string );
 	}
 
@@ -1157,7 +1157,7 @@ class wpdb {
 	 */
 	public function escape( $data ) {
 		if ( func_num_args() === 1 && function_exists( '_deprecated_function' ) )
-			_deprecated_function( __METHOD__, '3.6.0', 'wpdb::prepare() or esc_sql()' );
+			_deprecated_function( __METHOD__, 'WP-3.6.0', 'wpdb::prepare() or esc_sql()' );
 		if ( is_array( $data ) ) {
 			foreach ( $data as $k => $v ) {
 				if ( is_array( $v ) )
@@ -3325,7 +3325,7 @@ class wpdb {
 	 * @return bool True if collation is supported, false if version does not
 	 */
 	public function supports_collation() {
-		_deprecated_function( __FUNCTION__, '3.5.0', 'wpdb::has_cap( \'collation\' )' );
+		_deprecated_function( __FUNCTION__, 'WP-3.5.0', 'wpdb::has_cap( \'collation\' )' );
 		return $this->has_cap( 'collation' );
 	}
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1107,9 +1107,9 @@ class wpdb {
 			$class = get_class( $this );
 			if ( function_exists( '__' ) ) {
 				/* translators: %s: database access abstraction class, usually wpdb or a class extending wpdb */
-				_doing_it_wrong( $class, sprintf( __( '%s must set a database connection for use with escaping.' ), $class ), '3.6.0' );
+				_doing_it_wrong( $class, sprintf( __( '%s must set a database connection for use with escaping.' ), $class ), 'WP-3.6.0' );
 			} else {
-				_doing_it_wrong( $class, sprintf( '%s must set a database connection for use with escaping.', $class ), '3.6.0' );
+				_doing_it_wrong( $class, sprintf( '%s must set a database connection for use with escaping.', $class ), 'WP-3.6.0' );
 			}
 			$escaped = addslashes( $string );
 		}
@@ -1227,7 +1227,7 @@ class wpdb {
 		// This is not meant to be foolproof -- but it will catch obviously incorrect usage.
 		if ( strpos( $query, '%' ) === false ) {
 			wp_load_translations_early();
-			_doing_it_wrong( 'wpdb::prepare', sprintf( __( 'The query argument of %s must have a placeholder.' ), 'wpdb::prepare()' ), '3.9.0' );
+			_doing_it_wrong( 'wpdb::prepare', sprintf( __( 'The query argument of %s must have a placeholder.' ), 'wpdb::prepare()' ), 'WP-3.9.0' );
 		}
 
 		$args = func_get_args();
@@ -1243,7 +1243,7 @@ class wpdb {
 		foreach ( $args as $arg ) {
 			if ( ! is_scalar( $arg ) && ! is_null( $arg ) ) {
 				wp_load_translations_early();
-				_doing_it_wrong( 'wpdb::prepare', sprintf( __( 'Unsupported value type (%s).' ), gettype( $arg ) ), '4.8.2' );
+				_doing_it_wrong( 'wpdb::prepare', sprintf( __( 'Unsupported value type (%s).' ), gettype( $arg ) ), 'WP-4.8.2' );
 			}
 		}
 
@@ -1280,7 +1280,7 @@ class wpdb {
 			if ( 1 === $placeholders && $passed_as_array ) {
 				// If the passed query only expected one argument, but the wrong number of arguments were sent as an array, bail.
 				wp_load_translations_early();
-				_doing_it_wrong( 'wpdb::prepare', __( 'The query only expected one placeholder, but an array of multiple placeholders was sent.' ), '4.9.0' );
+				_doing_it_wrong( 'wpdb::prepare', __( 'The query only expected one placeholder, but an array of multiple placeholders was sent.' ), 'WP-4.9.0' );
 
 				return;
 			} else {

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1294,7 +1294,7 @@ class wpdb {
 					sprintf( __( 'The query does not contain the correct number of placeholders (%1$d) for the number of arguments passed (%2$d).' ),
 						$placeholders,
 						count( $args ) ),
-					'4.8.3'
+					'WP-4.8.3'
 				);
 			}
 		}

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -95,7 +95,7 @@ exit;
  * @param string $msg Information describing logging reason.
  */
 function logIO( $io, $msg ) {
-	_deprecated_function( __FUNCTION__, '3.4.0', 'error_log()' );
+	_deprecated_function( __FUNCTION__, 'WP-3.4.0', 'error_log()' );
 	if ( ! empty( $GLOBALS['xmlrpc_logging'] ) )
 		error_log( $io . ' - ' . $msg );
 }

--- a/tests/phpunit/tests/actions.php
+++ b/tests/phpunit/tests/actions.php
@@ -517,7 +517,7 @@ class Tests_Actions extends WP_UnitTestCase {
 		$p = new WP_Post( (object) array( 'post_title' => 'Foo' ) );
 
 		add_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback' ) );
-		do_action_deprecated( 'tests_do_action_deprecated', array( $p ), '4.6' );
+		do_action_deprecated( 'tests_do_action_deprecated', array( $p ), 'WP-4.6' );
 		remove_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback' ) );
 
 		$this->assertSame( 'Bar', $p->post_title );
@@ -536,7 +536,7 @@ class Tests_Actions extends WP_UnitTestCase {
 		$p2 = new WP_Post( (object) array( 'post_title' => 'Foo2' ) );
 
 		add_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback_multiple_params' ), 10, 2 );
-		do_action_deprecated( 'tests_do_action_deprecated', array( $p1, $p2 ), '4.6' );
+		do_action_deprecated( 'tests_do_action_deprecated', array( $p1, $p2 ), 'WP-4.6' );
 		remove_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback_multiple_params' ), 10, 2 );
 
 		$this->assertSame( 'Bar1', $p1->post_title );

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -303,7 +303,7 @@ class Tests_Filters extends WP_UnitTestCase {
 		$p = 'Foo';
 
 		add_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback' ) );
-		$p = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p ), '4.6' );
+		$p = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p ), 'WP-4.6' );
 		remove_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback' ) );
 
 		$this->assertSame( 'Bar', $p );
@@ -323,7 +323,7 @@ class Tests_Filters extends WP_UnitTestCase {
 		$p2 = 'Foo2';
 
 		add_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback_multiple_params' ), 10, 2 );
-		$p1 = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p1, $p2 ), '4.6' );
+		$p1 = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p1, $p2 ), 'WP-4.6' );
 		remove_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback_multiple_params' ), 10, 2 );
 
 		$this->assertSame( 'Bar1', $p1 );
@@ -345,7 +345,7 @@ class Tests_Filters extends WP_UnitTestCase {
 	public function test_apply_filters_deprecated_without_filter() {
 		$val = 'Foobar';
 
-		$this->assertSame( $val, apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $val ), '4.6' ) );
+		$this->assertSame( $val, apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $val ), 'WP-4.6' ) );
 	}
 
 	private $current_priority;

--- a/tests/phpunit/tests/includes/helpers.php
+++ b/tests/phpunit/tests/includes/helpers.php
@@ -196,7 +196,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	}
 
 	protected function mock_deprecated() {
-		_deprecated_function( __METHOD__, '2.5' );
+		_deprecated_function( __METHOD__, 'WP-2.5' );
 		return true;
 	}
 

--- a/tests/phpunit/tests/includes/helpers.php
+++ b/tests/phpunit/tests/includes/helpers.php
@@ -201,7 +201,7 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 	}
 
 	protected function mock_incorrect_usage() {
-		_doing_it_wrong( __METHOD__, __( 'Incorrect usage test' ), '2.5' );
+		_doing_it_wrong( __METHOD__, __( 'Incorrect usage test' ), 'WP-2.5' );
 		return true;
 	}
 


### PR DESCRIPTION
Updates version numbers in `_deprecated_*` and `_doing_it_wrong` functions to reflect that these are WP versions.

Closes #27.