### PR TITLE
WP-r44392: Customize: Safeguard a check on the `customize_validate_{$…

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2277,7 +2277,7 @@ final class WP_Customize_Manager {
 			if ( ! is_wp_error( $validity ) ) {
 				/** This filter is documented in wp-includes/class-wp-customize-setting.php */
 				$late_validity = apply_filters( "customize_validate_{$setting->id}", new WP_Error(), $unsanitized_value, $setting );
-				if ( ! empty( $late_validity->errors ) ) {
+				if ( is_wp_error( $late_validity ) && ! empty( $late_validity->errors ) ) {
 					$validity = $late_validity;
 				}
 			}


### PR DESCRIPTION
…setting_id}` filter value to ensure it is a `WP_Error`.

While the filter is documented to only support a `WP_Error`, it has been a common practice to return true in a validation function if no errors have occurred. This was already caught when the same filter was executed in `WP_Customize_Setting`, it was however missing in `WP_Customize_Manager::validate_setting_values()`.

WP:Props flixos90.

Merges https://core.trac.wordpress.org/changeset/43578 to the 5.0 branch.
Fixes https://core.trac.wordpress.org/ticket/44809.

----
Merges https://core.trac.wordpress.org/changeset/44392 / WordPress/wordpress-develop@45a8f1d7c5 to ClassicPress.