### PR TITLE
Harmonize the styling inconsistency that appears on about.php

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -145,12 +145,17 @@
 	font-weight: 400;
 }
 
-.about-wrap .about-description,
 .about-wrap .about-text {
 	margin-top: 1.4em;
 	font-weight: 400;
 	line-height: 1.6em;
 	font-size: 19px;
+}
+
+.about-wrap .about-description {
+	margin-top: 1.4em;
+	line-height: 1.5;
+	font-size: 14px;
 }
 
 .about-wrap .about-text {
@@ -176,11 +181,8 @@
 /* 1.3 - Point Releases */
 
 .about-wrap .changelog.point-releases h3 {
-	padding-top: 35px;
-}
-
-.about-wrap .changelog.point-releases h3:first-child {
 	padding-top: 7px;
+	font-size: 19px;
 }
 
 /*------------------------------------------------------------------------------

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -149,7 +149,7 @@
 	margin-top: 1.4em;
 	font-weight: 400;
 	line-height: 1.6em;
-	font-size: 19px;
+	font-size: 16px;
 }
 
 .about-wrap .about-description {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -135,8 +135,7 @@
 }
 
 .welcome-panel .about-description {
-	font-size: 16px;
-	margin: 0;
+	margin-top: 1em;
 }
 
 .welcome-panel .welcome-panel-close {


### PR DESCRIPTION
Fixing #255

## Description
Duplicating the style properties of the different classes `.about-wrap .about-text & .about-wrap .about-description` brings about conflict in the page. Their separation removes the "camel hump" styles.

Also one class for `.about-wrap .changelog.point-releases h3` removes the need for pseudo selectors.

## Screenshots (if appropriate):

* Initial issue fix.

![screenshot 12](https://user-images.githubusercontent.com/7713923/49864459-90aeab00-fe13-11e8-9c5d-6bfd1f130a94.png)

* Fix for huge spaces in the lists and headers.
![screenshot 12](https://user-images.githubusercontent.com/7713923/49864633-f6029c00-fe13-11e8-8b9c-8c321ad9df97.png)

Issues are below:

![screenshot 9](https://user-images.githubusercontent.com/7713923/49864559-c489d080-fe13-11e8-9971-6061e6628d6d.png)
![screenshot 11](https://user-images.githubusercontent.com/7713923/49864561-c5226700-fe13-11e8-82c2-b8fdb44886ba.png)

* Remove style issues on dashboard.

![screenshot 14](https://user-images.githubusercontent.com/7713923/49864657-0581e500-fe14-11e8-8843-5adf2e7c6905.png)

* Remove confusing start on list.

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

