### PR TITLE
Update `@ since` tags to mention the beta version

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1562,7 +1562,7 @@ function wp_welcome_panel() {
 /**
  * Callback function for the petitions dashboard widget
  *
- * @since 1.0.0
+ * @since 1.0.0-beta2
  */
 function cp_dashboard_petitions() {
 	$feeds = array(
@@ -1586,7 +1586,7 @@ function cp_dashboard_petitions() {
  * Query the ClassicPress.net API for data about ClassicPress petitions, and
  * echo the results as HTML.
  *
- * @since 1.0.0
+ * @since 1.0.0-beta2
  *
  * @param string $widget_id Widget ID.
  * @param array  $feeds     Array of petition feeds (possible sort orders).

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -35,6 +35,8 @@ $cp_version = '1.0.0-beta1+dev';
  * `function_exists( 'classicpress_version' )` is the recommended way for
  * plugins and themes to determine whether they are running under ClassicPress.
  *
+ * @since 1.0.0-alpha1
+ *
  * @return string The ClassicPress version string.
  */
 if ( ! function_exists( 'classicpress_version' ) ) {
@@ -50,6 +52,8 @@ if ( ! function_exists( 'classicpress_version' ) ) {
  *
  * This is mostly supported, but there are a few things that need to work
  * slightly differently or need to be disabled.
+ *
+ * @since 1.0.0-beta1
  *
  * @return bool Whether ClassicPress is running as a source install.
  */


### PR DESCRIPTION
A small celebration of every release.

Once we get past 1.0.0 we'll drop this and only put the version number
(without alpha/beta/etc) in the `@ since` and `@ deprecated` tags.