### PR TITLE
Update User-Agent header again

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2677,7 +2677,7 @@ function pingback( $content, $post_id ) {
 			 * @param string $pagelinkedto        URL of page linked to.
 			 * @param string $pagelinkedfrom      URL of page linked from.
 			 */
-			$client->useragent = apply_filters( 'pingback_useragent', $client->useragent . ' -- ' . classicpress_user_agent( false ), $client->useragent, $pingback_server_url, $pagelinkedto, $pagelinkedfrom );
+			$client->useragent = apply_filters( 'pingback_useragent', $client->useragent . ' -- ' . classicpress_user_agent(), $client->useragent, $pingback_server_url, $pagelinkedto, $pagelinkedfrom );
 			// when set to true, this outputs debug messages by itself
 			$client->debug = false;
 
@@ -2756,7 +2756,7 @@ function weblog_ping($server = '', $path = '') {
 	// using a timeout of 3 seconds should be enough to cover slow servers
 	$client = new WP_HTTP_IXR_Client($server, ((!strlen(trim($path)) || ('/' == $path)) ? false : $path));
 	$client->timeout = 3;
-	$client->useragent .= ' -- ' . classicpress_user_agent( false );
+	$client->useragent .= ' -- ' . classicpress_user_agent();
 
 	// when set to true, this outputs debug messages by itself
 	$client->debug = false;

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -750,7 +750,7 @@ function classicpress_user_agent( $include_site_id = false ) {
 
 	if ( $include_site_id ) {
 		$url .= '&site=' . sha1( preg_replace(
-			'#^https?:#i',
+			'#^https?:#',
 			'',
 			strtolower( home_url( '/' ) )
 		) );

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -749,11 +749,11 @@ function classicpress_user_agent( $include_site_id = false ) {
 		. '&ver=' . classicpress_version_short();
 
 	if ( $include_site_id ) {
-		$url .= '&site=' . sha1( strtolower( preg_replace(
+		$url .= '&site=' . sha1( preg_replace(
 			'#^https?:#i',
 			'',
-			home_url( '/' )
-		) ) );
+			strtolower( home_url( '/' ) )
+		) );
 	}
 
 	$user_agent = 'WordPress/' . get_bloginfo( 'version' ) . '; ' . $url;

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -739,24 +739,32 @@ function _wp_translate_php_url_constant_to_key( $constant ) {
  *
  * @since 1.0.0-rc1
  *
- * @param bool $include_url Whether to append a URL to the header.
+ * @param bool $include_site_id Whether to include a site identifier (used when
+ *                              communicating with the ClassicPress API).  This
+ *                              is not personally identifiable information.
  * @return string The User-Agent header value.
  */
-function classicpress_user_agent( $include_url = true ) {
-	$ua = 'WordPress/' . get_bloginfo( 'version' );
-	if ( $include_url ) {
-		$ua .= '; https://www.classicpress.net/?wp_compatible=true'
-			. '&ver=' . classicpress_version_short();
+function classicpress_user_agent( $include_site_id = false ) {
+	$url = 'https://www.classicpress.net/?wp_compatible=true'
+		. '&ver=' . classicpress_version_short();
+
+	if ( $include_site_id ) {
+		$url .= '&site=' . sha1( strtolower( preg_replace(
+			'#^https?:#i',
+			'',
+			home_url( '/' )
+		) ) );
 	}
+
+	$user_agent = 'WordPress/' . get_bloginfo( 'version' ) . '; ' . $url;
 
 	/**
 	 * Filters the user agent value sent with an HTTP request.
 	 *
 	 * @since WP-2.7.0
-	 * @since 1.0.0-rc1 Added the $include_url parameter.
+	 * @since 1.0.0-rc1 This filter is applied to all HTTP requests.
 	 *
 	 * @param string $user_agent ClassicPress user agent string.
-	 * @param bool $include_url Whether to append a URL to the header.
 	 */
-	return apply_filters( 'http_headers_useragent', $ua, $include_url );
+	return apply_filters( 'http_headers_useragent', $user_agent );
 }

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -144,7 +144,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	$options = array(
 		'timeout' => $doing_cron ? 30 : 3,
-		'user-agent' => classicpress_user_agent(),
+		'user-agent' => classicpress_user_agent( true ),
 		'headers' => array(
 			'wp_install' => $wp_install,
 			'wp_blog' => home_url( '/' )

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -309,22 +309,41 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		);
 	}
 
-	function test_classicpress_user_agent() {
+	function test_classicpress_user_agent_short() {
 		global $wp_version;
+
+		$ua_short = classicpress_user_agent();
 
 		$this->assertStringStartsWith(
 			"WordPress/$wp_version; https://",
-			classicpress_user_agent()
+			$ua_short
 		);
 
 		$this->assertStringEndsWith(
-			'&ver=' . classicpress_version_short(),
-			classicpress_user_agent()
-		);
-
-		$this->assertEquals(
-			"WordPress/$wp_version",
-			classicpress_user_agent( false )
+			'?wp_compatible=true&ver=' . classicpress_version_short(),
+			$ua_short
 		);
 	}
+
+	function test_classicpress_user_agent_full() {
+		global $wp_version;
+
+		$ua_full = classicpress_user_agent( true );
+
+		$this->assertStringStartsWith(
+			"WordPress/$wp_version; https://",
+			$ua_full
+		);
+
+		$this->assertContains(
+			'&ver=' . classicpress_version_short() . '&site=',
+			$ua_full
+		);
+
+		$this->assertRegExp(
+			'#&site=[0-9a-f]{40}$#',
+			$ua_full
+		);
+	}
+
 }


### PR DESCRIPTION
Follow-up to https://github.com/ClassicPress/ClassicPress/pull/361.

Previously:

- `classicpress_user_agent() => "WordPress/4.9.9; https://www.classicpress.net/?wp_compatible=true&ver=1.0.0"`
- `classicpress_user_agent( false ) => "WordPress/4.9.9"`

With this PR:

- `classicpress_user_agent() => "WordPress/4.9.9; https://www.classicpress.net/?wp_compatible=true&ver=1.0.0"`
- `classicpress_user_agent( true ) => "WordPress/4.9.9; https://www.classicpress.net/?wp_compatible=true&ver=1.0.0&site=abcdef1234"`