### PR TITLE
Update admin-bar support URLs to point to CP properties

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -152,29 +152,21 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		'href'      => __('https://www.classicpress.net'),
 	) );
 
-	// Add codex link
+	// Add documentation link
 	$wp_admin_bar->add_menu( array(
 		'parent'    => 'wp-logo-external',
 		'id'        => 'documentation',
 		'title'     => __('Documentation'),
-		'href'      => __('https://codex.wordpress.org/'),
+		'href'      => __('https://docs.classicpress.net/'),
 	) );
 
-	// Add forums link
+	// Add support link
 	$wp_admin_bar->add_menu( array(
 		'parent'    => 'wp-logo-external',
-		'id'        => 'support-forums',
-		'title'     => __('Support Forums'),
-		'href'      => __('https://wordpress.org/support/'),
-	) );
-
-	// Add feedback link
-	$wp_admin_bar->add_menu( array(
-		'parent'    => 'wp-logo-external',
-		'id'        => 'feedback',
-		'title'     => __('Feedback'),
-		'href'      => __('https://wordpress.org/support/forum/requests-and-feedback'),
-	) );
+		'id'        => 'support',
+		'title'     => __('Support'),
+		'href'      => __('https://docs.classicpress.net/faq-support/'),
+	) );	
 }
 
 /**


### PR DESCRIPTION
Update support URLs in admin bar logo pop-under. Changes made according to [this convo](https://classicpress.slack.com/archives/CCNEEH86P/p1540943310205800) and to address issue #195 .

## Description
Updated URLs for Documentation and Support, as well as related labels; re-pointed from WP properties to CP properties. Removed feedback URL. Updated comments.

## Motivation and context
CP users should be directed to CP channels for CP help.

## How has this been tested?
Entirely on localhost w/ Alpha 1.0.0

## Screenshots (if appropriate):
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
