### PR TITLE
Update about.php

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -58,7 +58,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				/* translators: %s: WordPress version number */
-				printf( __( '<strong>WordPress Version %s</strong> addressed some security issues.' ), '4.9.9' );
+				printf( __( '<strong>WordPress version %s</strong> addressed some security issues.' ), '4.9.9' );
 				?>
 				<?php
 				/* translators: %s: Codex URL */

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -58,7 +58,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				/* translators: %s: WordPress version number */
-				printf( __( '<strong>Version %s</strong> addressed some security issues.' ), '4.9.9' );
+				printf( __( '<strong>WordPress Version %s</strong> addressed some security issues.' ), '4.9.9' );
 				?>
 				<?php
 				/* translators: %s: Codex URL */


### PR DESCRIPTION
Missing text "WordPress" added to Version 4.9.9 line.

![about jethosted classicpress 1](https://user-images.githubusercontent.com/7461274/50346246-c16f9e00-04ff-11e9-9621-d83b15a39c2a.png)
