### PR TITLE
Add CORE_PATH and CONTENT_PATH constants

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -62,8 +62,10 @@ function wp_initial_constants() {
 	if ( ! isset($blog_id) )
 		$blog_id = 1;
 
-	if ( !defined('WP_CONTENT_DIR') )
-		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' ); // no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+	if ( ! defined( 'WP_CONTENT_DIR' ) ) {
+		// no trailing slash, full paths only - WP_CONTENT_URL is defined further down
+		define( 'WP_CONTENT_DIR', ABSPATH . ltrim( CONTENT_PATH, '/' ) );
+	}
 
 	// Add define('WP_DEBUG', true); to wp-config.php to enable display of notices during development.
 	if ( !defined('WP_DEBUG') )
@@ -135,8 +137,10 @@ function wp_initial_constants() {
  * @since WP-3.0.0
  */
 function wp_plugin_directory_constants() {
-	if ( !defined('WP_CONTENT_URL') )
-		define( 'WP_CONTENT_URL', get_option('siteurl') . '/wp-content'); // full url - WP_CONTENT_DIR is defined further up
+	if ( ! defined( 'WP_CONTENT_URL' ) ) {
+		// full url - WP_CONTENT_DIR is defined further up
+		define( 'WP_CONTENT_URL', get_option( 'siteurl' ) . CONTENT_PATH );
+	}
 
 	/**
 	 * Allows for the plugins directory to be moved from the default location.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -9,6 +9,17 @@
  */
 
 /**
+ * Ensure these were not omitted from wp-config.
+ * @see: wp-config-sample.php for better PHPDoc of these constants.
+ */
+if ( ! defined( 'CORE_PATH' ) ) {
+	define( 'CORE_PATH',  '/' );
+}
+if ( ! defined( 'CONTENT_PATH' ) ) {
+	define( 'CONTENT_PATH',  '/wp-content' );
+}
+
+/**
  * Stores the location of the ClassicPress directory of functions, classes, and core content.
  *
  * @since WP-1.0.0

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -81,9 +81,30 @@ define('WP_DEBUG', false);
 
 /* That's all, stop editing! Happy blogging. */
 
+/**
+ * Allow developer to specify that ClassicPress core is stored
+ * somewhere else besides the root, such as '/classicpress',
+ * '/cp', '/core', or elsewhere. To use this feature define()
+ * `CORE_PATH` at the top of this file.
+ */
+if ( ! defined( 'CORE_PATH' ) ) {
+	define( 'CORE_PATH',  '/' );
+}
+
+/**
+ * Allow developer to specify that the ClassicPress "content"
+ * directory is located somewhere else besides '/wp-content',
+ * such as '/content', '/app', or other. To use this feature define()
+ * `CONTENT_PATH` at the top of this file.
+ */
+if ( ! defined( 'CONTENT_PATH' ) ) {
+	define( 'CONTENT_PATH',  '/wp-content' );
+}
+
 /** Absolute path to the ClassicPress directory. */
-if ( !defined('ABSPATH') )
-	define('ABSPATH', dirname(__FILE__) . '/');
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . CORE_PATH );
+}
 
 /** Sets up ClassicPress vars and included files. */
 require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
## Description

Adds  logic to recognize and use or default constants named `CORE_PATH` and `CONTENT_PATH`.

## Motivation and context
My experience with [WPLib Box](https://github.com/wplib/wplib-box) and [WP-DevOps](https://github.com/wplib/wp-devops) for deploying to [Pantheon](https://pantheon.io/) and [WPEngine](https://wpengine.com/) taught me that one big missing link for automated deployment was being able to separately define the path to WordPress core &mdash; normally `/` but often changed to `/wp` or `/wordpress` to support site dependency management with [Composer](https://getcomposer.org/) use &mdash; and to what is normally the `/wp-content` directory, often changed to just `/content`, or to `/app` by frameworks like [Bedrock](https://roots.io/bedrock/).

Benefits of adding this means: 

1. The following code need need not be modified in `/wp-config.php` thus isolating the need for changes to mostly the beginning of the `wp-config.php` file:
    ```
    /** Absolute path to the ClassicPress directory. */
    if ( ! defined( 'ABSPATH' ) ) {
            define( 'ABSPATH', dirname( __FILE__ ) . '/' );
    } 
    ```
1. The ability to just set just the path and ignore having to also set the host name in the config when `WP_CONTENT_URL` and `WP_CONTENT_DIR` need to be changed.

## How has this been tested?
Within WPLib Box; made sure that sites would load with this code in place.

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] My code follows the code style of this project.
- [~] My change requires a change to the documentation.
- [&ndash;] I have updated the documentation accordingly.

I have documented in the code.  Point me to where I need to document it elsewhere and I will.