### PR TITLE
Add a constant to allow loading wp-config.php only

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -9,6 +9,17 @@
  */
 
 /**
+ * This constant can be used to allow external PHP tools to parse
+ * `wp-config.php`.  To use it, set the constant from within your tool and then
+ * require `wp-load.php`.
+ *
+ * @since 1.0.0-beta1
+ */
+if ( defined( 'LOAD_CONFIG_ONLY' ) && LOAD_CONFIG_ONLY ) {
+	return;
+}
+
+/**
  * Stores the location of the ClassicPress directory of functions, classes, and core content.
  *
  * @since WP-1.0.0


### PR DESCRIPTION
This is another PR spun off from #185 and #197.

This was mentioned there as a secondary goal:

> allowing other PHP tools to load /wp-config.php

This PR is the minimal code necessary to achieve this goal in a non-breaking way.  I think this change is worth having regardless of where we land on the other PRs like #239.