### PR TITLE
Fix the tests when `WP_TESTS_DOMAIN` is overridden

### DIFF
--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2283,7 +2283,10 @@ EOF;
 		wp_delete_attachment( $post_id );
 		wp_delete_post( $parent_id );
 
-		$this->assertSame( 'http://example.org/wp-content/uploads/2010/01/test-image-iptc.jpg', $url );
+		$this->assertSame(
+			content_url( 'uploads/2010/01/test-image-iptc.jpg' ),
+			$url
+		);
 	}
 
 	/**


### PR DESCRIPTION
When running the PHPUnit automated tests, `WP_TESTS_DOMAIN` is normally set to `example.org`, but it doesn't have to be.  This commit fixes a single failing test that appears when this value is set to a different domain in `wp-tests-config.php`.