### PR TITLE
WP-r44338: Correctly show post type hierarchy in admin

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1080,10 +1080,10 @@ function wp_edit_posts_query( $q = false ) {
 	$query = compact('post_type', 'post_status', 'perm', 'order', 'orderby', 'posts_per_page');
 
 	// Hierarchical types require special args.
-	if ( is_post_type_hierarchical( $post_type ) && !isset($orderby) ) {
-		$query['orderby'] = 'menu_order title';
-		$query['order'] = 'asc';
-		$query['posts_per_page'] = -1;
+	if ( is_post_type_hierarchical( $post_type ) && empty( $orderby ) ) {
+		$query['orderby']                = 'menu_order title';
+		$query['order']                  = 'asc';
+		$query['posts_per_page']         = -1;
 		$query['posts_per_archive_page'] = -1;
 		$query['fields'] = 'id=>parent';
 	}


### PR DESCRIPTION
…ierarchy in admin.

In [44185], a bug was introduced where hierarchical post types would not display in the correct default order (hierarchically).

This was caused by a `! isset()` check, which returned `false` after [44185], causing the correct default value to not be applied. This switches that conditional to use an `empty()` check, ignoring the new empty string assignment that was added to prevent a PHP notice when `compact()` is called.

Props davidbinda.
Fixes #45711.

git-svn-id: https://develop.svn.wordpress.org/trunk@44338 602fd350-edb4-49c9-b593-d223f7449a82

----
Merges https://core.trac.wordpress.org/changeset/44338 / WordPress/wordpress-develop@47584c7bc0 to ClassicPress.
