### PR TITLE
Define constants to avoid PHP Warning

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -401,7 +401,12 @@ function require_wp_db() {
 		return;
 	}
 
-	$wpdb = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+	$dbuser = defined( 'DB_USER' ) ? DB_USER : '';
+	$dbpassword = defined( 'DB_PASSWORD' ) ? DB_PASSWORD : '';
+	$dbname = defined( 'DB_NAME' ) ? DB_NAME : '';
+	$dbhost = defined( 'DB_HOST' ) ? DB_HOST : '';
+
+	$wpdb = new wpdb( $dbuser, $dbpassword, $dbname, $dbhost );
 }
 
 /**


### PR DESCRIPTION
Fixes issue #264

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

To suggest new features or major changes, please visit our Petitions website at:
https://petitions.classicpress.net/

For more details about our governance and change planning process, see:
https://www.classicpress.net/democracy/
-->

## Description
Explicitly define some constants to avoid PHP warnings, back ported fix from WordPress.

## Motivation and context
Resolves issues reported in tickets #264

## How has this been tested?
Tested on WordPress installs

## Screenshots (if appropriate):

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
