### PR TITLE
Update version; start planning future versions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -151,7 +151,11 @@ module.exports = function(grunt) {
 				options: {
 					processContent: function( src ) {
 						return src.replace( /^\$cp_version = '(.+?)';/m, function( str, version ) {
-							if ( process.env.CLASSICPRESS_NIGHTLY ) {
+							if ( process.env.CLASSICPRESS_RELEASE ) {
+								// This is an official build.  Remove the
+								// '+dev' suffix from the source tree.
+								version = version.replace( /\+dev$/, '' );
+							} else {
 								// This is a nightly build.  Replace the '+dev'
 								// suffix from the source tree with e.g.
 								// '+build.20181019'.  Use yesterday's date -
@@ -162,10 +166,6 @@ module.exports = function(grunt) {
 									/\+dev$/,
 									'+build.' + grunt.template.date( d, 'yyyymmdd' )
 								);
-							} else {
-								// This is an official build.  Remove the
-								// '+dev' suffix from the source tree.
-								version = version.replace( /\+dev$/, '' );
 							}
 
 							/* jshint quotmark: true */

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,14 +150,26 @@ module.exports = function(grunt) {
 			version: {
 				options: {
 					processContent: function( src ) {
-						return src.replace( /^\$wp_version = '(.+?)';/m, function( str, version ) {
-							version = version.replace( /-src$/, '' );
-
-							// If the version includes an SVN commit (-12345), it's not a released alpha/beta. Append a timestamp.
-							version = version.replace( /-[\d]{5}$/, '-' + grunt.template.today( 'yyyymmdd.HHMMss' ) );
+						return src.replace( /^\$cp_version = '(.+?)';/m, function( str, version ) {
+							if ( process.env.CLASSICPRESS_NIGHTLY ) {
+								// This is a nightly build.  Replace the '+dev'
+								// suffix from the source tree with e.g.
+								// '+build.20181019'.  Use yesterday's date -
+								// nightly builds are baked at midnight UTC.
+								var d = new Date();
+								d.setDate( d.getDate() - 1 );
+								version = version.replace(
+									/\+dev$/,
+									'+build.' + grunt.template.date( d, 'yyyymmdd' )
+								);
+							} else {
+								// This is an official build.  Remove the
+								// '+dev' suffix from the source tree.
+								version = version.replace( /\+dev$/, '' );
+							}
 
 							/* jshint quotmark: true */
-							return "$wp_version = '" + version + "';";
+							return "$cp_version = '" + version + "';";
 						});
 					}
 				},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ClassicPress",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0-alpha0+dev",
   "description": "ClassicPress is web software you can use to create a beautiful website or blog.",
   "repository": {
     "type": "git",

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -3,30 +3,31 @@
  * The ClassicPress version string
  *
  * This string is the "base" version of the current source tree.  It may have
- * one of the following formats:
+ * one of the following semver-compliant formats:
  *
- * - 1.0.0-alpha0-dev  : development version, before any official releases of
+ * - 1.0.0-alpha0+dev  : development version, before any official releases of
  *                       the 1.0.0 series
  * - 1.0.0-alpha1      : official release 1.0.0-alpha1
- * - 1.0.0-alpha2-dev  : the commit immediately after 1.0.0-alpha1, and any
+ * - 1.0.0-alpha2+dev  : the commit immediately after 1.0.0-alpha1, and any
  *                       development commits before the next release
  * - 1.0.0-beta1       : official release 1.0.0-beta1
- * - 1.0.0-beta2-dev   : the commit immediately after 1.0.0-beta1, and any
+ * - 1.0.0-beta2+dev   : the commit immediately after 1.0.0-beta1, and any
  *                       development commits before the next release
  * - 1.0.0             : official release 1.0.0
- * - 1.0.1-alpha0-dev  : the commit immediately after 1.0.0, and any
+ * - 1.0.1-alpha0+dev  : the commit immediately after 1.0.0, and any
  *                       development commits before the 1.0.1 alpha, beta, or
  *                       final release(s)
  *
- * On the `develop` branch this string will always contain the '-dev' suffix.
- * On the `master` branch it will never contain the '-dev' suffix.
+ * In the source repository this string will always contain the '+dev' suffix.
+ * In released builds it will never contain the '+dev' suffix.
  *
- * When nightly (development) builds are created, this is automatically updated
- * to a more appropriate value during the build process.
+ * When nightly (development) builds are created, this suffix is automatically
+ * updated to e.g. '+build.20181019'.  When alpha, beta, or final release
+ * builds are created, the suffix is removed.
  *
  * @global string $cp_version
  */
-$cp_version = '1.0.0-alpha0-dev';
+$cp_version = '1.0.0-alpha0+dev';
 
 /**
  * Return the ClassicPress version string.

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -55,7 +55,7 @@ if ( ! function_exists( 'classicpress_version' ) ) {
  *
  * @global string $wp_version
  */
-$wp_version = '4.9.9-alpha-43554-src';
+$wp_version = '4.9.8';
 
 /**
  * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -2,9 +2,31 @@
 /**
  * The ClassicPress version string
  *
+ * This string is the "base" version of the current source tree.  It may have
+ * one of the following formats:
+ *
+ * - 1.0.0-alpha0-dev  : development version, before any official releases of
+ *                       the 1.0.0 series
+ * - 1.0.0-alpha1      : official release 1.0.0-alpha1
+ * - 1.0.0-alpha2-dev  : the commit immediately after 1.0.0-alpha1, and any
+ *                       development commits before the next release
+ * - 1.0.0-beta1       : official release 1.0.0-beta1
+ * - 1.0.0-beta2-dev   : the commit immediately after 1.0.0-beta1, and any
+ *                       development commits before the next release
+ * - 1.0.0             : official release 1.0.0
+ * - 1.0.1-alpha0-dev  : the commit immediately after 1.0.0, and any
+ *                       development commits before the 1.0.1 alpha, beta, or
+ *                       final release(s)
+ *
+ * On the `develop` branch this string will always contain the '-dev' suffix.
+ * On the `master` branch it will never contain the '-dev' suffix.
+ *
+ * When nightly (development) builds are created, this is automatically updated
+ * to a more appropriate value during the build process.
+ *
  * @global string $cp_version
  */
-$cp_version = '1.0.0-alpha';
+$cp_version = '1.0.0-alpha0-dev';
 
 /**
  * Return the ClassicPress version string.


### PR DESCRIPTION
We've started using the convention `alpha0` for any builds before the first alpha, and `+dev` for development versions (ClassicPress installs from the source repository).  This PR updates the version string in the source accordingly and modifies the build process to either replace the `+dev` suffix or replace it with a nightly version string.

The inline documentation is related to ongoing discussion about versioning and can be improved as we refine our strategy there.