### PR TITLE
Remove WP-only features from the plugin installation section

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1021,7 +1021,7 @@ th.action-links {
 
 .filter-links {
 	display: inline-block;
-	margin: 0px 0px 0px 20px;
+	margin: 0;
 }
 
 .filter-links li {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1338,6 +1338,24 @@ th.action-links {
 	}
 }
 
+/* Plugin Search Categories filter */
+.plugin-categories-filter {
+	display: inline-block;
+}
+.plugin-categories-filter li {
+	background-color: #FFF;
+    border: 1px solid #DDD;
+	float: left;
+	padding: 20px;
+	width: 21.5%;
+}
+.plugin-categories-filter li {
+	margin-right: 5px;
+}
+.plugin-categories-filter li a {
+	font-size: 1.5em;
+}
+
 /*------------------------------------------------------------------------------
   4.0 - Notifications
 ------------------------------------------------------------------------------*/

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1052,7 +1052,7 @@ th.action-links {
 }
 
 .wp-filter .search-form {
-	float: right;
+	float: left;
 	margin: 10px 0;
 }
 
@@ -1066,10 +1066,11 @@ th.action-links {
 	line-height: 1.5;
 }
 
-.wp-filter .search-form select {
-	margin: 0;
+.wp-filter .search-form select, .wp-filter #search-plugin  {
+	margin: 0px 0px 0px 10px;
 	height: 32px;
 	vertical-align: top;
+	float: right;
 }
 
 .wp-filter .search-form.search-plugins {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1021,7 +1021,7 @@ th.action-links {
 
 .filter-links {
 	display: inline-block;
-	margin: 0;
+	margin: 0px 0px 0px 20px;
 }
 
 .filter-links li {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1066,7 +1066,8 @@ th.action-links {
 	line-height: 1.5;
 }
 
-.wp-filter .search-form select, .wp-filter #search-plugin  {
+.wp-filter .search-form select,
+.wp-filter .search-form.search-plugins input.submit {
 	margin: 0px 0px 0px 10px;
 	height: 32px;
 	vertical-align: top;
@@ -1344,7 +1345,7 @@ th.action-links {
 }
 .plugin-categories-filter li {
 	background-color: #FFF;
-    border: 1px solid #DDD;
+	border: 1px solid #DDD;
 	float: left;
 	padding: 20px;
 	width: 21.5%;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1052,7 +1052,7 @@ th.action-links {
 }
 
 .wp-filter .search-form {
-	float: left;
+	float: right;
 	margin: 10px 0;
 }
 
@@ -1066,12 +1066,10 @@ th.action-links {
 	line-height: 1.5;
 }
 
-.wp-filter .search-form select,
-.wp-filter .search-form.search-plugins input.submit {
-	margin: 0px 0px 0px 10px;
+.wp-filter .search-form select {
+	margin: 0;
 	height: 32px;
 	vertical-align: top;
-	float: right;
 }
 
 .wp-filter .search-form.search-plugins {

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -80,14 +80,10 @@ add_action( 'admin_head-nav-menus.php', '_wp_delete_orphaned_draft_menu_items' )
 add_filter( 'whitelist_options', 'option_update_filter' );
 
 // Plugin Install hooks.
-add_action( 'install_plugins_featured',               'install_dashboard' );
+add_action( 'install_plugins_popular',                'install_dashboard' );
+add_action( 'install_plugins_popular',                'display_plugins_categories_list', 1 );
 add_action( 'install_plugins_upload',                 'install_plugins_upload' );
 add_action( 'install_plugins_search',                 'display_plugins_table' );
-add_action( 'install_plugins_popular',                'display_plugins_table' );
-add_action( 'install_plugins_recommended',            'display_plugins_table' );
-add_action( 'install_plugins_new',                    'display_plugins_table' );
-add_action( 'install_plugins_beta',                   'display_plugins_table' );
-add_action( 'install_plugins_favorites',              'display_plugins_table' );
 add_action( 'install_plugins_pre_plugin-information', 'install_plugin_information' );
 
 // Template hooks.

--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -81,7 +81,7 @@ add_filter( 'whitelist_options', 'option_update_filter' );
 
 // Plugin Install hooks.
 add_action( 'install_plugins_popular',                'install_dashboard' );
-add_action( 'install_plugins_popular',                'display_plugins_categories_list', 1 );
+add_action( 'install_plugins_categories',             'display_plugins_categories_list' );
 add_action( 'install_plugins_upload',                 'install_plugins_upload' );
 add_action( 'install_plugins_search',                 'display_plugins_table' );
 add_action( 'install_plugins_pre_plugin-information', 'install_plugin_information' );

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -103,7 +103,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		if ( 'search' === $tab ) {
 			$tabs['search'] = __( 'Search Results' );
 		}
-		$tabs['popular'] = _x( 'Popular', 'Plugin Installer' );
+		$tabs['popular']    = _x( 'Popular', 'Plugin Installer' );
 		$tabs['categories'] = _x( 'Categories', 'Plugin Installer' );
 		if ( current_user_can( 'upload_plugins' ) ) {
 			// No longer a real tab. Here for filter compatibility.
@@ -118,7 +118,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 *
 		 * @since WP-2.7.0
 		 *
-		 * @param array $tabs The tabs shown on the Plugin Install screen. Defaults include 'popular'.
+		 * @param array $tabs The tabs shown on the Plugin Install screen.
+		 *                    Defaults include 'popular' and 'categories'.
 		 *
 		 */
 		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
@@ -183,7 +184,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 * Filters API request arguments for each Plugin Install screen tab.
 		 *
 		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
-		 * Default tabs include 'popular' and 'upload'.
+		 * Default tabs include 'popular', 'categories', and 'upload'.
 		 *
 		 * @since WP-3.7.0
 		 *

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -99,16 +99,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 		// These are the tabs which are shown on the page
 		$tabs = array();
-
 		if ( 'search' === $tab ) {
 			$tabs['search'] = __( 'Search Results' );
 		}
-		if ( $tab === 'beta' || false !== strpos( get_bloginfo( 'version' ), '-' ) ) {
-			$tabs['beta'] = _x( 'Beta Testing', 'Plugin Installer' );
-		}
-
-		$tabs['popular']     = _x( 'Popular', 'Plugin Installer' );
-
+		$tabs['popular'] = _x( 'Popular', 'Plugin Installer' );
 		if ( current_user_can( 'upload_plugins' ) ) {
 			// No longer a real tab. Here for filter compatibility.
 			// Gets skipped in get_views().
@@ -187,7 +181,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 * Filters API request arguments for each Plugin Install screen tab.
 		 *
 		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
-		 * Default tabs include popular' and 'upload'.
+		 * Default tabs include 'popular' and 'upload'.
 		 *
 		 * @since WP-3.7.0
 		 *

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -239,11 +239,12 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	/**
 	 */
 	public function no_items() {
+		global $tab;
 		if ( isset( $this->error ) ) { ?>
 			<div class="inline error"><p><?php echo $this->error->get_error_message(); ?></p>
 				<p class="hide-if-no-js"><button class="button try-again"><?php _e( 'Try Again' ); ?></button></p>
 			</div>
-		<?php } else { ?>
+		<?php } elseif ( $tab !== 'categories' ) { ?>
 			<div class="no-plugin-results"><?php _e( 'No plugins found. Try a different search.' ); ?></div>
 		<?php
 		}

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -106,10 +106,9 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		if ( $tab === 'beta' || false !== strpos( get_bloginfo( 'version' ), '-' ) ) {
 			$tabs['beta'] = _x( 'Beta Testing', 'Plugin Installer' );
 		}
-		$tabs['featured']    = _x( 'Featured', 'Plugin Installer' );
+
 		$tabs['popular']     = _x( 'Popular', 'Plugin Installer' );
-		$tabs['recommended'] = _x( 'Recommended', 'Plugin Installer' );
-		$tabs['favorites']   = _x( 'Favorites', 'Plugin Installer' );
+
 		if ( current_user_can( 'upload_plugins' ) ) {
 			// No longer a real tab. Here for filter compatibility.
 			// Gets skipped in get_views().
@@ -123,8 +122,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 *
 		 * @since WP-2.7.0
 		 *
-		 * @param array $tabs The tabs shown on the Plugin Install screen. Defaults include 'featured', 'popular',
-		 *                    'recommended', 'favorites', and 'upload'.
+		 * @param array $tabs The tabs shown on the Plugin Install screen. Defaults include 'popular'.
+		 *
 		 */
 		$tabs = apply_filters( 'install_plugins_tabs', $tabs );
 
@@ -175,31 +174,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 				break;
 
-			case 'featured':
-				$args['fields']['group'] = true;
-				$this->orderby = 'group';
-				// No break!
 			case 'popular':
-			case 'new':
-			case 'beta':
-			case 'recommended':
 				$args['browse'] = $tab;
-				break;
-
-			case 'favorites':
-				$action = 'save_wporg_username_' . get_current_user_id();
-				if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), $action ) ) {
-					$user = isset( $_GET['user'] ) ? wp_unslash( $_GET['user'] ) : get_user_option( 'wporg_favorites' );
-					update_user_meta( get_current_user_id(), 'wporg_favorites', $user );
-				} else {
-					$user = get_user_option( 'wporg_favorites' );
-				}
-				if ( $user )
-					$args['user'] = $user;
-				else
-					$args = false;
-
-				add_action( 'install_plugins_favorites', 'install_plugins_favorites_form', 9, 0 );
 				break;
 
 			default:
@@ -211,7 +187,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		 * Filters API request arguments for each Plugin Install screen tab.
 		 *
 		 * The dynamic portion of the hook name, `$tab`, refers to the plugin install tabs.
-		 * Default tabs include 'featured', 'popular', 'recommended', 'favorites', and 'upload'.
+		 * Default tabs include popular' and 'upload'.
 		 *
 		 * @since WP-3.7.0
 		 *

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -99,10 +99,12 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 		// These are the tabs which are shown on the page
 		$tabs = array();
+
 		if ( 'search' === $tab ) {
 			$tabs['search'] = __( 'Search Results' );
 		}
 		$tabs['popular'] = _x( 'Popular', 'Plugin Installer' );
+		$tabs['categories'] = _x( 'Categories', 'Plugin Installer' );
 		if ( current_user_can( 'upload_plugins' ) ) {
 			// No longer a real tab. Here for filter compatibility.
 			// Gets skipped in get_views().

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -358,7 +358,7 @@ function display_plugins_categories_list() {
 	);
 	?>
 	<div class="plugin-categories-filter-container">
-		<h2><?php _e( 'Browse Plugin Categories' ) ?></h3>
+		<p><?php _e( 'These are some of the most common types of plugins. Not all categories are represented here.' ); ?></p>
 		<ul class="plugin-categories-filter">
 		<?php
 		foreach ( $categories as $tag => $label ) {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -236,7 +236,7 @@ function install_popular_tags( $args = array() ) {
  */
 function install_dashboard() {
 	?>
-	<p><?php printf( __( 'Plugins extend and expand the functionality of ClassicPress. You may automatically install plugins from the <a href="%1$s">ClassicPress Plugin Directory</a> or upload a plugin in .zip format by clicking the button at the top of this page.' ), __( 'https://wordpress.org/plugins/' ) ); ?></p>
+	<p><?php printf( __( 'Plugins extend and expand the functionality of ClassicPress. You may automatically install plugins from the <a href="%1$s">WordPress Plugin Directory</a> or upload a plugin in .zip format by clicking the button at the top of this page.' ), __( 'https://wordpress.org/plugins/' ) ); ?></p>
 
 	<?php display_plugins_table(); ?>
 
@@ -288,7 +288,6 @@ function install_search_form( $deprecated = true ) {
 			<option value="author"<?php selected( 'author', $type ); ?>><?php _e( 'Author' ); ?></option>
 			<option value="tag"<?php selected( 'tag', $type ); ?>><?php _ex( 'Tag', 'Plugin Installer' ); ?></option>
 		</select>
-		<input type="submit" class="button submit" value="<?php _e( 'Search' ); ?>">
 		<label><span class="screen-reader-text"><?php _e( 'Search Plugins' ); ?></span>
 			<input type="search" name="s" value="<?php echo esc_attr( $term ) ?>" class="wp-filter-search" placeholder="<?php esc_attr_e( 'Search plugins...' ); ?>" />
 		</label>
@@ -345,7 +344,7 @@ function install_plugins_favorites_form() {
 function display_plugins_categories_list() {
 	?>
 	<div class="plugin-categories-filter-holder">
-		<h3><?php _e( 'Browse Categories' ) ?></h3>
+		<h2><?php _e( 'Browse Plugin Categories' ) ?></h3>
 		<ul class="plugin-categories-filter">
 			<li><a href="#" data-plugin-tag="form"><?php _e( 'Forms' ) ?></a></li>
 			<li><a href="#" data-plugin-tag="ecommerce"><?php _e( 'eCommerce' ) ?></a></li>
@@ -362,7 +361,6 @@ function display_plugins_categories_list() {
 			<li><a href="#"><?php _e( 'Interface Elements' ) ?></a></li>
 			<li><a href="#"><?php _e( 'Miscellaneous' ) ?></a></li>
 		</ul>
-		<h3><?php _e( 'Popular Plugins' ) ?></h3>
 	</div>
 	<?php
 }

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -59,7 +59,7 @@
  *     @type string  $tag               Tag to filter plugins. Default empty.
  *     @type string  $author            Username of an plugin author to filter plugins. Default empty.
  *     @type string  $user              Username to query for their favorites. Default empty.
- *     @type string  $browse            Browse view: 'popular', 'new', 'beta', 'recommended'.
+ *     @type string  $browse            Browse view: 'popular'.
  *     @type string  $locale            Locale to provide context-sensitive results. Default is the value
  *                                      of get_locale().
  *     @type string  $installed_plugins Installed plugins to provide context-sensitive results.

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -288,6 +288,7 @@ function install_search_form( $deprecated = true ) {
 			<option value="author"<?php selected( 'author', $type ); ?>><?php _e( 'Author' ); ?></option>
 			<option value="tag"<?php selected( 'tag', $type ); ?>><?php _ex( 'Tag', 'Plugin Installer' ); ?></option>
 		</select>
+		<input type="submit" id="search-plugin" class="button" value="<?php _e( 'Search' ); ?>">
 		<label><span class="screen-reader-text"><?php _e( 'Search Plugins' ); ?></span>
 			<input type="search" name="s" value="<?php echo esc_attr( $term ) ?>" class="wp-filter-search" placeholder="<?php esc_attr_e( 'Search plugins...' ); ?>" />
 		</label>

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -288,7 +288,7 @@ function install_search_form( $deprecated = true ) {
 			<option value="author"<?php selected( 'author', $type ); ?>><?php _e( 'Author' ); ?></option>
 			<option value="tag"<?php selected( 'tag', $type ); ?>><?php _ex( 'Tag', 'Plugin Installer' ); ?></option>
 		</select>
-		<input type="submit" id="search-plugin" class="button" value="<?php _e( 'Search' ); ?>">
+		<input type="submit" class="button submit" value="<?php _e( 'Search' ); ?>">
 		<label><span class="screen-reader-text"><?php _e( 'Search Plugins' ); ?></span>
 			<input type="search" name="s" value="<?php echo esc_attr( $term ) ?>" class="wp-filter-search" placeholder="<?php esc_attr_e( 'Search plugins...' ); ?>" />
 		</label>
@@ -339,7 +339,7 @@ function install_plugins_favorites_form() {
 /**
  * Display plugin content based on plugin category (using tags).
  *
- * @since CP-1.0
+ * @since 1.0.0-rc1
  *
  */
 function display_plugins_categories_list() {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -342,27 +342,38 @@ function install_plugins_favorites_form() {
  *
  */
 function display_plugins_categories_list() {
+	$categories = array(
+		'form'         => __( 'Forms' ),
+		'widget'       => __( 'Widgets' ),
+		'admin'        => __( 'Admin Utilities' ),
+		'page-builder' => __( 'Page Builders' ),
+		'e-commerce'   => __( 'eCommerce' ),
+		'media'        => __( 'Media' ),
+		'seo'          => __( 'SEO' ),
+		'ads'          => __( 'Advertising' ),
+		'social'       => __( 'Social Networking' ),
+		'membership'   => __( 'Membership' ),
+		'newsletter'   => __( 'Newsletters' ),
+		'forum'        => __( 'Forums' ),
+	);
 	?>
-	<div class="plugin-categories-filter-holder">
+	<div class="plugin-categories-filter-container">
 		<h2><?php _e( 'Browse Plugin Categories' ) ?></h3>
 		<ul class="plugin-categories-filter">
-			<li><a href="#" data-plugin-tag="form"><?php _e( 'Forms' ) ?></a></li>
-			<li><a href="#" data-plugin-tag="ecommerce"><?php _e( 'eCommerce' ) ?></a></li>
-			<li><a href="#" data-plugin-tag="seo"><?php _e( 'SEO' ) ?></a></li>
-			<li><a href="#" data-plugin-tag="newsletter"><?php _e( 'Newsletters' ) ?></a></li>
-			<li><a href="#" data-plugin-tag="forum"><?php _e( 'Forums' ) ?></a></li>
-			<li><a href="#" data-plugin-tag="advertising"><?php _e( 'Advertising' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Social Networking' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Media' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Membership' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Page Builders' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Utilities' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Widgets' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Interface Elements' ) ?></a></li>
-			<li><a href="#"><?php _e( 'Miscellaneous' ) ?></a></li>
+		<?php
+		foreach ( $categories as $tag => $label ) {
+			$tag   = esc_attr( $tag );
+			$label = esc_html( $label );
+			$href  = esc_attr( self_admin_url(
+				'plugin-install.php?tab=search&type=tag&s=' . urlencode( $tag )
+			) );
+			echo "\t\t\t<li><a href=\"$href\" data-plugin-tag=\"$tag\">$label</a></li>\n";
+		}
+		?>
 		</ul>
 	</div>
 	<?php
+	display_plugins_table();
 }
 
 /**

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -337,6 +337,37 @@ function install_plugins_favorites_form() {
 }
 
 /**
+ * Display plugin content based on plugin category (using tags).
+ *
+ * @since CP-1.0
+ *
+ */
+function display_plugins_categories_list() {
+	?>
+	<div class="plugin-categories-filter-holder">
+		<h3><?php _e( 'Browse Categories' ) ?></h3>
+		<ul class="plugin-categories-filter">
+			<li><a href="#" data-plugin-tag="form"><?php _e( 'Forms' ) ?></a></li>
+			<li><a href="#" data-plugin-tag="ecommerce"><?php _e( 'eCommerce' ) ?></a></li>
+			<li><a href="#" data-plugin-tag="seo"><?php _e( 'SEO' ) ?></a></li>
+			<li><a href="#" data-plugin-tag="newsletter"><?php _e( 'Newsletters' ) ?></a></li>
+			<li><a href="#" data-plugin-tag="forum"><?php _e( 'Forums' ) ?></a></li>
+			<li><a href="#" data-plugin-tag="advertising"><?php _e( 'Advertising' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Social Networking' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Media' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Membership' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Page Builders' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Utilities' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Widgets' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Interface Elements' ) ?></a></li>
+			<li><a href="#"><?php _e( 'Miscellaneous' ) ?></a></li>
+		</ul>
+		<h3><?php _e( 'Popular Plugins' ) ?></h3>
+	</div>
+	<?php
+}
+
+/**
  * Display plugin content based on plugin list.
  *
  * @since WP-2.7.0

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -222,12 +222,7 @@ jQuery( document ).ready( function( $ ) {
 	$( '.plugin-categories-filter a' ).click( function( event ) {
 		event.preventDefault();
 		var category = $(this).attr( 'data-plugin-tag' );
-
-		if ( ! category ) {
-			return;
-		}
 		$( '#typeselector' ).val( 'tag' );
-		$( '.wp-filter-search' ).val( category );
-		$( '.search-plugins input.submit' ).trigger( 'click' );
+		$( '.plugin-install-php .wp-filter-search' ).val( category );
 	});
 });

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -220,7 +220,6 @@ jQuery( document ).ready( function( $ ) {
 
 	/* Plugin install Category filter JS */
 	$( '.plugin-categories-filter a' ).click( function( event ) {
-
 		event.preventDefault();
 		var category = $(this).attr( 'data-plugin-tag' );
 
@@ -229,7 +228,6 @@ jQuery( document ).ready( function( $ ) {
 		}
 		$( '#typeselector' ).val( 'tag' );
 		$( '.wp-filter-search' ).val( category );
-		$( '#search-plugin' ).trigger( 'click' );
-
+		$( '.search-plugins input.submit' ).trigger( 'click' );
 	});
 });

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -217,4 +217,19 @@ jQuery( document ).ready( function( $ ) {
 				$uploadViewToggle.attr( 'aria-expanded', $body.hasClass( 'show-upload-view' ) );
 			});
 	}
+
+	/* Plugin install Category filter JS */
+	$( '.plugin-categories-filter a' ).click( function( event ) {
+
+		event.preventDefault();
+		var category = $(this).attr( 'data-plugin-tag' );
+
+		if ( ! category ) {
+			return;
+		}
+		$( '#typeselector' ).val( 'tag' );
+		$( '.wp-filter-search' ).val( category );
+		$( '#search-plugin' ).trigger( 'click' );
+
+	});
 });

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -223,6 +223,6 @@ jQuery( document ).ready( function( $ ) {
 		event.preventDefault();
 		var category = $(this).attr( 'data-plugin-tag' );
 		$( '#typeselector' ).val( 'tag' );
-		$( '.plugin-install-php .wp-filter-search' ).val( category );
+		$( '.plugin-install-php .wp-filter-search' ).val( category ).trigger( 'input' );
 	});
 });

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -2209,10 +2209,11 @@
 
 			if ( wp.updates.searchTerm === data.s && 'typechange' !== eventtype ) {
 				return;
-			} else {
-				$pluginFilter.empty();
-				wp.updates.searchTerm = data.s;
 			}
+
+			$pluginFilter.empty();
+			$( '.plugin-categories-filter-container' ).remove();
+			wp.updates.searchTerm = data.s;
 
 			if ( window.history && window.history.replaceState ) {
 				window.history.replaceState( null, '', searchLocation );

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -1725,7 +1725,7 @@
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),
 			$pluginSearch        = $( '.plugins-php .wp-filter-search' ),
-			$pluginInstallSearch = $( '.plugin-install-php .wp-filter-search' );
+			$pluginInstallSearch = $( '.plugin-install-php #search-plugin' );
 
 		settings = _.extend( settings, window._wpUpdatesItemCounts || {} );
 
@@ -2190,12 +2190,12 @@
 		 *
 		 * @since WP-4.6.0
 		 */
-		$pluginInstallSearch.on( 'keyup input', _.debounce( function( event, eventtype ) {
+		$pluginInstallSearch.on( 'click', _.debounce( function( event, eventtype ) {
 			var $searchTab = $( '.plugin-install-search' ), data, searchLocation;
 
 			data = {
 				_ajax_nonce: wp.updates.ajaxNonce,
-				s:           event.target.value,
+				s:           $( '.plugin-install-php .wp-filter-search' ).val(),
 				tab:         'search',
 				type:        $( '#typeselector' ).val(),
 				pagenow:     pagenow

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -1725,7 +1725,7 @@
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),
 			$pluginSearch        = $( '.plugins-php .wp-filter-search' ),
-			$pluginInstallSearch = $( '.plugin-install-php .search-plugins input.submit' );
+			$pluginInstallSearch = $( '.plugin-install-php .wp-filter-search' );
 
 		settings = _.extend( settings, window._wpUpdatesItemCounts || {} );
 
@@ -2190,12 +2190,12 @@
 		 *
 		 * @since WP-4.6.0
 		 */
-		$pluginInstallSearch.on( 'click', _.debounce( function( event, eventtype ) {
+		$pluginInstallSearch.on( 'keyup input', _.debounce( function( event, eventtype ) {
 			var $searchTab = $( '.plugin-install-search' ), data, searchLocation;
 
 			data = {
 				_ajax_nonce: wp.updates.ajaxNonce,
-				s:           $( '.plugin-install-php .wp-filter-search' ).val(),
+				s:           event.target.value,
 				tab:         'search',
 				type:        $( '#typeselector' ).val(),
 				pagenow:     pagenow
@@ -2211,7 +2211,6 @@
 				return;
 			} else {
 				$pluginFilter.empty();
-				$( '.plugin-categories-filter-holder').remove();
 				wp.updates.searchTerm = data.s;
 			}
 

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -1725,7 +1725,7 @@
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),
 			$pluginSearch        = $( '.plugins-php .wp-filter-search' ),
-			$pluginInstallSearch = $( '.plugin-install-php #search-plugin' );
+			$pluginInstallSearch = $( '.plugin-install-php .search-plugins input.submit' );
 
 		settings = _.extend( settings, window._wpUpdatesItemCounts || {} );
 

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -2211,6 +2211,7 @@
 				return;
 			} else {
 				$pluginFilter.empty();
+				$( '.plugin-categories-filter-holder').remove();
 				wp.updates.searchTerm = data.s;
 			}
 


### PR DESCRIPTION
This PR is related to the #117 

## Description
Several Tabs of the Plugin search were removed (beta, recommended, featured, favorites).

The auto search mechanism that was called when typing was disabled and it was added a button to perform the search only one click.

The Popular tab is now the dashboard page of the 'Add New' plugin page. 
It was also included Category navigation that will fill the input search with a predefined term and will execute a search using that term as a tag.

This new section was added using a hook so it can be removed easily.
Just part of the categories was filled with a corresponding tag so this content needs to be refined.

At the moment this is the list of the categories that are linked to a tag:

- Forms (form)

- eCommerce(ecommerce)

- SEO (seo)

- Newsletters (newsletter)

- Forums (forum) 

- Advertising (advertising)

## How has this been tested?
At the moment was tested the 'Add New' plugin option and the 'Installed plugins' option.
It was tested the new category browsing search using the form and eCommerce category.


## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/29898220/51613297-147fab00-1f1b-11e9-84b4-4ac8413c678c.png)

Search animation:
[https://cl.ly/764dca](url)

