### PR TITLE
Update the default theme to ClassicPress TwentySeventeen

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -387,7 +387,7 @@ function wp_templating_constants() {
 	 * @see WP_Theme::get_core_default_theme()
 	 */
 	if ( ! defined( 'WP_DEFAULT_THEME') ) {
-		define( 'WP_DEFAULT_THEME', 'twentyseventeen' );
+		define( 'WP_DEFAULT_THEME', 'classicpress-twentyseventeen' );
 	}
 
 }


### PR DESCRIPTION
Previously, a new install of ClassicPress would have the Twenty
Seventeen theme activated.  This will say "Powered by ClassicPress" in
the footer... until the site has a full theme update performed.  Then it
will change to "Powered by WordPress" because the default theme gets
updated too.

New installs of ClassicPress should continue to say "Powered by
ClassicPress" even after themes are updated, so this change sets the
default theme for new installations to ClassicPress TwentySeventeen, one
of the child themes added in #292.

See also #291.