### PR TITLE
fix test text to enable PR #75

### DIFF
--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -19,7 +19,7 @@ class Tests_Basic extends WP_UnitTestCase {
 		preg_match( '#Copyright 2003-(\d+) by the WordPress contributors#', $license, $matches );
 		$this->assertEquals( $this_year, trim( $matches[1] ), "license.txt's year needs to be updated to $this_year." );
 
-		preg_match( '#Copyright (2018-)?(\d+) by the contributors#', $license, $matches );
+		preg_match( '#Copyright &copy; (2018-)?(\d+) ClassicPress and contributors#', $license, $matches );
 		$this->assertEquals( $this_year, trim( $matches[2] ), "license.txt's year needs to be updated to $this_year." );
 	}
 


### PR DESCRIPTION
PR #75  does not pass Travis due to the fact that the text no longer matches. This PR changes the text in the test.

@nylen additional info for review:
in the same file on [lines 19-20](https://github.com/ClassicPress/ClassicPress/blob/master/tests/phpunit/tests/basic.php#L19-L20), there is another line of text, but I am not sure what to do with that.  