### PR TITLE
Backport script: Include original author in backported commits

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -209,7 +209,9 @@ PL
 
 if [ "$conflict_status" -eq 0 ]; then
 	edit_merge_msg
-	cmd git commit --no-edit
+	# Author information is preserved when there is a conflict, but not here.
+	author=$(git show -s --format='%an <%ae>' "$commit_short")
+	cmd git commit --no-edit --author="$author"
 	echo
 	if [ $current_branch = no ]; then
 		echo "All done!  You can push the changes to GitHub now:"

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -209,7 +209,8 @@ PL
 
 if [ "$conflict_status" -eq 0 ]; then
 	edit_merge_msg
-	# Author information is preserved when there is a conflict, but not here.
+	# Author information is preserved when there is a conflict, but not here,
+	# because we used `git cherry-pick --no-commit` above.
 	author=$(git show -s --format='%an <%ae>' "$commit_short")
 	cmd git commit --no-edit --author="$author"
 	echo


### PR DESCRIPTION
When using the [backport script](https://forums.classicpress.net/t/backport-wp5-trac-tickets/110/8) to port WP commits to ClassicPress, the commit's original author information is only preserved when there is a merge conflict.

This is due to an implementation detail of the backport script.  When there are no conflicts, `git cherry-pick --no-commit` is used to allow editing the commit message.  This causes the original author information to be dropped.  When a commit has conflicting changes, we don't use `git cherry-pick --no-commit`, so the original author info is preserved.

You can see this in #359:

![2019-02-11t21 16 15-05 00](https://user-images.githubusercontent.com/227022/52606933-5fb61b00-2e42-11e9-9640-09663f9e3168.png)

The first commit has the original author information because it included conflicting changes.  The last 2 commits should have the original author information preserved, but they didn't.  This PR fixes the issue.

I'm not going to re-do #359 to include this fix, but we can improve it for the future.