### PR TITLE
Update logo cachebuster on login screen too

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -141,8 +141,8 @@ p {
 }
 
 .login h1 a {
-	background-image: url(../images/w-logo-blue.png?ver=20131202);
-	background-image: none, url(../images/wordpress-logo.svg?ver=20131107);
+	background-image: url(../images/w-logo-blue.png?ver=20180905);
+	background-image: none, url(../images/wordpress-logo.svg?ver=20180905);
 	background-size: 84px;
 	background-position: center top;
 	background-repeat: no-repeat;


### PR DESCRIPTION
Several people have reported that upon switching to ClassicPress, the logo in the wp-login screen was still the WordPress logo.

This is fixable by clearing the browser cache, but we can (and should) also fix it ourselves by updating the version string of the logo.

In general we should always update this version string when our logos change, and the version string for all the logos should always be the same so that we can more easily track down instances that need to be updated.  Between this PR and #160 we should be in good shape there.