### PR TITLE
Update ClassicPress logo background on About screens

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -53,9 +53,19 @@
 /* ClassicPress Version Badge */
 
 .wp-badge {
-	background: #0073aa url(../images/w-logo-white.png?ver=20181031) no-repeat;
-	background-position: center;
+	/* Background: Really old browsers */
+	background: #057f99;
+	/* Background: Old browsers */
+	background-image: url(../images/wordpress-logo-white.svg?ver=20181031);
 	background-size: 80px 80px;
+	/* Background: Modern browsers */
+	background-image:
+		url(../images/wordpress-logo-white.svg?ver=20181031),
+		linear-gradient(-135deg, #3ebca6 0%, #057f99 50%, #006b81 100%);
+	background-size: 80px 80px, cover;
+	/* Other rules */
+	background-repeat: no-repeat;
+	background-position: center;
 	color: #fff;
 	font-size: 14px;
 	text-align: center;
@@ -66,10 +76,6 @@
 	display: inline-block;
 	text-rendering: optimizeLegibility;
 	box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-}
-
-.svg .wp-badge {
-	background-image: url(../images/wordpress-logo-white.svg?ver=20181031);
 }
 
 .about-wrap .wp-badge {


### PR DESCRIPTION
### Before

![2018-11-16t23 07 07-05 00](https://user-images.githubusercontent.com/227022/48656692-80630600-e9f6-11e8-9143-08bb96e5dfe1.png)

### After

![2018-11-16t23 21 31-05 00](https://user-images.githubusercontent.com/227022/48656695-85c05080-e9f6-11e8-92e2-7585c5a39227.png)

### Notes

This PR updates the "logo badge" on the About screens in the dashboard to use the ClassicPress colors and gradient background.

While researching how to apply the gradient background, I found that the multiple-browser-compatibility CSS prefixes that we've been using elsewhere are no longer necessary:  https://codepen.io/thebabydino/full/pjxVWp

And a couple more resources specifically about declaring multiple sets of background properties on a single element, as we are doing here:

- https://stackoverflow.com/a/2547064/106302
- https://stackoverflow.com/a/11468866/106302

