### PR TITLE
Add a script to check for build changes

### DIFF
--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -33,7 +33,8 @@ unminify_build_dir() {
 
 rm -rf build/ build-branch/ build-unminified/ build-branch-unminified/ build-compare.diff
 
-git checkout "$branch"
+git fetch origin
+git checkout "origin/$branch" -B "$branch"
 grunt build
 mv build/ build-branch/
 cp -var build-branch/ build-branch-unminified/

--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -18,6 +18,9 @@ if [ ! -x "$(which js-beautify)" ] || [ ! -x "$(which css-beautify)" ]; then
 	exit 1
 fi
 
+# exit on error
+set -e
+
 unminify_build_dir() {
 	dir="$1"
 	find "$dir" -name '*.min.css' | while read i; do

--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -46,8 +46,13 @@ unminify_build_dir build-unminified/
 # Changes in version.php (timestamp) are normal
 rm -v build-unminified/wp-includes/version.php
 rm -v build-branch-unminified/wp-includes/version.php
+
 diff -ur build-unminified/ build-branch-unminified/ > build-compare.diff
 
+echo
+echo "Diff results for branch: $branch"
+echo "Diff results for branch: $branch" | sed -r 's/./=/g'
 wc -l build-compare.diff
+echo
 
 git checkout "$branch"

--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Given a branch name, run a build before and after the changes in the branch,
+# and compare the contents of the `build/` folder each time.
+#
+# The most common use for this script is to check for potential issues with an
+# upgrade to a JS dependency, but it could come in handy for other things too.
+
+branch="$1"
+if [ -z "$branch" ]; then
+	echo "Usage: $0 branch-to-compare"
+	exit 1
+fi
+
+if [ ! -x "$(which js-beautify)" ] || [ ! -x "$(which css-beautify)" ]; then
+	echo "Install js-beautify and css-beautify first:"
+	echo "npm install -g js-beautify"
+	exit 1
+fi
+
+unminify_build_dir() {
+	dir="$1"
+	find "$dir" -name '*.min.css' | while read i; do
+		css-beautify -r "$i"
+	done
+	find "$dir" -name '*.min.js' | while read i; do
+		js-beautify -r "$i"
+	done
+}
+
+rm -rf build/ build-branch/ build-unminified/ build-branch-unminified/ build-compare.diff
+
+git checkout "$branch"
+grunt build
+mv build/ build-branch/
+cp -var build-branch/ build-branch-unminified/
+
+unminify_build_dir build-branch-unminified/
+
+git checkout "$(git merge-base origin/master $branch)"
+grunt build
+cp -var build/ build-unminified/
+
+unminify_build_dir build-unminified/
+
+# Changes in version.php (timestamp) are normal
+rm -v build-unminified/wp-includes/version.php
+rm -v build-branch-unminified/wp-includes/version.php
+diff -ur build-unminified/ build-branch-unminified/ > build-compare.diff
+
+wc -l build-compare.diff
+
+git checkout "$branch"


### PR DESCRIPTION
This PR adds a script to compare the contents of the `build/` folder (generated by `grunt build`) before and after the changes added by a branch.

This is intended to help with part of #113 for upgrades to our dependencies:

> No changes in the `build/` folder resulting from the upgrade, or all changes are harmless and non-breaking

In the future we can probably also use this to verify that other changes to the build are working as intended.

I'm not sure if this should be merged or not, but at least here it will be available for reference.