### PR TITLE
Port all remaining WP changes for PHP 7.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
   include:
   - php: 7.1
     env: WP_TRAVISCI=travis:precommit-and-js
+  - php: 7.3
   - php: 7.2
   - php: 7.1
   - php: 7.0
@@ -51,7 +52,7 @@ before_script:
 - |
   # Install the specified version of PHPUnit depending on the PHP version:
   case "$TRAVIS_PHP_VERSION" in
-    7.2|7.1|7.0|nightly)
+    7.3|7.2|7.1|7.0|nightly)
       echo "Using PHPUnit 6.x"
       composer global require "phpunit/phpunit:^6"
       ;;

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -633,6 +633,7 @@ class WP_Comment_Query {
 		$number = absint( $this->query_vars['number'] );
 		$offset = absint( $this->query_vars['offset'] );
 		$paged = absint( $this->query_vars['paged'] );
+ 		$limits = '';
 
 		if ( ! empty( $number ) ) {
 			if ( $offset ) {
@@ -817,7 +818,8 @@ class WP_Comment_Query {
 			$this->sql_clauses['where']['post_author__not_in'] = 'post_author NOT IN ( ' . implode( ',', wp_parse_id_list( $this->query_vars['post_author__not_in'] ) ) . ' )';
 		}
 
-		$join = '';
+		$join    = '';
+		$groupby = '';
 
 		if ( $join_posts_table ) {
 			$join .= "JOIN $wpdb->posts ON $wpdb->posts.ID = $wpdb->comments.comment_post_ID";

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -633,7 +633,7 @@ class WP_Comment_Query {
 		$number = absint( $this->query_vars['number'] );
 		$offset = absint( $this->query_vars['offset'] );
 		$paged = absint( $this->query_vars['paged'] );
- 		$limits = '';
+		$limits = '';
 
 		if ( ! empty( $number ) ) {
 			if ( $offset ) {

--- a/src/wp-includes/class-wp-site-query.php
+++ b/src/wp-includes/class-wp-site-query.php
@@ -522,11 +522,10 @@ class WP_Site_Query {
 			$this->sql_clauses['where']['date_query'] = preg_replace( '/^\s*AND\s*/', '', $this->date_query->get_sql() );
 		}
 
-		$join = '';
+		$join    = '';
+		$groupby = '';
 
 		$where = implode( ' AND ', $this->sql_clauses['where'] );
-
-		$groupby = '';
 
 		$pieces = array( 'fields', 'join', 'where', 'orderby', 'limits', 'groupby' );
 

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3517,9 +3517,9 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
 		do_action( 'xmlrpc_call', 'wp.editComment' );
- 		$comment = array(
- 			'comment_ID' => $comment_ID,
- 		);
+		$comment = array(
+			'comment_ID' => $comment_ID,
+		);
 
 
 		if ( isset($content_struct['status']) ) {
@@ -3528,32 +3528,32 @@ class wp_xmlrpc_server extends IXR_Server {
 
 			if ( ! in_array($content_struct['status'], $statuses) )
 				return new IXR_Error( 401, __( 'Invalid comment status.' ) );
- 			$comment['comment_approved'] = $content_struct['status'];
+			$comment['comment_approved'] = $content_struct['status'];
 		}
 
 		// Do some timestamp voodoo
 		if ( !empty( $content_struct['date_created_gmt'] ) ) {
 			// We know this is supposed to be GMT, so we're going to slap that Z on there by force
 
- 			$dateCreated                 = rtrim( $content_struct['date_created_gmt']->getIso(), 'Z' ) . 'Z';
- 			$comment['comment_date']     = get_date_from_gmt( iso8601_to_datetime( $dateCreated ) );
- 			$comment['comment_date_gmt'] = iso8601_to_datetime( $dateCreated, 'GMT' );
+			$dateCreated                 = rtrim( $content_struct['date_created_gmt']->getIso(), 'Z' ) . 'Z';
+			$comment['comment_date']     = get_date_from_gmt( iso8601_to_datetime( $dateCreated ) );
+			$comment['comment_date_gmt'] = iso8601_to_datetime( $dateCreated, 'GMT' );
 		}
 
 		if ( isset($content_struct['content']) ) {
- 			$comment['comment_content'] = $content_struct['content'];
+			$comment['comment_content'] = $content_struct['content'];
 		}
 
 		if ( isset($content_struct['author']) ) {
- 			$comment['comment_author'] = $content_struct['author'];
+			$comment['comment_author'] = $content_struct['author'];
 		}
 
 		if ( isset($content_struct['author_url']) ) {
- 			$comment['comment_author_url'] = $content_struct['author_url'];
+			$comment['comment_author_url'] = $content_struct['author_url'];
 		}
 
 		if ( isset($content_struct['author_email']) ) {
- 			$comment['comment_author_email'] = $content_struct['author_email'];
+			$comment['comment_author_email'] = $content_struct['author_email'];
 		}
 
 		$result = wp_update_comment($comment);
@@ -5004,16 +5004,16 @@ class wp_xmlrpc_server extends IXR_Server {
 		// Only set a post parent if one was provided.
 		if ( isset($content_struct['wp_page_parent_id']) ) {
 			$post_parent = $content_struct['wp_page_parent_id'];
- 		} else {
- 			$post_parent = 0;
-  		}
+		} else {
+			$post_parent = 0;
+		}
 
 		// Only set the menu_order if it was provided.
 		if ( isset($content_struct['wp_page_order']) ) {
 			$menu_order = $content_struct['wp_page_order'];
- 		} else {
- 			$menu_order = 0;
-  		}
+		} else {
+			$menu_order = 0;
+		}
 
 		$post_author = $user->ID;
 
@@ -5323,16 +5323,16 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		$this->escape($postdata);
 
- 		$ID             = $postdata['ID'];
- 		$post_content   = $postdata['post_content'];
- 		$post_title     = $postdata['post_title'];
- 		$post_excerpt   = $postdata['post_excerpt'];
- 		$post_password  = $postdata['post_password'];
- 		$post_parent    = $postdata['post_parent'];
- 		$post_type      = $postdata['post_type'];
- 		$menu_order     = $postdata['menu_order'];
- 		$ping_status    = $postdata['ping_status'];
- 		$comment_status = $postdata['comment_status'];
+		$ID             = $postdata['ID'];
+		$post_content   = $postdata['post_content'];
+		$post_title     = $postdata['post_title'];
+		$post_excerpt   = $postdata['post_excerpt'];
+		$post_password  = $postdata['post_password'];
+		$post_parent    = $postdata['post_parent'];
+		$post_type      = $postdata['post_type'];
+		$menu_order     = $postdata['menu_order'];
+		$ping_status    = $postdata['ping_status'];
+		$comment_status = $postdata['comment_status'];
 
 		// Let ClassicPress manage slug if none was provided.
 		$post_name = $postdata['post_name'];

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3517,6 +3517,10 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
 		do_action( 'xmlrpc_call', 'wp.editComment' );
+ 		$comment = array(
+ 			'comment_ID' => $comment_ID,
+ 		);
+
 
 		if ( isset($content_struct['status']) ) {
 			$statuses = get_comment_statuses();
@@ -3524,31 +3528,33 @@ class wp_xmlrpc_server extends IXR_Server {
 
 			if ( ! in_array($content_struct['status'], $statuses) )
 				return new IXR_Error( 401, __( 'Invalid comment status.' ) );
-			$comment_approved = $content_struct['status'];
+ 			$comment['comment_approved'] = $content_struct['status'];
 		}
 
 		// Do some timestamp voodoo
 		if ( !empty( $content_struct['date_created_gmt'] ) ) {
 			// We know this is supposed to be GMT, so we're going to slap that Z on there by force
-			$dateCreated = rtrim( $content_struct['date_created_gmt']->getIso(), 'Z' ) . 'Z';
-			$comment_date = get_date_from_gmt(iso8601_to_datetime($dateCreated));
-			$comment_date_gmt = iso8601_to_datetime($dateCreated, 'GMT');
+
+ 			$dateCreated                 = rtrim( $content_struct['date_created_gmt']->getIso(), 'Z' ) . 'Z';
+ 			$comment['comment_date']     = get_date_from_gmt( iso8601_to_datetime( $dateCreated ) );
+ 			$comment['comment_date_gmt'] = iso8601_to_datetime( $dateCreated, 'GMT' );
 		}
 
-		if ( isset($content_struct['content']) )
-			$comment_content = $content_struct['content'];
+		if ( isset($content_struct['content']) ) {
+ 			$comment['comment_content'] = $content_struct['content'];
+		}
 
-		if ( isset($content_struct['author']) )
-			$comment_author = $content_struct['author'];
+		if ( isset($content_struct['author']) ) {
+ 			$comment['comment_author'] = $content_struct['author'];
+		}
 
-		if ( isset($content_struct['author_url']) )
-			$comment_author_url = $content_struct['author_url'];
+		if ( isset($content_struct['author_url']) ) {
+ 			$comment['comment_author_url'] = $content_struct['author_url'];
+		}
 
-		if ( isset($content_struct['author_email']) )
-			$comment_author_email = $content_struct['author_email'];
-
-		// We've got all the data -- post it:
-		$comment = compact('comment_ID', 'comment_content', 'comment_approved', 'comment_date', 'comment_date_gmt', 'comment_author', 'comment_author_email', 'comment_author_url');
+		if ( isset($content_struct['author_email']) ) {
+ 			$comment['comment_author_email'] = $content_struct['author_email'];
+		}
 
 		$result = wp_update_comment($comment);
 		if ( is_wp_error( $result ) )
@@ -4989,16 +4995,25 @@ class wp_xmlrpc_server extends IXR_Server {
 			$post_name = $content_struct['wp_slug'];
 
 		// Only use a password if one was given.
-		if ( isset($content_struct['wp_password']) )
+		if ( isset($content_struct['wp_password']) ) {
 			$post_password = $content_struct['wp_password'];
+		} else {
+			$post_password = '';
+		}
 
 		// Only set a post parent if one was provided.
-		if ( isset($content_struct['wp_page_parent_id']) )
+		if ( isset($content_struct['wp_page_parent_id']) ) {
 			$post_parent = $content_struct['wp_page_parent_id'];
+ 		} else {
+ 			$post_parent = 0;
+  		}
 
 		// Only set the menu_order if it was provided.
-		if ( isset($content_struct['wp_page_order']) )
+		if ( isset($content_struct['wp_page_order']) ) {
 			$menu_order = $content_struct['wp_page_order'];
+ 		} else {
+ 			$menu_order = 0;
+  		}
 
 		$post_author = $user->ID;
 
@@ -5308,14 +5323,16 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		$this->escape($postdata);
 
-		$ID = $postdata['ID'];
-		$post_content = $postdata['post_content'];
-		$post_title = $postdata['post_title'];
-		$post_excerpt = $postdata['post_excerpt'];
-		$post_password = $postdata['post_password'];
-		$post_parent = $postdata['post_parent'];
-		$post_type = $postdata['post_type'];
-		$menu_order = $postdata['menu_order'];
+ 		$ID             = $postdata['ID'];
+ 		$post_content   = $postdata['post_content'];
+ 		$post_title     = $postdata['post_title'];
+ 		$post_excerpt   = $postdata['post_excerpt'];
+ 		$post_password  = $postdata['post_password'];
+ 		$post_parent    = $postdata['post_parent'];
+ 		$post_type      = $postdata['post_type'];
+ 		$menu_order     = $postdata['menu_order'];
+ 		$ping_status    = $postdata['ping_status'];
+ 		$comment_status = $postdata['comment_status'];
 
 		// Let ClassicPress manage slug if none was provided.
 		$post_name = $postdata['post_name'];

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2977,7 +2977,7 @@ function _close_comments_for_old_post( $open, $post_id ) {
  */
 function wp_handle_comment_submission( $comment_data ) {
 
- 	$comment_post_ID = $comment_parent = $user_ID = 0;
+	$comment_post_ID = $comment_parent = $user_ID = 0;
 	$comment_author = $comment_author_email = $comment_author_url = $comment_content = null;
 
 	if ( isset( $comment_data['comment_post_ID'] ) ) {

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2977,7 +2977,7 @@ function _close_comments_for_old_post( $open, $post_id ) {
  */
 function wp_handle_comment_submission( $comment_data ) {
 
-	$comment_post_ID = $comment_parent = 0;
+ 	$comment_post_ID = $comment_parent = $user_ID = 0;
 	$comment_author = $comment_author_email = $comment_author_url = $comment_content = null;
 
 	if ( isset( $comment_data['comment_post_ID'] ) ) {

--- a/src/wp-includes/nav-menu.php
+++ b/src/wp-includes/nav-menu.php
@@ -1139,7 +1139,9 @@ function wp_map_nav_menu_locations( $new_nav_menu_locations, $old_nav_menu_locat
 			foreach ( $registered_nav_menus as $new_location => $name ) {
 
 				// ...actually match!
-				if ( false === stripos( $new_location, $slug ) && false === stripos( $slug, $new_location ) ) {
+				if ( is_string( $new_location ) && false === stripos( $new_location, $slug ) && false === stripos( $slug, $new_location ) ) {
+					continue;
+				} elseif ( is_numeric( $new_location ) && $new_location !== $slug ) {
 					continue;
 				}
 
@@ -1150,7 +1152,9 @@ function wp_map_nav_menu_locations( $new_nav_menu_locations, $old_nav_menu_locat
 					foreach ( $slug_group as $slug ) {
 
 						// ... have a match as well.
-						if ( false === stripos( $location, $slug ) && false === stripos( $slug, $location ) ) {
+						if ( is_string( $location ) && false === stripos( $location, $slug ) && false === stripos( $slug, $location ) ) {
+							continue;
+						} elseif ( is_numeric( $location ) && $location !== $slug ) {
 							continue;
 						}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3374,6 +3374,13 @@ function wp_insert_post( $postarr, $wp_error = false ) {
 		$post_parent = 0;
 	}
 
+	$new_postarr = array_merge(
+		array(
+			'ID' => $post_ID,
+		),
+		compact( array_diff( array_keys( $defaults ), array( 'context', 'filter' ) ) )
+	);
+
 	/**
 	 * Filters the post parent -- used to check for and prevent hierarchy loops.
 	 *
@@ -3384,7 +3391,7 @@ function wp_insert_post( $postarr, $wp_error = false ) {
 	 * @param array $new_postarr Array of parsed post data.
 	 * @param array $postarr     Array of sanitized, but otherwise unmodified post data.
 	 */
-	$post_parent = apply_filters( 'wp_insert_post_parent', $post_parent, $post_ID, compact( array_keys( $postarr ) ), $postarr );
+	$post_parent = apply_filters( 'wp_insert_post_parent', $post_parent, $post_ID, $new_postarr, $postarr );
 
 	/*
 	 * If the post is being untrashed and it has a desired slug stored in post meta,

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -960,6 +960,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 	 * @covers wp_enqueue_code_editor()
 	 */
 	public function test_wp_enqueue_code_editor_when_generated_array_by_compact_will_be_passed() {
+		$file                   = '';
 		$wp_enqueue_code_editor = wp_enqueue_code_editor( compact( 'file' ) );
 		$this->assertNonEmptyMultidimensionalArray( $wp_enqueue_code_editor );
 

--- a/tests/phpunit/tests/menu/nav-menu.php
+++ b/tests/phpunit/tests/menu/nav-menu.php
@@ -200,4 +200,29 @@ class Tests_Nav_Menu_Theme_Change extends WP_UnitTestCase {
 		);
 		$this->assertEqualSets( $expected_nav_menu_locations, $new_next_theme_nav_menu_locations );
 	}
+
+	/**
+	 * Technically possible old nav menu locations were registered numerically.
+	 *
+	 * @covers wp_map_nav_menu_locations()
+	 */
+	public function test_numerical_old_locations() {
+		$this->register_nav_menu_locations( array( 'primary', 1 ) );
+
+		$old_nav_menu_locations = array(
+			'primary'  => 1,
+			'tertiary' => 2,
+			0          => 3,
+		);
+
+		$next_theme_nav_menu_locations     = array();
+		$new_next_theme_nav_menu_locations = wp_map_nav_menu_locations( $next_theme_nav_menu_locations, $old_nav_menu_locations );
+
+		$expected_nav_menu_locations = array(
+			'primary' => 1,
+			0         => 3,
+		);
+
+		$this->assertEqualSets( $expected_nav_menu_locations, $new_next_theme_nav_menu_locations );
+	}
 }


### PR DESCRIPTION
This PR ports several WP commits to ClassicPress:

- WordPress/wordpress-develop@b4d7e7a "Build/Test Tools: Use 7.3 for PHP 7.3" (`.travis.yml` updates)
- WordPress/wordpress-develop@5a3ad21 "php7.3 compatibility: Fix compact throwing notices"
- WordPress/wordpress-develop@61ee6d9 "Nav Menus: Fix a PHP 7.3 error when switching themes"

A passing Travis build will mean that all PHP 7.3 issues in unit-tested code are now fixed.

Closes #263.