### PR TITLE
Make User-Agent identifier consistent regardless of trailing slashes

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -752,7 +752,7 @@ function classicpress_user_agent( $include_site_id = false ) {
 		$url .= '&site=' . sha1( preg_replace(
 			'#^https?:#',
 			'',
-			strtolower( home_url( '/' ) )
+			strtolower( untrailingslashit( home_url( '/' ) ) )
 		) );
 	}
 


### PR DESCRIPTION
Follow-up to #390.