### PR TITLE
Remove more references to WP Trac tickets in tests

### DIFF
--- a/tests/phpunit/includes/testcase-canonical.php
+++ b/tests/phpunit/includes/testcase-canonical.php
@@ -151,13 +151,10 @@ class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @param string $test_url                Raw URL that will be run through redirect_canonical().
 	 * @param string $expected                Expected string.
-	 * @param int    $ticket                  Optional. Trac ticket number.
 	 * @param array  $expected_doing_it_wrong Array of class/function names expected to throw _doing_it_wrong() notices.
 	 */
-	public function assertCanonical( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
+	public function assertCanonical( $test_url, $expected, $expected_doing_it_wrong = array() ) {
 		$this->expected_doing_it_wrong = array_merge( $this->expected_doing_it_wrong, (array) $expected_doing_it_wrong );
-
-		$ticket_ref = ($ticket > 0) ? 'Ticket #' . $ticket : null;
 
 		if ( is_string($expected) )
 			$expected = array('url' => $expected);
@@ -175,7 +172,7 @@ class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 
 		// Just test the Path and Query if present
 		if ( isset($expected['url']) ) {
-			$this->assertEquals( $expected['url'], $parsed_can_url['path'] . (!empty($parsed_can_url['query']) ? '?' . $parsed_can_url['query'] : ''), $ticket_ref );
+			$this->assertEquals( $expected['url'], $parsed_can_url['path'] . (!empty($parsed_can_url['query']) ? '?' . $parsed_can_url['query'] : '') );
 		}
 
 		// If the test data doesn't include expected query vars, then we're done here
@@ -193,7 +190,7 @@ class WP_Canonical_UnitTestCase extends WP_UnitTestCase {
 			parse_str($parsed_can_url['query'], $_qv);
 
 			// $_qv should not contain any elements which are set in $query_vars already (ie. $_GET vars should not be present in the Rewrite)
-			$this->assertEquals( array(), array_intersect( $query_vars, $_qv ), 'Query vars are duplicated from the Rewrite into $_GET; ' . $ticket_ref );
+			$this->assertEquals( array(), array_intersect( $query_vars, $_qv ), 'Query vars are duplicated from the Rewrite into $_GET' );
 
 			$query_vars = array_merge($query_vars, $_qv);
 		}

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -18,7 +18,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider data_canonical
 	 */
-	function test_canonical( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
+	function test_canonical( $test_url, $expected, $expected_doing_it_wrong = array() ) {
 
 		if ( false !== strpos( $test_url, '%d' ) ) {
 			if ( false !== strpos( $test_url, '/?author=%d' ) )
@@ -27,7 +27,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				$test_url = sprintf( $test_url, self::$terms[ $expected['url'] ] );
 		}
 
-		$this->assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+		$this->assertCanonical( $test_url, $expected, $expected_doing_it_wrong );
 	}
 
 	function data_canonical() {
@@ -37,52 +37,51 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		 *      array( 'url': expected redirection location, 'qv': expected query vars to be set via the rewrite AND $_GET );
 		 *      array( expected query vars to be set, same as 'qv' above )
 		 *      (string) expected redirect location
-		 * [2]: (optional) The ticket the test refers to, Can be skipped if unknown.
-		 * [3]: (optional) Array of class/function names expected to throw `_doing_it_wrong()` notices.
+		 * [2]: (optional) Array of class/function names expected to throw `_doing_it_wrong()` notices.
 		 */
 
 		// Please Note: A few test cases are commented out below, Look at the test case following it, in most cases it's simply showing 2 options for the "proper" redirect.
 		return array(
 			// Categories
 
-			array( '?cat=%d', array( 'url' => '/category/parent/' ), 15256 ),
-			array( '?cat=%d', array( 'url' => '/category/parent/child-1/' ), 15256 ),
+			array( '?cat=%d', array( 'url' => '/category/parent/' ) ),
+			array( '?cat=%d', array( 'url' => '/category/parent/child-1/' ) ),
 			array( '?cat=%d', array( 'url' => '/category/parent/child-1/child-2/' ) ), // no children
 			array( '/category/uncategorized/', array( 'url' => '/category/uncategorized/', 'qv' => array( 'category_name' => 'uncategorized' ) ) ),
 			array( '/category/uncategorized/page/2/', array( 'url' => '/category/uncategorized/page/2/', 'qv' => array( 'category_name' => 'uncategorized', 'paged' => 2) ) ),
 			array( '/category/uncategorized/?paged=2', array( 'url' => '/category/uncategorized/page/2/', 'qv' => array( 'category_name' => 'uncategorized', 'paged' => 2) ) ),
-			array( '/category/uncategorized/?paged=2&category_name=uncategorized', array( 'url' => '/category/uncategorized/page/2/', 'qv' => array( 'category_name' => 'uncategorized', 'paged' => 2) ), 17174 ),
+			array( '/category/uncategorized/?paged=2&category_name=uncategorized', array( 'url' => '/category/uncategorized/page/2/', 'qv' => array( 'category_name' => 'uncategorized', 'paged' => 2) ) ),
 
 			// Categories & Intersections with other vars
 			array( '/category/uncategorized/?tag=post-formats', array( 'url' => '/category/uncategorized/?tag=post-formats', 'qv' => array('category_name' => 'uncategorized', 'tag' => 'post-formats') ) ),
 			array( '/?category_name=cat-a,cat-b', array( 'url' => '/?category_name=cat-a,cat-b', 'qv' => array( 'category_name' => 'cat-a,cat-b' ) ) ),
 
 			// Taxonomies with extra Query Vars
-			array( '/category/cat-a/page/1/?test=one%20two', '/category/cat-a/?test=one%20two', 18086), // Extra query vars should stay encoded
+			array( '/category/cat-a/page/1/?test=one%20two', '/category/cat-a/?test=one%20two' ), // Extra query vars should stay encoded
 
 			// Categories with Dates
-			array( '/2008/04/?cat=1', array( 'url' => '/2008/04/?cat=1', 'qv' => array('cat' => '1', 'year' => '2008', 'monthnum' => '04' ) ), 17661 ),
+			array( '/2008/04/?cat=1', array( 'url' => '/2008/04/?cat=1', 'qv' => array('cat' => '1', 'year' => '2008', 'monthnum' => '04' ) ) ),
 //			array( '/2008/?category_name=cat-a', array( 'url' => '/2008/?category_name=cat-a', 'qv' => array('category_name' => 'cat-a', 'year' => '2008' ) ) ),
 
 			// Pages
-			array( '/child-page-1/', '/parent-page/child-page-1/'),
-			array( '/?page_id=144', '/parent-page/child-page-1/'),
+			array( '/child-page-1/', '/parent-page/child-page-1/' ),
+			array( '/?page_id=144', '/parent-page/child-page-1/' ),
 			array( '/abo', '/about/' ),
 			array( '/parent/child1/grandchild/', '/parent/child1/grandchild/' ),
 			array( '/parent/child2/grandchild/', '/parent/child2/grandchild/' ),
 
 			// Posts
-			array( '?p=587', '/2008/06/02/post-format-test-audio/'),
-			array( '/?name=images-test', '/2008/09/03/images-test/'),
+			array( '?p=587', '/2008/06/02/post-format-test-audio/' ),
+			array( '/?name=images-test', '/2008/09/03/images-test/' ),
 			// Incomplete slug should resolve and remove the ?name= parameter
-			array( '/?name=images-te', '/2008/09/03/images-test/', 20374),
+			array( '/?name=images-te', '/2008/09/03/images-test/' ),
 			// Page slug should resolve to post slug and remove the ?pagename= parameter
-			array( '/?pagename=images-test', '/2008/09/03/images-test/', 20374),
+			array( '/?pagename=images-test', '/2008/09/03/images-test/' ),
 
-			array( '/2008/06/02/post-format-test-au/', '/2008/06/02/post-format-test-audio/'),
-			array( '/2008/06/post-format-test-au/', '/2008/06/02/post-format-test-audio/'),
-			array( '/2008/post-format-test-au/', '/2008/06/02/post-format-test-audio/'),
-			array( '/2010/post-format-test-au/', '/2008/06/02/post-format-test-audio/'), // A Year the post is not in
+			array( '/2008/06/02/post-format-test-au/', '/2008/06/02/post-format-test-audio/' ),
+			array( '/2008/06/post-format-test-au/', '/2008/06/02/post-format-test-audio/' ),
+			array( '/2008/post-format-test-au/', '/2008/06/02/post-format-test-audio/' ),
+			array( '/2010/post-format-test-au/', '/2008/06/02/post-format-test-audio/' ), // A Year the post is not in
 			array( '/post-format-test-au/', '/2008/06/02/post-format-test-audio/'),
 
 			array( '/2008/09/03/images-test/3/', array( 'url' => '/2008/09/03/images-test/3/', 'qv' => array( 'name' => 'images-test', 'year' => '2008', 'monthnum' => '09', 'day' => '03', 'page' => '3' ) ) ),
@@ -98,22 +97,22 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 			// Dates
 			array( '/?m=2008', '/2008/' ),
-			array( '/?m=200809', '/2008/09/'),
-			array( '/?m=20080905', '/2008/09/05/'),
+			array( '/?m=200809', '/2008/09/' ),
+			array( '/?m=20080905', '/2008/09/05/' ),
 
-			array( '/2008/?day=05', '/2008/?day=05'), // no redirect
-			array( '/2008/09/?day=05', '/2008/09/05/'),
-			array( '/2008/?monthnum=9', '/2008/09/'),
+			array( '/2008/?day=05', '/2008/?day=05' ), // no redirect
+			array( '/2008/09/?day=05', '/2008/09/05/' ),
+			array( '/2008/?monthnum=9', '/2008/09/' ),
 
-			array( '/?year=2008', '/2008/'),
+			array( '/?year=2008', '/2008/' ),
 
-			array( '/2012/13/', '/2012/'),
-			array( '/2012/11/51/', '/2012/11/', 0, array( 'WP_Date_Query' ) ),
+			array( '/2012/13/', '/2012/' ),
+			array( '/2012/11/51/', '/2012/11/', array( 'WP_Date_Query' ) ),
 
 			// Authors
 			array( '/?author=%d', '/author/canonical-author/' ),
-//			array( '/?author=%d&year=2008', '/2008/?author=3'),
-//			array( '/author/canonical-author/?year=2008', '/2008/?author=3'), //Either or, see previous testcase.
+//			array( '/?author=%d&year=2008', '/2008/?author=3' ),
+//			array( '/author/canonical-author/?year=2008', '/2008/?author=3' ), //Either or, see previous testcase.
 
 			// Feeds
 			array( '/?feed=atom', '/feed/atom/' ),
@@ -122,8 +121,8 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			array( '/?feed=comments-atom', '/comments/feed/atom/'),
 
 			// Feeds (per-post)
-			array( '/2008/03/03/comment-test/?feed=comments-atom', '/2008/03/03/comment-test/feed/atom/'),
-			array( '/?p=149&feed=comments-atom', '/2008/03/03/comment-test/feed/atom/'),
+			array( '/2008/03/03/comment-test/?feed=comments-atom', '/2008/03/03/comment-test/feed/atom/' ),
+			array( '/?p=149&feed=comments-atom', '/2008/03/03/comment-test/feed/atom/' ),
 
 			// Index
 			array( '/?paged=1', '/' ),

--- a/tests/phpunit/tests/canonical/category.php
+++ b/tests/phpunit/tests/canonical/category.php
@@ -25,8 +25,8 @@ class Tests_Canonical_Category extends WP_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider data_canonical_category
 	 */
-	public function test_canonical_category( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
-		$this->assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+	public function test_canonical_category( $test_url, $expected ) {
+		$this->assertCanonical( $test_url, $expected );
 	}
 
 	public function data_canonical_category() {
@@ -36,8 +36,6 @@ class Tests_Canonical_Category extends WP_Canonical_UnitTestCase {
 		 *      array( 'url': expected redirection location, 'qv': expected query vars to be set via the rewrite AND $_GET );
 		 *      array( expected query vars to be set, same as 'qv' above )
 		 *      (string) expected redirect location
-		 * [2]: (optional) The ticket the test refers to, Can be skipped if unknown.
-		 * [3]: (optional) Array of class/function names expected to throw `_doing_it_wrong()` notices.
 		 */
 
 		return array(

--- a/tests/phpunit/tests/canonical/customRules.php
+++ b/tests/phpunit/tests/canonical/customRules.php
@@ -18,8 +18,8 @@ class Tests_Canonical_CustomRules extends WP_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider data
 	 */
-	function test( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
-		$this->assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+	function test( $test_url, $expected ) {
+		$this->assertCanonical( $test_url, $expected );
 	}
 
 	function data() {
@@ -29,7 +29,6 @@ class Tests_Canonical_CustomRules extends WP_Canonical_UnitTestCase {
 		 *      array( 'url': expected redirection location, 'qv': expected query vars to be set via the rewrite AND $_GET );
 		 *      array( expected query vars to be set, same as 'qv' above )
 		 *      (string) expected redirect location
-		 * [3]: (optional) The ticket the test refers to, Can be skipped if unknown.
 		 */
 		return array(
 			// Custom Rewrite rules leading to Categories

--- a/tests/phpunit/tests/canonical/noRewrite.php
+++ b/tests/phpunit/tests/canonical/noRewrite.php
@@ -24,8 +24,8 @@ class Tests_Canonical_NoRewrite extends WP_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider data
 	 */
-	function test( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
-		$this->assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+	function test( $test_url, $expected ) {
+		$this->assertCanonical( $test_url, $expected );
 	}
 
 	function data() {
@@ -35,7 +35,6 @@ class Tests_Canonical_NoRewrite extends WP_Canonical_UnitTestCase {
 		 *      array( 'url': expected redirection location, 'qv': expected query vars to be set via the rewrite AND $_GET );
 		 *      array( expected query vars to be set, same as 'qv' above )
 		 *      (string) expected redirect location
-		 * [3]: (optional) The ticket the test refers to, Can be skipped if unknown.
 		 */
 		return array(
 			array( '/?p=123', '/?p=123' ),
@@ -47,62 +46,62 @@ class Tests_Canonical_NoRewrite extends WP_Canonical_UnitTestCase {
 			array( '/?post_type=page&page_id=1', '/?p=1' ),
 
 			// Trailing spaces and punctuation in query string args.
-			array( '/?p=358 ',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // space
-			array( '/?p=358%20',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded space
-			array( '/?p=358!',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // exclamation mark
-			array( '/?p=358%21',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded exclamation mark
-			array( '/?p=358"',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // double quote
-			array( '/?p=358%22',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded double quote
-			array( '/?p=358\'',         array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // single quote
-			array( '/?p=358%27',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded single quote
-			array( '/?p=358(',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // opening bracket
-			array( '/?p=358%28',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded opening bracket
-			array( '/?p=358)',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // closing bracket
-			array( '/?p=358%29',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded closing bracket
-			array( '/?p=358,',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // comma
-			array( '/?p=358%2C',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded comma
-			array( '/?p=358.',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // period
-			array( '/?p=358%2E',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded period
-			array( '/?p=358;',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // semicolon
-			array( '/?p=358%3B',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded semicolon
-			array( '/?p=358{',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // opening curly bracket
-			array( '/?p=358%7B',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded opening curly bracket
-			array( '/?p=358}',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // closing curly bracket
-			array( '/?p=358%7D',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded closing curly bracket
-			array( '/?p=358%E2%80%9C',  array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded opening curly quote
-			array( '/?p=358%E2%80%9D',  array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ), 20383 ), // encoded closing curly quote
+			array( '/?p=358 ',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // space
+			array( '/?p=358%20',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded space
+			array( '/?p=358!',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // exclamation mark
+			array( '/?p=358%21',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded exclamation mark
+			array( '/?p=358"',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // double quote
+			array( '/?p=358%22',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded double quote
+			array( '/?p=358\'',         array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // single quote
+			array( '/?p=358%27',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded single quote
+			array( '/?p=358(',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // opening bracket
+			array( '/?p=358%28',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded opening bracket
+			array( '/?p=358)',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // closing bracket
+			array( '/?p=358%29',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded closing bracket
+			array( '/?p=358,',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // comma
+			array( '/?p=358%2C',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded comma
+			array( '/?p=358.',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // period
+			array( '/?p=358%2E',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded period
+			array( '/?p=358;',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // semicolon
+			array( '/?p=358%3B',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded semicolon
+			array( '/?p=358{',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // opening curly bracket
+			array( '/?p=358%7B',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded opening curly bracket
+			array( '/?p=358}',          array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // closing curly bracket
+			array( '/?p=358%7D',        array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded closing curly bracket
+			array( '/?p=358%E2%80%9C',  array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded opening curly quote
+			array( '/?p=358%E2%80%9D',  array( 'url' => '/?p=358', 'qv' => array( 'p' => '358' ) ) ), // encoded closing curly quote
 
 			// Trailing spaces and punctuation in permalinks.
-			array( '/page/2/ ',         '/page/2/', 20383 ), // space
-			array( '/page/2/%20',       '/page/2/', 20383 ), // encoded space
-			array( '/page/2/!',         '/page/2/', 20383 ), // exclamation mark
-			array( '/page/2/%21',       '/page/2/', 20383 ), // encoded exclamation mark
-			array( '/page/2/"',         '/page/2/', 20383 ), // double quote
-			array( '/page/2/%22',       '/page/2/', 20383 ), // encoded double quote
-			array( '/page/2/\'',        '/page/2/', 20383 ), // single quote
-			array( '/page/2/%27',       '/page/2/', 20383 ), // encoded single quote
-			array( '/page/2/(',         '/page/2/', 20383 ), // opening bracket
-			array( '/page/2/%28',       '/page/2/', 20383 ), // encoded opening bracket
-			array( '/page/2/)',         '/page/2/', 20383 ), // closing bracket
-			array( '/page/2/%29',       '/page/2/', 20383 ), // encoded closing bracket
-			array( '/page/2/,',         '/page/2/', 20383 ), // comma
-			array( '/page/2/%2C',       '/page/2/', 20383 ), // encoded comma
-			array( '/page/2/.',         '/page/2/', 20383 ), // period
-			array( '/page/2/%2E',       '/page/2/', 20383 ), // encoded period
-			array( '/page/2/;',         '/page/2/', 20383 ), // semicolon
-			array( '/page/2/%3B',       '/page/2/', 20383 ), // encoded semicolon
-			array( '/page/2/{',         '/page/2/', 20383 ), // opening curly bracket
-			array( '/page/2/%7B',       '/page/2/', 20383 ), // encoded opening curly bracket
-			array( '/page/2/}',         '/page/2/', 20383 ), // closing curly bracket
-			array( '/page/2/%7D',       '/page/2/', 20383 ), // encoded closing curly bracket
-			array( '/page/2/%E2%80%9C', '/page/2/', 20383 ), // encoded opening curly quote
-			array( '/page/2/%E2%80%9D', '/page/2/', 20383 ), // encoded closing curly quote
+			array( '/page/2/ ',         '/page/2/' ), // space
+			array( '/page/2/%20',       '/page/2/' ), // encoded space
+			array( '/page/2/!',         '/page/2/' ), // exclamation mark
+			array( '/page/2/%21',       '/page/2/' ), // encoded exclamation mark
+			array( '/page/2/"',         '/page/2/' ), // double quote
+			array( '/page/2/%22',       '/page/2/' ), // encoded double quote
+			array( '/page/2/\'',        '/page/2/' ), // single quote
+			array( '/page/2/%27',       '/page/2/' ), // encoded single quote
+			array( '/page/2/(',         '/page/2/' ), // opening bracket
+			array( '/page/2/%28',       '/page/2/' ), // encoded opening bracket
+			array( '/page/2/)',         '/page/2/' ), // closing bracket
+			array( '/page/2/%29',       '/page/2/' ), // encoded closing bracket
+			array( '/page/2/,',         '/page/2/' ), // comma
+			array( '/page/2/%2C',       '/page/2/' ), // encoded comma
+			array( '/page/2/.',         '/page/2/' ), // period
+			array( '/page/2/%2E',       '/page/2/' ), // encoded period
+			array( '/page/2/;',         '/page/2/' ), // semicolon
+			array( '/page/2/%3B',       '/page/2/' ), // encoded semicolon
+			array( '/page/2/{',         '/page/2/' ), // opening curly bracket
+			array( '/page/2/%7B',       '/page/2/' ), // encoded opening curly bracket
+			array( '/page/2/}',         '/page/2/' ), // closing curly bracket
+			array( '/page/2/%7D',       '/page/2/' ), // encoded closing curly bracket
+			array( '/page/2/%E2%80%9C', '/page/2/' ), // encoded opening curly quote
+			array( '/page/2/%E2%80%9D', '/page/2/' ), // encoded closing curly quote
 
 			array( '/?page_id=1', '/?p=1' ), // redirect page_id to p (should cover page_id|p|attachment_id to one another
 			array( '/?page_id=1&post_type=revision', '/?p=1' ),
 
-			array( '/?feed=rss2&p=1', '/?feed=rss2&p=1', 21841 ),
-			array( '/?feed=rss&p=1', '/?feed=rss2&p=1', 24623 ),
+			array( '/?feed=rss2&p=1', '/?feed=rss2&p=1' ),
+			array( '/?feed=rss&p=1', '/?feed=rss2&p=1' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/canonical/pageOnFront.php
+++ b/tests/phpunit/tests/canonical/pageOnFront.php
@@ -18,8 +18,8 @@ class Tests_Canonical_PageOnFront extends WP_Canonical_UnitTestCase {
 	/**
 	 * @dataProvider data
 	 */
-	function test( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
-		$this->assertCanonical( $test_url, $expected, $ticket, $expected_doing_it_wrong );
+	function test( $test_url, $expected ) {
+		$this->assertCanonical( $test_url, $expected );
 	}
 
 	function data() {
@@ -29,7 +29,6 @@ class Tests_Canonical_PageOnFront extends WP_Canonical_UnitTestCase {
 		 *      array( 'url': expected redirection location, 'qv': expected query vars to be set via the rewrite AND $_GET );
 		 *      array( expected query vars to be set, same as 'qv' above )
 		 *      (string) expected redirect location
-		 * [3]: (optional) The ticket the test refers to, Can be skipped if unknown.
 		 */
 		 return array(
 			// Check against an odd redirect


### PR DESCRIPTION
There are some old tests for the `redirect_canonical` function that contain WP Trac ticket numbers in the test code.  These ticket numbers only show up when the tests fail, which has not happened in a long time because this is a stable part of the code.  Also, we can look back at the commit history if these references are ever needed, so I am ok with losing this information.

See also #145.