### PR TITLE
Fix downloads with chunked responses if cURL is not installed

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -973,7 +973,19 @@ function download_url( $url, $timeout = 300 ) {
 	if ( ! $tmpfname )
 		return new WP_Error('http_no_file', __('Could not create Temporary file.'));
 
-	$response = wp_safe_remote_get( $url, array( 'timeout' => $timeout, 'stream' => true, 'filename' => $tmpfname ) );
+	$options = array(
+		'timeout'  => $timeout,
+		'stream'   => true,
+		'filename' => $tmpfname,
+	);
+	if ( ! function_exists( 'curl_init' ) ) {
+		// Ask servers not to send us chunked responses.  See:
+		// - https://github.com/rmccue/Requests/issues/189
+		// - https://webmasters.stackexchange.com/a/44076/98758
+		error_log( 'The cURL extension for PHP is missing.  Please install it!' );
+		$options['protocol_version'] = '1.0';
+	}
+	$response = wp_safe_remote_get( $url, $options );
 
 	if ( is_wp_error( $response ) ) {
 		unlink( $tmpfname );

--- a/src/wp-includes/class-http.php
+++ b/src/wp-includes/class-http.php
@@ -305,6 +305,12 @@ class WP_Http {
 			$options['hooks']->register( 'requests.before_redirect', array( get_class(), 'validate_redirects' ) );
 		}
 
+		// Allow overriding the protocol version.  The 'httpversion' argument
+		// claims to do this but appears to be broken.
+		if ( isset( $r['protocol_version'] ) ) {
+			$options['protocol_version'] = $r['protocol_version'];
+		}
+
 		if ( $r['stream'] ) {
 			$options['filename'] = $r['filename'];
 		}


### PR DESCRIPTION
Reported here: https://forums.classicpress.net/t/update-failed-pclzip-error/849

<img src="https://forums.classicpress.net/uploads/default/original/1X/2164bc1e5d00d1d953b59e6aeb543bba37e1ab36.png">

This happens when GitHub sends a `Transfer-Encoding: chunked` response for an upgrade zip, which it sometimes does and sometimes doesn't, and when the PHP cURL extension is not present on the site's server.

In this case, the `fsockopen` transport of the underlying `Requests` library is used.  This transport does not support chunked responses, which is a known issue:  https://github.com/rmccue/Requests/issues/189

This PR is a workaround which drops the HTTP protocol version back down to 1.0 in this case, from https://webmasters.stackexchange.com/a/44076/98758.