### PR TITLE
Send a User-Agent header that looks more like WordPress

### DIFF
--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -97,7 +97,7 @@ class WP_Community_Events {
 
 		$api_url      = 'https://api.wordpress.org/events/1.0/';
 		$request_args = $this->get_request_args( $location_search, $timezone );
-		$request_args['user-agent'] = 'ClassicPress/' . $wp_version . '; ' . home_url( '/' );
+		$request_args['user-agent'] = classicpress_user_agent();
 
 		$response       = wp_remote_get( $api_url, $request_args );
 		$response_code  = wp_remote_retrieve_response_code( $response );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1476,7 +1476,7 @@ function wp_check_browser_version() {
 		$url = 'https://api.wordpress.org/core/browse-happy/1.1/';
 		$options = array(
 			'body'       => array( 'useragent' => $_SERVER['HTTP_USER_AGENT'] ),
-			'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' )
+			'user-agent' => classicpress_user_agent(),
 		);
 
 		$response = wp_remote_post( $url, $options );

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -134,7 +134,7 @@ function wp_get_popular_importers() {
 			'locale'  => $locale,
 			'version' => $wp_version,
 		), 'https://api.wordpress.org/core/importers/1.1/' );
-		$options = array( 'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ) );
+		$options = array( 'user-agent' => classicpress_user_agent() );
 
 		$response = wp_remote_get( $url, $options );
 		$popular_importers = json_decode( wp_remote_retrieve_body( $response ), true );

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -148,7 +148,7 @@ function plugins_api( $action, $args = array() ) {
 
 		$http_args = array(
 			'timeout' => 15,
-			'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ),
+			'user-agent' => classicpress_user_agent(),
 			'body' => array(
 				'action' => $action,
 				'request' => serialize( $args )

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -447,7 +447,7 @@ function themes_api( $action, $args = array() ) {
 		$url = 'https://api.wordpress.org/themes/info/1.0/';
 
 		$http_args = array(
-			'user-agent' => 'ClassicPress/' . $wp_version . '; ' . home_url( '/' ),
+			'user-agent' => classicpress_user_agent(),
 			'body' => array(
 				'action' => $action,
 				'request' => serialize( $args )

--- a/src/wp-includes/class-http.php
+++ b/src/wp-includes/class-http.php
@@ -173,14 +173,9 @@ class WP_Http {
 			 *                        Default '1.0'.
 			 */
 			'httpversion' => apply_filters( 'http_request_version', '1.0' ),
-			/**
-			 * Filters the user agent value sent with an HTTP request.
-			 *
-			 * @since WP-2.7.0
-			 *
-			 * @param string $user_agent ClassicPress user agent string.
-			 */
-			'user-agent' => apply_filters( 'http_headers_useragent', 'ClassicPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ) ),
+
+			'user-agent' => classicpress_user_agent(),
+
 			/**
 			 * Filters whether to pass URLs through wp_http_validate_url() in an HTTP request.
 			 *

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -6405,8 +6405,7 @@ class wp_xmlrpc_server extends IXR_Server {
 
 		$remote_ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] );
 
-		/** This filter is documented in wp-includes/class-http.php */
-		$user_agent = apply_filters( 'http_headers_useragent', 'ClassicPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ) );
+		$user_agent = classicpress_user_agent();
 
 		// Let's check the remote site
 		$http_api_args = array(

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2670,14 +2670,14 @@ function pingback( $content, $post_id ) {
 			 *
 			 * @since WP-2.9.0
 			 *
-			 * @param string $concat_useragent    The user agent concatenated with ' -- ClassicPress/'
-			 *                                    and the ClassicPress version.
+			 * @param string $concat_useragent    The user agent concatenated with ' -- WordPress/'
+			 *                                    and the equivalent WordPress version.
 			 * @param string $useragent           The useragent.
 			 * @param string $pingback_server_url The server URL being linked to.
 			 * @param string $pagelinkedto        URL of page linked to.
 			 * @param string $pagelinkedfrom      URL of page linked from.
 			 */
-			$client->useragent = apply_filters( 'pingback_useragent', $client->useragent . ' -- ClassicPress/' . get_bloginfo( 'version' ), $client->useragent, $pingback_server_url, $pagelinkedto, $pagelinkedfrom );
+			$client->useragent = apply_filters( 'pingback_useragent', $client->useragent . ' -- ' . classicpress_user_agent( false ), $client->useragent, $pingback_server_url, $pagelinkedto, $pagelinkedfrom );
 			// when set to true, this outputs debug messages by itself
 			$client->debug = false;
 
@@ -2756,7 +2756,7 @@ function weblog_ping($server = '', $path = '') {
 	// using a timeout of 3 seconds should be enough to cover slow servers
 	$client = new WP_HTTP_IXR_Client($server, ((!strlen(trim($path)) || ('/' == $path)) ? false : $path));
 	$client->timeout = 3;
-	$client->useragent .= ' -- ClassicPress/' . get_bloginfo( 'version' );
+	$client->useragent .= ' -- ' . classicpress_user_agent( false );
 
 	// when set to true, this outputs debug messages by itself
 	$client->debug = false;

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -728,3 +728,34 @@ function _wp_translate_php_url_constant_to_key( $constant ) {
 		return false;
 	}
 }
+
+/**
+ * Returns the ClassicPress User-Agent header for outgoing requests.
+ *
+ * In WordPress, this header looks like "WordPress/X.Y.Z; https://siteurl.com".
+ * To ensure compatibility with third-party services that expect requests to
+ * come from WordPress, ClassicPress uses the same pattern, but uses the URL to
+ * indicate that requests come from a ClassicPress site.
+ *
+ * @since 1.0.0-rc1
+ *
+ * @param bool $include_url Whether to append a URL to the header.
+ * @return string The User-Agent header value.
+ */
+function classicpress_user_agent( $include_url = true ) {
+	$ua = 'WordPress/' . get_bloginfo( 'version' );
+	if ( $include_url ) {
+		$ua .= '; https://www.classicpress.net/?wp_compatible=true';
+	}
+
+	/**
+	 * Filters the user agent value sent with an HTTP request.
+	 *
+	 * @since WP-2.7.0
+	 * @since 1.0.0-rc1 Added the $include_url parameter.
+	 *
+	 * @param string $user_agent ClassicPress user agent string.
+	 * @param bool $include_url Whether to append a URL to the header.
+	 */
+	return apply_filters( 'http_headers_useragent', $ua, $include_url );
+}

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -745,7 +745,8 @@ function _wp_translate_php_url_constant_to_key( $constant ) {
 function classicpress_user_agent( $include_url = true ) {
 	$ua = 'WordPress/' . get_bloginfo( 'version' );
 	if ( $include_url ) {
-		$ua .= '; https://www.classicpress.net/?wp_compatible=true';
+		$ua .= '; https://www.classicpress.net/?wp_compatible=true'
+			. '&ver=' . classicpress_version_short();
 	}
 
 	/**

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -144,7 +144,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	$options = array(
 		'timeout' => $doing_cron ? 30 : 3,
-		'user-agent' => 'ClassicPress/' . $cp_version . '; ' . home_url( '/' ),
+		'user-agent' => classicpress_user_agent(),
 		'headers' => array(
 			'wp_install' => $wp_install,
 			'wp_blog' => home_url( '/' )
@@ -334,7 +334,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 			'locale'       => wp_json_encode( $locales ),
 			'all'          => wp_json_encode( true ),
 		),
-		'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' )
+		'user-agent' => classicpress_user_agent(),
 	);
 
 	if ( $extra_stats ) {
@@ -516,7 +516,7 @@ function wp_update_themes( $extra_stats = array() ) {
 			'translations' => wp_json_encode( $translations ),
 			'locale'       => wp_json_encode( $locales ),
 		),
-		'user-agent'	=> 'WordPress/' . $wp_version . '; ' . home_url( '/' )
+		'user-agent' => classicpress_user_agent(),
 	);
 
 	if ( $extra_stats ) {

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -309,4 +309,17 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		);
 	}
 
+	function test_classicpress_user_agent() {
+		global $wp_version;
+
+		$this->assertStringStartsWith(
+			"WordPress/$wp_version; https://",
+			classicpress_user_agent()
+		);
+
+		$this->assertEquals(
+			"WordPress/$wp_version",
+			classicpress_user_agent( false )
+		);
+	}
 }

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -317,6 +317,11 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 			classicpress_user_agent()
 		);
 
+		$this->assertStringEndsWith(
+			'&ver=' . classicpress_version_short(),
+			classicpress_user_agent()
+		);
+
 		$this->assertEquals(
 			"WordPress/$wp_version",
 			classicpress_user_agent( false )


### PR DESCRIPTION
We've had several reports of users of premium plugins being unable to receive updates from custom update servers, services that connect from within WordPress not working properly, etc.

The cause we've identified so far is the modified `User-Agent` header that ClassicPress sends in `1.0.0-beta2` and older.

This PR changes the default `User-Agent` header to be recognizable to services that expect requests to come from WordPress.  This will fix the following reported issues:

- https://forums.classicpress.net/t/is-yoast-toast/685/53 (confirmed)
- https://forum.ait-pro.com/forums/topic/bps-pro-compatibility-with-classicpress/ (confirmed)
- https://forums.classicpress.net/t/genesis-update-doesnt-work/190/13 (potentially)