### PR TITLE
adjust upload site-icon text Customizer, fix issue #219

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -4902,7 +4902,7 @@ final class WP_Customize_Manager {
 		$this->add_control( new WP_Customize_Site_Icon_Control( $this, 'site_icon', array(
 			'label'       => __( 'Site Icon' ),
 			'description' => sprintf(
-				'<p>' . __( 'Site Icons are what you see in browser tabs, bookmark bars, and within the ClassicPress mobile apps. Upload one here!' ) . '</p>' .
+				'<p>' . __( 'Site Icons are what you see in browser tabs and bookmark bars. Upload one here!' ) . '</p>' .
 				/* translators: %s: site icon size in pixels */
 				'<p>' . __( 'Site Icons should be square and at least %s pixels.' ) . '</p>',
 				'<strong>512 &times; 512</strong>'


### PR DESCRIPTION
Adjust upload site-con text Customizer, fix issue #219

## Description
See issue #219 (upload site-icon text in Customizer)

## Motivation and context
Text refers to ClassicPress mobile apps, which do not exist at this point
Fixes #219 

## How has this been tested?
Local dev

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
