### PR TITLE
Remove capital_P_dangit()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4791,34 +4791,6 @@ function wp_basename( $path, $suffix = '' ) {
 }
 
 /**
- * Forever eliminate "Classicpress" from the planet (or at least the little bit we can influence).
- *
- * Violating our coding standards for a good function name.
- *
- * @since WP-3.0.0
- *
- * @staticvar string|false $dblq
- *
- * @param string $text The text to be modified.
- * @return string The modified text.
- */
-function capital_P_dangit( $text ) {
-	// Simple replacement for titles
-	$current_filter = current_filter();
-	if ( 'the_title' === $current_filter || 'wp_title' === $current_filter )
-		return str_replace( 'Classicpress', 'ClassicPress', $text );
-	// Still here? Use the more judicious replacement
-	static $dblq = false;
-	if ( false === $dblq ) {
-		$dblq = _x( '&#8220;', 'opening curly double quote' );
-	}
-	return str_replace(
-		array( ' Classicpress', '&#8216;Classicpress', $dblq . 'Classicpress', '>Classicpress', '(Classicpress' ),
-		array( ' ClassicPress', '&#8216;ClassicPress', $dblq . 'ClassicPress', '>ClassicPress', '(ClassicPress' ),
-	$text );
-}
-
-/**
  * Sanitize a mime type
  *
  * @since WP-3.1.3


### PR DESCRIPTION
Remove capital_P_dangit() function.

Along with other filters, this function can be expensive CPU-wise if there's enough traffic/activity and content.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
