### PR TITLE
Update version for get_bloginfo() to use ClassicPress version.

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -625,8 +625,6 @@ function bloginfo( $show = '' ) {
  *
  * @since WP-0.71
  *
- * @global string $wp_version
- *
  * @param string $show   Optional. Site info to retrieve. Default empty (site name).
  * @param string $filter Optional. How to filter what is retrieved. Default 'raw'.
  * @return string Mostly string values, might be empty.
@@ -693,8 +691,7 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			$output = get_option('html_type');
 			break;
 		case 'version':
-			global $cp_version;
-			$output = $cp_version;
+			$output = classicpress_version();
 			break;
 		case 'language':
 			/* translators: Translate this to the correct language tag for your locale,

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -693,8 +693,8 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			$output = get_option('html_type');
 			break;
 		case 'version':
-			global $wp_version;
-			$output = $wp_version;
+			global $cp_version;
+			$output = $cp_version;
 			break;
 		case 'language':
 			/* translators: Translate this to the correct language tag for your locale,

--- a/tests/phpunit/tests/xmlrpc/wp/getOptions.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getOptions.php
@@ -33,7 +33,6 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/20201
 	 */
 	function test_option_values_subscriber() {
-		global $cp_version;
 		$this->make_user_by_role( 'subscriber' );
 
 		$result = $this->myxmlrpcserver->wp_getOptions( array( 1, 'subscriber', 'subscriber' ) );
@@ -43,7 +42,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( $cp_version, $result['software_version']['value'] );
+		$this->assertEquals( classicpress_version(), $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );
@@ -121,8 +120,6 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	}
 
 	function test_option_values_admin() {
-		global $cp_version;
-
 		$this->make_user_by_role( 'administrator' );
 
 		$result = $this->myxmlrpcserver->wp_getOptions( array( 1, 'administrator', 'administrator' ) );
@@ -132,7 +129,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( $cp_version, $result['software_version']['value'] );
+		$this->assertEquals( classicpress_version(), $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );

--- a/tests/phpunit/tests/xmlrpc/wp/getOptions.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getOptions.php
@@ -33,7 +33,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/20201
 	 */
 	function test_option_values_subscriber() {
-		global $wp_version;
+		global $cp_version;
 		$this->make_user_by_role( 'subscriber' );
 
 		$result = $this->myxmlrpcserver->wp_getOptions( array( 1, 'subscriber', 'subscriber' ) );
@@ -43,7 +43,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( $wp_version, $result['software_version']['value'] );
+		$this->assertEquals( $cp_version, $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );
@@ -121,7 +121,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	}
 
 	function test_option_values_admin() {
-		global $wp_version;
+		global $cp_version;
 
 		$this->make_user_by_role( 'administrator' );
 
@@ -132,7 +132,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( $wp_version, $result['software_version']['value'] );
+		$this->assertEquals( $cp_version, $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );


### PR DESCRIPTION
`get_bloginfo( 'version' )` is used all over the place, I noticed `get_the_generator()` was still showing 4.9.8 because it uses `get_bloginfo()` to get the version which in turn uses the `$wp_version` global.
