### PR TITLE
Change default database prefix and name during install

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -195,7 +195,7 @@ switch($step) {
 	<table class="form-table">
 		<tr>
 			<th scope="row"><label for="dbname"><?php _e( 'Database Name' ); ?></label></th>
-			<td><input name="dbname" id="dbname" type="text" size="25" value="wordpress" /></td>
+			<td><input name="dbname" id="dbname" type="text" size="25" value="classicpress" /></td>
 			<td><?php _e( 'The name of the database you want to use with ClassicPress.' ); ?></td>
 		</tr>
 		<tr>

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -218,7 +218,7 @@ switch($step) {
 		</tr>
 		<tr>
 			<th scope="row"><label for="prefix"><?php _e( 'Table Prefix' ); ?></label></th>
-			<td><input name="prefix" id="prefix" type="text" value="wp_" size="25" /></td>
+			<td><input name="prefix" id="prefix" type="text" value="cp_" size="25" /></td>
 			<td><?php _e( 'If you want to run multiple ClassicPress installations in a single database, change this.' ); ?></td>
 		</tr>
 	</table>


### PR DESCRIPTION
Update `wp_` to `cp_` (default database table prefix) and `wordpress` to `classicpress` (default database name) in the install procedure. Thanks @invisnet for pointing this out