### PR TITLE
Clean up '@ since' and '@ deprecated' from earlier PRs

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -8,6 +8,8 @@
 
  /**
   * Prints information about the ClassicPress development version, if any.
+  *
+  * @since 1.0.0-beta1
   */
 function classicpress_dev_version_info() {
 	if ( ! classicpress_is_dev_install() ) {

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -356,8 +356,8 @@ function wp_remote_retrieve_cookie_value( $response, $name ) {
 /**
  * Determines if there is an HTTP Transport that can process this request.
  *
- * @since WP-3.2.0 
- * @deprecated 1.0.0-beta1 
+ * @since WP-3.2.0
+ * @deprecated 1.0.0-beta1
  *
  * @param array  $capabilities Array of capabilities to test or a wp_remote_request() $args array.
  * @param string $url          Optional. If given, will check if the URL requires SSL and adds


### PR DESCRIPTION
- #201: `wp_http_supports()`
- #231: `classicpress_dev_version_info()`