### PR TITLE
Use ClassicPress version for asset cache busters

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -136,7 +136,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
  * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
  *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
+ *                                    number is automatically added equal to current installed ClassicPress version.
  *                                    If set to null, no version is added.
  * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
  *                                    Default 'false'.
@@ -256,7 +256,7 @@ function wp_deregister_script( $handle ) {
  * @param array            $deps      Optional. An array of registered script handles this script depends on. Default empty array.
  * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
  *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
+ *                                    number is automatically added equal to current installed ClassicPress version.
  *                                    If set to null, no version is added.
  * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
  *                                    Default 'false'.

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -110,7 +110,7 @@ function wp_add_inline_style( $handle, $data ) {
  * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
  * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
  *                                 as a query string for cache busting purposes. If version is set to false, a version
- *                                 number is automatically added equal to current installed WordPress version.
+ *                                 number is automatically added equal to current installed ClassicPress version.
  *                                 If set to null, no version is added.
  * @param string           $media  Optional. The media for which this stylesheet has been defined.
  *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
@@ -155,7 +155,7 @@ function wp_deregister_style( $handle ) {
  * @param array            $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
  * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
  *                                 as a query string for cache busting purposes. If version is set to false, a version
- *                                 number is automatically added equal to current installed WordPress version.
+ *                                 number is automatically added equal to current installed ClassicPress version.
  *                                 If set to null, no version is added.
  * @param string           $media  Optional. The media for which this stylesheet has been defined.
  *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -61,7 +61,7 @@ function wp_default_scripts( &$scripts ) {
 
 	$scripts->base_url = $guessurl;
 	$scripts->content_url = defined('WP_CONTENT_URL')? WP_CONTENT_URL : '';
-	$scripts->default_version = get_bloginfo( 'version' );
+	$scripts->default_version = preg_replace( '#\+.*$#', '', classicpress_version() );
 	$scripts->default_dirs = array('/wp-admin/js/', '/wp-includes/js/');
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
@@ -934,7 +934,7 @@ function wp_default_styles( &$styles ) {
 
 	$styles->base_url = $guessurl;
 	$styles->content_url = defined('WP_CONTENT_URL')? WP_CONTENT_URL : '';
-	$styles->default_version = get_bloginfo( 'version' );
+	$styles->default_version = preg_replace( '#\+.*$#', '', classicpress_version() );
 	$styles->text_direction = function_exists( 'is_rtl' ) && is_rtl() ? 'rtl' : 'ltr';
 	$styles->default_dirs = array('/wp-admin/', '/wp-includes/css/');
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -4,14 +4,20 @@
  * @group scripts
  */
 class Tests_Dependencies_Scripts extends WP_UnitTestCase {
-	var $old_wp_scripts;
+	public $old_wp_scripts;
+	public static $asset_version;
+
+	public static function setUpBeforeClass() {
+		self::$asset_version = preg_replace( '#\+.*$#', '', classicpress_version() );
+		parent::setUpBeforeClass();
+	}
 
 	function setUp() {
 		parent::setUp();
 		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
 		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
-		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
+		$GLOBALS['wp_scripts']->default_version = self::$asset_version;
 	}
 
 	function tearDown() {
@@ -29,7 +35,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_enqueue_script('empty-deps-no-version', 'example.com' );
 		wp_enqueue_script('empty-deps-version', 'example.com', array(), 1.2);
 		wp_enqueue_script('empty-deps-null-version', 'example.com', array(), null);
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='http://example.com?ver=$ver'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com?ver=$ver'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com?ver=1.2'></script>\n";
@@ -52,7 +58,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$base_url_backup = $wp_scripts->base_url;
 		$wp_scripts->base_url = 'http://example.com/wordpress';
 		$expected = '';
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 
 		// Try with an HTTP reference
 		wp_enqueue_script( 'jquery-http', 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js' );
@@ -101,7 +107,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=one,two,three&amp;ver={$ver}'></script>\n";
 
 		$this->assertEquals( $expected, $print_scripts );
@@ -449,7 +455,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 		wp_add_inline_script( 'two', 'console.log("before two");', 'before' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected = "<script type='text/javascript'>\nconsole.log(\"before one\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/directory/one.js?ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"before two\");\n</script>\n";
@@ -474,7 +480,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected = "<script type='text/javascript'>\nconsole.log(\"before one\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/directory/one.js?ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/directory/two.js?ver={$ver}'></script>\n";
@@ -500,7 +506,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_add_inline_script( 'two', 'console.log("after two");' );
 		wp_add_inline_script( 'three', 'console.log("after three");' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=one&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/directory/two.js?ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"after two\");\n</script>\n";
@@ -552,7 +558,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=jquery-core,jquery-migrate&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"after\");\n</script>\n";
@@ -577,7 +583,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=jquery-core,jquery-migrate&amp;ver={$ver}'></script>\n";
 		$expected .= "<!--[if gte IE 9]>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com'></script>\n";
@@ -605,7 +611,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=jquery-core,jquery-migrate&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"before\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com'></script>\n";
@@ -630,7 +636,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=jquery-core,jquery-migrate,wp-a11y&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"before\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com'></script>\n";
@@ -691,7 +697,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_enqueue_script( 'three', '/wp-includes/js/script3.js' );
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-includes/js/script.js?ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"after one\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script2.js?ver={$ver}'></script>\n";
@@ -716,7 +722,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		wp_add_inline_script( 'three', 'console.log("before three");', 'before' );
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
-		$ver = get_bloginfo( 'version' );
+		$ver = self::$asset_version;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5B%5D=one,two&amp;ver={$ver}'></script>\n";
 		$expected .= "<script type='text/javascript'>\nconsole.log(\"before three\");\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$ver}'></script>\n";


### PR DESCRIPTION
Closes #56 and addresses issues with cached WP stylesheets being loaded
after migrating to ClassicPress (note the missing logo in the top right, because its CSS rules were not loaded):

![2018-10-21t00 15 57-05 00](https://user-images.githubusercontent.com/227022/47263907-943b4b00-d4d0-11e8-9b42-286a2b7ede23.png)
