### PR TITLE
php7.3 compatibility: Fix compact throwing notices for multisite

### DIFF
--- a/src/wp-includes/class-wp-network-query.php
+++ b/src/wp-includes/class-wp-network-query.php
@@ -328,6 +328,7 @@ class WP_Network_Query {
 
 		$number = absint( $this->query_vars['number'] );
 		$offset = absint( $this->query_vars['offset'] );
+		$limits = '';
 
 		if ( ! empty( $number ) ) {
 			if ( $offset ) {
@@ -392,6 +393,8 @@ class WP_Network_Query {
 		$join = '';
 
 		$where = implode( ' AND ', $this->sql_clauses['where'] );
+
+		$groupby = '';
 
 		$pieces = array( 'fields', 'join', 'where', 'orderby', 'limits', 'groupby' );
 

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -372,6 +372,7 @@ class WP_Site_Query {
 
 		$number = absint( $this->query_vars['number'] );
 		$offset = absint( $this->query_vars['offset'] );
+		$limits = '';
 
 		if ( ! empty( $number ) ) {
 			if ( $offset ) {
@@ -524,6 +525,8 @@ class WP_Site_Query {
 		$join = '';
 
 		$where = implode( ' AND ', $this->sql_clauses['where'] );
+
+		$groupby = '';
 
 		$pieces = array( 'fields', 'join', 'where', 'orderby', 'limits', 'groupby' );
 


### PR DESCRIPTION
See #263.

Merges https://core.trac.wordpress.org/changeset/43832 / https://github.com/WordPress/wordpress-develop/commit/894e8472389547757c2c0698cc6f2f6d4ac2015a to ClassicPress.

In PHP 7.3, the compact() function has been changed to issue an E_NOTICE level error if a passed string refers to an unset variable. In previous versions of PHP, this notice was silently skipped. The full RFC can be viewed here: https://wiki.php.net/rfc/compact

By initializing these variables, they can be compacted.
Props @desrosj.