### PR TITLE
A couple more updater fixes

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -79,9 +79,6 @@ function find_core_auto_update() {
 	$auto_update = false;
 	$upgrader = new WP_Automatic_Updater;
 	foreach ( $updates->updates as $update ) {
-		if ( 'autoupdate' != $update->response )
-			continue;
-
 		if ( ! $upgrader->should_update( 'core', $update, ABSPATH ) )
 			continue;
 

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -243,7 +243,7 @@ function update_nag() {
 			__( '<a href="%1$s">ClassicPress %2$s</a> is available! <a href="%3$s" aria-label="%4$s">Please update now</a>.' ),
 			sprintf(
 				/* translators: %s: ClassicPress version */
-				esc_url( __( 'https://codex.wordpress.org/Version_%s' ) ),
+				esc_url( __( 'https://www.classicpress.net/version/%s' ) ),
 				$cur->current
 			),
 			$cur->current,
@@ -256,7 +256,7 @@ function update_nag() {
 			__( '<a href="%1$s">ClassicPress %2$s</a> is available! Please notify the site administrator.' ),
 			sprintf(
 				/* translators: %s: ClassicPress version */
-				esc_url( __( 'https://codex.wordpress.org/Version_%s' ) ),
+				esc_url( __( 'https://www.classicpress.net/version/%s' ) ),
 				$cur->current
 			),
 			$cur->current

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -69,16 +69,16 @@ function list_core_update( $update ) {
 
 			if ( !$mysql_compat && !$php_compat )
 				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number */
-				$message = sprintf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.'), $update->current, $update->php_version, $update->mysql_version, $php_version, $mysql_version );
+				$message = sprintf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.'), $update->current, $update->php_version, $update->mysql_version, $php_version, $mysql_version );
 			elseif ( !$php_compat )
 				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number */
-				$message = sprintf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.'), $update->current, $update->php_version, $php_version );
+				$message = sprintf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.'), $update->current, $update->php_version, $php_version );
 			elseif ( !$mysql_compat )
 				/* translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number */
-				$message = sprintf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.'), $update->current, $update->mysql_version, $mysql_version );
+				$message = sprintf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.'), $update->current, $update->mysql_version, $mysql_version );
 			else
 				/* translators: 1: ClassicPress version number, 2: ClassicPress version number including locale if necessary */
-				$message = 	sprintf(__('You can update to <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %2$s</a> automatically:'), $update->current, $version_string);
+				$message = 	sprintf(__('You can update to <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> automatically:'), $update->current, $version_string);
 			if ( !$mysql_compat || !$php_compat )
 				$show_buttons = false;
 		}

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -78,11 +78,11 @@ else
 
 <?php elseif ( !$php_compat || !$mysql_compat ) :
 	if ( !$mysql_compat && !$php_compat )
-		printf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.'), $wp_version, $required_php_version, $required_mysql_version, $php_version, $mysql_version );
+		printf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.'), $wp_version, $required_php_version, $required_mysql_version, $php_version, $mysql_version );
 	elseif ( !$php_compat )
-		printf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.'), $wp_version, $required_php_version, $php_version );
+		printf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.'), $wp_version, $required_php_version, $php_version );
 	elseif ( !$mysql_compat )
-		printf( __('You cannot update because <a href="https://codex.wordpress.org/Version_%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.'), $wp_version, $required_mysql_version, $mysql_version );
+		printf( __('You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.'), $wp_version, $required_mysql_version, $mysql_version );
 ?>
 <?php else :
 switch ( $step ) :


### PR DESCRIPTION
- Don't link to e.g. https://codex.wordpress.org/Version_1.0.0 for ClassicPress versions
- Another missing piece to enable automatic (background) upgrades