### PR TITLE
Explain default themes better

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -48,6 +48,9 @@ body.js .theme-browser.search-loading {
 	right: 0;
 	top: 0;
 }
+.theme .notice.update-message + .notice {
+	top: 39px;
+}
 
 /**
  * Main theme element

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -609,6 +609,18 @@ function wp_prepare_themes_for_js( $themes = null ) {
 		unset( $prepared_themes[ $parents[ $current_theme ] ]['actions']['delete'] );
 	}
 
+	// Indicate a preferred ClassicPress child theme for the WP parent themes
+	$wp_theme_slugs = array( 'twentyfifteen', 'twentysixteen', 'twentyseventeen' );
+	foreach ( $wp_theme_slugs as $slug ) {
+		if (
+			isset( $prepared_themes[ $slug ] ) &&
+			isset( $prepared_themes[ "classicpress-$slug" ] )
+		) {
+			$prepared_themes[ $slug ]['preferredChildName'] =
+				$prepared_themes[ "classicpress-$slug" ]['name'];
+		}
+	}
+
 	/**
 	 * Filters the themes prepared for JavaScript, for themes.php.
 	 *

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -278,7 +278,6 @@ foreach ( $themes as $theme ) :
 		); ?></p></div>
 	<?php } ?>
 
-
 	<span class="more-details" id="<?php echo $aria_action; ?>"><?php _e( 'Theme Details' ); ?></span>
 	<div class="theme-author"><?php printf( __( 'By %s' ), $theme['author'] ); ?></div>
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -274,7 +274,7 @@ foreach ( $themes as $theme ) :
 		<div class="notice inline notice-info notice-alt"><p><?php printf(
 			/* translators: ClassicPress child theme name */
 			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-			$theme['preferredChildName'] . ' twentypress themes.php PHP'
+			$theme['preferredChildName']
 		); ?></p></div>
 	<?php } ?>
 
@@ -413,7 +413,7 @@ $can_install = current_user_can( 'install_themes' );
 		<div class="notice inline notice-info notice-alt"><p><?php printf(
 			/* translators: ClassicPress child theme name */
 			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-			'{{ data.preferredChildName }} twentypress themes.php JS'
+			'{{ data.preferredChildName }}'
 		); ?></p></div>
 	<# } #>
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -270,6 +270,15 @@ foreach ( $themes as $theme ) :
 		</div>
 	<?php endif; ?>
 
+	<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
+		<div class="notice inline notice-info notice-alt"><p><?php printf(
+			/* translators: ClassicPress child theme name */
+			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+			$theme['preferredChildName'] . ' twentypress themes.php PHP'
+		); ?></p></div>
+	<?php } ?>
+
+
 	<span class="more-details" id="<?php echo $aria_action; ?>"><?php _e( 'Theme Details' ); ?></span>
 	<div class="theme-author"><?php printf( __( 'By %s' ), $theme['author'] ); ?></div>
 
@@ -398,6 +407,14 @@ $can_install = current_user_can( 'install_themes' );
 		<# } else { #>
 			<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
 		<# } #>
+	<# } #>
+
+	<# if ( data.preferredChildName ) { #>
+		<div class="notice inline notice-info notice-alt"><p><?php printf(
+			/* translators: ClassicPress child theme name */
+			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+			'{{ data.preferredChildName }} twentypress themes.php JS'
+		); ?></p></div>
 	<# } #>
 
 	<span class="more-details" id="{{ data.id }}-action"><?php _e( 'Theme Details' ); ?></span>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -102,7 +102,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 					/* translators: ClassicPress child theme name */
 					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-					'{{ data.theme.preferredChildName }} twentypress customize JS'
+					'{{ data.theme.preferredChildName }}'
 				); ?></p></div>
 			<# } #>
 

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -98,6 +98,14 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				</div>
 			<# } #>
 
+			<# if ( data.theme.preferredChildName ) { #>
+				<div class="notice inline notice-info notice-alt"><p><?php printf(
+					/* translators: ClassicPress child theme name */
+					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+					'{{ data.theme.preferredChildName }} twentypress customize JS'
+				); ?></p></div>
+			<# } #>
+
 			<# if ( data.theme.active ) { #>
 				<div class="theme-id-container">
 					<h3 class="theme-name" id="{{ data.section }}-{{ data.theme.id }}-name">


### PR DESCRIPTION
The blue notices are new:

![2019-02-26t22 38 45-05 00](https://user-images.githubusercontent.com/227022/53464171-510d5d80-3a17-11e9-8335-3f76348c37f2.png)

Closes #299.  Other solutions are more complicated with lots of edge cases (even more edge cases).

Note, there are three places where this notice needs to be rendered:

- `/wp-admin/themes.php`, JavaScript disabled
- `/wp-admin/themes.php`, JavaScript enabled
- `/wp-admin/customize.php`, after clicking the Change button next to the active theme

Also, the new notice should only appear if both the child theme and the parent theme for a given year are present.