### PR TITLE
Prefix more WP versions with "WP-"

### DIFF
--- a/src/wp-admin/custom-background.php
+++ b/src/wp-admin/custom-background.php
@@ -52,7 +52,7 @@ class Custom_Background {
 
 		add_action( 'wp_ajax_custom-background-add', array( $this, 'ajax_background_add' ) );
 
-		// Unused since 3.5.0.
+		// Unused since WP-3.5.0.
 		add_action( 'wp_ajax_set-background-image', array( $this, 'wp_set_background_image' ) );
 	}
 

--- a/src/wp-admin/custom-header.php
+++ b/src/wp-admin/custom-header.php
@@ -973,7 +973,7 @@ wp_nonce_field( 'custom-header-options', '_wpnonce-custom-header-options' ); ?>
 	}
 
 	/**
-	 * Unused since 3.5.0.
+	 * Unused since WP-3.5.0.
 	 *
 	 * @since WP-3.4.0
 	 *
@@ -985,7 +985,7 @@ wp_nonce_field( 'custom-header-options', '_wpnonce-custom-header-options' ); ?>
 	}
 
 	/**
-	 * Unused since 3.5.0.
+	 * Unused since WP-3.5.0.
 	 *
 	 * @since WP-3.4.0
 	 *

--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -280,7 +280,7 @@ class Core_Upgrader extends WP_Upgrader {
 
 			// Cannot update if we're retrying the same A to B update that caused a non-critical failure.
 			// Some non-critical failures do allow retries, like download_failed.
-			// 3.7.1 => 3.7.2 resulted in files_not_writable, if we are still on 3.7.1 and still trying to update to 3.7.2.
+			// WP-3.7.1 => WP-3.7.2 resulted in files_not_writable, if we are still on WP-3.7.1 and still trying to update to WP-3.7.2.
 			if ( empty( $failure_data['retry'] ) && $wp_version == $failure_data['current'] && $offered_ver == $failure_data['attempted'] )
 				return false;
 		}

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -938,7 +938,7 @@ class WP_List_Table {
 		// $_column_headers is already set / cached
 		if ( isset( $this->_column_headers ) && is_array( $this->_column_headers ) ) {
 			// Back-compat for list tables that have been manually setting $_column_headers for horse reasons.
-			// In 4.3, we added a fourth argument for primary column.
+			// In WP-4.3, we added a fourth argument for primary column.
 			$column_headers = array( array(), array(), array(), $this->get_primary_column_name() );
 			foreach ( $this->_column_headers as $key => $value ) {
 				$column_headers[ $key ] = $value;

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -760,7 +760,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 * Given a top level page ID, display the nested hierarchy of sub-pages
 	 * together with paging support
 	 *
-	 * @since WP-3.1.0 (Standalone function exists since 2.6.0)
+	 * @since WP-3.1.0 (Standalone function exists since WP-2.6.0)
 	 * @since WP-4.2.0 Added the `$to_display` parameter.
 	 *
 	 * @param array $children_pages

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -294,7 +294,7 @@ function wp_dashboard_right_now() {
 	 * Filters the array of extra elements to list in the 'At a Glance'
 	 * dashboard widget.
 	 *
-	 * Prior to 3.8.0, the widget was named 'Right Now'. Each element
+	 * Prior to WP-3.8.0, the widget was named 'Right Now'. Each element
 	 * is wrapped in list-item tags on output.
 	 *
 	 * @since WP-3.8.0
@@ -319,7 +319,7 @@ function wp_dashboard_right_now() {
 		 * Filters the link title attribute for the 'Search Engines Discouraged'
 		 * message displayed in the 'At a Glance' dashboard widget.
 		 *
-		 * Prior to 3.8.0, the widget was named 'Right Now'.
+		 * Prior to WP-3.8.0, the widget was named 'Right Now'.
 		 *
 		 * @since WP-3.0.0
 		 * @since WP-4.5.0 The default for `$title` was updated to an empty string.
@@ -332,7 +332,7 @@ function wp_dashboard_right_now() {
 		 * Filters the link label for the 'Search Engines Discouraged' message
 		 * displayed in the 'At a Glance' dashboard widget.
 		 *
-		 * Prior to 3.8.0, the widget was named 'Right Now'.
+		 * Prior to WP-3.8.0, the widget was named 'Right Now'.
 		 *
 		 * @since WP-3.0.0
 		 *
@@ -355,7 +355,7 @@ function wp_dashboard_right_now() {
 	/**
 	 * Fires at the end of the 'At a Glance' dashboard widget.
 	 *
-	 * Prior to 3.8.0, the widget was named 'Right Now'.
+	 * Prior to WP-3.8.0, the widget was named 'Right Now'.
 	 *
 	 * @since WP-2.5.0
 	 */
@@ -364,7 +364,7 @@ function wp_dashboard_right_now() {
 	/**
 	 * Fires at the end of the 'At a Glance' dashboard widget.
 	 *
-	 * Prior to 3.8.0, the widget was named 'Right Now'.
+	 * Prior to WP-3.8.0, the widget was named 'Right Now'.
 	 *
 	 * @since WP-2.0.0
 	 */

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1228,7 +1228,7 @@ function screen_icon() {
 }
 
 /**
- * Retrieves the screen icon (no longer used in 3.8+).
+ * Retrieves the screen icon (no longer used in WP-3.8+).
  *
  * @since WP-3.2.0
  * @deprecated WP-3.8.0

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1165,7 +1165,7 @@ function wp_update_core($current, $feedback = '') {
  *
  * Deprecated in favor of instantating a Plugin_Upgrader instance directly,
  * and calling the 'upgrade' method.
- * Unused since 2.8.0.
+ * Unused since WP-2.8.0.
  *
  * @since WP-2.5.0
  * @deprecated WP-3.7.0 Use Plugin_Upgrader
@@ -1187,7 +1187,7 @@ function wp_update_plugin($plugin, $feedback = '') {
  *
  * Deprecated in favor of instantiating a Theme_Upgrader instance directly,
  * and calling the 'upgrade' method.
- * Unused since 2.8.0.
+ * Unused since WP-2.8.0.
  *
  * @since WP-2.7.0
  * @deprecated WP-3.7.0 Use Theme_Upgrader

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1870,7 +1870,7 @@ $post_params = array(
 $post_params = apply_filters( 'upload_post_params', $post_params );
 
 /*
- * Since 4.9 the `runtimes` setting is hardcoded in our version of Plupload to `html5,html4`,
+ * Since WP-4.9 the `runtimes` setting is hardcoded in our version of Plupload to `html5,html4`,
  * and the `flash_swf_url` and `silverlight_xap_url` are not used.
  */
 $plupload_init = array(

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1271,7 +1271,7 @@ final class WP_Privacy_Policy_Content {
 	 *
 	 * Intended for use from `wp_add_privacy_policy_content()`.
 	 *
-	 * $since 4.9.6
+	 * @since WP-4.9.6
 	 *
 	 * @param string $plugin_name The name of the plugin or theme that is suggesting content for the site's privacy policy.
 	 * @param string $policy_text The suggested content for inclusion in the policy.

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -24,7 +24,7 @@ $theme_field_defaults = array( 'description' => true, 'sections' => false, 'test
  *
  * @since WP-2.8.0
  *
- * @deprecated since 3.1.0 Use get_theme_feature_list() instead.
+ * @deprecated since WP-3.1.0 Use get_theme_feature_list() instead.
  *
  * @return array
  */

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -598,7 +598,7 @@ $_old_files = array(
 'wp-admin/css/colors.min.css',
 'wp-admin/css/colors-rtl.css',
 'wp-admin/css/colors-rtl.min.css',
-// Following files added back in 4.5 see https://core.trac.wordpress.org/ticket/36083
+// Following files added back in WP-4.5 see https://core.trac.wordpress.org/ticket/36083
 // 'wp-admin/css/media-rtl.min.css',
 // 'wp-admin/css/media.min.css',
 // 'wp-admin/css/farbtastic-rtl.min.css',
@@ -613,7 +613,7 @@ $_old_files = array(
 'wp-includes/js/plupload/changelog.txt',
 'wp-includes/js/plupload/plupload.silverlight.js',
 'wp-includes/js/plupload/plupload.flash.js',
-// Added back in 4.9 [41328], see https://core.trac.wordpress.org/ticket/41755
+// Added back in WP-4.9 [41328], see https://core.trac.wordpress.org/ticket/41755
 // 'wp-includes/js/plupload/plupload.js',
 'wp-includes/js/tinymce/plugins/spellchecker',
 'wp-includes/js/tinymce/plugins/inlinepopups',

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1100,7 +1100,7 @@ function update_core($from, $to) {
 	// Remove maintenance file, we're done with potential site-breaking changes
 	$wp_filesystem->delete( $maintenance_file );
 
-	// 3.5 -> 3.5+ - an empty twentytwelve directory was created upon upgrade to 3.5 for some users, preventing installation of Twenty Twelve.
+	// WP-3.5 -> WP-3.5+ - an empty twentytwelve directory was created upon upgrade to WP-3.5 for some users, preventing installation of Twenty Twelve.
 	if ( '3.5' == $old_wp_version ) {
 		if ( is_dir( WP_CONTENT_DIR . '/themes/twentytwelve' ) && ! file_exists( WP_CONTENT_DIR . '/themes/twentytwelve/style.css' )  ) {
 			$wp_filesystem->delete( $wp_filesystem->wp_themes_dir() . 'twentytwelve/' );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -285,7 +285,7 @@ function update_right_now_message() {
 	/**
 	 * Filters the text displayed in the 'At a Glance' dashboard widget.
 	 *
-	 * Prior to 3.8.0, the widget was named 'Right Now'.
+	 * Prior to WP-3.8.0, the widget was named 'Right Now'.
 	 *
 	 * @since WP-4.4.0
 	 *

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2843,7 +2843,7 @@ function maybe_disable_link_manager() {
 function pre_schema_upgrade() {
 	global $wp_current_db_version, $wpdb;
 
-	// Upgrade versions prior to 2.9
+	// Upgrade versions prior to WP-2.9
 	if ( $wp_current_db_version < 11557 ) {
 		// Delete duplicate options. Keep the option with the highest option_id.
 		$wpdb->query("DELETE o1 FROM $wpdb->options AS o1 JOIN $wpdb->options AS o2 USING (`option_name`) WHERE o2.option_id > o1.option_id");
@@ -2858,7 +2858,7 @@ function pre_schema_upgrade() {
 	// Multisite schema upgrades.
 	if ( $wp_current_db_version < 25448 && is_multisite() && wp_should_upgrade_global_tables() ) {
 
-		// Upgrade versions prior to 3.7
+		// Upgrade versions prior to WP-3.7
 		if ( $wp_current_db_version < 25179 ) {
 			// New primary key for signups.
 			$wpdb->query( "ALTER TABLE $wpdb->signups ADD signup_id BIGINT(20) NOT NULL AUTO_INCREMENT PRIMARY KEY FIRST" );
@@ -2872,7 +2872,7 @@ function pre_schema_upgrade() {
 		}
 	}
 
-	// Upgrade versions prior to 4.2.
+	// Upgrade versions prior to WP-4.2.
 	if ( $wp_current_db_version < 31351 ) {
 		if ( ! is_multisite() && wp_should_upgrade_global_tables() ) {
 			$wpdb->query( "ALTER TABLE $wpdb->usermeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191))" );
@@ -2884,7 +2884,7 @@ function pre_schema_upgrade() {
 		$wpdb->query( "ALTER TABLE $wpdb->posts DROP INDEX post_name, ADD INDEX post_name(post_name(191))" );
 	}
 
-	// Upgrade versions prior to 4.4.
+	// Upgrade versions prior to WP-4.4.
 	if ( $wp_current_db_version < 34978 ) {
 		// If compatible termmeta table is found, use it, but enforce a proper index and update collation.
 		if ( $wpdb->get_var( "SHOW TABLES LIKE '{$wpdb->termmeta}'" ) && $wpdb->get_results( "SHOW INDEX FROM {$wpdb->termmeta} WHERE Column_name = 'meta_key'" ) ) {

--- a/src/wp-admin/js/common.js
+++ b/src/wp-admin/js/common.js
@@ -5,7 +5,7 @@ var showNotice, adminMenu, columns, validateForm, screenMeta;
 		$window = $( window ),
 		$body = $( document.body );
 
-// Removed in 3.3.
+// Removed in WP-3.3.
 // (perhaps) needed for back-compat
 adminMenu = {
 	init : function() {},

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -3111,7 +3111,7 @@
 		nav_menu_item: api.Menus.MenuItemControl,
 		nav_menu: api.Menus.MenuControl,
 		nav_menu_name: api.Menus.MenuNameControl,
-		new_menu: api.Menus.NewMenuControl, // @todo Remove in 5.0. See https://core.trac.wordpress.org/ticket/42364.
+		new_menu: api.Menus.NewMenuControl, // @todo Remove in WP-5.0. See https://core.trac.wordpress.org/ticket/42364.
 		nav_menu_locations: api.Menus.MenuLocationsControl,
 		nav_menu_auto_add: api.Menus.MenuAutoAddControl
 	});

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -854,12 +854,12 @@
 		}, 2000 ),
 
 		/**
-		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
+		 * @deprecated Since WP-4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		checked: function() {},
 
 		/**
-		 * @deprecated Since 4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
+		 * @deprecated Since WP-4.7.0 now that the nav_menu sections are responsible for toggling the classes on their own containers.
 		 */
 		unchecked: function() {},
 

--- a/src/wp-admin/js/media-gallery.js
+++ b/src/wp-admin/js/media-gallery.js
@@ -2,7 +2,7 @@
 
 /**
  * This file is used on media-upload.php which has been replaced by media-new.php and upload.php
- * Deprecated since 3.5.0
+ * Deprecated since WP-3.5.0
  */
 jQuery(function($) {
 	/**
@@ -21,7 +21,7 @@ jQuery(function($) {
 			img_size = $( 'input[name="attachments[' + id + '][image-size]"]:checked').val();
 
 			/**
-			 * This AJAX action has been deprecated since 3.5.0, see custom-background.php
+			 * This AJAX action has been deprecated since WP-3.5.0, see custom-background.php
 			 */
 			jQuery.post(ajaxurl, {
 				action: 'set-background-image',

--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -136,7 +136,7 @@
 		/**
 		 * Whether a url is a supported external host.
 		 *
-		 * @deprecated since 4.9.
+		 * @deprecated since WP-4.9.
 		 *
 		 * @returns {boolean} Whether url is a supported video host.
 		 */

--- a/src/wp-admin/js/wp-fullscreen-stub.js
+++ b/src/wp-admin/js/wp-fullscreen-stub.js
@@ -2,7 +2,7 @@
  * Distraction-Free Writing (wp-fullscreen) backward compatibility stub.
  * Todo: remove at the end of 2016.
  *
- * Original was deprecated in 4.1, removed in 4.3.
+ * Original was deprecated in WP-4.1, removed in WP-4.3.
  */
 ( function() {
 	var noop = function(){};

--- a/src/wp-content/themes/twentyfifteen/inc/back-compat.php
+++ b/src/wp-content/themes/twentyfifteen/inc/back-compat.php
@@ -2,7 +2,7 @@
 /**
  * Twenty Fifteen back compat functionality
  *
- * Prevents Twenty Fifteen from running on WordPress versions prior to 4.1,
+ * Prevents Twenty Fifteen from running on WordPress versions prior to WP-4.1,
  * since this theme is not meant to be backward compatible beyond that and
  * relies on many newer functions and markup changes introduced in WP-4.1.
  *
@@ -29,7 +29,7 @@ add_action( 'after_switch_theme', 'twentyfifteen_switch_theme' );
  * Add message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Twenty Fifteen on WordPress versions prior to 4.1.
+ * Twenty Fifteen on WordPress versions prior to WP-4.1.
  *
  * @since Twenty Fifteen 1.0
  */
@@ -39,7 +39,7 @@ function twentyfifteen_upgrade_notice() {
 }
 
 /**
- * Prevent the Customizer from being loaded on WordPress versions prior to 4.1.
+ * Prevent the Customizer from being loaded on WordPress versions prior to WP-4.1.
  *
  * @since Twenty Fifteen 1.0
  */
@@ -51,7 +51,7 @@ function twentyfifteen_customize() {
 add_action( 'load-customize.php', 'twentyfifteen_customize' );
 
 /**
- * Prevent the Theme Preview from being loaded on WordPress versions prior to 4.1.
+ * Prevent the Theme Preview from being loaded on WordPress versions prior to WP-4.1.
  *
  * @since Twenty Fifteen 1.0
  */

--- a/src/wp-content/themes/twentyfifteen/inc/back-compat.php
+++ b/src/wp-content/themes/twentyfifteen/inc/back-compat.php
@@ -4,7 +4,7 @@
  *
  * Prevents Twenty Fifteen from running on WordPress versions prior to 4.1,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.1.
+ * relies on many newer functions and markup changes introduced in WP-4.1.
  *
  * @package WordPress
  * @subpackage Twenty_Fifteen

--- a/src/wp-content/themes/twentyseventeen/inc/back-compat.php
+++ b/src/wp-content/themes/twentyseventeen/inc/back-compat.php
@@ -2,7 +2,7 @@
 /**
  * Twenty Seventeen back compat functionality
  *
- * Prevents Twenty Seventeen from running on WordPress versions prior to 4.7,
+ * Prevents Twenty Seventeen from running on WordPress versions prior to WP-4.7,
  * since this theme is not meant to be backward compatible beyond that and
  * relies on many newer functions and markup changes introduced in WP-4.7.
  *
@@ -29,7 +29,7 @@ add_action( 'after_switch_theme', 'twentyseventeen_switch_theme' );
  * Adds a message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Twenty Seventeen on WordPress versions prior to 4.7.
+ * Twenty Seventeen on WordPress versions prior to WP-4.7.
  *
  * @since Twenty Seventeen 1.0
  *
@@ -41,7 +41,7 @@ function twentyseventeen_upgrade_notice() {
 }
 
 /**
- * Prevents the Customizer from being loaded on WordPress versions prior to 4.7.
+ * Prevents the Customizer from being loaded on WordPress versions prior to WP-4.7.
  *
  * @since Twenty Seventeen 1.0
  *
@@ -55,7 +55,7 @@ function twentyseventeen_customize() {
 add_action( 'load-customize.php', 'twentyseventeen_customize' );
 
 /**
- * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.7.
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to WP-4.7.
  *
  * @since Twenty Seventeen 1.0
  *

--- a/src/wp-content/themes/twentyseventeen/inc/back-compat.php
+++ b/src/wp-content/themes/twentyseventeen/inc/back-compat.php
@@ -4,7 +4,7 @@
  *
  * Prevents Twenty Seventeen from running on WordPress versions prior to 4.7,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.7.
+ * relies on many newer functions and markup changes introduced in WP-4.7.
  *
  * @package WordPress
  * @subpackage Twenty_Seventeen

--- a/src/wp-content/themes/twentysixteen/inc/back-compat.php
+++ b/src/wp-content/themes/twentysixteen/inc/back-compat.php
@@ -2,7 +2,7 @@
 /**
  * Twenty Sixteen back compat functionality
  *
- * Prevents Twenty Sixteen from running on WordPress versions prior to 4.4,
+ * Prevents Twenty Sixteen from running on WordPress versions prior to WP-4.4,
  * since this theme is not meant to be backward compatible beyond that and
  * relies on many newer functions and markup changes introduced in WP-4.4.
  *
@@ -31,7 +31,7 @@ add_action( 'after_switch_theme', 'twentysixteen_switch_theme' );
  * Adds a message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Twenty Sixteen on WordPress versions prior to 4.4.
+ * Twenty Sixteen on WordPress versions prior to WP-4.4.
  *
  * @since Twenty Sixteen 1.0
  *
@@ -43,7 +43,7 @@ function twentysixteen_upgrade_notice() {
 }
 
 /**
- * Prevents the Customizer from being loaded on WordPress versions prior to 4.4.
+ * Prevents the Customizer from being loaded on WordPress versions prior to WP-4.4.
  *
  * @since Twenty Sixteen 1.0
  *
@@ -57,7 +57,7 @@ function twentysixteen_customize() {
 add_action( 'load-customize.php', 'twentysixteen_customize' );
 
 /**
- * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.4.
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to WP-4.4.
  *
  * @since Twenty Sixteen 1.0
  *

--- a/src/wp-content/themes/twentysixteen/inc/back-compat.php
+++ b/src/wp-content/themes/twentysixteen/inc/back-compat.php
@@ -4,7 +4,7 @@
  *
  * Prevents Twenty Sixteen from running on WordPress versions prior to 4.4,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.4.
+ * relies on many newer functions and markup changes introduced in WP-4.4.
  *
  * @package WordPress
  * @subpackage Twenty_Sixteen

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -87,7 +87,7 @@ function map_meta_cap( $cap, $user_id ) {
 
 		if ( ! $post_type->map_meta_cap ) {
 			$caps[] = $post_type->cap->$cap;
-			// Prior to 3.1 we would re-call map_meta_cap here.
+			// Prior to WP-3.1 we would re-call map_meta_cap here.
 			if ( 'delete_post' == $cap )
 				$cap = $post_type->cap->$cap;
 			break;
@@ -157,7 +157,7 @@ function map_meta_cap( $cap, $user_id ) {
 
 		if ( ! $post_type->map_meta_cap ) {
 			$caps[] = $post_type->cap->$cap;
-			// Prior to 3.1 we would re-call map_meta_cap here.
+			// Prior to WP-3.1 we would re-call map_meta_cap here.
 			if ( 'edit_post' == $cap )
 				$cap = $post_type->cap->$cap;
 			break;
@@ -225,7 +225,7 @@ function map_meta_cap( $cap, $user_id ) {
 
 		if ( ! $post_type->map_meta_cap ) {
 			$caps[] = $post_type->cap->$cap;
-			// Prior to 3.1 we would re-call map_meta_cap here.
+			// Prior to WP-3.1 we would re-call map_meta_cap here.
 			if ( 'read_post' == $cap )
 				$cap = $post_type->cap->$cap;
 			break;

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -226,7 +226,7 @@ function get_the_category_list( $separator = '', $parents = '', $post_id = false
  * @since WP-1.2.0
  *
  * @param int|string|array $category Category ID, name or slug, or array of said.
- * @param int|object $post Optional. Post to check instead of the current post. (since 2.7.0)
+ * @param int|object $post Optional. Post to check instead of the current post. (since WP-2.7.0)
  * @return bool True if the current post is in any of the given categories.
  */
 function in_category( $category, $post = null ) {
@@ -1380,7 +1380,7 @@ function has_category( $category = '', $post = null ) {
  * @since WP-2.6.0
  *
  * @param string|int|array $tag Optional. The tag name/term_id/slug or array of them to check for.
- * @param int|object $post Optional. Post to check instead of the current post. (since 2.7.0)
+ * @param int|object $post Optional. Post to check instead of the current post. (since WP-2.7.0)
  * @return bool True if the current post has any of the given tags (or any tag, if no tag specified).
  */
 function has_tag( $tag = '', $post = null ) {

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -317,7 +317,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-name-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-locations-control.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-auto-add-control.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' ); // @todo Remove in 5.0. See https://core.trac.wordpress.org/ticket/42364.
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-control.php' ); // @todo Remove in WP-5.0. See https://core.trac.wordpress.org/ticket/42364.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menus-panel.php' );
 
@@ -325,7 +325,7 @@ final class WP_Customize_Manager {
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-themes-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-sidebar-section.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-nav-menu-section.php' );
-		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' ); // @todo Remove in 5.0. See https://core.trac.wordpress.org/ticket/42364.
+		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-new-menu-section.php' ); // @todo Remove in WP-5.0. See https://core.trac.wordpress.org/ticket/42364.
 
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-custom-css-setting.php' );
 		require_once( ABSPATH . WPINC . '/customize/class-wp-customize-filter-setting.php' );
@@ -1744,8 +1744,8 @@ final class WP_Customize_Manager {
 	 * @see WP_REST_Request::has_valid_params()
 	 *
 	 * @param WP_Customize_Setting $setting A WP_Customize_Setting derived object.
-	 * @param mixed                $default Value returned $setting has no post value (added in 4.2.0)
-	 *                                      or the post value is invalid (added in 4.6.0).
+	 * @param mixed                $default Value returned $setting has no post value (added in WP-4.2.0)
+	 *                                      or the post value is invalid (added in WP-4.6.0).
 	 * @return string|mixed $post_value Sanitized value or the $default provided.
 	 */
 	public function post_value( $setting, $default = null ) {

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -57,7 +57,7 @@ final class _WP_Editors {
 	 *     @type string     $editor_class      Extra classes to add to the editor textarea element. Default empty.
 	 *     @type bool       $teeny             Whether to output the minimal editor config. Examples include
 	 *                                         Press This and the Comment editor. Default false.
-	 *     @type bool       $dfw               Deprecated in WP-4.1. Since 4.3 used only to enqueue wp-fullscreen-stub.js
+	 *     @type bool       $dfw               Deprecated in WP-4.1. Since WP-4.3 used only to enqueue wp-fullscreen-stub.js
 	 *                                         for backward compatibility.
 	 *     @type bool|array $tinymce           Whether to load TinyMCE. Can be used to pass settings directly to
 	 *                                         TinyMCE using an array. Default true.

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -57,7 +57,7 @@ final class _WP_Editors {
 	 *     @type string     $editor_class      Extra classes to add to the editor textarea element. Default empty.
 	 *     @type bool       $teeny             Whether to output the minimal editor config. Examples include
 	 *                                         Press This and the Comment editor. Default false.
-	 *     @type bool       $dfw               Deprecated in 4.1. Since 4.3 used only to enqueue wp-fullscreen-stub.js
+	 *     @type bool       $dfw               Deprecated in WP-4.1. Since 4.3 used only to enqueue wp-fullscreen-stub.js
 	 *                                         for backward compatibility.
 	 *     @type bool|array $tinymce           Whether to load TinyMCE. Can be used to pass settings directly to
 	 *                                         TinyMCE using an array. Default true.

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -233,7 +233,7 @@ class wp_xmlrpc_server extends IXR_Server {
 	public function login( $username, $password ) {
 		/*
 		 * Respect old get_option() filters left for back-compat when the 'enable_xmlrpc'
-		 * option was deprecated in 3.5.0. Use the 'xmlrpc_enabled' hook instead.
+		 * option was deprecated in WP-3.5.0. Use the 'xmlrpc_enabled' hook instead.
 		 */
 		$enabled = apply_filters( 'pre_option_enable_xmlrpc', false );
 		if ( false === $enabled ) {
@@ -249,7 +249,7 @@ class wp_xmlrpc_server extends IXR_Server {
 		 *
 		 * Further, the filter does not control whether pingbacks or other custom endpoints that don't
 		 * require authentication are enabled. This behavior is expected, and due to how parity was matched
-		 * with the `enable_xmlrpc` UI option the filter replaced when it was introduced in 3.5.
+		 * with the `enable_xmlrpc` UI option the filter replaced when it was introduced in WP-3.5.
 		 *
 		 * To disable XML-RPC methods that require authentication, use:
 		 *

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -1151,7 +1151,7 @@ function trackback_url( $deprecated_echo = true ) {
 /**
  * Generate and display the RDF for the trackback information of current post.
  *
- * Deprecated in 3.0.0, and restored in 3.0.1.
+ * Deprecated in WP-3.0.0, and restored in WP-3.0.1.
  *
  * @since WP-0.71
  *
@@ -1238,11 +1238,11 @@ function pings_open( $post_id = null ) {
  * Will only display nonce token if the current user has permissions for
  * unfiltered html. Won't display the token for other users.
  *
- * The function was backported to 2.0.10 and was added to versions 2.1.3 and
- * above. Does not exist in versions prior to 2.0.10 in the 2.0 branch and in
- * the 2.1 branch, prior to 2.1.3. Technically added in 2.2.0.
+ * The function was backported to WP-2.0.10 and was added to versions WP-2.1.3 and
+ * above. Does not exist in versions prior to WP-2.0.10 in the WP-2.0 branch and in
+ * the WP-2.1 branch, prior to WP-2.1.3. Technically added in WP-2.2.0.
  *
- * Backported to 2.0.10.
+ * Backported to WP-2.0.10.
  *
  * @since WP-2.1.3
  */

--- a/src/wp-includes/customize/class-wp-customize-new-menu-control.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-control.php
@@ -36,7 +36,7 @@ class WP_Customize_New_Menu_Control extends WP_Customize_Control {
 	 * @param array                $args    Args.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-control.php. See https://core.trac.wordpress.org/ticket/42364.
+		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in WP-5.0, and remove its require_once() from class-wp-customize-control.php. See https://core.trac.wordpress.org/ticket/42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-new-menu-section.php
+++ b/src/wp-includes/customize/class-wp-customize-new-menu-section.php
@@ -38,7 +38,7 @@ class WP_Customize_New_Menu_Section extends WP_Customize_Section {
 	 * @param array                $args    Section arguments.
 	 */
 	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
-		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in 5.0, and remove its require_once() from class-wp-customize-section.php. See https://core.trac.wordpress.org/ticket/42364.
+		_deprecated_file( basename( __FILE__ ), 'WP-4.9.0' ); // @todo Move this outside of class in WP-5.0, and remove its require_once() from class-wp-customize-section.php. See https://core.trac.wordpress.org/ticket/42364.
 		parent::__construct( $manager, $id, $args );
 	}
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -2396,7 +2396,7 @@ function automatic_feed_links( $add = true ) {
 	if ( $add )
 		add_theme_support( 'automatic-feed-links' );
 	else
-		remove_action( 'wp_head', 'feed_links_extra', 3 ); // Just do this yourself in 3.0+
+		remove_action( 'wp_head', 'feed_links_extra', 3 ); // Just do this yourself in WP-3.0+
 }
 
 /**
@@ -3116,7 +3116,7 @@ function clean_page_cache( $id ) {
 /**
  * Retrieve nonce action "Are you sure" message.
  *
- * Deprecated in 3.4.1 and 3.5.0. Backported to 3.3.3.
+ * Deprecated in WP-3.4.1 and WP-3.5.0. Backported to WP-3.3.3.
  *
  * @since WP-2.0.4
  * @deprecated WP-3.4.1 Use wp_nonce_ays()

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2516,7 +2516,7 @@ function antispambot( $email_address, $hex_encoding = 0 ) {
 /**
  * Callback to convert URI match to HTML A element.
  *
- * This function was backported from 2.5.0 to 2.3.2. Regex callback for make_clickable().
+ * This function was backported from WP-2.5.0 to WP-2.3.2. Regex callback for make_clickable().
  *
  * @since WP-2.3.2
  * @access private
@@ -2552,7 +2552,7 @@ function _make_url_clickable_cb( $matches ) {
 /**
  * Callback to convert URL match to HTML A element.
  *
- * This function was backported from 2.5.0 to 2.3.2. Regex callback for make_clickable().
+ * This function was backported from WP-2.5.0 to WP-2.3.2. Regex callback for make_clickable().
  *
  * @since WP-2.3.2
  * @access private
@@ -2581,7 +2581,7 @@ function _make_web_ftp_clickable_cb( $matches ) {
 /**
  * Callback to convert email address match to HTML A element.
  *
- * This function was backported from 2.5.0 to 2.3.2. Regex callback for make_clickable().
+ * This function was backported from WP-2.5.0 to WP-2.3.2. Regex callback for make_clickable().
  *
  * @since WP-2.3.2
  * @access private

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -665,7 +665,7 @@ function get_html_split_regex() {
  *
  * @access private
  * @ignore
- * @internal This function will be removed in 4.5.0 per Shortcode API Roadmap.
+ * @internal This function will be removed in WP-4.5.0 per Shortcode API Roadmap.
  * @since WP-4.4.0
  *
  * @staticvar string $html_regex
@@ -708,7 +708,7 @@ function _get_wptexturize_split_regex( $shortcode_regex = '' ) {
  *
  * @access private
  * @ignore
- * @internal This function will be removed in 4.5.0 per Shortcode API Roadmap.
+ * @internal This function will be removed in WP-4.5.0 per Shortcode API Roadmap.
  * @since WP-4.4.0
  *
  * @param array $tagnames List of shortcodes to find.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3754,7 +3754,7 @@ function _deep_replace( $search, $subject ) {
  * Sometimes, spot-escaping is required or useful. One example
  * is preparing an array for use in an IN clause.
  *
- * NOTE: Since 4.8.3, '%' characters will be replaced with a placeholder string,
+ * NOTE: Since WP-4.8.3, '%' characters will be replaced with a placeholder string,
  * this prevents certain SQLi attacks from taking place. This change in behaviour
  * may cause issues for code that expects the return value of esc_sql() to be useable
  * for other purposes.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2153,7 +2153,7 @@ function get_pagenum_link($pagenum = 1, $escape = true ) {
 /**
  * Retrieves the next posts page link.
  *
- * Backported from 2.1.3 to 2.0.10.
+ * Backported from WP-2.1.3 to WP-2.0.10.
  *
  * @since WP-2.0.10
  *
@@ -2249,7 +2249,7 @@ function next_posts_link( $label = null, $max_page = 0 ) {
  *
  * Will only return string, if not on a single page or post.
  *
- * Backported to 2.0.10 from 2.1.3.
+ * Backported from WP-2.1.3 to WP-2.0.10.
  *
  * @since WP-2.0.10
  *

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3003,7 +3003,7 @@ function wp_plupload_default_settings() {
 	}
 
 	/*
-	 * Since 4.9 the `runtimes` setting is hardcoded in our version of Plupload to `html5,html4`,
+	 * Since WP-4.9 the `runtimes` setting is hardcoded in our version of Plupload to `html5,html4`,
 	 * and the `flash_swf_url` and `silverlight_xap_url` are not used.
 	 */
 	$defaults = array(

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1100,7 +1100,7 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 		}
 	}
 
-	// Global registry only contains meta keys registered with the array of arguments added in 4.6.0.
+	// Global registry only contains meta keys registered with the array of arguments added in WP-4.6.0.
 	if ( ! $has_old_auth_cb && ! $has_old_sanitize_cb ) {
 		unset( $args['object_subtype'] );
 

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -122,7 +122,7 @@ function ms_site_check() {
  *
  * @since WP-3.9.0
  *
- * @internal In 4.4.0, converted to a wrapper for WP_Network::get_by_path()
+ * @internal In WP-4.4.0, converted to a wrapper for WP_Network::get_by_path()
  *
  * @param string   $domain   Domain to check.
  * @param string   $path     Path to check.
@@ -534,7 +534,7 @@ function wpmu_current_site() {
  * @deprecated WP-4.7.0 Use `get_network()`
  * @see get_network()
  *
- * @internal In 4.6.0, converted to use get_network()
+ * @internal In WP-4.6.0, converted to use get_network()
  *
  * @param object|int $network The network's database row or ID.
  * @return WP_Network|false Object containing network information if found, false if not.

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -253,7 +253,7 @@ function get_site_by_path( $domain, $path, $segments = null ) {
  * Identifies the network and site of a requested domain and path and populates the
  * corresponding network and site global objects as part of the multisite bootstrap process.
  *
- * Prior to 4.6.0, this was a procedural block in `ms-settings.php`. It was wrapped into
+ * Prior to WP-4.6.0, this was a procedural block in `ms-settings.php`. It was wrapped into
  * a function to facilitate unit tests. It should not be used outside of core.
  *
  * Usually, it's easier to query the site first, which then declares its network.

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1112,7 +1112,7 @@ function get_site_option( $option, $default = false, $deprecated = true ) {
 /**
  * Add a new option for the current network.
  *
- * Existing options will not be updated. Note that prior to 3.3 this wasn't the case.
+ * Existing options will not be updated. Note that prior to WP-3.3 this wasn't the case.
  *
  * @since WP-2.8.0
  * @since WP-4.4.0 Modified into wrapper for add_network_option()

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1073,7 +1073,7 @@ if ( !function_exists('check_admin_referer') ) :
  * @since WP-1.2.0
  *
  * @param int|string $action    Action nonce.
- * @param string     $query_arg Optional. Key to check for nonce in `$_REQUEST` (since 2.5).
+ * @param string     $query_arg Optional. Key to check for nonce in `$_REQUEST` (since WP-2.5).
  *                              Default '_wpnonce'.
  * @return false|int False if the nonce is invalid, 1 if the nonce is valid and generated between
  *                   0-12 hours ago, 2 if the nonce is valid and generated between 12-24 hours ago.
@@ -1113,7 +1113,7 @@ if ( !function_exists('check_ajax_referer') ) :
  * @since WP-2.0.3
  *
  * @param int|string   $action    Action nonce.
- * @param false|string $query_arg Optional. Key to check for the nonce in `$_REQUEST` (since 2.5). If false,
+ * @param false|string $query_arg Optional. Key to check for the nonce in `$_REQUEST` (since WP-2.5). If false,
  *                                `$_REQUEST` values will be evaluated for '_ajax_nonce', and '_wpnonce'
  *                                (in that order). Default false.
  * @param bool         $die       Optional. Whether to die early when the nonce cannot be verified.

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1797,7 +1797,7 @@ function wp_list_post_revisions( $post_id = 0, $type = 'all' ) {
 	if ( ! $post = get_post( $post_id ) )
 		return;
 
-	// $args array with (parent, format, right, left, type) deprecated since 3.6
+	// $args array with (parent, format, right, left, type) deprecated since WP-3.6
 	if ( is_array( $type ) ) {
 		$type = ! empty( $type['type'] ) ? $type['type']  : $type;
 		_deprecated_argument( __FUNCTION__, 'WP-3.6.0' );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3061,7 +3061,7 @@ function wp_get_recent_posts( $args = array(), $output = ARRAY_A ) {
 
 	$results = get_posts( $r );
 
-	// Backward compatibility. Prior to 3.1 expected posts to be returned in array.
+	// Backward compatibility. Prior to WP-3.1 expected posts to be returned in array.
 	if ( ARRAY_A == $output ){
 		foreach ( $results as $key => $result ) {
 			$results[$key] = get_object_vars( $result );

--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -340,7 +340,7 @@ function _wp_filter_taxonomy_base( $base ) {
  * This function detects conflicts of this type and resolves them in favor of the
  * post permalink.
  *
- * Note that, since 4.3.0, wp_unique_post_slug() prevents the creation of post slugs
+ * Note that, since WP-4.3.0, wp_unique_post_slug() prevents the creation of post slugs
  * that would result in a date archive conflict. The resolution performed in this
  * function is primarily for legacy content, as well as cases when the admin has changed
  * the site's permalink structure in a way that introduces URL conflicts.

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3911,7 +3911,7 @@ function wp_get_split_term( $old_term_id, $taxonomy ) {
 /**
  * Determine whether a term is shared between multiple taxonomies.
  *
- * Shared taxonomy terms began to be split in 4.3, but failed cron tasks or
+ * Shared taxonomy terms began to be split in WP-4.3, but failed cron tasks or
  * other delays in upgrade routines may cause shared terms to remain.
  *
  * @since WP-4.4.0

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1029,7 +1029,7 @@ function get_term_to_edit( $id, $taxonomy ) {
  *         'hide_empty' => false,
  *     ) );
  *
- * Since 4.5.0, taxonomies should be passed via the 'taxonomy' argument in the `$args` array:
+ * Since WP-4.5.0, taxonomies should be passed via the 'taxonomy' argument in the `$args` array:
  *
  *     $terms = get_terms( array(
  *         'taxonomy' => 'post_tag',

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1023,7 +1023,7 @@ function get_term_to_edit( $id, $taxonomy ) {
  * The {@see 'get_terms_orderby'} filter passes the `ORDER BY` clause for the query
  * along with the $args array.
  *
- * Prior to 4.5.0, the first parameter of `get_terms()` was a taxonomy or list of taxonomies:
+ * Prior to WP-4.5.0, the first parameter of `get_terms()` was a taxonomy or list of taxonomies:
  *
  *     $terms = get_terms( 'post_tag', array(
  *         'hide_empty' => false,

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -244,7 +244,7 @@ function get_taxonomy( $taxonomy ) {
 /**
  * Checks that the taxonomy name exists.
  *
- * Formerly is_taxonomy(), introduced in 2.3.0.
+ * Formerly is_taxonomy(), introduced in WP-2.3.0.
  *
  * @since WP-3.0.0
  *
@@ -1313,7 +1313,7 @@ function unregister_term_meta( $taxonomy, $meta_key ) {
 /**
  * Check if Term exists.
  *
- * Formerly is_term(), introduced in 2.3.0.
+ * Formerly is_term(), introduced in WP-2.3.0.
  *
  * @since WP-3.0.0
  *

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2054,7 +2054,7 @@ function _get_additional_user_keys( $user ) {
 /**
  * Set up the user contact methods.
  *
- * Default contact methods were removed in 3.6. A filter dictates contact methods.
+ * Default contact methods were removed in WP-3.6. A filter dictates contact methods.
  *
  * @since WP-3.7.0
  *

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -89,7 +89,7 @@ class WP_Widget_Text extends WP_Widget {
 			return ! $instance['visual'];
 		}
 
-		// Or, the widget has been added/updated in 4.8.0 then filter prop is 'content' and it is no longer legacy.
+		// Or, the widget has been added/updated in WP-4.8.0 then filter prop is 'content' and it is no longer legacy.
 		if ( isset( $instance['filter'] ) && 'content' === $instance['filter'] ) {
 			return false;
 		}

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -222,7 +222,7 @@ class WP_Widget_Text extends WP_Widget {
 		$text = ! empty( $instance['text'] ) ? $instance['text'] : '';
 		$is_visual_text_widget = ( ! empty( $instance['visual'] ) && ! empty( $instance['filter'] ) );
 
-		// In 4.8.0 only, visual Text widgets get filter=content, without visual prop; upgrade instance props just-in-time.
+		// In WP-4.8.0 only, visual Text widgets get filter=content, without visual prop; upgrade instance props just-in-time.
 		if ( ! $is_visual_text_widget ) {
 			$is_visual_text_widget = ( isset( $instance['filter'] ) && 'content' === $instance['filter'] );
 		}

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -247,7 +247,7 @@ class wpdb {
 	/**
 	 * List of deprecated ClassicPress tables
 	 *
-	 * categories, post2cat, and link2cat were deprecated in 2.3.0, db version 5539
+	 * categories, post2cat, and link2cat were deprecated in WP-2.3.0, db version 5539
 	 *
 	 * @since WP-2.9.0
 	 * @see wpdb::tables()
@@ -1499,7 +1499,7 @@ class wpdb {
 		$this->is_mysql = true;
 
 		/*
-		 * Deprecated in 3.9+ when using MySQLi. No equivalent
+		 * Deprecated in WP-3.9+ when using MySQLi. No equivalent
 		 * $new_link parameter exists for mysqli_* functions.
 		 */
 		$new_link = defined( 'MYSQL_NEW_LINK' ) ? MYSQL_NEW_LINK : true;

--- a/tests/phpunit/data/formatting/sizzle.js
+++ b/tests/phpunit/data/formatting/sizzle.js
@@ -1300,7 +1300,7 @@ if ( document.querySelectorAll ) {
 		return;
 	}
 
-	// Safari caches class attributes, doesn't catch changes (in WP-3.2)
+	// Safari caches class attributes, doesn't catch changes (in 3.2)
 	div.lastChild.className = "e";
 
 	if ( div.getElementsByClassName("e").length === 1 ) {

--- a/tests/phpunit/data/formatting/sizzle.js
+++ b/tests/phpunit/data/formatting/sizzle.js
@@ -1300,7 +1300,7 @@ if ( document.querySelectorAll ) {
 		return;
 	}
 
-	// Safari caches class attributes, doesn't catch changes (in 3.2)
+	// Safari caches class attributes, doesn't catch changes (in WP-3.2)
 	div.lastChild.className = "e";
 
 	if ( div.getElementsByClassName("e").length === 1 ) {

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -350,7 +350,7 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 */
 	public function test_branching() {
 		$wp_customize = new WP_Customize_Manager();
-		$this->assertTrue( $wp_customize->branching(), 'Branching should default to true since it is original behavior in 4.7.' );
+		$this->assertTrue( $wp_customize->branching(), 'Branching should default to true since it is original behavior in WP-4.7.' );
 
 		$wp_customize = new WP_Customize_Manager( array( 'branching' => false ) );
 		$this->assertFalse( $wp_customize->branching() );

--- a/tests/phpunit/tests/formatting/MakeClickable.php
+++ b/tests/phpunit/tests/formatting/MakeClickable.php
@@ -348,7 +348,7 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	function test_no_links_within_links() {
 		$in = array(
 			'Some text with a link <a href="http://example.com">http://example.com</a>',
-			//'<a href="http://wordpress.org">This is already a link www.wordpress.org</a>', // fails in 3.3.1 too
+			//'<a href="http://wordpress.org">This is already a link www.wordpress.org</a>', // fails in WP-3.3.1 too
 		);
 		foreach ( $in as $text ) {
 			$this->assertEquals( $text, make_clickable( $text ) );

--- a/tests/phpunit/tests/formatting/WPTexturize.php
+++ b/tests/phpunit/tests/formatting/WPTexturize.php
@@ -337,7 +337,7 @@ class Tests_Formatting_WPTexturize extends WP_UnitTestCase {
 				"word&#8217;99word",
 			),
 			array(
-				"word '99&#8217;s word", // Appears as a separate but logically superfluous pattern in 3.8.
+				"word '99&#8217;s word", // Appears as a separate but logically superfluous pattern in WP-3.8.
 				"word &#8217;99&#8217;s word",
 			),
 			array(
@@ -1872,7 +1872,7 @@ class Tests_Formatting_WPTexturize extends WP_UnitTestCase {
 			),
 			array(
 				'[audio]...[/audio]]...', // These are potentially usable shortcodes.  Unfortunately, the meaning of [/audio]] is ambiguous unless we run the entire shortcode regexp.
-				'[audio]...[/audio]]...', // This test would not pass in 3.9 because the extra brace was always ignored by texturize.
+				'[audio]...[/audio]]...', // This test would not pass in WP-3.9 because the extra brace was always ignored by texturize.
 			),
 			array(
 				'<span>hello[/audio]---</span>',

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1314,7 +1314,7 @@ EOF;
 		$expected = '';
 
 		foreach ( $image_meta['sizes'] as $name => $size ) {
-			// Whitelist the sizes that should be included so we pick up 'medium_large' in 4.4.
+			// Whitelist the sizes that should be included so we pick up 'medium_large' in WP-4.4.
 			if ( in_array( $name, $intermediates ) ) {
 				$expected .= $uploads_dir_url . $year_month . '/' . $size['file'] . ' ' . $size['width'] . 'w, ';
 			}
@@ -1359,7 +1359,7 @@ EOF;
 		$expected = '';
 
 		foreach ( $image_meta['sizes'] as $name => $size ) {
-			// Whitelist the sizes that should be included so we pick up 'medium_large' in 4.4.
+			// Whitelist the sizes that should be included so we pick up 'medium_large' in WP-4.4.
 			if ( in_array( $name, $intermediates ) ) {
 				$expected .= $uploads_dir_url . $size['file'] . ' ' . $size['width'] . 'w, ';
 			}
@@ -1436,7 +1436,7 @@ EOF;
 		$expected = '';
 
 		foreach( $image_meta['sizes'] as $name => $size ) {
-			// Whitelist the sizes that should be included so we pick up 'medium_large' in 4.4.
+			// Whitelist the sizes that should be included so we pick up 'medium_large' in WP-4.4.
 			if ( in_array( $name, $intermediates ) ) {
 				$expected .= $uploads_dir_url . $year_month . '/' . $size['file'] . ' ' . $size['width'] . 'w, ';
 			}
@@ -1715,7 +1715,7 @@ EOF;
 		$expected = "";
 
 		foreach ( $image_meta['sizes'] as $name => $size ) {
-			// Whitelist the sizes that should be included so we pick up 'medium_large' in 4.4.
+			// Whitelist the sizes that should be included so we pick up 'medium_large' in WP-4.4.
 			if ( in_array( $name, $intermediates ) ) {
 				$expected .= $uploads_dir . $year_month . '/' . $size['file'] . ' ' . $size['width'] . 'w, ';
 			}

--- a/tests/phpunit/tests/widgets/text-widget.php
+++ b/tests/phpunit/tests/widgets/text-widget.php
@@ -180,7 +180,7 @@ class Test_WP_Widget_Text extends WP_UnitTestCase {
 		$this->assertContains( '[filter:widget_text]', $output );
 		$this->assertNotContains( '[filter:widget_text_content]', $output );
 
-		// Test with filter=content, the upgraded widget, in 4.8.0 only.
+		// Test with filter=content, the upgraded widget, in WP-4.8.0 only.
 		$this->widget_text_content_args = null;
 		$instance = array(
 			'title'  => 'Foo',
@@ -206,7 +206,7 @@ class Test_WP_Widget_Text extends WP_UnitTestCase {
 		$this->assertEquals( $widget, $this->widget_text_content_args[2] );
 		$this->assertContains( wpautop( $expected_instance['text'] . '[filter:widget_text][filter:widget_text_content]' ), $output );
 
-		// Test with filter=true&visual=true, the upgraded widget, in 4.8.1 and above.
+		// Test with filter=true&visual=true, the upgraded widget, in WP-4.8.1 and above.
 		$this->widget_text_content_args = null;
 		$instance = array(
 			'title'  => 'Foo',
@@ -230,7 +230,7 @@ class Test_WP_Widget_Text extends WP_UnitTestCase {
 		$this->assertEquals( $widget, $this->widget_text_content_args[2] );
 		$this->assertContains( wpautop( $expected_instance['text'] . '[filter:widget_text][filter:widget_text_content]' ), $output );
 
-		// Test with filter=true&visual=true, the upgraded widget, in 4.8.1 and above.
+		// Test with filter=true&visual=true, the upgraded widget, in WP-4.8.1 and above.
 		$this->widget_text_content_args = null;
 		$instance = array(
 			'title'  => 'Foo',
@@ -251,7 +251,7 @@ class Test_WP_Widget_Text extends WP_UnitTestCase {
 		$this->assertNull( $this->widget_text_content_args );
 		$this->assertContains( wpautop( $expected_instance['text'] . '[filter:widget_text]' ), $output );
 
-		// Test with filter=false&visual=false, the upgraded widget, in 4.8.1 and above.
+		// Test with filter=false&visual=false, the upgraded widget, in WP-4.8.1 and above.
 		$this->widget_text_content_args = null;
 		$instance = array(
 			'title'  => 'Foo',

--- a/tests/phpunit/tests/widgets/text-widget.php
+++ b/tests/phpunit/tests/widgets/text-widget.php
@@ -672,7 +672,7 @@ class Test_WP_Widget_Text extends WP_UnitTestCase {
 		);
 		$result = $widget->update( $instance, array() );
 		$this->assertEquals( $expected, $result );
-		$this->assertTrue( ! empty( $expected['filter'] ), 'Expected filter prop to be truthy, to handle case where 4.8 is downgraded to 4.7.' );
+		$this->assertTrue( ! empty( $expected['filter'] ), 'Expected filter prop to be truthy, to handle case where WP-4.8 is downgraded to WP-4.7.' );
 
 		add_filter( 'map_meta_cap', array( $this, 'grant_unfiltered_html_cap' ), 10, 2 );
 		$this->assertTrue( current_user_can( 'unfiltered_html' ) );


### PR DESCRIPTION
Following up on #26, #57, and #59, this PR adds a `WP-` prefix to some more instances of WP version numbers in the code.