### PR TITLE
Update admin buttons: gradient background

### DIFF
--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -231,39 +231,46 @@ TABLE OF CONTENTS:
 ---------------------------------------------------------------------------- */
 
 .wp-core-ui .button-primary {
-	background: #0085ba;
-	border-color: #0073aa #006799 #006799;
-	box-shadow: 0 1px 0 #006799;
+	background: #07989e;
+	background: -moz-linear-gradient(60deg, #07989e 0%, #034b59 100%);
+	background: -webkit-gradient(left top, right bottom, color-stop(0%, #07989e), color-stop(100%, #034b59));
+	background: -webkit-linear-gradient(60deg, #07989e 0%, #034b59 100%);
+	background: -o-linear-gradient(60deg, #07989e 0%, #034b59 100%);
+	background: -ms-linear-gradient(60deg, #07989e 0%, #034b59 100%);
+	background: linear-gradient(60deg, #07989e 0%, #034b59 100%);
+	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#07989e', endColorstr='#034b59', GradientType=1 );
+	border-color: #034b59;
+	box-shadow: 0 1px 0 #034b59;
 	color: #fff;
 	text-decoration: none;
-	text-shadow: 0 -1px 1px #006799,
-		1px 0 1px #006799,
-		0 1px 1px #006799,
-		-1px 0 1px #006799;
+	text-shadow: 0 -1px 1px #034b59,
+		1px 0 1px #034b59,
+		0 1px 1px #034b59,
+		-1px 0 1px #034b59;
 }
 
 .wp-core-ui .button-primary.hover,
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	background: #008ec2;
-	border-color: #006799;
+	background: #034b59;
+	border-color: #034b59;
 	color: #fff;
 }
 
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	box-shadow: 0 1px 0 #0073aa,
-		0 0 2px 1px #33b3db;
+	box-shadow: 0 1px 0 #034b59,
+		0 0 2px 1px #07989e;
 }
 
 .wp-core-ui .button-primary.active,
 .wp-core-ui .button-primary.active:hover,
 .wp-core-ui .button-primary.active:focus,
 .wp-core-ui .button-primary:active {
-	background: #0073aa;
-	border-color: #006799;
-	box-shadow: inset 0 2px 0 #006799;
+	background: #034b59;
+	border-color: #034b59;
+	box-shadow: inset 0 2px 0 #057f99;
 	vertical-align: top;
 }
 


### PR DESCRIPTION
Part of #210, alternative 1 of 2 (solid button background coming soon in a separate PR).

This changes the primary button style (colors) **across of all of wp-admin**.  Needs testing to make sure there are no core screens where this looks terrible.

### Before

![2018-11-10t13 25 09-05 00](https://user-images.githubusercontent.com/227022/48304918-2511af00-e4f0-11e8-961f-9b80d4007651.png)

### After

![2018-11-10t13 24 00-05 00](https://user-images.githubusercontent.com/227022/48304915-1deaa100-e4f0-11e8-8ecd-dd8fb05438c8.png)