### PR TITLE
Improve version display on wp-admin about screen

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -14,15 +14,18 @@ wp_enqueue_script( 'underscore' );
 /* translators: Page title of the About ClassicPress page in the admin. */
 $title = _x( 'About', 'page title' );
 
-$display_version = classicpress_version();
-
 include( ABSPATH . 'wp-admin/admin-header.php' );
 ?>
 	<div class="wrap about-wrap full-width-layout">
-		<h1><?php printf( __( 'Welcome to ClassicPress&nbsp;%s' ), $display_version ); ?></h1>
+		<h1><?php _e( 'Welcome to ClassicPress!' ); ?></h1>
 
-		<p class="about-text"><?php printf( __( 'Thank you for trying ClassicPress! We are under heavy development while we prepare for an initial release.' ), $display_version ); ?></p>
-		<div class="wp-badge"><?php printf( __( 'Version %s' ), $display_version ); ?></div>
+		<p class="about-text">
+			<?php printf( __( 'Version %s' ), classicpress_version() ); ?>
+		</p>
+		<p class="about-text">
+			<?php _e( 'Thank you for trying ClassicPress! We are under heavy development while we prepare for an initial release.' ); ?>
+		</p>
+		<div class="wp-badge"></div>
 
 		<h2 class="nav-tab-wrapper wp-clearfix">
 			<a href="about.php" class="nav-tab nav-tab-active"><?php _e( 'What&#8217;s New' ); ?></a>

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -58,24 +58,23 @@
 /* ClassicPress Version Badge */
 
 .wp-badge {
-	background: #0073aa url(../images/w-logo-white.png?ver=20160308) no-repeat;
-	background-position: center 25px;
+	background: #0073aa url(../images/w-logo-white.png?ver=20180905) no-repeat;
+	background-position: center;
 	background-size: 80px 80px;
 	color: #fff;
 	font-size: 14px;
 	text-align: center;
 	font-weight: 600;
 	margin: 5px 0 0;
-	padding-top: 120px;
-	height: 40px;
+	width: 130px;
+	height: 130px;
 	display: inline-block;
-	width: 140px;
 	text-rendering: optimizeLegibility;
 	box-shadow: 0 1px 3px rgba(0,0,0,0.2);
 }
 
 .svg .wp-badge {
-	background-image: url(../images/wordpress-logo-white.svg?ver=20160308);
+	background-image: url(../images/wordpress-logo-white.svg?ver=20180905);
 }
 
 .about-wrap .wp-badge {
@@ -161,7 +160,6 @@
 
 .about-wrap .about-text {
 	margin: 1em 200px 1em 0;
-	min-height: 60px;
 	color: #555d66;
 }
 


### PR DESCRIPTION
We're including the full ClassicPress version string in the dashboard, because the way WordPress does this is pretty confusing.

Since this string can be a good bit longer than the corresponding string in WP, which is never longer than 5 characters (e.g. `4.9.8`), we'll need to tweak the About screen a bit.

### Before

![2018-10-21t20 57 46-05 00](https://user-images.githubusercontent.com/227022/47321911-dcb34f80-d61b-11e8-9b38-267aa31f6482.png)

### After

![2018-10-21t20 57 36-05 00](https://user-images.githubusercontent.com/227022/47321912-dcb34f80-d61b-11e8-8c55-e5dafabe401b.png)