### PR TITLE
Change endpoint for translation packages (temporary endpoint)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ wp-tests-config.php
 .svn
 
 vendor
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen

--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,3 @@ wp-tests-config.php
 .svn
 
 vendor
-
-# IntelliJ project files
-.idea
-*.iml
-out
-gen

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -17,8 +17,7 @@
  * @return object|WP_Error On success an object of translations, WP_Error on failure.
  */
 function translations_api( $type, $args = null ) {
-	include_once( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
-	global $wp_version,$cp_version;
+	include( ABSPATH . WPINC . '/version.php' ); // include an unmodified $wp_version
 	if ( ! in_array( $type, array( 'plugins', 'themes', 'core' ) ) ) {
 		return	new WP_Error( 'invalid_type', __( 'Invalid translation type.' ) );
 	}
@@ -43,14 +42,14 @@ function translations_api( $type, $args = null ) {
 		$options = array(
 			'timeout' => 3,
 		);
-		if('core' !== $type){
-			$url = $http_url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
+		if( 'core' !== $type ){
+			$url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
 			$options['body']['slug'] = $args['slug']; // Plugin or theme slug
 			$request = wp_remote_post( $url, array_merge( $options, array(
 				'body' => $stats
 			)));
 		}else{
-			$url = $http_url = add_query_arg($stats,'https://translate.classicpress.net/wp-content/translations/' . $type . '/1.0.0/translations.json');
+			$url = add_query_arg($stats,'https://translate.classicpress.net/wp-content/translations/' . $type . '/1.0.0/translations.json');
 			$request = wp_remote_get( $url, $options);
 		}
 

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -42,15 +42,17 @@ function translations_api( $type, $args = null ) {
 		$options = array(
 			'timeout' => 3,
 		);
-		if( 'core' !== $type ){
+		if( 'core' !== $type ) {
+			$stats['wp_version'] = $wp_version;
+			$stats['cp_version'] = $cp_version;
 			$url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
 			$options['body']['slug'] = $args['slug']; // Plugin or theme slug
 			$request = wp_remote_post( $url, array_merge( $options, array(
 				'body' => $stats
-			)));
+			) ) );
 		} else {
 			$url = add_query_arg($stats, 'https://translate.classicpress.net/wp-content/translations/' . $type . '/1.0.0/translations.json');
-			$request = wp_remote_get($url, $options);
+			$request = wp_remote_get( $url, $options );
 		}
 
 		if ( is_wp_error( $request ) ) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -48,9 +48,9 @@ function translations_api( $type, $args = null ) {
 			$request = wp_remote_post( $url, array_merge( $options, array(
 				'body' => $stats
 			)));
-		}else{
-			$url = add_query_arg($stats,'https://translate.classicpress.net/wp-content/translations/' . $type . '/1.0.0/translations.json');
-			$request = wp_remote_get( $url, $options);
+		} else {
+			$url = add_query_arg($stats, 'https://translate.classicpress.net/wp-content/translations/' . $type . '/1.0.0/translations.json');
+			$request = wp_remote_get($url, $options);
 		}
 
 		if ( is_wp_error( $request ) ) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -113,7 +113,6 @@ function translations_api( $type, $args = null ) {
  *               in an error, an empty array will be returned.
  */
 function wp_get_available_translations() {
-	global $wp_version;
 	if ( ! wp_installing() && false !== ( $translations = get_site_transient( 'available_translations' ) ) ) {
 		return $translations;
 	}

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -35,7 +35,7 @@ function translations_api( $type, $args = null ) {
 
 	if ( false === $res ) {
 		$stats = array(
-			'wp_version' => $cp_version,
+			'wp_version' => '4.9.9', //since CP is based on 4.9.9
 			'locale'     => get_locale(),
 			'version'    => $args['version'], // Version of plugin, theme or core
 		);
@@ -43,7 +43,6 @@ function translations_api( $type, $args = null ) {
 			'timeout' => 3,
 		);
 		if( 'core' !== $type ) {
-			$stats['wp_version'] = $wp_version;
 			$stats['cp_version'] = $cp_version;
 			$url = 'https://api.wordpress.org/translations/' . $type . '/1.0/';
 			$options['body']['slug'] = $args['slug']; // Plugin or theme slug


### PR DESCRIPTION

## Description

This will change the endpoint that retrive translation packages https://github.com/ClassicPress/ClassicPress/issues/183

## How has this been tested?
By running a first clean installation (that uses `translations_api` function defined in `src/wp-admin/includes/translation-install.php`).
Endpoint currently respond:
```json
{
  "translations": [
    {
      "language": "it_IT",
      "version": "1.0.0",
      "package": "https://translate.classicpress.net/wp-content/translations/core/1.0.0/it_IT.zip",
      "english_name": "Italian",
      "native_name": "Italiano",
      "iso": [
        "it",
        "ita",
        null
      ],
      "updated": "2018-12-15 16:00:32",
      "strings": {
        "continue": "Continue"
      }
    }
  ]
}
```

## Screenshots (if appropriate):

 ![image](https://user-images.githubusercontent.com/10535089/50047536-6ed55280-00b7-11e9-8781-71be9dfc91d9.png)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
