### PR TITLE
Update admin buttons: solid color background

### DIFF
--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -231,39 +231,39 @@ TABLE OF CONTENTS:
 ---------------------------------------------------------------------------- */
 
 .wp-core-ui .button-primary {
-	background: #0085ba;
-	border-color: #0073aa #006799 #006799;
-	box-shadow: 0 1px 0 #006799;
+	background: #057f99;
+	border-color: #034b59;
+	box-shadow: 0 1px 0 #034b59;
 	color: #fff;
 	text-decoration: none;
-	text-shadow: 0 -1px 1px #006799,
-		1px 0 1px #006799,
-		0 1px 1px #006799,
-		-1px 0 1px #006799;
+	text-shadow: 0 -1px 1px #034b59,
+		1px 0 1px #034b59,
+		0 1px 1px #034b59,
+		-1px 0 1px #034b59;
 }
 
 .wp-core-ui .button-primary.hover,
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	background: #008ec2;
-	border-color: #006799;
+	background: #034b59;
+	border-color: #034b59;
 	color: #fff;
 }
 
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	box-shadow: 0 1px 0 #0073aa,
-		0 0 2px 1px #33b3db;
+	box-shadow: 0 1px 0 #034b59,
+		0 0 2px 1px #07989e;
 }
 
 .wp-core-ui .button-primary.active,
 .wp-core-ui .button-primary.active:hover,
 .wp-core-ui .button-primary.active:focus,
 .wp-core-ui .button-primary:active {
-	background: #0073aa;
-	border-color: #006799;
-	box-shadow: inset 0 2px 0 #006799;
+	background: #034b59;
+	border-color: #034b59;
+	box-shadow: inset 0 2px 0 #057f99;
 	vertical-align: top;
 }
 

--- a/src/wp-includes/css/buttons.css
+++ b/src/wp-includes/css/buttons.css
@@ -246,7 +246,7 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-primary:hover,
 .wp-core-ui .button-primary.focus,
 .wp-core-ui .button-primary:focus {
-	background: #034b59;
+	background: #006b81;
 	border-color: #034b59;
 	color: #fff;
 }
@@ -261,9 +261,9 @@ TABLE OF CONTENTS:
 .wp-core-ui .button-primary.active:hover,
 .wp-core-ui .button-primary.active:focus,
 .wp-core-ui .button-primary:active {
-	background: #034b59;
+	background: #006b81;
 	border-color: #034b59;
-	box-shadow: inset 0 2px 0 #057f99;
+	box-shadow: inset 0 2px 0 #034b59;
 	vertical-align: top;
 }
 


### PR DESCRIPTION
Part of #210, alternative 2 of 2 (see #222 for gradient button background).

This changes the primary button style (colors) **across of all of wp-admin**.  Needs testing to make sure there are no core screens where this looks terrible.

Bonus: we are improving on WP's contrast ratios here.

### Before

![2018-11-10t13 25 09-05 00](https://user-images.githubusercontent.com/227022/48304918-2511af00-e4f0-11e8-961f-9b80d4007651.png)

### After

![2018-11-10t13 43 51-05 00](https://user-images.githubusercontent.com/227022/48304933-62763c80-e4f0-11e8-875a-8262dc39966e.png)