### PR TITLE
Drop support for PHP 5.5 and lower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ matrix:
   - php: 5.6
     env: WP_TRAVIS_OBJECT_CACHE=true
     services: memcached
-  - php: 5.5
-  - php: 5.4
-  - php: 5.3
-    dist: precise
-  - php: 5.2
-    dist: precise
   - php: nightly
   allow_failures:
   - php: nightly
@@ -53,11 +47,9 @@ before_script:
     echo "xdebug.ini does not exist"
   fi
 - |
-  # Export Composer's global bin dir to PATH, but not on PHP 5.2:
-  if [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-    composer config --list --global
-    export PATH=`composer config --list --global | grep '\[home\]' | { read a; echo "${a#* }/vendor/bin:$PATH"; }`
-  fi
+  # Export Composer's global bin dir to PATH
+  composer config --list --global
+  export PATH=`composer config --list --global | grep '\[home\]' | { read a; echo "${a#* }/vendor/bin:$PATH"; }`
 - |
   # Install the specified version of PHPUnit depending on the PHP version:
   if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
@@ -66,13 +58,9 @@ before_script:
         echo "Using PHPUnit 6.x"
         composer global require "phpunit/phpunit:^6"
         ;;
-      5.6|5.5|5.4|5.3)
+      5.6)
         echo "Using PHPUnit 4.x"
         composer global require "phpunit/phpunit:^4"
-        ;;
-      5.2)
-        # Do nothing, use default PHPUnit 3.6.x
-        echo "Using default PHPUnit, hopefully 3.6"
         ;;
       *)
         echo "No PHPUnit version handling for PHP version $TRAVIS_PHP_VERSION"

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -53,7 +53,7 @@ $tinymce_version = '4800-20180716';
  *
  * @global string $required_php_version
  */
-$required_php_version = '5.2.4';
+$required_php_version = '5.6.0';
 
 /**
  * Holds the required MySQL version


### PR DESCRIPTION
See:

- https://vote.classicpress.net/posts/3/increase-the-minimum-php-version-to-5-6
- https://vote.classicpress.net/posts/6/minimum-php-version-should-be-7-0
- https://wordpress.org/about/stats/
- https://classicpress.slack.com/archives/CCQ01LKDX/p1536848528000100

This is an intermediate step to bumping the minimum PHP version to 7.x, which we will be looking at for v2.  I would love to go ahead and drop 5.6 now, but 38.3% of all WordPress sites are on it, which to me is way too many people to exclude.

The only immediate effect of this change is that Travis CI builds will now be significantly faster.

We _could_ go ahead and remove some compatibility code for PHP <= 5.5, but I don't really think it's necessary for v1.  Let's track that at #63.

To avoid any ill effects from this change, we'll implement a minimum PHP version check in the [migration plugin](https://github.com/ClassicPress/ClassicPress-Migration-Plugin) and block the installation for PHP <= 5.5.