### PR TITLE
Prepare the core auto-update system for the ClassicPress´ API 🚀

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -128,11 +128,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	if ( is_array( $extra_stats ) )
 		$post_body = array_merge( $post_body, $extra_stats );
 
-	/**
-	 * The auto-update API URL needs to be changed to point to the ClassicPress API instead of WP
-	 *
-	 * @since CP-1.0.0
-	 */
 	$url = $http_url = 'https://api-v1.classicpress.net/core/version-check/1.0/?' . http_build_query( $query, null, '&' );
 	if ( $ssl = wp_http_supports( array( 'ssl' ) ) )
 		$url = set_url_scheme( $url, 'https' );
@@ -154,8 +149,8 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		trigger_error(
 			sprintf(
 				/* translators: %s: support forums URL */
-				__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support channel</a>.' ),
-				__( 'https://classicpress.net/' )
+				__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please join our <a href="%s">Slack group</a> and report this issue.' ),
+				__( 'https://www.classicpress.net/' )
 			) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -27,7 +27,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	}
 
 	global $wpdb, $wp_local_package;
-	// include an unmodified $wp_version
+	// include an unmodified $cp_version
 	include( ABSPATH . WPINC . '/version.php' );
 	$php_version = phpversion();
 
@@ -35,13 +35,13 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$translations = wp_get_installed_translations( 'core' );
 
 	// Invalidate the transient when $wp_version changes
-	if ( is_object( $current ) && $wp_version != $current->version_checked )
+	if ( is_object( $current ) && $cp_version != $current->version_checked )
 		$current = false;
 
 	if ( ! is_object($current) ) {
 		$current = new stdClass;
 		$current->updates = array();
-		$current->version_checked = $wp_version;
+		$current->version_checked = $cp_version;
 	}
 
 	if ( ! empty( $extra_stats ) )
@@ -86,7 +86,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	}
 
 	$query = array(
-		'version'            => $wp_version,
+		'version'            => $cp_version,
 		'php'                => $php_version,
 		'locale'             => $locale,
 		'mysql'              => $mysql_version,
@@ -136,7 +136,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	$options = array(
 		'timeout' => $doing_cron ? 30 : 3,
-		'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ),
+		'user-agent' => 'ClassicPress/' . $cp_version . '; ' . home_url( '/' ),
 		'headers' => array(
 			'wp_install' => $wp_install,
 			'wp_blog' => home_url( '/' )
@@ -187,7 +187,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$updates = new stdClass();
 	$updates->updates = $offers;
 	$updates->last_checked = time();
-	$updates->version_checked = $wp_version;
+	$updates->version_checked = $cp_version;
 
 	if ( isset( $body['translations'] ) )
 		$updates->translations = $body['translations'];
@@ -660,14 +660,14 @@ function wp_get_update_data() {
  * @global string $wp_version
  */
 function _maybe_update_core() {
-	// include an unmodified $wp_version
+	// include an unmodified $cp_version
 	include( ABSPATH . WPINC . '/version.php' );
 
 	$current = get_site_transient( 'update_core' );
 
 	if ( isset( $current->last_checked, $current->version_checked ) &&
 		12 * HOUR_IN_SECONDS > ( time() - $current->last_checked ) &&
-		$current->version_checked == $wp_version ) {
+		$current->version_checked == $cp_version ) {
 		return;
 	}
 	wp_version_check();

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -128,7 +128,12 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	if ( is_array( $extra_stats ) )
 		$post_body = array_merge( $post_body, $extra_stats );
 
-	$url = $http_url = 'http://api.wordpress.org/core/version-check/1.7/?' . http_build_query( $query, null, '&' );
+	/**
+	 * The auto-update API URL needs to be changed to point to the ClassicPress API instead of WP
+	 *
+	 * @since CP-1.0.0
+	 */
+	$url = $http_url = 'https://api-v1.classicpress.net/core/version-check/1.0/?' . http_build_query( $query, null, '&' );
 	if ( $ssl = wp_http_supports( array( 'ssl' ) ) )
 		$url = set_url_scheme( $url, 'https' );
 
@@ -136,7 +141,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	$options = array(
 		'timeout' => $doing_cron ? 30 : 3,
-		'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),
+		'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ),
 		'headers' => array(
 			'wp_install' => $wp_install,
 			'wp_blog' => home_url( '/' )
@@ -149,9 +154,9 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		trigger_error(
 			sprintf(
 				/* translators: %s: support forums URL */
-				__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-				__( 'https://wordpress.org/support/' )
-			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
+				__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support channel</a>.' ),
+				__( 'https://classicpress.net/' )
+			) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
 		$response = wp_remote_post( $http_url, $options );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -14,7 +14,6 @@
  * isn't installing.
  *
  * @since WP-2.3.0
- * @global string $wp_version Used to check against the newest WordPress version.
  * @global wpdb   $wpdb
  * @global string $wp_local_package
  *
@@ -34,7 +33,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$current = get_site_transient( 'update_core' );
 	$translations = wp_get_installed_translations( 'core' );
 
-	// Invalidate the transient when $wp_version changes
+	// Invalidate the transient when $cp_version changes
 	if ( is_object( $current ) && $cp_version != $current->version_checked )
 		$current = false;
 


### PR DESCRIPTION
## Description

There are few things to consider here.

1. Instead of disabling the auto updates I've changed the URL to point to the actual ClassicPress API to be able to use it in the future.

2. ~The actual ClassicPress API response is badly formatted~ Fixed!

~`offers` is an array of objects but ClassicPress is returned just an object, resulting in a lot of warnings~

3. The ClassicPress Version is `4.9.9-alpha-43554-src` we should start using `0.x.x` or something to be ready to the `1.0.0` release.

## Motivation and context

Closes #110.

## How has this been tested?
There is no way to tests if an auto-update breaks a site see [43395](https://core.trac.wordpress.org/ticket/43395) 

But the  update flow is triggered in 3 points I run this functions manually.

- `_maybe_update_core` via an `admin_init` action
- `wp_version_check()` this is the function that call the API to store appropiate data
- `wp_maybe_auto_update()` triggers the real update based on the dara collected in the `wp_version_check()` function

## Types of changes
~~Bug fix (non-breaking change which fixes an issue)~~
~~New feature (non-breaking change which adds functionality)~~
~~Breaking change (fix or feature that would cause existing functionality to change)~~
**None of the above**

## Checklist:
- ✅ My code follows the code style of this project.
- ❌ My change requires a change to the documentation.
- ❌ I have updated the documentation accordingly.
