### PR TITLE
Update default tagline text

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -395,7 +395,7 @@ function populate_options() {
 	'home' => $guessurl,
 	'blogname' => __('My Site'),
 	/* translators: site tagline */
-	'blogdescription' => __('Just another ClassicPress site'),
+	'blogdescription' => __('Another great ClassicPress site'),
 	'users_can_register' => 0,
 	'admin_email' => 'you@example.com',
 	/* translators: default start of the week. 0 = Sunday, 1 = Monday */
@@ -533,7 +533,7 @@ function populate_options() {
 	// 3.0 multisite
 	if ( is_multisite() ) {
 		/* translators: site tagline */
-		$options[ 'blogdescription' ] = sprintf(__('Just another %s site'), get_network()->site_name );
+		$options[ 'blogdescription' ] = sprintf(__('Another great %s site'), get_network()->site_name );
 		$options[ 'permalink_structure' ] = '/%year%/%monthnum%/%day%/%postname%/';
 	}
 


### PR DESCRIPTION
Updates the tagline text from "Just another ClassicPress site" to "Another great ClassicPress site". Changed from a petition into a PR. Source: [petitions site](https://petitions.classicpress.net/posts/97/update-the-default-just-another-tagline)

## Description
Updated two instances of the tagline.

## Motivation and context
The term "just another" always makes me think, "oh, great, not another..."

## How has this been tested?
With love.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
