### PR TITLE
Fix problems with Travis build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -964,6 +964,8 @@ module.exports = function(grunt) {
 	} );
 
 	grunt.registerTask( 'precommit:check-for-changes', function() {
+		grunt.task.requires( 'precommit' );
+
 		var done = this.async();
 
 		grunt.util.spawn( {

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -165,6 +165,7 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 			$GLOBALS[ $global ] = null;
 		}
 
+		$this->unregister_all_meta_keys();
 		remove_theme_support( 'html5' );
 		remove_filter( 'query', array( $this, '_create_temporary_tables' ) );
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
@@ -328,6 +329,20 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 		wp_cache_flush();
 		wp_cache_add_global_groups( array( 'users', 'userlogins', 'usermeta', 'user_meta', 'useremail', 'userslugs', 'site-transient', 'site-options', 'blog-lookup', 'blog-details', 'rss', 'global-posts', 'blog-id-cache', 'networks', 'sites', 'site-details' ) );
 		wp_cache_add_non_persistent_groups( array( 'comment', 'counts', 'plugins' ) );
+	}
+
+	function unregister_all_meta_keys() {
+		global $wp_meta_keys;
+		if ( ! is_array( $wp_meta_keys ) ) {
+			return;
+		}
+		foreach ( $wp_meta_keys as $object_type => $type_keys ) {
+			foreach ( $type_keys as $object_subtype => $subtype_keys ) {
+				foreach ( $subtype_keys as $key => $value ) {
+					unregister_meta_key( $object_type, $key, $object_subtype );
+				}
+			}
+		}
 	}
 
 	function start_transaction() {

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -204,8 +204,16 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'single'            => true,
 			'show_in_rest'      => true,
 		);
+		$meta_multi_args = $meta_args;
+		$meta_multi_args['single'] = false;
 
 		// Set up meta.
+		register_meta( 'term', 'test_single', $meta_args );
+		register_meta( 'term', 'test_multi', $meta_multi_args );
+		register_term_meta( 'category', 'test_cat_single', $meta_args );
+		register_term_meta( 'category', 'test_cat_multi', $meta_multi_args );
+		register_term_meta( 'post_tag', 'test_tag_meta', $meta_args );
+
 		register_meta( 'user', 'meta_key', $meta_args );
 		update_user_meta( 1, 'meta_key', 'meta_value' ); // Always use the first user.
 		register_meta( 'post', 'meta_key', $meta_args );


### PR DESCRIPTION
Recent PRs like #302, #306, #307, #308 have a failing Travis build.  This is due to the `tests/qunit/fixtures/wp-api-generated.js` file changing when running `grunt precommit:verify`.  The differences are related to which meta keys are registered while running only the related PHPUnit tests, vs. running all PHPUnit tests:

```diff
diff --git a/tests/qunit/fixtures/wp-api-generated.js b/tests/qunit/fixtures/wp-api-generated.js
index a98ee997a6..e6272d2ce8 100644
--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -4278,11 +4278,7 @@ mockedApiResponse.CategoriesCollection = [
         "taxonomy": "category",
         "parent": 0,
         "meta": {
-            "test_single": "",
-            "test_multi": [],
-            "meta_key": "",
-            "test_cat_single": "",
-            "test_cat_multi": []
+            "meta_key": ""
         },
         "_links": {
             "self": [
@@ -4326,11 +4322,7 @@ mockedApiResponse.CategoryModel = {
     "taxonomy": "category",
     "parent": 0,
     "meta": {
-        "test_single": "",
-        "test_multi": [],
-        "meta_key": "",
-        "test_cat_single": "",
-        "test_cat_multi": []
+        "meta_key": ""
     }
 };
 
@@ -4344,10 +4336,7 @@ mockedApiResponse.TagsCollection = [
         "slug": "restapi-client-fixture-tag",
         "taxonomy": "post_tag",
         "meta": {
-            "test_single": "",
-            "test_multi": [],
-            "meta_key": "meta_value",
-            "test_tag_meta": ""
+            "meta_key": "meta_value"
         },
         "_links": {
             "self": [
@@ -4390,10 +4379,7 @@ mockedApiResponse.TagModel = {
     "slug": "restapi-client-fixture-tag",
     "taxonomy": "post_tag",
     "meta": {
-        "test_single": "",
-        "test_multi": [],
-        "meta_key": "meta_value",
-        "test_tag_meta": ""
+        "meta_key": "meta_value"
     }
 };
 ```

This PR fixes the issue by unregistering all meta keys after each PHPUnit test case and re-registering the expected meta keys in the test that generates the `tests/qunit/fixtures/wp-api-generated.js` file.