### PR TITLE
Check mu-plugins for updates; display update notice

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -728,7 +728,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			$plugin_name = $plugin_data['Name'];
 		}
 
-		if ( ! empty( $totals['upgrade'] ) && ! empty( $plugin_data['update'] ) )
+		if ( ! empty( $totals['upgrade'] ) && ( ! empty( $plugin_data['update'] ) || 'mustuse' === $context ) )
 			$class .= ' update';
 
 		$plugin_slug = isset( $plugin_data['slug'] ) ? $plugin_data['slug'] : sanitize_title( $plugin_name );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -363,7 +363,11 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 	$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
 
 	if ( is_network_admin() || ! is_multisite() ) {
-		if ( is_network_admin() ) {
+        $is_mu_plugin = array_key_exists( $file, get_mu_plugins() );
+
+        if ( $is_mu_plugin ) {
+            $active_class = ' active';
+		} elseif ( is_network_admin() ) {
 			$active_class = is_plugin_active_for_network( $file ) ? ' active' : '';
 		} else {
 			$active_class = is_plugin_active( $file ) ? ' active' : '';
@@ -382,6 +386,17 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 				),
 				$response->new_version
 			);
+        } elseif ( $is_mu_plugin ) {
+            /* translators: 1: plugin name, 2: details URL, 3: additional link attributes, 4: version number */
+            printf( __( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>.' ),
+                $plugin_name,
+                esc_url( $details_url ),
+                sprintf( 'class="thickbox open-plugin-details-modal" aria-label="%s"',
+                    /* translators: 1: plugin name, 2: version number */
+                    esc_attr( sprintf( __( 'View %1$s version %2$s details' ), $plugin_name, $response->new_version ) )
+                ),
+                $response->new_version
+            );
 		} elseif ( empty( $response->package ) ) {
 			/* translators: 1: plugin name, 2: details URL, 3: additional link attributes, 4: version number */
 			printf( __( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this plugin.</em>' ),

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -238,7 +238,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 	if ( !function_exists( 'get_plugins' ) )
 		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-	$plugins = get_plugins();
+	$plugins = array_merge( get_mu_plugins(), get_plugins() );
 	$translations = wp_get_installed_translations( 'plugins' );
 
 	$active  = get_option( 'active_plugins', array() );


### PR DESCRIPTION
I've never understood why mu-plugins aren't checked for updates; they can't be updated automatically, but that's no reason not to check if there's an update available.
This PR includes mu-plugins in the update check, and displays a notice - without an update link - for plugins with an update available.
This needs more testing and consideration before merging - e.g. does it do what's expected for multisite?