### PR TITLE
addresses #171 (Missing img alt attributes in admin menu)

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -119,7 +119,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 	$wp_logo_menu_args = array(
 		'id'    => 'wp-logo',
 		'title' => (
-			'<img class="cp-logo" src="' . $cp_logo_src . '" alt="ClassicPress" />'
+			'<img class="cp-logo" src="' . $cp_logo_src . '" alt="ClassicPress logo" />'
 			. '<span class="screen-reader-text">' . __( 'About ClassicPress' ) . '</span>'
 		),
 		'href'  => $about_url,

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -119,7 +119,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 	$wp_logo_menu_args = array(
 		'id'    => 'wp-logo',
 		'title' => (
-			'<img class="cp-logo" src="' . $cp_logo_src . '" />'
+			'<img class="cp-logo" src="' . $cp_logo_src . '" alt="ClassicPress" />'
 			. '<span class="screen-reader-text">' . __( 'About ClassicPress' ) . '</span>'
 		),
 		'href'  => $about_url,
@@ -166,7 +166,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		'id'        => 'support',
 		'title'     => __('Support'),
 		'href'      => __('https://docs.classicpress.net/faq-support/'),
-	) );	
+	) );
 }
 
 /**
@@ -507,7 +507,7 @@ function wp_admin_bar_my_sites_menu( $wp_admin_bar ) {
 
 		$cp_logo_src = includes_url( 'images/classicpress-logo-dashicon-style.svg' );
 
-		$cplogo = '<img class="cp-logo" src="' . $cp_logo_src . '" />';
+		$cplogo = '<img class="cp-logo" src="' . $cp_logo_src . '" alt="" />';
 
 		$blogname = $blog->blogname;
 


### PR DESCRIPTION
Added the missing alt tags:
* `alt="ClassicPress"` for the primary one
* `alt=""` for the multisite blogs list

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
