### PR TITLE
Remove WP-only features from the theme installation section

### DIFF
--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -1916,7 +1916,7 @@ themes.RunInstaller = {
 		// Set up the view
 		// Passes the default 'section' as an option
 		this.view = new themes.view.Installer({
-			section: 'featured',
+			section: 'popular',
 			SearchView: themes.view.InstallerSearch
 		});
 
@@ -1982,11 +1982,11 @@ themes.RunInstaller = {
 
 		// Handles sorting / browsing routes
 		// Also handles the root URL triggering a sort request
-		// for `featured`, the default view
+		// for `popular`, the default view
 		themes.router.on( 'route:sort', function( sort ) {
 			if ( ! sort ) {
-				sort = 'featured';
-				themes.router.navigate( themes.router.baseUrl( '?browse=featured' ), { replace: true } );
+				sort = 'popular';
+				themes.router.navigate( themes.router.baseUrl( '?browse=popular' ), { replace: true } );
 			}
 			self.view.sort( sort );
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -78,7 +78,7 @@ if ( $tab ) {
 	 *
 	 * The dynamic portion of the hook name, `$tab`, refers to the current
 	 * theme installation tab. Possible values are 'dashboard', 'search', 'upload',
-	 * 'featured', 'new', or 'updated'.
+	 * 'new', or 'updated'.
 	 *
 	 * @since WP-2.8.0
 	 */
@@ -92,7 +92,7 @@ $help_overview =
 			__( 'https://wordpress.org/themes/' )
 		) . '</p>' .
 	'<p>' . __( 'You can Search for themes by keyword, author, or tag, or can get more specific and search by criteria listed in the feature filter.' ) . ' <span id="live-search-desc">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
-	'<p>' . __( 'Alternately, you can browse the themes that are Featured, Popular, or Latest. When you find a theme you like, you can preview it or install it.' ) . '</p>' .
+	'<p>' . __( 'Alternately, you can browse the themes that are Popular, or Latest. When you find a theme you like, you can preview it or install it.' ) . '</p>' .
 	'<p>' . sprintf(
 			/* translators: %s: /wp-content/themes */
 			__( 'You can Upload a theme manually if you have already downloaded its ZIP archive onto your computer (make sure it is from a trusted and original source). You can also do it the old-fashioned way and copy a downloaded theme&#8217;s folder via FTP into your %s directory.' ),
@@ -162,35 +162,13 @@ include(ABSPATH . 'wp-admin/admin-header.php');
 		</div>
 
 		<ul class="filter-links">
-			<li><a href="#" data-sort="featured"><?php _ex( 'Featured', 'themes' ); ?></a></li>
 			<li><a href="#" data-sort="popular"><?php _ex( 'Popular', 'themes' ); ?></a></li>
 			<li><a href="#" data-sort="new"><?php _ex( 'Latest', 'themes' ); ?></a></li>
-			<li><a href="#" data-sort="favorites"><?php _ex( 'Favorites', 'themes' ); ?></a></li>
 		</ul>
 
 		<button type="button" class="button drawer-toggle" aria-expanded="false"><?php _e( 'Feature Filter' ); ?></button>
 
 		<form class="search-form"></form>
-
-		<div class="favorites-form">
-			<?php
-			$action = 'save_wporg_username_' . get_current_user_id();
-			if ( isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), $action ) ) {
-				$user = isset( $_GET['user'] ) ? wp_unslash( $_GET['user'] ) : get_user_option( 'wporg_favorites' );
-				update_user_meta( get_current_user_id(), 'wporg_favorites', $user );
-			} else {
-				$user = get_user_option( 'wporg_favorites' );
-			}
-			?>
-			<p class="install-help"><?php _e( 'If you have marked themes as favorites on WordPress.org, you can browse them here.' ); ?></p>
-
-			<p>
-				<label for="wporg-username-input"><?php _e( 'Your WordPress.org username:' ); ?></label>
-				<input type="hidden" id="wporg-username-nonce" name="_wpnonce" value="<?php echo esc_attr( wp_create_nonce( $action ) ); ?>" />
-				<input type="search" id="wporg-username-input" value="<?php echo esc_attr( $user ); ?>" />
-				<input type="button" class="button favorites-form-submit" value="<?php esc_attr_e( 'Get Favorites' ); ?>" />
-			</p>
-		</div>
 
 		<div class="filter-drawer">
 			<div class="buttons">
@@ -238,7 +216,7 @@ if ( $tab ) {
 	 *
 	 * The dynamic portion of the hook name, `$tab`, refers to the current
 	 * theme installation tab. Possible values are 'dashboard', 'search', 'upload',
-	 * 'featured', 'new', or 'updated'.
+	 * 'new', or 'updated'.
 	 *
 	 * @since WP-2.8.0
 	 *


### PR DESCRIPTION
Follow-up to #342.  Reported [on the forums](https://forums.classicpress.net/t/favorite-plugins-using-wordpress-org-account/834).

## Before

![2019-02-26t22 58 57-05 00](https://user-images.githubusercontent.com/227022/53464955-2244b680-3a1a-11e9-9927-6a5aaa3f5568.png)

## After

![2019-02-26t22 58 46-05 00](https://user-images.githubusercontent.com/227022/53464956-2244b680-3a1a-11e9-8da3-c5cb4fe6205b.png)