### PR TITLE
Add new "posts_name_filter" for posts Post Type

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -18,9 +18,13 @@
  * @since WP-2.9.0
  */
 function create_initial_post_types() {
+
+	$values = apply_filters( 'posts_name_filter', array('post','posts') );
+	$singular_name = $values[0];
+
 	register_post_type( 'post', array(
 		'labels' => array(
-			'name_admin_bar' => _x( 'Post', 'add new from admin bar' ),
+			'name_admin_bar' => _x( ucfirst($singular_name), 'add new from admin bar' ),
 		),
 		'public'  => true,
 		'_builtin' => true, /* internal use only. don't use this when registering your own post type. */
@@ -1440,31 +1444,36 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * @return object Object with all the labels as member variables.
  */
 function get_post_type_labels( $post_type_object ) {
+
+	$values = apply_filters( 'posts_name_filter', array('post','posts') );
+	$singular_name = $values[0];
+	$plural_name = $values[1];
+
 	$nohier_vs_hier_defaults = array(
-		'name' => array( _x('Posts', 'post type general name'), _x('Pages', 'post type general name') ),
-		'singular_name' => array( _x('Post', 'post type singular name'), _x('Page', 'post type singular name') ),
-		'add_new' => array( _x('Add New', 'post'), _x('Add New', 'page') ),
-		'add_new_item' => array( __('Add New Post'), __('Add New Page') ),
-		'edit_item' => array( __('Edit Post'), __('Edit Page') ),
-		'new_item' => array( __('New Post'), __('New Page') ),
-		'view_item' => array( __('View Post'), __('View Page') ),
-		'view_items' => array( __('View Posts'), __('View Pages') ),
-		'search_items' => array( __('Search Posts'), __('Search Pages') ),
-		'not_found' => array( __('No posts found.'), __('No pages found.') ),
-		'not_found_in_trash' => array( __('No posts found in Trash.'), __('No pages found in Trash.') ),
+		'name' => array( _x($plural_name, $singular_name . ' type general name'), _x('Pages', $singular_name . ' type general name') ),
+		'singular_name' => array( _x($plural_name, $singular_name . ' type singular name'), _x('Page', $singular_name . ' type singular name') ),
+		'add_new' => array( _x('Add New', $singular_name), _x('Add New', 'page') ),
+		'add_new_item' => array( __('Add New ' . $singular_name), __('Add New Page') ),
+		'edit_item' => array( __('Edit ' . $singular_name), __('Edit Page') ),
+		'new_item' => array( __('New ' . $singular_name), __('New Page') ),
+		'view_item' => array( __('View ' . $singular_name), __('View Page') ),
+		'view_items' => array( __('View ' . $plural_name), __('View Pages') ),
+		'search_items' => array( __('Search ' . $plural_name), __('Search Pages') ),
+		'not_found' => array( __('No ' . $plural_name . 'found.'), __('No pages found.') ),
+		'not_found_in_trash' => array( __('No ' . $plural_name . 'found in Trash.'), __('No pages found in Trash.') ),
 		'parent_item_colon' => array( null, __('Parent Page:') ),
-		'all_items' => array( __( 'All Posts' ), __( 'All Pages' ) ),
-		'archives' => array( __( 'Post Archives' ), __( 'Page Archives' ) ),
-		'attributes' => array( __( 'Post Attributes' ), __( 'Page Attributes' ) ),
-		'insert_into_item' => array( __( 'Insert into post' ), __( 'Insert into page' ) ),
-		'uploaded_to_this_item' => array( __( 'Uploaded to this post' ), __( 'Uploaded to this page' ) ),
-		'featured_image' => array( _x( 'Featured Image', 'post' ), _x( 'Featured Image', 'page' ) ),
-		'set_featured_image' => array( _x( 'Set featured image', 'post' ), _x( 'Set featured image', 'page' ) ),
-		'remove_featured_image' => array( _x( 'Remove featured image', 'post' ), _x( 'Remove featured image', 'page' ) ),
-		'use_featured_image' => array( _x( 'Use as featured image', 'post' ), _x( 'Use as featured image', 'page' ) ),
-		'filter_items_list' => array( __( 'Filter posts list' ), __( 'Filter pages list' ) ),
-		'items_list_navigation' => array( __( 'Posts list navigation' ), __( 'Pages list navigation' ) ),
-		'items_list' => array( __( 'Posts list' ), __( 'Pages list' ) ),
+		'all_items' => array( __( 'All ' . $plural_name ), __( 'All Pages' ) ),
+		'archives' => array( __( $singular_name . ' Archives' ), __( 'Page Archives' ) ),
+		'attributes' => array( __( $singular_name . ' Attributes' ), __( 'Page Attributes' ) ),
+		'insert_into_item' => array( __( 'Insert into ' . $singular_name ), __( 'Insert into page' ) ),
+		'uploaded_to_this_item' => array( __( 'Uploaded to this ' . $singular_name ), __( 'Uploaded to this page' ) ),
+		'featured_image' => array( _x( 'Featured Image', $singular_name ), _x( 'Featured Image', 'page' ) ),
+		'set_featured_image' => array( _x( 'Set featured image', $singular_name ), _x( 'Set featured image', 'page' ) ),
+		'remove_featured_image' => array( _x( 'Remove featured image', $singular_name ), _x( 'Remove featured image', 'page' ) ),
+		'use_featured_image' => array( _x( 'Use as featured image', $singular_name ), _x( 'Use as featured image', 'page' ) ),
+		'filter_items_list' => array( __( 'Filter ' . $plural_name . ' list' ), __( 'Filter pages list' ) ),
+		'items_list_navigation' => array( __( $plural_name . ' list navigation' ), __( 'Pages list navigation' ) ),
+		'items_list' => array( __( $plural_name . ' list' ), __( 'Pages list' ) ),
 	);
 	$nohier_vs_hier_defaults['menu_name'] = $nohier_vs_hier_defaults['name'];
 


### PR DESCRIPTION
## Description

**This is a proof of concept**

Created a new apply_filter functionality. This requires an `array()` with the filter considering that many words in different languages have different ways of handling plurals and singulars thus the array.

Using a filter to make the change of the default "Post" and "Posts" naming convention possible.

Front End development usage would be like this to change posts to articles or any desired name via `functions.php` or a plugin with this snippet. 

```
function example_callback( $array_titles ) {
    $array_titles = array("Article", "Articles");
    return $array_titles;
}

add_filter( 'posts_name_filter', 'example_callback' );
```
However, querying remains as posts Post Type for Backward compatibility.

**Help**  is need when considering whether to type hint this section for the array as a must.

## Motivation and context
https://petitions.classicpress.net/posts/100/change-posts-to-articles-or-make-them-editable-so-they-can-be-changed-into-anything

## How has this been tested?
1. use a local branch for testing the code.

## Screenshots (if appropriate):

![Screen Shot 2019-06-19 at 14 51 11](https://user-images.githubusercontent.com/7713923/59765990-ec1c9280-92a7-11e9-88f0-11233f04c6a8.png)

![Screen Shot 2019-06-19 at 14 50 53](https://user-images.githubusercontent.com/7713923/59765991-ecb52900-92a7-11e9-9925-08e6c068579a.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
