### PR TITLE
Support installing from a migration build

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -899,7 +899,10 @@ function update_core($from, $to) {
 	$entries = array_values( $wp_filesystem->dirlist( $from ) );
 	if (
 		count( $entries ) === 1 &&
-		substr( $entries[0]['name'], 0, 13 ) === 'ClassicPress-' &&
+		(
+			substr( $entries[0]['name'], 0, 13 ) === 'ClassicPress-' ||
+			$entries[0]['name'] === 'wordpress' // migration build
+		) &&
 		$entries[0]['type'] === 'd'
 	) {
 		$distro = '/' . $entries[0]['name'] . '/';


### PR DESCRIPTION
Follow-up to #141.

We've decided to do the migration build separately from the clean install build so that we can get rid of this absurdity:

https://github.com/ClassicPress/ClassicPress-Migration-Plugin/blob/e79d3437c9e60311dbd1ce301887bf740790df5b/lib/class.wp-filesystem-shenanigans.php#L20

The first migration build is live at https://github.com/ClassyBot/ClassicPress-nightly/releases.

I have not tested this PR, please don't merge it yet.