### PR TITLE
Add a common prefix to all Renovate PR titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,6 @@
 	],
 	"labels": [
 		"bot"
-	]
+	],
+	"commitMessagePrefix": "Renovate[bot]:"
 }


### PR DESCRIPTION
https://renovatebot.com/ will be generating a lot of PRs for us (so far #88 #89 and #90).  This change should configure it to use a common prefix for all of its PR titles and commit messages.