### PR TITLE
Remove contributors from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ For more information, see:
 
 ## Contributors
 
-This project exists thanks to all the people who contribute.
+This project exists thanks to all the people who contribute and who have contributed in the past, whether as part of the long history of thousands of contributions to WordPress from many different people, or as contributions to ClassicPress itself.
 
+You can see a list of WordPress contributors by going to the [WordPress releases page](https://wordpress.org/news/category/releases/) and looking at the credits for each release.  All changes in WordPress 4.9.8 and earlier are part of ClassicPress, along with selected changes from later releases.
+
+We are working on several ways to recognize people for their contributions to ClassicPress.  In the meantime, you can view a list of code contributions [here on GitHub](https://github.com/ClassicPress/ClassicPress/compare/LAST_WP_COMMIT...develop).
 
 ## Backers
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ For more information, see:
 ## Contributors
 
 This project exists thanks to all the people who contribute.
-<a href="https://github.com/ClassicPress/ClassicPress/contributors"><img src="https://opencollective.com/classicpress/contributors.svg?width=890&button=false" /></a>
 
 
 ## Backers


### PR DESCRIPTION
The 'contributors' list in the readme is disingenuous and misleading. I'm going to assume good intentions here and hope that you haven't done it on purpose, but listing the WordPress core team (and many other easily recognisable faces from the WordPress community) as your contributors is hugely misleading and makes it seem like this is an 'official' fork of WordPress.

You are a legitimate fork - don't mar that legitimacy by appearing to use shady tactics to make your project seem more significant. While it's nominally true that all of those folks have contributed to ClassicPress by virtue of their WordPress contributions, it is very obviously disingenuous to publish them in a list of contributors here.

I'm sure you can find a proper way of listing contributors here, but for now removing that list completely would be a very good idea.
