### PR TITLE
Make migration and upgrades work

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -895,19 +895,25 @@ function update_core($from, $to) {
 	apply_filters( 'update_feedback', __( 'Verifying the unpacked files&#8230;' ) );
 
 	// Sanity check the unzipped distribution.
-	$distro = '';
-	$roots = array( '/wordpress/', '/wordpress-mu/' );
-	foreach ( $roots as $root ) {
-		if ( $wp_filesystem->exists( $from . $root . 'readme.html' ) && $wp_filesystem->exists( $from . $root . 'wp-includes/version.php' ) ) {
-			$distro = $root;
-			break;
+	$distro = null;
+	$entries = array_values( $wp_filesystem->dirlist( $from ) );
+	if (
+		count( $entries ) === 1 &&
+		substr( $entries[0]['name'], 0, 13 ) === 'ClassicPress-' &&
+		$entries[0]['type'] === 'd'
+	) {
+		$distro = '/' . $entries[0]['name'] . '/';
+		if (
+			! $wp_filesystem->exists( $from . $distro . 'readme.html' ) ||
+			! $wp_filesystem->exists( $from . $distro . 'wp-includes/version.php' )
+		) {
+			$distro = null;
 		}
 	}
 	if ( ! $distro ) {
 		$wp_filesystem->delete( $from, true );
 		return new WP_Error( 'insane_distro', __('The update could not be unpacked') );
 	}
-
 
 	/*
 	 * Import $wp_version, $required_php_version, and $required_mysql_version from the new version.


### PR DESCRIPTION
Fixes #136.

Tested by running `grunt build`, zipping up the result, modifying the zip file URL and version number in the current version of the migration plugin, and attempting the migration.

Here is the result:

![switch-to-classicpress](https://user-images.githubusercontent.com/227022/47132692-de22f780-d26a-11e8-850a-44c8f85628f3.gif)
