### PR TITLE
change tagline to "Another great website powered by ClassicPress"

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -395,7 +395,7 @@ function populate_options() {
 	'home' => $guessurl,
 	'blogname' => __('My Site'),
 	/* translators: site tagline */
-	'blogdescription' => __('Just another ClassicPress site'),
+	'blogdescription' => __('Another great website powered by ClassicPress'),
 	'users_can_register' => 0,
 	'admin_email' => 'you@example.com',
 	/* translators: default start of the week. 0 = Sunday, 1 = Monday */
@@ -533,7 +533,7 @@ function populate_options() {
 	// 3.0 multisite
 	if ( is_multisite() ) {
 		/* translators: site tagline */
-		$options[ 'blogdescription' ] = sprintf(__('Just another %s site'), get_network()->site_name );
+		$options[ 'blogdescription' ] = sprintf(__('Another great %s website powered by ClassicPress'), get_network()->site_name );
 		$options[ 'permalink_structure' ] = '/%year%/%monthnum%/%day%/%postname%/';
 	}
 

--- a/tests/phpunit/data/export/small-export.xml
+++ b/tests/phpunit/data/export/small-export.xml
@@ -28,7 +28,7 @@
 <channel>
 	<title>trunk</title>
 	<link>http://localhost/</link>
-	<description>Just another ClassicPress site</description>
+	<description>Another great website powered by ClassicPress</description>
 	<pubDate>Tue, 18 Jan 2011 08:06:21 +0000</pubDate>
 	<language>en</language>
 	<wp:wxr_version>1.1</wp:wxr_version>

--- a/tests/phpunit/data/export/test-serialized-postmeta-no-cdata.xml
+++ b/tests/phpunit/data/export/test-serialized-postmeta-no-cdata.xml
@@ -27,7 +27,7 @@
 <channel>
 	<title>Test With Serialized Postmeta</title>
 	<link>http://test.wordpress.org/</link>
-	<description>Just another blog</description>
+	<description>Another great website</description>
 	<pubDate>Mon, 30 Nov 2009 21:35:27 +0000</pubDate>
 	<generator>http://wordpress.org/?v=2.8.4</generator>
 	<language>en</language>

--- a/tests/phpunit/data/export/test-serialized-postmeta-with-cdata.xml
+++ b/tests/phpunit/data/export/test-serialized-postmeta-with-cdata.xml
@@ -27,7 +27,7 @@
 <channel>
 	<title>Test With Serialized Postmeta</title>
 	<link>http://test.wordpress.org/</link>
-	<description>Just another blog</description>
+	<description>Another great website</description>
 	<pubDate>Mon, 30 Nov 2009 21:35:27 +0000</pubDate>
 	<generator>http://wordpress.org/?v=2.8.4</generator>
 	<language>en</language>

--- a/tests/phpunit/data/export/test-utw-post-meta-import.xml
+++ b/tests/phpunit/data/export/test-utw-post-meta-import.xml
@@ -27,7 +27,7 @@
 <channel>
 	<title>Test With Serialized Postmeta</title>
 	<link>http://test.wordpress.org/</link>
-	<description>Just another blog</description>
+	<description>Another great website</description>
 	<pubDate>Mon, 30 Nov 2009 21:35:27 +0000</pubDate>
 	<generator>http://wordpress.org/?v=2.8.4</generator>
 	<language>en</language>

--- a/tests/phpunit/data/export/valid-wxr-1.0.xml
+++ b/tests/phpunit/data/export/valid-wxr-1.0.xml
@@ -27,7 +27,7 @@
 <channel>
 	<title>Export Dataset</title>
 	<link>http://localhost/</link>
-	<description>Just another ClassicPress site</description>
+	<description>Another great website powered by ClassicPress</description>
 	<pubDate>Wed, 20 Oct 2010 14:10:09 +0000</pubDate>
 	<generator>http://wordpress.org/?v=3.0.1</generator>
 	<language>en</language>
@@ -43,7 +43,7 @@
 		<wp:tag><wp:tag_slug>face</wp:tag_slug><wp:tag_name><![CDATA[face]]></wp:tag_name></wp:tag>
 		<wp:tag><wp:tag_slug>news</wp:tag_slug><wp:tag_name><![CDATA[news]]></wp:tag_name></wp:tag>
 		<wp:tag><wp:tag_slug>roar</wp:tag_slug><wp:tag_name><![CDATA[roar]]></wp:tag_name></wp:tag>
-		
+
 	<generator>http://wordpress.org/?v=3.0.1</generator>
 
 		<item>
@@ -51,7 +51,7 @@
 		<link>http://localhost/?p=1</link>
 		<pubDate>Wed, 20 Oct 2010 14:08:20 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<category><![CDATA[Uncategorized]]></category>
 
 		<category domain="category" nicename="uncategorized"><![CDATA[Uncategorized]]></category>
@@ -92,7 +92,7 @@
 		<link>http://localhost/?page_id=2</link>
 		<pubDate>Wed, 20 Oct 2010 14:08:20 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<guid isPermaLink="false">http://localhost/?page_id=2</guid>
 		<description></description>
 		<content:encoded><![CDATA[This is an example of a ClassicPress page, you could edit this to put information about yourself or your site so readers know where you are coming from. You can create as many pages like this one or sub-pages as you like and manage all of your content inside of ClassicPress.]]></content:encoded>
@@ -119,7 +119,7 @@
 		<link>http://localhost/?p=4</link>
 		<pubDate>Wed, 20 Oct 2010 14:09:37 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<category><![CDATA[alpha]]></category>
 
 		<category domain="category" nicename="alpha"><![CDATA[alpha]]></category>
@@ -166,7 +166,7 @@
 		<link>http://localhost/?p=6</link>
 		<pubDate>Wed, 20 Oct 2010 14:10:09 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<category domain="tag"><![CDATA[chicken]]></category>
 
 		<category domain="tag" nicename="chicken"><![CDATA[chicken]]></category>
@@ -213,7 +213,7 @@
 		<link>http://localhost/?page_id=8</link>
 		<pubDate>Wed, 20 Oct 2010 14:10:35 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<guid isPermaLink="false">http://localhost/?page_id=8</guid>
 		<description></description>
 		<content:encoded><![CDATA[Should have lower ID than parent!]]></content:encoded>
@@ -248,7 +248,7 @@
 		<link>http://localhost/?page_id=10</link>
 		<pubDate>Wed, 20 Oct 2010 14:10:44 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		
+
 		<guid isPermaLink="false">http://localhost/?page_id=10</guid>
 		<description></description>
 		<content:encoded><![CDATA[woop]]></content:encoded>

--- a/tests/phpunit/data/export/valid-wxr-1.1.xml
+++ b/tests/phpunit/data/export/valid-wxr-1.1.xml
@@ -28,7 +28,7 @@
 <channel>
 	<title>Export Datasets</title>
 	<link>http://localhost/</link>
-	<description>Just another ClassicPress site</description>
+	<description>Another great website powered by ClassicPress</description>
 	<pubDate>Sat, 16 Oct 2010 20:53:18 +0000</pubDate>
 	<language>en</language>
 	<wp:wxr_version>1.1</wp:wxr_version>

--- a/tests/phpunit/tests/general/document-title.php
+++ b/tests/phpunit/tests/general/document-title.php
@@ -87,12 +87,12 @@ class Tests_General_DocumentTitle extends WP_UnitTestCase {
 		add_filter( 'document_title_parts', array( $this, '_front_page_title_parts' ) );
 
 		$this->go_to( '/' );
-		$this->assertEquals( sprintf( '%s &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Another great website powered by ClassicPress', $this->blog_name ), wp_get_document_title() );
 
 		update_option( 'show_on_front', 'posts' );
 
 		$this->go_to( '/' );
-		$this->assertEquals( sprintf( '%s &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Another great website powered by ClassicPress', $this->blog_name ), wp_get_document_title() );
 	}
 
 	function _front_page_title_parts( $parts ) {
@@ -118,7 +118,7 @@ class Tests_General_DocumentTitle extends WP_UnitTestCase {
 
 		add_filter( 'document_title_parts', array( $this, '_paged_title_parts' ) );
 
-		$this->assertEquals( sprintf( '%s &#8211; Page 4 &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Page 4 &#8211; Another great website powered by ClassicPress', $this->blog_name ), wp_get_document_title() );
 	}
 
 	function _paged_title_parts( $parts ) {

--- a/tests/phpunit/tests/general/document-title.php
+++ b/tests/phpunit/tests/general/document-title.php
@@ -87,12 +87,12 @@ class Tests_General_DocumentTitle extends WP_UnitTestCase {
 		add_filter( 'document_title_parts', array( $this, '_front_page_title_parts' ) );
 
 		$this->go_to( '/' );
-		$this->assertEquals( sprintf( '%s &#8211; Just another ClassicPress site', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
 
 		update_option( 'show_on_front', 'posts' );
 
 		$this->go_to( '/' );
-		$this->assertEquals( sprintf( '%s &#8211; Just another ClassicPress site', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
 	}
 
 	function _front_page_title_parts( $parts ) {
@@ -118,7 +118,7 @@ class Tests_General_DocumentTitle extends WP_UnitTestCase {
 
 		add_filter( 'document_title_parts', array( $this, '_paged_title_parts' ) );
 
-		$this->assertEquals( sprintf( '%s &#8211; Page 4 &#8211; Just another ClassicPress site', $this->blog_name ), wp_get_document_title() );
+		$this->assertEquals( sprintf( '%s &#8211; Page 4 &#8211; Another great ClassicPress website', $this->blog_name ), wp_get_document_title() );
 	}
 
 	function _paged_title_parts( $parts ) {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -7,7 +7,7 @@ var mockedApiResponse = {};
 
 mockedApiResponse.Schema = {
     "name": "Test Blog",
-    "description": "Just another ClassicPress site",
+    "description": "Another great website powered by ClassicPress",
     "url": "http://example.org",
     "home": "http://example.org",
     "gmt_offset": "0",
@@ -4549,7 +4549,7 @@ mockedApiResponse.CommentModel = {
 
 mockedApiResponse.settings = {
     "title": "Test Blog",
-    "description": "Just another ClassicPress site",
+    "description": "Another great website powered by ClassicPress",
     "url": "http://example.org",
     "email": "admin@example.org",
     "timezone": "",


### PR DESCRIPTION
Petitioned in https://petitions.classicpress.net/posts/97/update-the-default-just-another-tagline

But because not a major change and a nice way to differentiate ClassicPress from Wordpress, we have discussed it [on Slack](https://classicpress.slack.com/archives/CCQ01LKDX/p1541634907073100) and decided on the line in the title

## Description
Change "Just another ClassicPress site" to "Another great website powered by ClassicPress"

## Motivation and context
To stay with the original petition: to jazz it up a bit

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
