### PR TITLE
WP-r43578: Customize: Safeguard a check on the `customize_validate_{$setting_id}` filter value to ensure it is a `WP_Error`.

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2277,7 +2277,7 @@ final class WP_Customize_Manager {
 			if ( ! is_wp_error( $validity ) ) {
 				/** This filter is documented in wp-includes/class-wp-customize-setting.php */
 				$late_validity = apply_filters( "customize_validate_{$setting->id}", new WP_Error(), $unsanitized_value, $setting );
-				if ( ! empty( $late_validity->errors ) ) {
+				if ( is_wp_error( $late_validity ) && $late_validity->has_errors() ) {
 					$validity = $late_validity;
 				}
 			}


### PR DESCRIPTION
WP-r43578: Customize: Safeguard a check on the `customize_validate_{$setting_id}` filter value to ensure it is a `WP_Error`.

While the filter is documented to only support a `WP_Error`, it has been a common practice to return true in a validation function if no errors have occurred. This was already caught when the same filter was executed in `WP_Customize_Setting`, it was however missing in `WP_Customize_Manager::validate_setting_values()`.

Fixes https://core.trac.wordpress.org/ticket/44809.

Conflicts:
  src/wp-includes/class-wp-customize-manager.php
----
Merges https://core.trac.wordpress.org/changeset/43578 / WordPress/wordpress-develop@1e4e60f11c to ClassicPress.

