### PR TITLE
Add braces to bare if()s in default-constants.php and wp-settings.php.

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -59,27 +59,33 @@ function wp_initial_constants() {
 		@ini_set( 'memory_limit', WP_MEMORY_LIMIT );
 	}
 
-	if ( ! isset($blog_id) )
+	if ( ! isset($blog_id) ) {
 		$blog_id = 1;
+	}
 
-	if ( !defined('WP_CONTENT_DIR') )
+	if ( ! defined( 'WP_CONTENT_DIR') ) {
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+	}
 
 	// Add define('WP_DEBUG', true); to wp-config.php to enable display of notices during development.
-	if ( !defined('WP_DEBUG') )
+	if ( ! defined( 'WP_DEBUG') ) {
 		define( 'WP_DEBUG', false );
+	}
 
 	// Add define('WP_DEBUG_DISPLAY', null); to wp-config.php use the globally configured setting for
 	// display_errors and not force errors to be displayed. Use false to force display_errors off.
-	if ( !defined('WP_DEBUG_DISPLAY') )
+	if ( ! defined( 'WP_DEBUG_DISPLAY') ) {
 		define( 'WP_DEBUG_DISPLAY', true );
+	}
 
 	// Add define('WP_DEBUG_LOG', true); to enable error logging to wp-content/debug.log.
-	if ( !defined('WP_DEBUG_LOG') )
-		define('WP_DEBUG_LOG', false);
+	if ( ! defined( 'WP_DEBUG_LOG') ) {
+		define( 'WP_DEBUG_LOG', false );
+	}
 
-	if ( !defined('WP_CACHE') )
-		define('WP_CACHE', false);
+	if ( ! defined( 'WP_CACHE') ) {
+		define( 'WP_CACHE', false );
+	}
 
 	// Add define('SCRIPT_DEBUG', true); to wp-config.php to enable loading of non-minified,
 	// non-concatenated scripts and stylesheets.
@@ -96,11 +102,13 @@ function wp_initial_constants() {
 	/**
 	 * Private
 	 */
-	if ( !defined('MEDIA_TRASH') )
-		define('MEDIA_TRASH', false);
+	if ( ! defined( 'MEDIA_TRASH') ) {
+		define( 'MEDIA_TRASH', false );
+	}
 
-	if ( !defined('SHORTINIT') )
-		define('SHORTINIT', false);
+	if ( ! defined( 'SHORTINIT') ) {
+		define( 'SHORTINIT', false );
+	}
 
 	// Constants for features added to WP that should short-circuit their plugin implementations
 	define( 'WP_FEATURE_BETTER_PASSWORDS', true );
@@ -135,24 +143,27 @@ function wp_initial_constants() {
  * @since WP-3.0.0
  */
 function wp_plugin_directory_constants() {
-	if ( !defined('WP_CONTENT_URL') )
+	if ( !defined('WP_CONTENT_URL') ) {
 		define( 'WP_CONTENT_URL', get_option('siteurl') . '/wp-content'); // full url - WP_CONTENT_DIR is defined further up
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('WP_PLUGIN_DIR') )
+	if ( ! defined( 'WP_PLUGIN_DIR') ) {
 		define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . '/plugins' ); // full path, no trailing slash
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('WP_PLUGIN_URL') )
+	if ( ! defined( 'WP_PLUGIN_URL') ) {
 		define( 'WP_PLUGIN_URL', WP_CONTENT_URL . '/plugins' ); // full url, no trailing slash
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.
@@ -160,24 +171,27 @@ function wp_plugin_directory_constants() {
 	 * @since WP-2.1.0
 	 * @deprecated
 	 */
-	if ( !defined('PLUGINDIR') )
+	if ( ! defined( 'PLUGINDIR') ) {
 		define( 'PLUGINDIR', 'wp-content/plugins' ); // Relative to ABSPATH. For back compat.
+	}
 
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.8.0
 	 */
-	if ( !defined('WPMU_PLUGIN_DIR') )
+	if ( ! defined( 'WPMU_PLUGIN_DIR') ) {
 		define( 'WPMU_PLUGIN_DIR', WP_CONTENT_DIR . '/mu-plugins' ); // full path, no trailing slash
+	}
 
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
 	 *
 	 * @since WP-2.8.0
 	 */
-	if ( !defined('WPMU_PLUGIN_URL') )
+	if ( ! defined( 'WPMU_PLUGIN_URL') ) {
 		define( 'WPMU_PLUGIN_URL', WP_CONTENT_URL . '/mu-plugins' ); // full url, no trailing slash
+	}
 
 	/**
 	 * Allows for the mu-plugins directory to be moved from the default location.
@@ -185,8 +199,9 @@ function wp_plugin_directory_constants() {
 	 * @since WP-2.8.0
 	 * @deprecated
 	 */
-	if ( !defined( 'MUPLUGINDIR' ) )
+	if ( ! defined( 'MUPLUGINDIR' ) ) {
 		define( 'MUPLUGINDIR', 'wp-content/mu-plugins' ); // Relative to ABSPATH. For back compat.
+	}
 }
 
 /**
@@ -201,7 +216,7 @@ function wp_cookie_constants() {
 	 *
 	 * @since WP-1.5.0
 	 */
-	if ( !defined( 'COOKIEHASH' ) ) {
+	if ( ! defined( 'COOKIEHASH' ) ) {
 		$siteurl = get_site_option( 'siteurl' );
 		if ( $siteurl )
 			define( 'COOKIEHASH', md5( $siteurl ) );
@@ -212,68 +227,78 @@ function wp_cookie_constants() {
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('USER_COOKIE') )
-		define('USER_COOKIE', 'wordpressuser_' . COOKIEHASH);
+	if ( ! defined( 'USER_COOKIE') ) {
+		define( 'USER_COOKIE', 'wordpressuser_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('PASS_COOKIE') )
-		define('PASS_COOKIE', 'wordpresspass_' . COOKIEHASH);
+	if ( ! defined( 'PASS_COOKIE') ) {
+		define( 'PASS_COOKIE', 'wordpresspass_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.5.0
 	 */
-	if ( !defined('AUTH_COOKIE') )
-		define('AUTH_COOKIE', 'wordpress_' . COOKIEHASH);
+	if ( ! defined( 'AUTH_COOKIE') ) {
+		define( 'AUTH_COOKIE', 'wordpress_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('SECURE_AUTH_COOKIE') )
+	if ( ! defined( 'SECURE_AUTH_COOKIE') )
 		define('SECURE_AUTH_COOKIE', 'wordpress_sec_' . COOKIEHASH);
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('LOGGED_IN_COOKIE') )
-		define('LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH);
+	if ( ! defined( 'LOGGED_IN_COOKIE') ) {
+		define( 'LOGGED_IN_COOKIE', 'wordpress_logged_in_' . COOKIEHASH );
+	}
 
 	/**
 	 * @since WP-2.3.0
 	 */
-	if ( !defined('TEST_COOKIE') )
-		define('TEST_COOKIE', 'wordpress_test_cookie');
+	if ( ! defined( 'TEST_COOKIE') ) {
+		define( 'TEST_COOKIE', 'wordpress_test_cookie' );
+	}
 
 	/**
 	 * @since WP-1.2.0
 	 */
-	if ( !defined('COOKIEPATH') )
-		define('COOKIEPATH', preg_replace('|https?://[^/]+|i', '', get_option('home') . '/' ) );
+	if ( ! defined( 'COOKIEPATH') ) {
+		define( 'COOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'home' ) . '/' ) );
+	}
 
 	/**
 	 * @since WP-1.5.0
 	 */
-	if ( !defined('SITECOOKIEPATH') )
-		define('SITECOOKIEPATH', preg_replace('|https?://[^/]+|i', '', get_option('siteurl') . '/' ) );
+	if ( ! defined( 'SITECOOKIEPATH') ) {
+		define( 'SITECOOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'siteurl' ) . '/' ) );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('ADMIN_COOKIE_PATH') )
+	if ( ! defined( 'ADMIN_COOKIE_PATH') ) {
 		define( 'ADMIN_COOKIE_PATH', SITECOOKIEPATH . 'wp-admin' );
+	}
 
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined('PLUGINS_COOKIE_PATH') )
-		define( 'PLUGINS_COOKIE_PATH', preg_replace('|https?://[^/]+|i', '', WP_PLUGIN_URL)  );
+	if ( ! defined( 'PLUGINS_COOKIE_PATH') ) {
+		define( 'PLUGINS_COOKIE_PATH', preg_replace( '|https?://[^/]+|i', '', WP_PLUGIN_URL ) );
+	}
 
 	/**
 	 * @since WP-2.0.0
 	 */
-	if ( !defined('COOKIE_DOMAIN') )
-		define('COOKIE_DOMAIN', false);
+	if ( ! defined( 'COOKIE_DOMAIN') ) {
+		define( 'COOKIE_DOMAIN', false );
+	}
 }
 
 /**
@@ -285,7 +310,7 @@ function wp_ssl_constants() {
 	/**
 	 * @since WP-2.6.0
 	 */
-	if ( !defined( 'FORCE_SSL_ADMIN' ) ) {
+	if ( ! defined( 'FORCE_SSL_ADMIN' ) ) {
 		if ( 'https' === parse_url( get_option( 'siteurl' ), PHP_URL_SCHEME ) ) {
 			define( 'FORCE_SSL_ADMIN', true );
 		} else {
@@ -312,23 +337,27 @@ function wp_functionality_constants() {
 	/**
 	 * @since WP-2.5.0
 	 */
-	if ( !defined( 'AUTOSAVE_INTERVAL' ) )
+	if ( ! defined( 'AUTOSAVE_INTERVAL' ) ) {
 		define( 'AUTOSAVE_INTERVAL', 60 );
+	}
 
 	/**
 	 * @since WP-2.9.0
 	 */
-	if ( !defined( 'EMPTY_TRASH_DAYS' ) )
+	if ( ! defined( 'EMPTY_TRASH_DAYS' ) ) {
 		define( 'EMPTY_TRASH_DAYS', 30 );
+	}
 
-	if ( !defined('WP_POST_REVISIONS') )
-		define('WP_POST_REVISIONS', true);
+	if ( ! defined( 'WP_POST_REVISIONS') ) {
+		define( 'WP_POST_REVISIONS', true );
+	}
 
 	/**
 	 * @since WP-3.3.0
 	 */
-	if ( !defined( 'WP_CRON_LOCK_TIMEOUT' ) )
-		define('WP_CRON_LOCK_TIMEOUT', 60);  // In seconds
+	if ( ! defined( 'WP_CRON_LOCK_TIMEOUT' ) ) {
+		define( 'WP_CRON_LOCK_TIMEOUT', 60 );  // In seconds
+	}
 }
 
 /**
@@ -341,13 +370,13 @@ function wp_templating_constants() {
 	 * Filesystem path to the current active template directory
 	 * @since WP-1.5.0
 	 */
-	define('TEMPLATEPATH', get_template_directory());
+	define( 'TEMPLATEPATH', get_template_directory() );
 
 	/**
 	 * Filesystem path to the current active template stylesheet directory
 	 * @since WP-2.1.0
 	 */
-	define('STYLESHEETPATH', get_stylesheet_directory());
+	define( 'STYLESHEETPATH', get_stylesheet_directory() );
 
 	/**
 	 * Slug of the default theme for this installation.
@@ -357,7 +386,8 @@ function wp_templating_constants() {
 	 * @since WP-3.0.0
 	 * @see WP_Theme::get_core_default_theme()
 	 */
-	if ( !defined('WP_DEFAULT_THEME') )
+	if ( ! defined( 'WP_DEFAULT_THEME') ) {
 		define( 'WP_DEFAULT_THEME', 'twentyseventeen' );
+	}
 
 }

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -128,8 +128,9 @@ if ( is_multisite() ) {
 register_shutdown_function( 'shutdown_action_hook' );
 
 // Stop most of ClassicPress from being loaded if we just want the basics.
-if ( SHORTINIT )
+if ( SHORTINIT ) {
 	return false;
+}
 
 // Load the L10n library.
 require_once( ABSPATH . WPINC . '/l10n.php' );
@@ -277,8 +278,9 @@ if ( is_multisite() ) {
  */
 do_action( 'muplugins_loaded' );
 
-if ( is_multisite() )
-	ms_cookie_constants(  );
+if ( is_multisite() ) {
+	ms_cookie_constants();
+}
 
 // Define constants after multisite is loaded.
 wp_cookie_constants();
@@ -314,8 +316,9 @@ require( ABSPATH . WPINC . '/pluggable-deprecated.php' );
 wp_set_internal_encoding();
 
 // Run wp_cache_postload() if object cache is enabled and the function exists.
-if ( WP_CACHE && function_exists( 'wp_cache_postload' ) )
+if ( WP_CACHE && function_exists( 'wp_cache_postload' ) ) {
 	wp_cache_postload();
+}
 
 /**
  * Fires once activated plugins have loaded.
@@ -397,8 +400,9 @@ load_default_textdomain();
 
 $locale = get_locale();
 $locale_file = WP_LANG_DIR . "/$locale.php";
-if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) )
+if ( ( 0 === validate_file( $locale ) ) && is_readable( $locale_file ) ) {
 	require( $locale_file );
+}
 unset( $locale_file );
 
 /**
@@ -420,10 +424,12 @@ $GLOBALS['wp_locale_switcher']->init();
 
 // Load the functions for the active theme, for both parent and child theme if applicable.
 if ( ! wp_installing() || 'wp-activate.php' === $pagenow ) {
-	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) )
+	if ( TEMPLATEPATH !== STYLESHEETPATH && file_exists( STYLESHEETPATH . '/functions.php' ) ) {
 		include( STYLESHEETPATH . '/functions.php' );
-	if ( file_exists( TEMPLATEPATH . '/functions.php' ) )
+	}
+	if ( file_exists( TEMPLATEPATH . '/functions.php' ) ) {
 		include( TEMPLATEPATH . '/functions.php' );
+	}
 }
 
 /**


### PR DESCRIPTION
If you use XDEBUG breakpoint PHP code as a method of either debugging or learning, it is difficult when bare `if()`s are used, as WordPress core has so many of.  

Also, the current WordPress standard which ClassicPress has decided to follow says [braces are to be used even if not required](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style). 

## Description
Addition of braces on any `if()` statements found in those two files in the following form:

```
if ( expression ) 
    statement;
```

Those were changed to be:

```
if ( expression ) {
    statement;
}
```
No other changes were made.

## Motivation and context
It is harder to use XDEBUG with bare `if()`s because you can't breakpoint only for when the expression is true.

## How has this been tested?
Loaded the site with WPLib Box.
No other testing really needed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [--] My change requires a change to the documentation.
- [--] I have updated the documentation accordingly.
