### PR TITLE
Remove `$http_url` cruft

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -144,7 +144,7 @@ function plugins_api( $action, $args = array() ) {
 		// include an unmodified $wp_version
 		include( ABSPATH . WPINC . '/version.php' );
 
-		$url = $http_url = 'https://api.wordpress.org/plugins/info/1.0/';
+		$url = 'https://api.wordpress.org/plugins/info/1.0/';
 
 		$http_args = array(
 			'timeout' => 15,
@@ -165,10 +165,12 @@ function plugins_api( $action, $args = array() ) {
 				) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 				headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 			);
-			$request = wp_remote_post( $http_url, $http_args );
+
+			// Retry request
+			$request = wp_remote_post( $url, $http_args );
 		}
 
-		if ( is_wp_error($request) ) {
+		if ( is_wp_error( $request ) ) {
 			$res = new WP_Error( 'plugins_api_failed',
 				sprintf(
 					/* translators: %s: support forums URL */

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -444,7 +444,7 @@ function themes_api( $action, $args = array() ) {
 		// include an unmodified $wp_version
 		include( ABSPATH . WPINC . '/version.php' );
 
-		$url = $http_url = 'https://api.wordpress.org/themes/info/1.0/';
+		$url = 'https://api.wordpress.org/themes/info/1.0/';
 
 		$http_args = array(
 			'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ),
@@ -466,10 +466,12 @@ function themes_api( $action, $args = array() ) {
 					headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 				);
 			}
-			$request = wp_remote_post( $http_url, $http_args );
+
+			// Retry request
+			$request = wp_remote_post( $url, $http_args );
 		}
 
-		if ( is_wp_error($request) ) {
+		if ( is_wp_error( $request ) ) {
 			$res = new WP_Error( 'themes_api_failed',
 				sprintf(
 					/* translators: %s: support forums URL */

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -35,7 +35,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url = $http_url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
+		$url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
 
 		$options = array(
 			'timeout' => 3,
@@ -62,7 +62,8 @@ function translations_api( $type, $args = null ) {
 				headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 			);
 
-			$request = wp_remote_post( $http_url, $options );
+			// Retry request
+			$request = wp_remote_post( $url, $options );
 		}
 
 		if ( is_wp_error( $request ) ) {

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -101,7 +101,7 @@ function find_core_auto_update() {
  * @return bool|array False on failure. An array of checksums on success.
  */
 function get_core_checksums( $version, $locale ) {
-	$url = $http_url = 'https://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), null, '&' );
+	$url = 'https://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), null, '&' );
 
 	$options = array(
 		'timeout' => wp_doing_cron() ? 30 : 3,
@@ -117,7 +117,9 @@ function get_core_checksums( $version, $locale ) {
 			) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
-		$response = wp_remote_get( $http_url, $options );
+
+		// Retry request
+		$response = wp_remote_get( $url, $options );
 	}
 
 	if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) )

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -353,6 +353,8 @@ function wp_update_plugins( $extra_stats = array() ) {
 			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
+
+		// Retry request
 		$raw_response = wp_remote_post( $url, $options );
 	}
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -341,7 +341,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url = $http_url = 'https://api.wordpress.org/plugins/update-check/1.1/';
+	$url = 'https://api.wordpress.org/plugins/update-check/1.1/';
 
 	$raw_response = wp_remote_post( $url, $options );
 	if ( is_wp_error( $raw_response ) ) {
@@ -353,7 +353,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
-		$raw_response = wp_remote_post( $http_url, $options );
+		$raw_response = wp_remote_post( $url, $options );
 	}
 
 	if ( is_wp_error( $raw_response ) || 200 != wp_remote_retrieve_response_code( $raw_response ) ) {
@@ -521,7 +521,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url = $http_url = 'https://api.wordpress.org/themes/update-check/1.1/';
+	$url = 'https://api.wordpress.org/themes/update-check/1.1/';
 
 	$raw_response = wp_remote_post( $url, $options );
 	if ( is_wp_error( $raw_response ) ) {
@@ -533,7 +533,9 @@ function wp_update_themes( $extra_stats = array() ) {
 			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
-		$raw_response = wp_remote_post( $http_url, $options );
+
+		// Retry request
+		$raw_response = wp_remote_post( $url, $options );
 	}
 
 	if ( is_wp_error( $raw_response ) || 200 != wp_remote_retrieve_response_code( $raw_response ) ) {


### PR DESCRIPTION
Follow-up to #201 and #142.

Removes variables that were set to `$http_url` in WordPress, because
WordPress API calls support HTTP without SSL (ClassicPress API calls do
not).

Leaves the existing "request retry" logic in place, and adds comments to
make it easier to find places where requests are retried in the future.