### PR TITLE
Improve "update locked" message

### DIFF
--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -26,14 +26,14 @@ class Core_Upgrader extends WP_Upgrader {
 	 * @since WP-2.8.0
 	 */
 	public function upgrade_strings() {
-		$this->strings['up_to_date'] = __('ClassicPress is at the latest version.');
-		$this->strings['locked'] = __('Another update is currently in progress.');
-		$this->strings['no_package'] = __('Update package not available.');
+		$this->strings['up_to_date'] = __( 'ClassicPress is at the latest version.' );
+		$this->strings['locked'] = __( 'Another update was started but has not completed yet.' );
+		$this->strings['no_package'] = __( 'Update package not available.' );
 		/* translators: %s: package URL */
 		$this->strings['downloading_package'] = sprintf( __( 'Downloading update from %s&#8230;' ), '<span class="code">%s</span>' );
-		$this->strings['unpack_package'] = __('Unpacking the update&#8230;');
-		$this->strings['copy_failed'] = __('Could not copy files.');
-		$this->strings['copy_failed_space'] = __('Could not copy files. You may have run out of disk space.' );
+		$this->strings['unpack_package'] = __( 'Unpacking the update&#8230;' );
+		$this->strings['copy_failed'] = __( 'Could not copy files.' );
+		$this->strings['copy_failed_space'] = __( 'Could not copy files. You may have run out of disk space.'  );
 		$this->strings['start_rollback'] = __( 'Attempting to roll back to previous version.' );
 		$this->strings['rollback_was_required'] = __( 'Due to an error during updating, ClassicPress has rolled back to your previous version.' );
 	}

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -527,15 +527,41 @@ function do_core_upgrade( $reinstall = false ) {
 		'allow_relaxed_file_ownership' => $allow_relaxed_file_ownership
 	) );
 
-	if ( is_wp_error($result) ) {
-		show_message($result);
-		if ( 'up_to_date' != $result->get_error_code() && 'locked' != $result->get_error_code() )
-			show_message( __('Installation Failed') );
+	if ( is_wp_error( $result ) ) {
+		show_message( $result );
+		switch ( $result->get_error_code() ) {
+			case 'up_to_date':
+				// ClassicPress is already up to date, no need to show a different message
+				break;
+
+			case 'locked':
+				// Show a bit more info for this fairly common error
+				show_message( __(
+					'It\'s possible that an update started, but the server encountered a temporary issue and could not continue.'
+				) );
+				show_message( __(
+					'Or, you may have clicked the update button multiple times.'
+				) );
+				show_message( __(
+					'Please wait <strong>15 minutes</strong> and try again.'
+				) );
+				show_message( sprintf(
+					/* translators: URL to support forum */
+					__( 'If you see this message multiple times, please make a post on our <a href="%s">support forum</a>.' ),
+					'https://forums.classicpress.net/c/support/'
+				) );
+				break;
+
+			default:
+				// Show a generic failure message
+				show_message( __( 'Installation Failed' ) );
+				break;
+		}
 		echo '</div>';
 		return;
 	}
 
-	show_message( __('ClassicPress updated successfully') );
+	show_message( __( 'ClassicPress updated successfully' ) );
 	show_message( '<span class="hide-if-no-js">' . sprintf( __( 'Welcome to ClassicPress %1$s. You will be redirected to the About ClassicPress screen. If not, click <a href="%2$s">here</a>.' ), $result, esc_url( self_admin_url( 'about.php?updated' ) ) ) . '</span>' );
 	show_message( '<span class="hide-if-js">' . sprintf( __( 'Welcome to ClassicPress %1$s. <a href="%2$s">Learn more</a>.' ), $result, esc_url( self_admin_url( 'about.php?updated' ) ) ) . '</span>' );
 	?>


### PR DESCRIPTION
This PR aims to improve the messaging around the following error:

> Another update is currently in progress.

We've gotten a few questions about this from people using the migration plugin, and presumably the same issue can appear with the core update functionality itself.

Here's the new message:

![2018-12-04t23 16 49-05 00](https://user-images.githubusercontent.com/227022/49490277-38791700-f81d-11e8-9c0c-53b3e9361bda.png)

As indicated, there are multiple reasons why this error could occur, and it's not going to be easy to determine exactly what happened.

I would not recommend disabling or modifying the [upgrade locking logic](https://github.com/ClassicPress/ClassicPress/blob/ced817fd49e84f0efa646591e1faa941ca5a83bd/src/wp-admin/includes/class-core-upgrader.php#L168-L172) because one possibility is that an upgrade is actually still being performed in a separate request.  Instead, the new message just prompts users to wait 15 minutes and try again.

There is also one more string change here, modifying the main error message as follows so that it is more accurate:

> Another update was started but has not completed yet.

Due to the way the updater works, this change will take effect after **two release cycles** (e.g. beta2 and the new string will appear during the upgrade to rc1).

See also:  https://github.com/ClassicPress/ClassicPress-Migration-Plugin/pull/46

cc: @ginsterbusch