### PR TITLE
Change cache-busting logic for child themes classicpress-twentyfifteen (Issue #331)

### DIFF
--- a/src/wp-content/themes/classicpress-twentyfifteen/functions.php
+++ b/src/wp-content/themes/classicpress-twentyfifteen/functions.php
@@ -27,7 +27,7 @@ function cp2015_enqueue_styles() {
 
     wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css' );
 	
-    $version = classicpress_asset_version( 'style', 'classicpress-twentyseventeen' );
+    $version = classicpress_asset_version( 'style', 'classicpress-twentyfifteen' );
     wp_enqueue_style( 'classicpress-twentyfifteen',
         get_stylesheet_directory_uri() . '/style.css',
         array( $parent_style ),

--- a/src/wp-content/themes/classicpress-twentyfifteen/functions.php
+++ b/src/wp-content/themes/classicpress-twentyfifteen/functions.php
@@ -26,10 +26,13 @@ function cp2015_enqueue_styles() {
     $parent_style = 'twentyfifteen-style';
 
     wp_enqueue_style( $parent_style, get_template_directory_uri() . '/style.css' );
+	
+    $version = classicpress_asset_version( 'style', 'classicpress-twentyseventeen' );
     wp_enqueue_style( 'classicpress-twentyfifteen',
         get_stylesheet_directory_uri() . '/style.css',
         array( $parent_style ),
-        filemtime( get_stylesheet_directory() . '/style.css' )
+	$version
+        //filemtime( get_stylesheet_directory() . '/style.css' )
     );
 
 }


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

To suggest new features or major changes, please visit our Petitions website at:
https://petitions.classicpress.net/

For more details about our governance and change planning process, see:
https://www.classicpress.net/democracy/
-->

## Description
<!--
Describe your changes in detail.
-->
For Issue #331 :
Replaced filemtime with classicpress_asset_version function for adding versions of child themes stylesheet. 
