### PR TITLE
Revert "Update version for get_bloginfo() to use ClassicPress version"

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -625,6 +625,8 @@ function bloginfo( $show = '' ) {
  *
  * @since WP-0.71
  *
+ * @global string $wp_version
+ *
  * @param string $show   Optional. Site info to retrieve. Default empty (site name).
  * @param string $filter Optional. How to filter what is retrieved. Default 'raw'.
  * @return string Mostly string values, might be empty.
@@ -691,7 +693,8 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			$output = get_option('html_type');
 			break;
 		case 'version':
-			$output = classicpress_version();
+			global $wp_version;
+			$output = $wp_version;
 			break;
 		case 'language':
 			/* translators: Translate this to the correct language tag for your locale,

--- a/tests/phpunit/tests/xmlrpc/wp/getOptions.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getOptions.php
@@ -33,6 +33,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/20201
 	 */
 	function test_option_values_subscriber() {
+		global $wp_version;
 		$this->make_user_by_role( 'subscriber' );
 
 		$result = $this->myxmlrpcserver->wp_getOptions( array( 1, 'subscriber', 'subscriber' ) );
@@ -42,7 +43,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( classicpress_version(), $result['software_version']['value'] );
+		$this->assertEquals( $wp_version, $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );
@@ -120,6 +121,8 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 	}
 
 	function test_option_values_admin() {
+		global $wp_version;
+
 		$this->make_user_by_role( 'administrator' );
 
 		$result = $this->myxmlrpcserver->wp_getOptions( array( 1, 'administrator', 'administrator' ) );
@@ -129,7 +132,7 @@ class Tests_XMLRPC_wp_getOptions extends WP_XMLRPC_UnitTestCase {
 		$this->assertEquals( 'ClassicPress', $result['software_name']['value'] );
 		$this->assertTrue( $result['software_name']['readonly'] );
 
-		$this->assertEquals( classicpress_version(), $result['software_version']['value'] );
+		$this->assertEquals( $wp_version, $result['software_version']['value'] );
 		$this->assertTrue( $result['software_version']['readonly'] );
 
 		$this->assertEquals( get_site_url(), $result['blog_url']['value'] );


### PR DESCRIPTION
Reverts ClassicPress/ClassicPress#253

Until we know how people rely on `get_bloginfo( 'version ')`, we need to update the specific uses of this function in core to use `classicpress_version()` instead.

Much like how we leave `$wp_version` intact (it still says `4.9.8`) we need to make sure `get_bloginfo( 'version' )` returns a version that is understandable by code looking for a WordPress version.  Otherwise this is a breaking change.