### PR TITLE
Fix #194 and #198

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -832,8 +832,8 @@ class WP_Automatic_Updater {
 This debugging email is sent when you are using a development version of ClassicPress.
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
- * Open a thread in the support forums: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://docs.classicpress.net/faq-support/
+ * If you need general support: https://docs.classicpress.net/faq-support/
+ * Or, if you're comfortable writing a bug report: https://docs.classicpress.net/testing-classicpress/#reporting-bugs
 
 Thanks! -- The ClassicPress Team" ) );
 			$body[] = '';

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -833,7 +833,7 @@ This debugging email is sent when you are using a development version of Classic
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
  * Open a thread in the support forums: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://core.trac.wordpress.org/
+ * Or, if you're comfortable writing a bug report: https://docs.classicpress.net/faq-support/
 
 Thanks! -- The ClassicPress Team" ) );
 			$body[] = '';

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -832,7 +832,7 @@ class WP_Automatic_Updater {
 This debugging email is sent when you are using a development version of ClassicPress.
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
- * Open a thread in the support forums: https://wordpress.org/support/forum/alphabeta
+ * Open a thread in the support forums: https://docs.classicpress.net/faq-support/
  * Or, if you're comfortable writing a bug report: https://core.trac.wordpress.org/
 
 Thanks! -- The ClassicPress Team" ) );

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -994,5 +994,5 @@ function get_site_screen_help_tab_args() {
 function get_site_screen_help_sidebar_content() {
 	return '<p><strong>' . __('For more information:') . '</strong></p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-		'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>';
+		'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>';
 }

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -994,5 +994,5 @@ function get_site_screen_help_tab_args() {
 function get_site_screen_help_sidebar_content() {
 	return '<p><strong>' . __('For more information:') . '</strong></p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-		'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>';
+		'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>';
 }

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -202,7 +202,7 @@ function wp_install_defaults( $user_id ) {
 	}
 
 	$first_comment_author = ! empty( $first_comment_author ) ? $first_comment_author : __( 'A ClassicPress Commenter' );
-	$first_comment_email = ! empty( $first_comment_email ) ? $first_comment_email : 'wapuu@classicpress.example';
+	$first_comment_email = ! empty( $first_comment_email ) ? $first_comment_email : 'social@classicpress.net';
 	$first_comment_url = ! empty( $first_comment_url ) ? $first_comment_url : 'https://www.classicpress.net/';
 	$first_comment = ! empty( $first_comment ) ? $first_comment :  __( 'Hi, this is a comment.
 To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -144,7 +144,7 @@ if ( ! defined( 'WP_ALLOW_REPAIR' ) ) {
 	}
 
 	if ( $problems ) {
-		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors to the <a href="%s">ClassicPress support forums</a> to get additional assistance.') . '</p>', __( 'https://docs.classicpress.net/faq-support/' ) );
+		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors into the #support channel in our <a href="%s">Slack</a> workspace for additional assistance.') . '</p>', __( 'https://www.classicpress.net/join-slack/' ) );
 		$problem_output = '';
 		foreach ( $problems as $table => $problem )
 			$problem_output .= "$table: $problem\n";

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -144,7 +144,7 @@ if ( ! defined( 'WP_ALLOW_REPAIR' ) ) {
 	}
 
 	if ( $problems ) {
-		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors to the <a href="%s">ClassicPress support forums</a> to get additional assistance.') . '</p>', __( 'https://wordpress.org/support/forum/how-to-and-troubleshooting' ) );
+		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors to the <a href="%s">ClassicPress support forums</a> to get additional assistance.') . '</p>', __( 'https://docs.classicpress.net/faq-support/' ) );
 		$problem_output = '';
 		foreach ( $problems as $table => $problem )
 			$problem_output .= "$table: $problem\n";

--- a/src/wp-admin/network/index.php
+++ b/src/wp-admin/network/index.php
@@ -48,7 +48,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin">Documentation on the Network Admin</a>') . '</p>' .
-	'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
 );
 
 wp_dashboard_setup();

--- a/src/wp-admin/network/index.php
+++ b/src/wp-admin/network/index.php
@@ -48,7 +48,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin">Documentation on the Network Admin</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 wp_dashboard_setup();

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -28,7 +28,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-site' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -28,7 +28,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-site' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -40,7 +40,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -40,7 +40,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -24,7 +24,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-user' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -24,7 +24,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-user' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -177,7 +177,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -177,7 +177,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://wordpress.org/support/forum/multisite/">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(


### PR DESCRIPTION
For issue #194, #198. This PR corrects the default email of the example commenter installed with the system, and updates support URLs.

## Description
Changed email from wapuu@classicpress.example to social@classicpress.net. Updated source URLs to reflect current support channels.

## Motivation and context
Email address was invalid; support URLs invalid.

## How has this been tested?
Locally. Manually updated database with new address to see that the new avatar worked correctly.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
