### PR TITLE
 Use a random string as an asset cache buster

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,6 +111,8 @@ module.exports = function(grunt) {
 							// Exclude some things present in a configured install
 							'!wp-config.php',
 							'!wp-content/uploads/**',
+							// Exclude script-loader.php (handled in `copy:script-loader` task)
+							'!wp-includes/script-loader.php',
 							// Exclude version.php (handled in `copy:version` task)
 							'!wp-includes/version.php'
 						],
@@ -147,6 +149,22 @@ module.exports = function(grunt) {
 						dest: BUILD_DIR + 'wp-admin/css/wp-admin-rtl.min.css'
 					}
 				]
+			},
+			'script-loader': {
+				options: {
+					processContent: function( src ) {
+						return src.replace( /\$version = 'cb' \. .*;/m, function( str, version ) {
+							var chars = 'abcdefghijklmnopqrstuvwxyz', ver = '';
+							for ( var i = 0; i < 8; i++ ) {
+								ver += chars.charAt( Math.floor( Math.random() * chars.length ) );
+							}
+							/* jshint quotmark: true */
+							return "$version = '" + ver + "';";
+						});
+					}
+				},
+				src: SOURCE_DIR + 'wp-includes/script-loader.php',
+				dest: BUILD_DIR + 'wp-includes/script-loader.php'
 			},
 			version: {
 				options: {
@@ -947,6 +965,7 @@ module.exports = function(grunt) {
 		'copy:files',
 		'copy:wp-admin-css-compat-rtl',
 		'copy:wp-admin-css-compat-min',
+		'copy:script-loader',
 		'copy:version'
 	] );
 

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -246,6 +246,9 @@ class WP_Scripts extends WP_Dependencies {
 		if ( isset($this->args[$handle]) )
 			$ver = $ver ? $ver . '&amp;' . $this->args[$handle] : $this->args[$handle];
 
+		/** This filter is documented in wp-includes/script-loader.php */
+		$ver = apply_filters( 'classicpress_asset_version', $ver, 'script', $handle );
+
 		$src = $obj->src;
 		$cond_before = $cond_after = '';
 		$conditional = isset( $obj->extra['conditional'] ) ? $obj->extra['conditional'] : '';

--- a/src/wp-includes/class.wp-styles.php
+++ b/src/wp-includes/class.wp-styles.php
@@ -139,6 +139,9 @@ class WP_Styles extends WP_Dependencies {
 		if ( isset($this->args[$handle]) )
 			$ver = $ver ? $ver . '&amp;' . $this->args[$handle] : $this->args[$handle];
 
+		/** This filter is documented in wp-includes/script-loader.php */
+		$ver = apply_filters( 'classicpress_asset_version', $ver, 'style', $handle );
+
 		if ( $this->do_concat ) {
 			if ( $this->in_default_dir($obj->src) && !isset($obj->extra['conditional']) && !isset($obj->extra['alt']) ) {
 				$this->concat .= "$handle,";

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5063,14 +5063,15 @@ function _print_emoji_detection_script() {
 		'svgExt' => apply_filters( 'emoji_svg_ext', '.svg' ),
 	);
 
-	$version = 'ver=' . get_bloginfo( 'version' );
-
 	if ( SCRIPT_DEBUG ) {
+		$version_wpemoji = 'ver=' . classicpress_asset_version( 'script', 'wpemoji' );
+		$version_twemoji = 'ver=' . classicpress_asset_version( 'script', 'twemoji' );
+
 		$settings['source'] = array(
 			/** This filter is documented in wp-includes/class.wp-scripts.php */
-			'wpemoji' => apply_filters( 'script_loader_src', includes_url( "js/wp-emoji.js?$version" ), 'wpemoji' ),
+			'wpemoji' => apply_filters( 'script_loader_src', includes_url( "js/wp-emoji.js?$version_wpemoji" ), 'wpemoji' ),
 			/** This filter is documented in wp-includes/class.wp-scripts.php */
-			'twemoji' => apply_filters( 'script_loader_src', includes_url( "js/twemoji.js?$version" ), 'twemoji' ),
+			'twemoji' => apply_filters( 'script_loader_src', includes_url( "js/twemoji.js?$version_twemoji" ), 'twemoji' ),
 		);
 
 		?>
@@ -5080,6 +5081,7 @@ function _print_emoji_detection_script() {
 		</script>
 		<?php
 	} else {
+		$version = 'ver=' . classicpress_asset_version( 'script', 'concatemoji' );
 		$settings['source'] = array(
 			/** This filter is documented in wp-includes/class.wp-scripts.php */
 			'concatemoji' => apply_filters( 'script_loader_src', includes_url( "js/wp-emoji-release.min.js?$version" ), 'concatemoji' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -35,6 +35,39 @@ require( ABSPATH . WPINC . '/class.wp-styles.php' );
 require( ABSPATH . WPINC . '/functions.wp-styles.php' );
 
 /**
+ * Returns a cache buster string for an enqueued script or stylesheet.
+ *
+ * @since 1.0.0-beta2
+ *
+ * @param string $type    The type of asset being enqueued ('script' or 'style').
+ * @param string $handle  The handle of the asset being enqueued (or `null` to
+ *                        get the default asset version).
+ * @return string         The cache buster string for this asset.
+ */
+function classicpress_asset_version( $type = 'script', $handle = null ) {
+	/**
+	 * The default asset version.  In the source repository this is based on
+	 * the ClassicPress version; at build time it is replaced with a random
+	 * string.
+	 */
+	$version = 'cb' . substr( md5( classicpress_version() ), 0, 6 );
+
+	/**
+	 * Allows modifying the asset version for each script and style.
+	 *
+	 * @since 1.0.0-beta2
+	 *
+	 * @param string $version The default version for this asset.
+	 * @param string $type    The type of asset being enqueued ('script' or 'style').
+	 * @param string $handle  The handle of the asset being enqueued (or `null` to
+	 *                        get the default asset version).
+	 */
+	$version = apply_filters( 'classicpress_asset_version', $version, $type, $handle );
+
+	return $version;
+}
+
+/**
  * Register all ClassicPress scripts.
  *
  * Localizes some of them.
@@ -61,7 +94,7 @@ function wp_default_scripts( &$scripts ) {
 
 	$scripts->base_url = $guessurl;
 	$scripts->content_url = defined('WP_CONTENT_URL')? WP_CONTENT_URL : '';
-	$scripts->default_version = preg_replace( '#\+.*$#', '', classicpress_version() );
+	$scripts->default_version = classicpress_asset_version( 'script' );
 	$scripts->default_dirs = array('/wp-admin/js/', '/wp-includes/js/');
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
@@ -936,7 +969,7 @@ function wp_default_styles( &$styles ) {
 
 	$styles->base_url = $guessurl;
 	$styles->content_url = defined('WP_CONTENT_URL')? WP_CONTENT_URL : '';
-	$styles->default_version = preg_replace( '#\+.*$#', '', classicpress_version() );
+	$styles->default_version = classicpress_asset_version( 'style' );
 	$styles->text_direction = function_exists( 'is_rtl' ) && is_rtl() ? 'rtl' : 'ltr';
 	$styles->default_dirs = array('/wp-admin/', '/wp-includes/css/');
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -6,9 +6,11 @@
 class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 	public $old_wp_scripts;
 	public static $asset_version;
+	public $classicpress_asset_version_calls = array();
+	public $classicpress_asset_version_override = null;
 
 	public static function setUpBeforeClass() {
-		self::$asset_version = preg_replace( '#\+.*$#', '', classicpress_version() );
+		self::$asset_version = classicpress_asset_version( 'script' );
 		parent::setUpBeforeClass();
 	}
 
@@ -16,6 +18,12 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		parent::setUp();
 		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
 		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
+		add_filter(
+			'classicpress_asset_version',
+			array( $this, 'classicpress_asset_version_handler' ),
+			10, 4
+		);
+		$this->classicpress_asset_version_calls = array();
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		$GLOBALS['wp_scripts']->default_version = self::$asset_version;
 	}
@@ -23,7 +31,27 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 	function tearDown() {
 		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
 		add_action( 'wp_default_scripts', 'wp_default_scripts' );
+		remove_filter(
+			'classicpress_asset_version',
+			array( $this, 'classicpress_asset_version_handler' ),
+			10
+		);
 		parent::tearDown();
+	}
+
+	function classicpress_asset_version_handler( $version, $type, $handle ) {
+		if ( is_null( $this->classicpress_asset_version_override ) ) {
+			$return = $version;
+		} else {
+			$return = $this->classicpress_asset_version_override;
+		}
+		array_push( $this->classicpress_asset_version_calls, array(
+			'version' => $version,
+			'type'    => $type,
+			'handle'  => $handle,
+			'return'  => $return,
+		) );
+		return $return;
 	}
 
 	/**
@@ -45,6 +73,113 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 
 		// No scripts left to print
 		$this->assertEquals("", get_echo('wp_print_scripts'));
+
+		// 'classicpress_asset_version' filter called as expected
+		$this->assertEquals( array(
+			array(
+				'version' => $ver,
+				'type'    => 'script',
+				'handle'  => 'no-deps-no-version',
+				'return'  => $ver,
+			),
+			array(
+				'version' => $ver,
+				'type'    => 'script',
+				'handle'  => 'empty-deps-no-version',
+				'return'  => $ver,
+			),
+			array(
+				'version' => 1.2,
+				'type'    => 'script',
+				'handle'  => 'empty-deps-version',
+				'return'  => 1.2,
+			),
+			array(
+				'version' => '',
+				'type'    => 'script',
+				'handle'  => 'empty-deps-null-version',
+				'return'  => '',
+			),
+		), $this->classicpress_asset_version_calls );
+	}
+
+	function test_wp_enqueue_script_override_default_version() {
+		$ver = 'aaaa';
+		$GLOBALS['wp_scripts']->default_version = $ver;
+		wp_enqueue_script( 'override-default-version', 'example.com' );
+		$expected = "<script type='text/javascript' src='http://example.com?ver=$ver'></script>\n";
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+		$this->assertEquals( array(
+			array(
+				'version' => $ver,
+				'type'    => 'script',
+				'handle'  => 'override-default-version',
+				'return'  => $ver,
+			),
+		), $this->classicpress_asset_version_calls );
+	}
+
+	function test_wp_enqueue_script_override_default_version_and_filter() {
+		$ver = 'bbbb';
+		$GLOBALS['wp_scripts']->default_version = 'aaaa';
+		$this->classicpress_asset_version_override = $ver;
+		wp_enqueue_script( 'override-default-version-and-filter', 'example.com' );
+		$expected = "<script type='text/javascript' src='http://example.com?ver=$ver'></script>\n";
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+		$this->assertEquals( array(
+			array(
+				'version' => $GLOBALS['wp_scripts']->default_version,
+				'type'    => 'script',
+				'handle'  => 'override-default-version-and-filter',
+				'return'  => $ver,
+			),
+		), $this->classicpress_asset_version_calls );
+	}
+
+	function test_wp_enqueue_script_filter_default_version() {
+		$ver = 'cccc';
+		$this->classicpress_asset_version_override = $ver;
+		wp_enqueue_script( 'filter-default-version', 'example.com' );
+		$expected = "<script type='text/javascript' src='http://example.com?ver=$ver'></script>\n";
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+		$this->assertEquals( array(
+			array(
+				'version' => $GLOBALS['wp_scripts']->default_version,
+				'type'    => 'script',
+				'handle'  => 'filter-default-version',
+				'return'  => $ver,
+			),
+		), $this->classicpress_asset_version_calls );
+	}
+
+	function test_wp_enqueue_script_filter_declared_version() {
+		$this->classicpress_asset_version_override = 'oooo';
+		wp_enqueue_script( 'filter-declared-version', 'example.com', array(), 'dddd' );
+		$expected = "<script type='text/javascript' src='http://example.com?ver=oooo'></script>\n";
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+		$this->assertEquals( array(
+			array(
+				'version' => 'dddd',
+				'type'    => 'script',
+				'handle'  => 'filter-declared-version',
+				'return'  => 'oooo',
+			),
+		), $this->classicpress_asset_version_calls );
+	}
+
+	function test_wp_enqueue_script_filter_null_version() {
+		$this->classicpress_asset_version_override = 'oooo';
+		wp_enqueue_script( 'filter-null-version', 'example.com', array(), null );
+		$expected = "<script type='text/javascript' src='http://example.com?ver=oooo'></script>\n";
+		$this->assertEquals( $expected, get_echo( 'wp_print_scripts' ) );
+		$this->assertEquals( array(
+			array(
+				'version' => '',
+				'type'    => 'script',
+				'handle'  => 'filter-null-version',
+				'return'  => 'oooo',
+			),
+		), $this->classicpress_asset_version_calls );
 	}
 
 	/**


### PR DESCRIPTION
Currently:

```
<script type='text/javascript' src='https://site/wp-includes/js/admin-bar.js?ver=1.0.0-beta1'></script>
```

This PR moves away from using the ClassicPress version as the cache buster for scripts and stylesheets.  This is causing some tools to detect sites as WordPress 1.0.0-beta1, and there's no reason to expose it anyway.

The current approach works as follows:

- When running from the source repository, use a cache buster string based on the ClassicPress version, e.g. `?ver=cb9ac6ef`
- When running from a build, use a random sequence of letters generated by `grunt build`,  e.g. `?ver=jasjkqab`

This approach has the advantage of being simple and fast, but it has the drawbacks of 1-1 correspondence between cache buster strings and official ClassicPress versions, and also non-repeatable builds.

An alternative approach would be to generate the cache buster when it is first needed or when the ClassicPress version has changed, and store it in the database.