### PR TITLE
WP-r44297: PHP 7.3 Compatibility: Fix compact related notices

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -394,6 +394,7 @@ function install_plugin_install_status($api, $loop = false) {
 	$status = 'install';
 	$url = false;
 	$update_file = false;
+	$version     = '';
 
 	/*
 	 * Check to see if this plugin is known to be installed,

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1028,18 +1028,24 @@ function wp_edit_posts_query( $q = false ) {
 	else
 		$post_type = 'post';
 
-	$avail_post_stati = get_available_post_statuses($post_type);
+	$avail_post_stati = get_available_post_statuses( $post_type );
+	$post_status      = '';
+	$perm             = '';
 
 	if ( isset($q['post_status']) && in_array( $q['post_status'], $post_stati ) ) {
 		$post_status = $q['post_status'];
 		$perm = 'readable';
 	}
 
+	$orderby = '';
+
 	if ( isset( $q['orderby'] ) ) {
 		$orderby = $q['orderby'];
 	} elseif ( isset( $q['post_status'] ) && in_array( $q['post_status'], array( 'pending', 'draft' ) ) ) {
 		$orderby = 'modified';
 	}
+
+	$order = '';
 
 	if ( isset( $q['order'] ) ) {
 		$order = $q['order'];


### PR DESCRIPTION
PR to test https://gist.github.com/Mte90/a8c06567855ecde19db245e64d96f739

---------

In PHP 7.3, the `compact()` function has been changed to issue an `E_NOTICE` level error if a passed string refers to an unset variable. In previous versions of PHP, this notice was silently skipped. This fixes a few more instances of unset variables in the WordPress admin.

The full RFC can be viewed here: https://wiki.php.net/rfc/compact.

See https://core.trac.wordpress.org/ticket/44416.

Fixes https://core.trac.wordpress.org/ticket/45483

----

Merges https://core.trac.wordpress.org/changeset/44185 / WordPress/wordpress-develop@7cda2404b5b86249d548b3215c1e5809d2b95541 to ClassicPress.