### PR TITLE
Move wp-settings require from wp-config to wp-load

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -64,7 +64,8 @@ function wp_initial_constants() {
 	}
 
 	if ( ! defined( 'WP_CONTENT_DIR') ) {
-		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+		// no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+		define( 'WP_CONTENT_DIR', ABSPATH . ltrim( CP_CONTENT_PATH, '/' ) );
 	}
 
 	// Add define('WP_DEBUG', true); to wp-config.php to enable display of notices during development.
@@ -144,7 +145,8 @@ function wp_initial_constants() {
  */
 function wp_plugin_directory_constants() {
 	if ( !defined('WP_CONTENT_URL') ) {
-		define( 'WP_CONTENT_URL', get_option( 'siteurl' ) . '/wp-content' ); // full url - WP_CONTENT_DIR is defined further up
+		// full url - WP_CONTENT_DIR is defined further up
+		define( 'WP_CONTENT_URL', get_option( 'siteurl' ) . CP_CONTENT_PATH );
 	}
 
 	/**

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -59,27 +59,33 @@ function wp_initial_constants() {
 		@ini_set( 'memory_limit', WP_MEMORY_LIMIT );
 	}
 
-	if ( ! isset($blog_id) )
+	if ( ! isset($blog_id) ) {
 		$blog_id = 1;
+	}
 
-	if ( !defined('WP_CONTENT_DIR') )
+	if ( ! defined( 'WP_CONTENT_DIR') ) {
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+	}
 
 	// Add define('WP_DEBUG', true); to wp-config.php to enable display of notices during development.
-	if ( !defined('WP_DEBUG') )
+	if ( ! defined( 'WP_DEBUG') ) {
 		define( 'WP_DEBUG', false );
+	}
 
 	// Add define('WP_DEBUG_DISPLAY', null); to wp-config.php use the globally configured setting for
 	// display_errors and not force errors to be displayed. Use false to force display_errors off.
-	if ( !defined('WP_DEBUG_DISPLAY') )
+	if ( ! defined( 'WP_DEBUG_DISPLAY') ) {
 		define( 'WP_DEBUG_DISPLAY', true );
+	}
 
 	// Add define('WP_DEBUG_LOG', true); to enable error logging to wp-content/debug.log.
-	if ( !defined('WP_DEBUG_LOG') )
-		define('WP_DEBUG_LOG', false);
+	if ( ! defined( 'WP_DEBUG_LOG') ) {
+		define( 'WP_DEBUG_LOG', false );
+	}
 
-	if ( !defined('WP_CACHE') )
-		define('WP_CACHE', false);
+	if ( ! defined( 'WP_CACHE') ) {
+		define( 'WP_CACHE', false );
+	}
 
 	// Add define('SCRIPT_DEBUG', true); to wp-config.php to enable loading of non-minified,
 	// non-concatenated scripts and stylesheets.
@@ -96,11 +102,13 @@ function wp_initial_constants() {
 	/**
 	 * Private
 	 */
-	if ( !defined('MEDIA_TRASH') )
-		define('MEDIA_TRASH', false);
+	if ( ! defined( 'MEDIA_TRASH') ) {
+		define( 'MEDIA_TRASH', false );
+	}
 
-	if ( !defined('SHORTINIT') )
-		define('SHORTINIT', false);
+	if ( ! defined( 'SHORTINIT') ) {
+		define( 'SHORTINIT', false );
+	}
 
 	// Constants for features added to WP that should short-circuit their plugin implementations
 	define( 'WP_FEATURE_BETTER_PASSWORDS', true );
@@ -135,24 +143,27 @@ function wp_initial_constants() {
  * @since WP-3.0.0
  */
 function wp_plugin_directory_constants() {
-	if ( !defined('WP_CONTENT_URL') )
-		define( 'WP_CONTENT_URL', get_option('siteurl') . '/wp-content'); // full url - WP_CONTENT_DIR is defined further up
+	if ( !defined('WP_CONTENT_URL') ) {
+		define( 'WP_CONTENT_URL', get_option( 'siteurl' ) . '/wp-content' ); // full url - WP_CONTENT_DIR is defined further up
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('WP_PLUGIN_DIR') )
+	if ( ! defined( 'WP_PLUGIN_DIR') ) {
 		define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins' ); // full path, no trailing slash
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('WP_PLUGIN_URL') )
+	if ( ! defined( 'WP_PLUGIN_URL') ) {
 		define( 'WP_PLUGIN_URL', WP_CONTENT_URL . '/plugins' ); // full url, no trailing slash
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
@@ -160,33 +171,37 @@ function wp_plugin_directory_constants() {
 	 * @since WP-2.1.0
 	 * @deprecated
 	 */
-	if ( !defined('PLUGINDIR') )
+	if ( ! defined( 'PLUGINDIR') ) {
 		define( 'PLUGINDIR', 'wp-content/plugins' ); // Relative to ABSPATH. For back compat.
-
+	}
+	
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.8.0
 	 */
-	if ( !defined('WPMU_PLUGIN_DIR') )
+	if ( ! defined( 'WPMU_PLUGIN_DIR') ) {
 		define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' ); // full path, no trailing slash
-
+	}
+	
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.8.0
 	 */
-	if ( !defined('WPMU_PLUGIN_URL') )
+	if ( ! defined( 'WPMU_PLUGIN_URL') ) {
 		define( 'WPMU_PLUGIN_URL', WP_CONTENT_URL . '/mu-plugins' ); // full url, no trailing slash
-
+	}
+	
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.8.0
 	 * @deprecated
 	 */
-	if ( !defined( 'MUPLUGINDIR' ) )
+	if ( ! defined( 'MUPLUGINDIR' ) ) {
 		define( 'MUPLUGINDIR', 'wp-content/mu-plugins' ); // Relative to ABSPATH. For back compat.
+	}
 }
 
 /**
@@ -201,7 +216,7 @@ function wp_cookie_constants() {
 	 *
 	 * @since WP-1.5.0
 	 */
-	if ( !defined( 'COOKIEHASH' ) ) {
+	if ( ! defined( 'COOKIEHASH' ) ) {
 		$siteurl = get_site_option( 'siteurl' );
 		if ( $siteurl )
 			define( 'COOKIEHASH', md5( $siteurl ) );
@@ -212,68 +227,78 @@ function wp_cookie_constants() {
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('USER_COOKIE') )
-		define('USER_COOKIE', 'wordpressuser_' . COOKIEHASH);
+	if ( ! defined( 'USER_COOKIE') ) {
+		define( 'USER_COOKIE', 'wordpressuser_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('PASS_COOKIE') )
-		define('PASS_COOKIE', 'wordpresspass_' . COOKIEHASH);
+	if ( ! defined( 'PASS_COOKIE') ) {
+		define( 'PASS_COOKIE', 'wordpresspass_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.5.0
 	 */
-	if ( !defined('AUTH_COOKIE') )
-		define('AUTH_COOKIE', 'wordpress_' . COOKIEHASH);
+	if ( ! defined( 'AUTH_COOKIE') ) {
+		define( 'AUTH_COOKIE', 'wordpress_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('SECURE_AUTH_COOKIE') )
+	if ( ! defined( 'SECURE_AUTH_COOKIE') )
 		define('SECURE_AUTH_COOKIE', 'wordpress_sec_' . COOKIEHASH);
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('LOGGED_IN_COOKIE') )
-		define('LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH);
+	if ( ! defined( 'LOGGED_IN_COOKIE') ) {
+		define( 'LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.3.0
 	 */
-	if ( !defined('TEST_COOKIE') )
-		define('TEST_COOKIE', 'wordpress_test_cookie');
+	if ( ! defined( 'TEST_COOKIE') ) {
+		define( 'TEST_COOKIE', 'wordpress_test_cookie' );
+	}
 
 	/**
 	 * @since WP-1.2.0
 	 */
-	if ( !defined('COOKIEPATH') )
-		define('COOKIEPATH', preg_replace('|https?://[^/]+|i', '', get_option('home') . '/' ) );
+	if ( ! defined( 'COOKIEPATH') ) {
+		define( 'COOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'home' ) . '/' ) );
+	}
 
 	/**
 	 * @since WP-1.5.0
 	 */
-	if ( !defined('SITECOOKIEPATH') )
-		define('SITECOOKIEPATH', preg_replace('|https?://[^/]+|i', '', get_option('siteurl') . '/' ) );
+	if ( ! defined( 'SITECOOKIEPATH') ) {
+		define( 'SITECOOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'siteurl' ) . '/' ) );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('ADMIN_COOKIE_PATH') )
+	if ( ! defined( 'ADMIN_COOKIE_PATH') ) {
 		define( 'ADMIN_COOKIE_PATH', SITECOOKIEPATH . 'wp-admin' );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('PLUGINS_COOKIE_PATH') )
-		define( 'PLUGINS_COOKIE_PATH', preg_replace('|https?://[^/]+|i', '', WP_PLUGIN_URL)  );
+	if ( ! defined( 'PLUGINS_COOKIE_PATH') ) {
+		define( 'PLUGINS_COOKIE_PATH', preg_replace( '|https?://[^/]+|i', '', WP_PLUGIN_URL ) );
+	}
 
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('COOKIE_DOMAIN') )
-		define('COOKIE_DOMAIN', false);
+	if ( ! defined( 'COOKIE_DOMAIN') ) {
+		define( 'COOKIE_DOMAIN', false );
+	}
 }
 
 /**
@@ -285,7 +310,7 @@ function wp_ssl_constants() {
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined( 'FORCE_SSL_ADMIN' ) ) {
+	if ( ! defined( 'FORCE_SSL_ADMIN' ) ) {
 		if ( 'https' === parse_url( get_option( 'siteurl' ), PHP_URL_SCHEME ) ) {
 			define( 'FORCE_SSL_ADMIN', true );
 		} else {
@@ -312,23 +337,27 @@ function wp_functionality_constants() {
 	/**
 	 * @since WP-2.5.0
 	 */
-	if ( !defined( 'AUTOSAVE_INTERVAL' ) )
+	if ( ! defined( 'AUTOSAVE_INTERVAL' ) ) {
 		define( 'AUTOSAVE_INTERVAL', 60 );
+	}
 
 	/**
 	 * @since WP-2.9.0
 	 */
-	if ( !defined( 'EMPTY_TRASH_DAYS' ) )
+	if ( ! defined( 'EMPTY_TRASH_DAYS' ) ) {
 		define( 'EMPTY_TRASH_DAYS', 30 );
+	}
 
-	if ( !defined('WP_POST_REVISIONS') )
-		define('WP_POST_REVISIONS', true);
+	if ( ! defined( 'WP_POST_REVISIONS') ) {
+		define( 'WP_POST_REVISIONS', true );
+	}
 
 	/**
 	 * @since WP-3.3.0
 	 */
-	if ( !defined( 'WP_CRON_LOCK_TIMEOUT' ) )
-		define('WP_CRON_LOCK_TIMEOUT', 60);  // In seconds
+	if ( ! defined( 'WP_CRON_LOCK_TIMEOUT' ) ) {
+		define( 'WP_CRON_LOCK_TIMEOUT', 60 );  // In seconds
+	}
 }
 
 /**
@@ -341,13 +370,13 @@ function wp_templating_constants() {
 	 * Filesystem path to the current active template directory
 	 * @since WP-1.5.0
 	 */
-	define('TEMPLATEPATH', get_template_directory());
+	define( 'TEMPLATEPATH', get_template_directory() );
 
 	/**
 	 * Filesystem path to the current active template stylesheet directory
 	 * @since WP-2.1.0
 	 */
-	define('STYLESHEETPATH', get_stylesheet_directory());
+	define( 'STYLESHEETPATH', get_stylesheet_directory() );
 
 	/**
 	 * Slug of the default theme for this installation.
@@ -357,7 +386,8 @@ function wp_templating_constants() {
 	 * @since WP-3.0.0
 	 * @see WP_Theme::get_core_default_theme()
 	 */
-	if ( !defined('WP_DEFAULT_THEME') )
+	if ( ! defined( 'WP_DEFAULT_THEME') ) {
 		define( 'WP_DEFAULT_THEME', 'twentyseventeen' );
+	}
 
 }

--- a/src/wp-load.php
+++ b/src/wp-load.php
@@ -91,3 +91,12 @@ if ( file_exists( ABSPATH . 'wp-config.php') ) {
 
 	wp_die( $die, __( 'ClassicPress &rsaquo; Error' ) );
 }
+
+/**
+ * Sets up ClassicPress vars and included files.
+ *
+ * Only required this if not previously loaded via
+ * a legacy-style WordPress wp-config.php file that
+ * requires wp-settings.php at its end.
+ */
+require_once( ABSPATH . 'wp-settings.php' );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -128,8 +128,9 @@ if ( is_multisite() ) {
 register_shutdown_function( 'shutdown_action_hook' );
 
 // Stop most of ClassicPress from being loaded if we just want the basics.
-if ( SHORTINIT )
+if ( SHORTINIT ) {
 	return false;
+}
 
 // Load the L10n library.
 require_once( ABSPATH . WPINC . '/l10n.php' );
@@ -277,8 +278,9 @@ if ( is_multisite() ) {
  */
 do_action( 'muplugins_loaded' );
 
-if ( is_multisite() )
-	ms_cookie_constants(  );
+if ( is_multisite() ) {
+	ms_cookie_constants();
+}
 
 // Define constants after multisite is loaded.
 wp_cookie_constants();
@@ -314,8 +316,9 @@ require( ABSPATH . WPINC . '/pluggable-deprecated.php' );
 wp_set_internal_encoding();
 
 // Run wp_cache_postload() if object cache is enabled and the function exists.
-if ( WP_CACHE && function_exists( 'wp_cache_postload' ) )
+if ( WP_CACHE && function_exists( 'wp_cache_postload' ) ) {
 	wp_cache_postload();
+}
 
 /**
  * Fires once activated plugins have loaded.
@@ -397,8 +400,9 @@ load_default_textdomain();
 
 $locale = get_locale();
 $locale_file = WP_LANG_DIR . "/$locale.php";
-if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) )
+if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) ) {
 	require( $locale_file );
+}
 unset( $locale_file );
 
 /**
@@ -420,10 +424,12 @@ $GLOBALS['wp_locale_switcher']->init();
 
 // Load the functions for the active theme, for both parent and child theme if applicable.
 if ( ! wp_installing() || 'wp-activate.php' === $pagenow ) {
-	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) )
+	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) ) {
 		include( STYLESHEETPATH . '/functions.php' );
-	if ( file_exists( TEMPLATEPATH . '/functions.php' ) )
+	}
+	if ( file_exists( TEMPLATEPATH . '/functions.php' ) ) {
 		include( TEMPLATEPATH . '/functions.php' );
+	}
 }
 
 /**

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -9,6 +9,13 @@
  */
 
 /**
+ * Ensure these were not omitted from wp-config.
+ * @see: wp-config-sample.php for better PHPDoc of these constants.
+ */
+if ( ! defined( 'CP_CORE_PATH' ) ) { define( 'CP_CORE_PATH',  '/' ); }
+if ( ! defined( 'CP_CONTENT_PATH' ) ) { define( 'CP_CONTENT_PATH',  '/wp-content' ); }
+
+/**
  * Stores the location of the ClassicPress directory of functions, classes, and core content.
  *
  * @since WP-1.0.0

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -82,8 +82,9 @@ define('WP_DEBUG', false);
 /* That's all, stop editing! Happy blogging. */
 
 /** Absolute path to the ClassicPress directory. */
-if ( !defined('ABSPATH') )
-	define('ABSPATH', dirname(__FILE__) . '/');
+if ( !defined('ABSPATH') ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
 
 /** Sets up ClassicPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -18,24 +18,15 @@
  * @package ClassicPress
  */
 
-// ** MySQL settings - You can get this info from your web host ** //
-/** The name of the database for ClassicPress */
-define('DB_NAME', 'database_name_here');
+/*----------------------------------------------------*
+ * BEGIN-CONFIG - Add your configuration changes BELOW
+ * ---------------------------------------------------*/
 
-/** MySQL database username */
-define('DB_USER', 'username_here');
-
-/** MySQL database password */
-define('DB_PASSWORD', 'password_here');
-
-/** MySQL hostname */
-define('DB_HOST', 'localhost');
-
-/** Database Charset to use in creating database tables. */
-define('DB_CHARSET', 'utf8');
-
-/** The Database Collate type. Don't change this if in doubt. */
-define('DB_COLLATE', '');
+/** MySQL settings - You can get this info from your web host **/
+/** The name of the database, user and password for ClassicPress **/
+define( 'DB_NAME',     'database_name_here' );
+define( 'DB_USER',     'username_here' );
+define( 'DB_PASSWORD', 'password_here' );
 
 /**#@+
  * Authentication Unique Keys and Salts.
@@ -46,7 +37,6 @@ define('DB_COLLATE', '');
  *
  * @since WP-2.6.0
  */
-
 define( 'AUTH_KEY',         'put your unique phrase here' );
 define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
 define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
@@ -58,13 +48,188 @@ define( 'NONCE_SALT',       'put your unique phrase here' );
 
 /**#@-*/
 
+// Add/uncomment any OVERRIDES here for the default config
+// settings found below "END-CONFIG" as well as any additions
+// your ClassicPress installation needs.
+//
+// Here is example syntax for overrides/additions you might
+// use (after removing the leading // to uncomment them and
+// changing their settings to your specific needs, of course.
+//
+// ** Define location of database server, if not localhost
+// define( 'DB_HOST', 'mysql.your-webhost.com' );
+//
+// ** Define the charset and collation used in the database
+// ** for this ClassicPress installation
+// define( 'DB_CHARSET', 'utf8mb4' );
+// define( 'DB_COLLATE', 'utf8mb4_unicode_ci' );
+//
+// ** Define the prefix for all database table names
+// ** for this ClassicPress installation
+// $table_prefix = 'abc_'
+//
+// ** Define where WordPress core files are located
+// ** relative to the web root.
+// define( 'CP_CORE_PATH', '/core' );
+//
+// ** Define where site-specific files such as plugins
+// ** and themes are located, relative to the web root.
+// define( 'CP_CONTENT_PATH', '/app' );
+//
+// ** Show errors in browser that would otherwise be suppressed.
+// define( 'WP_DEBUG', true );
+//
+// ** Shortcut for @ini_set( 'log_errors', 1 ) and
+// ** ini_set( 'error_log', __DIR__.CP_CONTENT_PATH.'/debug.log' );
+// define( 'WP_DEBUG_LOG', true );
+//
+// ** Shortcut for @ini_set( 'display_errors', 1 );
+// define( 'WP_DEBUG_DISPLAY', true );
+//
+// ** Serve non-minified version of ClassicPress' Javascript files and
+// ** any Javascript files from plugins and themes that respect this
+// ** settting in order to simplify front-end debugging.
+// define( 'SCRIPT_DEBUG', true );
+//
+// ** Specify if WordPress should concatonate Javascript into fewer
+// ** <link> references to improve performance.
+// define( 'CONCATENATE_SCRIPTS', true );
+//
+// ** Log PHP errors, Display PHP errors to browser, and write them to a
+// ** text file in a subdirectory in the content directory, respectively.
+// @ini_set( 'log_errors', 'On' );
+// @ini_set( 'display_errors', 'On' );
+// @ini_set( 'error_log', __DIR__ . CP_CONTENT_PATH . '/logs/php_error.log' );
+//
+// ** Set website root URL and URL for ClassicPress core files, respectively. **
+// define( 'WP_HOME', https://www.example.com' );
+// define( 'WP_SITEURL', 'https://www.example.com' . CP_CORE_PATH );
+//
+// ** Set an alternate location for your plugins. **
+// define( 'WP_PLUGIN_DIR', __DIR__ . '/src/cp-plugins' );
+// define( 'WP_PLUGIN_URL', WP_HOME . '/cp-plugins' );
+//
+// ** Set an alternate location for your uploaded media. **
+// define( 'UPLOADS', '../cp-media' );
+//
+// ** Set an alternate location for your uploaded media. **
+// define( 'AUTOSAVE_INTERVAL', 600 ); // 600 seconds/10 minutes
+// define( 'WP_POST_REVISIONS', 10 );
+//
+// ** Increase front-end memory and admin memory, respectively. **
+// define( 'WP_MEMORY_LIMIT', '128M' );
+// define( 'WP_MAX_MEMORY_LIMIT', '256M' );
+//
+// ** Use CP_CONTENT_PATH . '/advanced-cache.php' **
+// define( 'WP_CACHE', true );
+//
+// ** Useful when multiple WordPress sites with different $table_prefix
+// ** want to share the same user table, e.g. for multi-tenancy.
+// define( 'CUSTOM_USER_TABLE', 'shared_cp_users' );
+// define( 'CUSTOM_USER_META_TABLE', 'shared_cp_usermeta' );
+//
+// ** Useful if you want to chance the default language and/or
+// ** support multiple languages.
+// define( 'WPLANG', 'de_DE' );
+// define( 'WP_LANG_DIR', CP_CONTENT_PATH . '/languages' );
+//
+// ** Collect up all the queries run during a page load for analysis.
+// define( 'SAVEQUERIES', true );
+//
+// ** Override default file permissions, if necessary.
+// define( 'FS_CHMOD_DIR', ( 0755 & ~ umask() ) );
+// define( 'FS_CHMOD_FILE', ( 0644 & ~ umask() ) );
+//
+// ** Used to support upgrades and when the web server
+// ** does not have permissions to write to the plugin
+// ** directory.
+// define( 'FS_METHOD', 'ftpext' ); // "direct", "ssh2", "ftpext", or "ftpsockets".
+// define( 'FTP_BASE', __DIR__ . CP_CORE_PATH );
+// define( 'FTP_CONTENT_DIR', __DIR__ . CP_CONTENT_PATH );
+// define( 'FTP_PLUGIN_DIR ', WP_PLUGIN_DIR );
+// define( 'FTP_PUBKEY', '/home/username/.ssh/id_rsa.pub' );
+// define( 'FTP_PRIKEY', '/home/username/.ssh/id_rsa' );
+// define( 'FTP_USER', 'username' );
+// define( 'FTP_PASS', 'password' );
+// define( 'FTP_HOST', 'ftp.example.org' );
+// define( 'FTP_SSL', true );
+//
+// ** Control the psuedo-cron built into ClassicPress **
+// ** This allows disabling so an external cron service like
+// ** SetCronJob.com can be used,
+// define( 'DISABLE_WP_CRON', true );
+// ** This allows cron to run on a redirect rather than at
+// ** the end of a page load. Only use as last resort.
+// define( 'ALTERNATE_WP_CRON', true );
+// ** Ensure cron can only one once ever "n" seconds.
+// define( 'WP_CRON_LOCK_TIMEOUT', 300 );
+//
+// ** Delete trashed posts ever "n" days **
+// define( 'EMPTY_TRASH_DAYS', 30 );
+//
+// ** Stop end-users from adding plugins or changing themes **
+// define( 'DISALLOW_FILE_MODS', true );
+//
+// ** Stop editing of plugins or themes from within the admin **
+// define( 'DISALLOW_FILE_EDIT', true );
+//
+// ** Secure the wp-admin and login via HTTPS, respectively **
+// define( 'FORCE_SSL_ADMIN', true );
+// define( 'FORCE_SSL_LOGIN', true );
+//
+// ** Block outgoing HTTP requests, except for those whitelisted **
+// define( 'WP_HTTP_BLOCK_EXTERNAL', true );
+// define( 'WP_ACCESSIBLE_HOSTS', 'api.classicpress.org,*.github.com' );
+//
+// ** Disable automatic updater from updating core, plugins, themes, etc.
+// define( 'AUTOMATIC_UPDATER_DISABLED', true );
+//
+// ** Disable automatic update of specific types of core updates **
+// ** Disable all core updates
+// define( 'WP_AUTO_UPDATE_CORE', false );
+//
+// ** Enable all core updates, including minor and major
+// define( 'WP_AUTO_UPDATE_CORE', true );
+//
+// ** Enable core updates for minor releases (default):
+// define( 'WP_AUTO_UPDATE_CORE', 'minor' );
+//
+// ** Overwrite image edits rather than keep all edits
+// define( 'IMAGE_EDIT_OVERWRITE', true );
+//
+// ** No unfiltered HTML, even Administrator and Editor roles
+// define( 'DISALLOW_UNFILTERED_HTML', true );
+//
+// ** Set the theme ClassicPress will default to
+// define('WP_DEFAULT_THEME', 'my-custom-theme');;
+//
+// NOTE: The above are not all potential options. Plugins and
+// themes often have their own config settings, and there are
+// a several more obscure settings buried in ClassicPress.
+// So check the docs and/or Google to discover more.
+//
+
+/*----------------------------------------------------*
+ *  END-CONFIG - Add your configuration changes ABOVE
+ *  What follows is ClassicPress default config.
+ * ---------------------------------------------------*/
+
+/** MySQL hostname */
+if ( ! defined( 'DB_HOST' ) ) { define( 'DB_HOST', 'localhost' ); }
+
+/** Database Charset to use in creating database tables. */
+if ( ! defined( 'DB_CHARSET' ) ) { define( 'DB_CHARSET', 'utf8' ); }
+
+/** The Database Collate type. Don't change this if in doubt. */
+if ( ! defined( 'DB_COLLATE' ) ) { define( 'DB_COLLATE', '' ); }
+
 /**
  * ClassicPress Database Table prefix.
  *
  * You can have multiple installations in one database if you give each
  * a unique prefix. Only numbers, letters, and underscores please!
  */
-$table_prefix  = 'cp_';
+if ( ! isset( $table_prefix ) ) { $table_prefix = 'cp_'; }
 
 /**
  * For developers: ClassicPress debugging mode.
@@ -78,13 +243,27 @@ $table_prefix  = 'cp_';
  *
  * @link https://codex.wordpress.org/Debugging_in_WordPress
  */
-define('WP_DEBUG', false);
+if ( ! defined( 'WP_DEBUG' ) ) { define( 'WP_DEBUG', false ); }
 
-/* That's all, stop editing! Happy blogging. */
+/**
+ * Allow developer to specify that ClassicPress core is stored
+ * somewhere else besides the root, such as '/classicpress',
+ * '/cp', '/core', or elsewhere. To use this feature define()
+ * `CP_CORE_PATH` at the top of this file.
+ */
+if ( ! defined( 'CP_CORE_PATH' ) ) { define( 'CP_CORE_PATH',  '/' ); }
+
+/**
+ * Allow developer to specify that the ClassicPress "content"
+ * directory is located somewhere else besides '/wp-content',
+ * such as '/content', '/app', or other. To use this feature define()
+ * `CP_CONTENT_PATH` at the top of this file.
+ */
+if ( ! defined( 'CP_CONTENT_PATH' ) ) { define( 'CP_CONTENT_PATH',  '/wp-content' ); }
 
 /** Absolute path to the ClassicPress directory. */
-if ( !defined('ABSPATH') ) {
-	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
-}
+if ( ! defined( 'ABSPATH' ) ) { define( 'ABSPATH', __DIR__ . CP_CORE_PATH ); }
+
+/* That's it, you are all done! Happy Pressing. */
 
 

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -46,14 +46,15 @@ define('DB_COLLATE', '');
  *
  * @since WP-2.6.0
  */
-define('AUTH_KEY',         'put your unique phrase here');
-define('SECURE_AUTH_KEY',  'put your unique phrase here');
-define('LOGGED_IN_KEY',    'put your unique phrase here');
-define('NONCE_KEY',        'put your unique phrase here');
-define('AUTH_SALT',        'put your unique phrase here');
-define('SECURE_AUTH_SALT', 'put your unique phrase here');
-define('LOGGED_IN_SALT',   'put your unique phrase here');
-define('NONCE_SALT',       'put your unique phrase here');
+
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
 
 /**#@-*/
 
@@ -86,5 +87,4 @@ if ( !defined('ABSPATH') ) {
 	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
 }
 
-/** Sets up ClassicPress vars and included files. */
-require_once(ABSPATH . 'wp-settings.php');
+


### PR DESCRIPTION
As per #197

## Description
This PR:
1. Moves `wp-settings.php` from `wp-config.php` to `wp-load.php`
2. Makes `wp-config.php` a lot more developer friendly _(hopefully you will agree.)_
3. Adds braces _(`{...}`)_ to single line `if()` statements in the files I had to edit, to follow WP standard and make explorative debugging easier.

## Motivation and context
See #197 

## How has this been tested?
Tested to verify it works within WPLib Box

## Types of changes
- [  ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [  ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [?] My change requires a change to the documentation.
- [-] I have updated the documentation accordingly.
