### PR TITLE
Add call for translators

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -42,6 +42,17 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 		</h2>
 
 		<div class="changelog point-releases about-wrap-content">
+
+			<?php if ( get_locale() !== 'en_US' ) { ?>
+				<p class="about-inline-notice notice-warning">
+					<?php printf(
+						/* translators: link to learn more about translating ClassicPress */
+						__( 'Help us translate ClassicPress into your language! <a href="%s">Learn more</a>.' ),
+						'https://www.classicpress.net/translating-classicpress/'
+					); ?>
+				</p>
+			<?php } ?>
+
 			<h3><?php _e( 'Introducing ClassicPress' ); ?></h3>
 
 			<p>

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -37,6 +37,11 @@
 	display: none !important;
 }
 
+.about-wrap .about-inline-notice {
+	margin: -12px 0 12px 0;
+	padding: 6px 8px;
+}
+
 .about-wrap hr {
 	border: 0;
 	height: 0;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1343,7 +1343,8 @@ th.action-links {
 
 .notice,
 div.updated,
-div.error {
+div.error,
+.about-inline-notice {
 	background: #fff;
 	border-left: 4px solid #fff;
 	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1529,11 +1529,27 @@ function wp_welcome_panel() {
 		); ?>
 	</p>
 	<p>
-		<?php printf(
+<?php
+	if ( get_locale() === 'en_US' ) {
+		printf(
 			/* translators: link to "About ClassicPress" dashboard page */
-			'To see how you can help, visit the <a href="%s">About ClassicPress</a> page.',
+			__( 'To see how you can help, visit the <a href="%s">About ClassicPress</a> page.' ),
 			esc_url( self_admin_url( 'about.php' ) )
-		); ?>
+		);
+	} else {
+		printf(
+			/* translators: link to learn more about translating ClassicPress */
+			__( 'Help us translate ClassicPress into your language! <a href="%s">Learn more</a>.' ),
+			'https://www.classicpress.net/translating-classicpress/'
+		);
+		echo '</p><p>';
+		printf(
+			/* translators: link to "About ClassicPress" dashboard page */
+			__( 'For other ways you can help, visit the <a href="%s">About ClassicPress</a> page.' ),
+			esc_url( self_admin_url( 'about.php' ) )
+		);
+	}
+?>
 	</p>
 </div>
 <?php

--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -70,7 +70,7 @@ if ( is_blog_admin() && current_user_can( 'edit_posts' ) )
 	$help .= '<p>' . __( "<strong>Quick Draft</strong> &mdash; Allows you to create a new post and save it as a draft. Also displays links to the 5 most recent draft posts you've started." ) . '</p>';
 $help .= '<p>' . sprintf(
 		/* translators: %s: ClassicPress Planet URL */
-		__( '<strong>ClassicPress News</strong> &mdash; Latest news from the official <a href="%s">ClassicPress blog</a></a>.' ),
+		__( '<strong>ClassicPress News</strong> &mdash; Latest news from the official <a href="%s">ClassicPress blog</a>.' ),
 		__( 'https://www.classicpress.net/blog/' )
 ) . '</p>';
 if ( current_user_can( 'edit_theme_options' ) )


### PR DESCRIPTION
cc @Mte90 

When you are using a language that is not English, this PR makes the following changes in the dashboard:

![2019-02-18t16 21 09-05 00](https://user-images.githubusercontent.com/227022/52976927-6213fa00-3399-11e9-8a44-72ae3fdaac4d.png)

![2019-02-18t16 22 08-05 00](https://user-images.githubusercontent.com/227022/52976924-6213fa00-3399-11e9-9da8-2687cc008edb.png)

Also fixes an issue with a translated string reported by @ginsterbusch [here](https://forums.classicpress.net/t/how-to-localize-classicpress/459/11).