### PR TITLE
src/composer.json: don't use fixed versions on dependencies

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -17,6 +17,6 @@
         "issues": "https://github.com/ClassicPress/ClassicPress/issues"
     },
     "require": {
-        "johnpbloch/wordpress-core-installer": "1.0.0"
+        "johnpbloch/wordpress-core-installer": "^1.0.0"
     }
 }


### PR DESCRIPTION
Related to https://github.com/ClassicPress/ClassicPress/pull/169 and https://github.com/ClassicPress/ClassicPress/issues/37

I was running some test this morning (https://github.com/globalis-ms/wp-cubi/commit/fc45fac34424b3af43f8f98d0a6004e149bf6150), and I saw that, when installing ClassicPress with composer, we end up using https://github.com/johnpbloch/wordpress-core-installer **version 1.0.0** instead of **latest version 1.0.0.2**, because I used a fix version number in the ClassicPress composer.json dependencies.

This PR fixes that.