### PR TITLE
Improve handling of development versions

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -40,7 +40,7 @@ require_once( ABSPATH . 'wp-admin/includes/translation-install.php' );
 
 nocache_headers();
 
-// Support wp-config-sample.php one level up, for the develop repo.
+// Support wp-config-sample.php one level up, for the source repository.
 if ( file_exists( ABSPATH . 'wp-config-sample.php' ) ) {
 	$config_file = file( ABSPATH . 'wp-config-sample.php' );
 } elseif ( file_exists( dirname( ABSPATH ) . '/wp-config-sample.php' ) ) {

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -1411,7 +1411,7 @@ final class _WP_Editors {
 			&& false !== stripos( $_SERVER['HTTP_ACCEPT_ENCODING'], 'gzip' ) && ! $has_custom_theme;
 
 		// Load tinymce.js when running from /src, else load wp-tinymce.js.gz (production) or tinymce.min.js (SCRIPT_DEBUG)
-		$mce_suffix = false !== strpos( get_bloginfo( 'version' ), '-src' ) ? '' : '.min';
+		$mce_suffix = classicpress_is_dev_install() ? '' : '.min';
 
 		if ( $compressed ) {
 			echo "<script type='text/javascript' src='{$baseurl}/wp-tinymce.php?c=1&amp;$version'></script>\n";

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -228,7 +228,7 @@ class WP_Locale {
 		elseif ( 'rtl' == _x( 'ltr', 'text direction' ) )
 			$this->text_direction = 'rtl';
 
-		if ( 'rtl' === $this->text_direction && strpos( get_bloginfo( 'version' ), '-src' ) ) {
+		if ( 'rtl' === $this->text_direction && classicpress_is_dev_install() ) {
 			$this->text_direction = 'ltr';
 			add_action( 'all_admin_notices', array( $this, 'rtl_src_admin_notice' ) );
 		}
@@ -241,7 +241,7 @@ class WP_Locale {
 	 */
 	public function rtl_src_admin_notice() {
 		/* translators: %s: Name of the directory (build) */
-		echo '<div class="error"><p>' . sprintf( __( 'The %s directory of the develop repository must be used for RTL.' ), '<code>build</code>' ) . '</p></div>';
+		echo '<div class="error"><p>' . sprintf( __( 'The %s directory of the source repository must be used for RTL.' ), '<code>build</code>' ) . '</p></div>';
 	}
 
 	/**

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -84,8 +84,8 @@ function wp_initial_constants() {
 	// Add define('SCRIPT_DEBUG', true); to wp-config.php to enable loading of non-minified,
 	// non-concatenated scripts and stylesheets.
 	if ( ! defined( 'SCRIPT_DEBUG' ) ) {
-		if ( ! empty( $GLOBALS['cp_version'] ) && function_exists( 'classicpress_is_dev_version' ) ) {
-			$develop_src = classicpress_is_dev_version();
+		if ( ! empty( $GLOBALS['cp_version'] ) && function_exists( 'classicpress_is_dev_install' ) ) {
+			$develop_src = classicpress_is_dev_install();
 		} else {
 			$develop_src = false;
 		}

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -84,8 +84,8 @@ function wp_initial_constants() {
 	// Add define('SCRIPT_DEBUG', true); to wp-config.php to enable loading of non-minified,
 	// non-concatenated scripts and stylesheets.
 	if ( ! defined( 'SCRIPT_DEBUG' ) ) {
-		if ( ! empty( $GLOBALS['wp_version'] ) ) {
-			$develop_src = false !== strpos( $GLOBALS['wp_version'], '-src' );
+		if ( ! empty( $GLOBALS['cp_version'] ) && function_exists( 'classicpress_is_dev_version' ) ) {
+			$develop_src = classicpress_is_dev_version();
 		} else {
 			$develop_src = false;
 		}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3887,7 +3887,7 @@ function register_admin_color_schemes() {
 	);
 
 	// Other color schemes are not available when running out of src
-	if ( false !== strpos( get_bloginfo( 'version' ), '-src' ) ) {
+	if ( classicpress_is_dev_install() ) {
 		return;
 	}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -46,9 +46,9 @@ require( ABSPATH . WPINC . '/functions.wp-styles.php' );
  * @param WP_Scripts $scripts WP_Scripts object.
  */
 function wp_default_scripts( &$scripts ) {
-	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $cp_version
 
-	$develop_src = false !== strpos( $wp_version, '-src' );
+	$develop_src = classicpress_is_dev_install();
 
 	if ( ! defined( 'SCRIPT_DEBUG' ) ) {
 		define( 'SCRIPT_DEBUG', $develop_src );
@@ -926,11 +926,13 @@ function wp_default_scripts( &$scripts ) {
 function wp_default_styles( &$styles ) {
 	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
 
-	if ( ! defined( 'SCRIPT_DEBUG' ) )
-		define( 'SCRIPT_DEBUG', false !== strpos( $wp_version, '-src' ) );
+	if ( ! defined( 'SCRIPT_DEBUG' ) ) {
+		define( 'SCRIPT_DEBUG', classicpress_is_dev_install() );
+	}
 
-	if ( ! $guessurl = site_url() )
+	if ( ! $guessurl = site_url() ) {
 		$guessurl = wp_guess_url();
+	}
 
 	$styles->base_url = $guessurl;
 	$styles->content_url = defined('WP_CONTENT_URL')? WP_CONTENT_URL : '';

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -38,10 +38,26 @@ $cp_version = '1.0.0-alpha0+dev';
  * @return string The ClassicPress version string.
  */
 if ( ! function_exists( 'classicpress_version' ) ) {
-    function classicpress_version() {
-        global $cp_version;
-        return $cp_version;
-    }
+	function classicpress_version() {
+		global $cp_version;
+		return $cp_version;
+	}
+}
+
+/**
+ * Return whether ClassicPress is running as a source install (the result of
+ * cloning the source repository rather than installing a built version).
+ *
+ * This is mostly supported, but there are a few things that need to work
+ * slightly differently or need to be disabled.
+ *
+ * @return bool Whether ClassicPress is running as a source install.
+ */
+if ( ! function_exists( 'classicpress_is_dev_install' ) ) {
+	function classicpress_is_dev_install() {
+		global $cp_version;
+		return substr( $cp_version, -4 ) === '+dev';
+	}
 }
 
 /**

--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -12,7 +12,7 @@ if ( class_exists( 'PHPUnit\Runner\Version' ) ) {
 
 $config_file_path = dirname( dirname( __FILE__ ) );
 if ( ! file_exists( $config_file_path . '/wp-tests-config.php' ) ) {
-	// Support the config file from the root of the develop repository.
+	// Support the config file from the root of the source repository.
 	if ( basename( $config_file_path ) === 'phpunit' && basename( dirname( $config_file_path ) ) === 'tests' )
 		$config_file_path = dirname( dirname( $config_file_path ) );
 }


### PR DESCRIPTION
Closes #58.

Fixes some breakage introduced by the version string changes in #147 with installs directly from the source repository (note the blank space where the admin bar should be):

![2018-10-21t01 31 02-05 00](https://user-images.githubusercontent.com/227022/47263934-03b13a80-d4d1-11e8-8fb0-ffd83cc1c16b.png)

Introduces a more unified way to do the check for dev versions.  If we need something more sophisticated in the future then we can add another function, but I think we should keep it simple.