### PR TITLE
Add more information about the current dev version

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -21,6 +21,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 
 		<p class="about-text">
 			<?php printf( __( 'Version %s' ), classicpress_version() ); ?>
+			<?php classicpress_dev_version_info(); ?>
 		</p>
 		<p class="about-text">
 			<?php _e( 'Thank you for using ClassicPress, the business focused CMS.' ); ?><br>

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -19,6 +19,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 
 <p class="about-text">
 	<?php printf( __( 'Version %s' ), classicpress_version() ); ?>
+	<?php classicpress_dev_version_info(); ?>
 </p>
 <p class="about-text">
 	<?php _e( 'Thank you for using ClassicPress, the business focused CMS.' ); ?><br>

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -152,6 +152,19 @@
 	color: #555d66;
 }
 
+.about-wrap .dev-version-info {
+	font-size: 14px;
+	font-weight: 400;
+	margin-left: 0.5em;
+}
+
+@media screen and (max-width: 640px) {
+	.about-wrap .dev-version-info {
+		display: block;
+		margin-left: 0;
+	}
+}
+
 /* 1.2 - Structure */
 
 /* 1.3 - Point Releases */

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -22,6 +22,7 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 
 <p class="about-text">
 	<?php printf( __( 'Version %s' ), classicpress_version() ); ?>
+	<?php classicpress_dev_version_info(); ?>
 </p>
 <p class="about-text">
 	<?php _e( 'Thank you for using ClassicPress, the business focused CMS.' ); ?><br>

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -35,11 +35,10 @@ function classicpress_dev_version_info() {
 	}
 
 	echo '<span class="dev-version-info">';
-	$commit_url = "https://github.com/ClassicPress/ClassicPress/commit/$git_commit";
-	/* translators: link to the current development commit on GitHub */
+	/* translators: current development commit on GitHub */
 	printf(
 		__( 'commit %s' ),
-		'<a href="' . $commit_url . '">' . substr( $git_commit, 0, 8 ) . '</a>'
+		substr( $git_commit, 0, 8 )
 	);
 	echo '</a>';
 	echo '</span>';

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -39,7 +39,7 @@ function classicpress_dev_version_info() {
 	/* translators: link to the current development commit on GitHub */
 	printf(
 		__( 'commit %s' ),
-		'<a href="' . $commit_url . '">' . substr( $git_commit, 0, 7 ) . '</a>'
+		'<a href="' . $commit_url . '">' . substr( $git_commit, 0, 8 ) . '</a>'
 	);
 	echo '</a>';
 	echo '</span>';

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -35,9 +35,12 @@ function classicpress_dev_version_info() {
 	}
 
 	echo '<span class="dev-version-info">';
-	echo 'commit ';
-	echo '<a href="https://github.com/ClassicPress/ClassicPress/commit/' . $git_commit . '">';
-	echo '<code>' . substr( $git_commit, 0, 8 ) . '</code>';
+	$commit_url = "https://github.com/ClassicPress/ClassicPress/commit/$git_commit";
+	/* translators: link to the current development commit on GitHub */
+	printf(
+		__( 'commit %s' ),
+		'<a href="' . $commit_url . '">' . substr( $git_commit, 0, 7 ) . '</a>'
+	);
 	echo '</a>';
 	echo '</span>';
 }

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -6,6 +6,42 @@
  * @subpackage Administration
  */
 
+ /**
+  * Prints information about the ClassicPress development version, if any.
+  */
+function classicpress_dev_version_info() {
+	if ( ! classicpress_is_dev_install() ) {
+		return;
+	}
+
+	$git_head = ABSPATH . '../.git/HEAD';
+	$git_commit = null;
+	if ( @is_file( $git_head ) ) {
+		$git_head = trim( file_get_contents( $git_head ) );
+		if ( preg_match( '#^ref: (refs/.*)$#', $git_head, $matches ) ) {
+			// on a branch
+			$git_head = ABSPATH . '../.git/' . $matches[1];
+			if ( @is_file( $git_head ) ) {
+				$git_commit = trim( file_get_contents( $git_head ) );
+			}
+		} else {
+			// detached HEAD
+			$git_commit = $git_head;
+		}
+	}
+
+	if ( ! $git_commit ) {
+		return;
+	}
+
+	echo '<span class="dev-version-info">';
+	echo 'commit ';
+	echo '<a href="https://github.com/ClassicPress/ClassicPress/commit/' . $git_commit . '">';
+	echo '<code>' . substr( $git_commit, 0, 8 ) . '</code>';
+	echo '</a>';
+	echo '</span>';
+}
+
 /**
  * Returns whether the server is running Apache with the mod_rewrite module loaded.
  *


### PR DESCRIPTION
For **development installs** (running ClassicPress from this source repository), this PR adds a small marker next to the version number on the wp-admin About page that shows the current `git` commit and links it to GitHub:

![2018-11-14t22 39 27-05 00](https://user-images.githubusercontent.com/227022/48528703-2b8c8780-e85e-11e8-986d-b672ad0cc209.png)

The goal of the PR is to make it more clear exactly which version of ClassicPress you are running, since the version number in this repository looks like `1.0.0-alpha1+dev` which actually represents a pretty wide range of commits.