### PR TITLE
Add Twentyseventeen child theme

### DIFF
--- a/src/wp-content/themes/cp2017-child/functions.php
+++ b/src/wp-content/themes/cp2017-child/functions.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * CP2017 Child functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ *
+ * @package ClassicPress
+ * @subpackage CP2017_Child
+ * @since 1.0.0
+ */
+
+
+add_action( 'after_setup_theme', 'cp2017_child_setup' );
+
+function cp2017_child_setup() {
+
+	load_theme_textdomain( 'cp2017-child' );
+
+}
+
+// Enqueue parent/child themes styles with cachebusting for child theme styles built in
+add_action( 'wp_enqueue_scripts', 'cp2017_child_enqueue_styles' );
+
+function cp2017_child_enqueue_styles() {
+
+    $parent_style = 'twentyseventeen-style';
+
+    wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css' );
+    wp_enqueue_style( 'cp2017-child',
+        get_stylesheet_directory_uri() . '/style.css',
+        array( $parent_style ),
+        filemtime( get_stylesheet_directory() . '/style.css' )
+    );
+
+}

--- a/src/wp-content/themes/cp2017-child/style.css
+++ b/src/wp-content/themes/cp2017-child/style.css
@@ -1,0 +1,13 @@
+/*
+ Theme Name:   CP2017 Child
+ Theme URI:    https://www.classicpress.net/themes/cp2017-child/
+ Description:  ClassicPress Child Theme of the WordPress Twenty Seventeen Theme
+ Author:       the ClassicPress team
+ Author URI:   https://www.classicpress.net
+ Template:     twentyseventeen
+ Version:      1.0.0
+ License:      GNU General Public License v2 or later
+ License URI:  http://www.gnu.org/licenses/gpl-2.0.html
+ Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
+ Text Domain:  cp2017-child
+*/

--- a/src/wp-content/themes/cp2017-child/template-parts/footer/site-info.php
+++ b/src/wp-content/themes/cp2017-child/template-parts/footer/site-info.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Displays footer site info
+ *
+ * @package ClassicPress
+ * @subpackage CP2017_Child
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+?>
+<div class="site-info">
+	<?php
+	if ( function_exists( 'the_privacy_policy_link' ) ) {
+		the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );
+	}
+	?>
+	<a href="<?php echo esc_url( __( 'https://www.classicpress.net/', 'cp2017-child' ) ); ?>" class="imprint">
+		<?php printf( __( 'Proudly powered by %s', 'cp2017-child' ), 'ClassicPress' ); ?>
+	</a>
+</div><!-- .site-info -->


### PR DESCRIPTION
This commit adds a ClassicPress child theme of the WordPress Twenty Seventeen theme.

This ensures that the "Proudly powered by link" of the theme remains pointing to ClassicPress, even when the Twenty Seventeen theme receives an update.

This idea was brought up in ticket #291 (Theme footers show "Proudly Powered by WordPress")

## Description
The main file of this child theme is cp2017-child/template-parts/footer/site-info.php where the footer text "Proudly powered by ClassicPress" is printed.

## Motivation and context
The reason for adding this child theme is to ensure that even when the default WP themes receive an update, the powered by text remains ClassicPress and does not switch back to WordPress, which would happen if the child theme is not active.

## How has this been tested?
Tested the child theme on a local install

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [x] My change might require a change to the documentation, not entirely sure?
- [ ] I have updated the documentation accordingly.
