### PR TITLE
Change default category to "General"

### DIFF
--- a/src/wp-admin/edit-tags.php
+++ b/src/wp-admin/edit-tags.php
@@ -217,7 +217,7 @@ if ( current_user_can($tax->cap->edit_terms) )
 if ( 'category' == $taxonomy || 'link_category' == $taxonomy || 'post_tag' == $taxonomy  ) {
 	$help ='';
 	if ( 'category' == $taxonomy )
-		$help = '<p>' . sprintf(__( 'You can use categories to define sections of your site and group related posts. The default category is &#8220;Uncategorized&#8221; until you change it in your <a href="%s">writing settings</a>.' ) , 'options-writing.php' ) . '</p>';
+		$help = '<p>' . sprintf(__( 'You can use categories to define sections of your site and group related posts. The default category is &#8220;General&#8221; until you change it in your <a href="%s">writing settings</a>.' ) , 'options-writing.php' ) . '</p>';
 	elseif ( 'link_category' == $taxonomy )
 		$help = '<p>' . __( 'You can create groups of links by using Link Categories. Link Category names must be unique and Link Categories are separate from the categories you use for posts.' ) . '</p>';
 	else

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -116,7 +116,7 @@ if ( !function_exists('wp_install_defaults') ) :
 /**
  * Creates the initial content for a newly-installed site.
  *
- * Adds the default "Uncategorized" category, the first post (with comment),
+ * Adds the default "General" category, the first post (with comment),
  * first page, and default widgets for default theme for the current version.
  *
  * @since WP-2.1.0
@@ -131,9 +131,9 @@ function wp_install_defaults( $user_id ) {
 	global $wpdb, $wp_rewrite, $table_prefix;
 
 	// Default category
-	$cat_name = __('Uncategorized');
+	$cat_name = __('General');
 	/* translators: Default category slug */
-	$cat_slug = sanitize_title(_x('Uncategorized', 'Default category slug'));
+	$cat_slug = sanitize_title(_x('General', 'Default category slug'));
 
 	if ( global_terms_enabled() ) {
 		$cat_id = $wpdb->get_var( $wpdb->prepare( "SELECT cat_ID FROM {$wpdb->sitecategories} WHERE category_nicename = %s", $cat_slug ) );

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -35,7 +35,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->add_help_tab( array(
 	'id'      => 'custom-structures',
 	'title'   => __('Custom Structures'),
-	'content' => '<p>' . __('The Optional fields let you customize the &#8220;category&#8221; and &#8220;tag&#8221; base names that will appear in archive URLs. For example, the page listing all posts in the &#8220;Uncategorized&#8221; category could be <code>/topics/uncategorized</code> instead of <code>/category/uncategorized</code>.') . '</p>' .
+	'content' => '<p>' . __('The Optional fields let you customize the &#8220;category&#8221; and &#8220;tag&#8221; base names that will appear in archive URLs. For example, the page listing all posts in the &#8220;General&#8221; category could be <code>/topics/general</code> instead of <code>/category/general</code>.') . '</p>' .
 		'<p>' . __('You must click the Save Changes button at the bottom of the screen for new settings to take effect.') . '</p>',
 ) );
 
@@ -280,7 +280,7 @@ $structures = array(
 <h2 class="title"><?php _e('Optional'); ?></h2>
 <p><?php
 /* translators: %s: placeholder that must come at the start of the URL */
-printf( __( 'If you like, you may enter custom structures for your category and tag URLs here. For example, using <code>topics</code> as your category base would make your category links like <code>%s/topics/uncategorized/</code>. If you leave these blank the defaults will be used.' ), get_option( 'home' ) . $blog_prefix . $prefix ); ?></p>
+printf( __( 'If you like, you may enter custom structures for your category and tag URLs here. For example, using <code>topics</code> as your category base would make your category links like <code>%s/topics/general/</code>. If you leave these blank the defaults will be used.' ), get_option( 'home' ) . $blog_prefix . $prefix ); ?></p>
 
 <table class="form-table">
 	<tr>

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -145,7 +145,7 @@ function get_the_category_list( $separator = '', $parents = '', $post_id = false
 
 	if ( empty( $categories ) ) {
 		/** This filter is documented in wp-includes/category-template.php */
-		return apply_filters( 'the_category', __( 'Uncategorized' ), $separator, $parents );
+		return apply_filters( 'the_category', __( 'General' ), $separator, $parents );
 	}
 
 	$rel = ( is_object( $wp_rewrite ) && $wp_rewrite->using_permalinks() ) ? 'rel="category tag"' : 'rel="category"';


### PR DESCRIPTION
[Petitioned](https://petitions.classicpress.net/posts/98/change-the-name-of-the-uncategorized-category) but I'm submitting the PR as this is not a major change; same reasoning as [here](https://petitions.classicpress.net/posts/97/update-the-default-just-another-tagline) and [here](https://github.com/ClassicPress/ClassicPress/pull/214).

## Description
Updated the default category to "General", including the label and supporting texts.

## Motivation and context
A category should never be named "Uncategorized" – it's nonsensical and looks unprofessional. Changing the category to General is a better fallback for times when you forget to categorize an item.

## How has this been tested?
Locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
