### PR TITLE
Move variables back to top of version.php file to fix WPCLI

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -30,6 +30,47 @@
 $cp_version = '1.0.0-rc2+dev';
 
 /**
+ * The WordPress version string
+ *
+ * This is still used internally for various core and plugin functions, and to
+ * keep compatibility checks working as intended.  The ClassicPress version is
+ * stored separately.
+ *
+ * @see classicpress_version()
+ *
+ * @global string $wp_version
+ */
+$wp_version = '4.9.9';
+
+/**
+ * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.
+ *
+ * @global int $wp_db_version
+ */
+$wp_db_version = 38590;
+
+/**
+ * Holds the TinyMCE version
+ *
+ * @global string $tinymce_version
+ */
+$tinymce_version = '4800-20180716';
+
+/**
+ * Holds the required PHP version
+ *
+ * @global string $required_php_version
+ */
+$required_php_version = '5.6.0';
+
+/**
+ * Holds the required MySQL version
+ *
+ * @global string $required_mysql_version
+ */
+$required_mysql_version = '5.0';
+
+/**
  * Return the ClassicPress version string.
  *
  * `function_exists( 'classicpress_version' )` is the recommended way for
@@ -77,44 +118,3 @@ if ( ! function_exists( 'classicpress_is_dev_install' ) ) {
 		return substr( $cp_version, -4 ) === '+dev';
 	}
 }
-
-/**
- * The WordPress version string
- *
- * This is still used internally for various core and plugin functions, and to
- * keep compatibility checks working as intended.  The ClassicPress version is
- * stored separately.
- *
- * @see classicpress_version()
- *
- * @global string $wp_version
- */
-$wp_version = '4.9.9';
-
-/**
- * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.
- *
- * @global int $wp_db_version
- */
-$wp_db_version = 38590;
-
-/**
- * Holds the TinyMCE version
- *
- * @global string $tinymce_version
- */
-$tinymce_version = '4800-20180716';
-
-/**
- * Holds the required PHP version
- *
- * @global string $required_php_version
- */
-$required_php_version = '5.6.0';
-
-/**
- * Holds the required MySQL version
- *
- * @global string $required_mysql_version
- */
-$required_mysql_version = '5.0';


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

To suggest new features or major changes, please visit our Petitions website at:
https://petitions.classicpress.net/

For more details about our governance and change planning process, see:
https://www.classicpress.net/democracy/
-->

## Description
WPCLI only fetches the first 2048 bytes of the version file with file_get_contents and so is returning invalid versions.
See https://forums.classicpress.net/t/wp-cli-compatibility/891/
This is where the parse instead of include was merged into wpcli https://github.com/wp-cli/wp-cli/pull/2459

## Motivation and context
```
wp core version --extra
WordPress version: 
Database revision: 
TinyMCE version:
Package language: en_US
```

## How has this been tested?
Tested against latest develop branch
```pross@pross ~/public_html $ wp core version --extra
WordPress version: 4.9.9
Database revision: 38590
TinyMCE version:   4.800 (4800-20180716)
Package language:  en_US
```

<!--
Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to see how
your change affects other areas of the code, etc.

Please include unit tests with new or changed code, if applicable.
-->
## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
