### PR TITLE
rename WP site name and link of Widget Meta

### DIFF
--- a/src/wp-includes/widgets/class-wp-widget-meta.php
+++ b/src/wp-includes/widgets/class-wp-widget-meta.php
@@ -26,7 +26,7 @@ class WP_Widget_Meta extends WP_Widget {
 	public function __construct() {
 		$widget_ops = array(
 			'classname' => 'widget_meta',
-			'description' => __( 'Login, RSS, &amp; WordPress.org links.' ),
+			'description' => __( 'Login, RSS, &amp; ClassicPress.net links.' ),
 			'customize_selective_refresh' => true,
 		);
 		parent::__construct( 'meta', __( 'Meta' ), $widget_ops );
@@ -65,13 +65,13 @@ class WP_Widget_Meta extends WP_Widget {
 			 * @since WP-3.6.0
 			 * @since WP-4.9.0 Added the `$instance` parameter.
 			 *
-			 * @param string $title_text Default title text for the WordPress.org link.
+			 * @param string $title_text Default title text for the ClassicPress.net link.
 			 * @param array  $instance   Array of settings for the current widget.
 			 */
 			echo apply_filters( 'widget_meta_poweredby', sprintf( '<li><a href="%s" title="%s">%s</a></li>',
-				esc_url( __( 'https://wordpress.org/' ) ),
+				esc_url( __( 'https://www.classicpress.net/' ) ),
 				esc_attr__( 'Powered by ClassicPress, state-of-the-art semantic personal publishing platform.' ),
-				_x( 'WordPress.org', 'meta widget link text' )
+				_x( 'ClassicPress.net', 'meta widget link text' )
 			), $instance );
 
 			wp_meta();


### PR DESCRIPTION
As per title, I guess we missed this during #34 