### PR TITLE
Fixed theme update notices (overlapping, fixed height and excessive length)

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2968,3 +2968,19 @@ body.adding-widget .add-new-widget:before,
 		left: 0;
 	}
 }
+
+/* Fix theme notices in customizer (overrides wp-admin/css/theme.css) */
+
+@media screen  and ( min-width: 650px ) and ( max-width: 850px ) {
+	/* Themes are shown in 1 wide column, can show full notices */
+	.customize-control-theme .theme .notice .cut {
+		display: inline;
+	}
+}
+
+@media screen and ( min-width: 851px ) and ( max-width: 1018px )  {
+	/* Themes are shown in 2 narrow columns, cut the notices */
+	.customize-control-theme .theme .notice .cut {
+		display: none;
+	}
+}

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2971,7 +2971,7 @@ body.adding-widget .add-new-widget:before,
 
 /* Fix theme notices in customizer (overrides wp-admin/css/theme.css) */
 
-@media screen  and ( min-width: 650px ) and ( max-width: 850px ) {
+@media screen and ( min-width: 650px ) and ( max-width: 850px ) {
 	/* Themes are shown in 1 wide column, can show full notices */
 	.customize-control-theme .theme .notice .cut {
 		display: inline;

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -825,6 +825,10 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-browser .theme:nth-child(odd) {
 		margin-right: 5%;
 	}
+
+	.theme .notice .cut {
+		display: none;
+	}
 }
 
 /* Admin menu is folded */

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -826,9 +826,6 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 		margin-right: 5%;
 	}
 
-	.theme .notice .cut {
-		display: none;
-	}
 }
 
 /* Admin menu is folded */
@@ -892,6 +889,10 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-browser.rendered .theme:hover .theme-screenshot img,
 	.theme-browser.rendered .theme:focus .theme-screenshot img {
 		opacity: 1.0;
+	}
+
+	.theme .notice .cut {
+		display: none;
 	}
 }
 

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -825,7 +825,6 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-browser .theme:nth-child(odd) {
 		margin-right: 5%;
 	}
-
 }
 
 /* Admin menu is folded */

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -40,16 +40,15 @@ body.js .theme-browser.search-loading {
 }
 
 /* Position admin messages */
-.theme .notice,
-.theme .notice.is-dismissible {
+.theme .notices {
 	left: 0;
 	margin: 0;
 	position: absolute;
 	right: 0;
 	top: 0;
 }
-.theme .notice.update-message + .notice {
-	top: 39px;
+.theme .notices .notice {
+	margin: 0;
 }
 
 /**

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -265,7 +265,12 @@ foreach ( $themes as $theme ) :
 			<?php if ( $theme['hasUpdate'] ) : ?>
 				<div class="update-message notice inline notice-warning notice-alt">
 				<?php if ( $theme['hasPackage'] ) : ?>
-					<p><?php _e( '<span class="cut">New version available. </span><button class="button-link" type="button">Update now</button>' ); ?></p>
+					<p><?php
+							/* translators: Notice text */ _e('New version available.');
+						?> <button class="button-link update-theme" type="button"><?php
+							/* translators: Button text */ _e('Update now');
+						?></button>
+					</p>
 				<?php else : ?>
 					<p><?php _e( 'New version available.' ); ?></p>
 				<?php endif; ?>
@@ -274,10 +279,15 @@ foreach ( $themes as $theme ) :
 
 			<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
-					/* translators: ClassicPress child theme name */
-					__( 'Use the "%s" child theme instead!<span class="cut"> This is a parent theme that says "Powered by WordPress" in its footer.</span>' ),
-					$theme['preferredChildName']
-				); ?></p></div>
+						/* translators: %s: ClassicPress child theme name */
+						__('Use the "%s" child theme instead!'),
+						$theme['preferredChildName']
+					); ?>
+					<span class="cut"><?php
+						/* translators: Advanced part of the notice text, hidden on mobiles */
+						_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+					?></span>
+				</p></div>
 			<?php } ?>
 		</div>
 	<?php endif; ?>
@@ -407,7 +417,12 @@ $can_install = current_user_can( 'install_themes' );
 		<div class="notices">
 			<# if ( data.hasUpdate ) { #>
 				<# if ( data.hasPackage ) { #>
-					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( '<span class="cut">New version available. </span><button class="button-link" type="button">Update now</button>' ); ?></p></div>
+					<div class="update-message notice inline notice-warning notice-alt"><p><?php
+							/* translators: Notice text */ _e('New version available.');
+						?> <button class="button-link update-theme" type="button"><?php
+							/* translators: Button text */ _e('Update now');
+						?></button>
+					</p></div>
 				<# } else { #>
 					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
 				<# } #>
@@ -415,10 +430,15 @@ $can_install = current_user_can( 'install_themes' );
 
 			<# if ( data.preferredChildName ) { #>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
-					/* translators: ClassicPress child theme name */
-					__( 'Use the "%s" child theme instead!<span class="cut"> This is a parent theme that says "Powered by WordPress" in its footer.</span>' ),
-					'{{ data.preferredChildName }}'
-				); ?></p></div>
+						/* translators: %s: ClassicPress child theme name */
+						__('Use the "%s" child theme instead!'),
+						'{{ data.theme.preferredChildName }}'
+					); ?>
+					<span class="cut"><?php
+						/* translators: Advanced part of the notice text, hidden on mobiles */
+						_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+					?></span>
+				</p></div>
 			<# } #>
 		</div>
 	<# } #>

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -260,23 +260,27 @@ foreach ( $themes as $theme ) :
 		<div class="theme-screenshot blank"></div>
 	<?php } ?>
 
-	<?php if ( $theme['hasUpdate'] ) : ?>
-		<div class="update-message notice inline notice-warning notice-alt">
-		<?php if ( $theme['hasPackage'] ) : ?>
-			<p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p>
-		<?php else : ?>
-			<p><?php _e( 'New version available.' ); ?></p>
-		<?php endif; ?>
+	<?php if ( $theme['hasUpdate'] || isset( $theme['preferredChildName'] ) ) : ?>
+		<div class="notices">
+			<?php if ( $theme['hasUpdate'] ) : ?>
+				<div class="update-message notice inline notice-warning notice-alt">
+				<?php if ( $theme['hasPackage'] ) : ?>
+					<p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p>
+				<?php else : ?>
+					<p><?php _e( 'New version available.' ); ?></p>
+				<?php endif; ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
+				<div class="notice inline notice-info notice-alt"><p><?php printf(
+					/* translators: ClassicPress child theme name */
+					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+					$theme['preferredChildName']
+				); ?></p></div>
+			<?php } ?>
 		</div>
 	<?php endif; ?>
-
-	<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
-		<div class="notice inline notice-info notice-alt"><p><?php printf(
-			/* translators: ClassicPress child theme name */
-			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-			$theme['preferredChildName']
-		); ?></p></div>
-	<?php } ?>
 
 	<span class="more-details" id="<?php echo $aria_action; ?>"><?php _e( 'Theme Details' ); ?></span>
 	<div class="theme-author"><?php printf( __( 'By %s' ), $theme['author'] ); ?></div>
@@ -399,21 +403,24 @@ $can_install = current_user_can( 'install_themes' );
 	<# } else { #>
 		<div class="theme-screenshot blank"></div>
 	<# } #>
+	<# if ( data.hasUpdate || data.preferredChildName ) { #>
+		<div class="notices">
+			<# if ( data.hasUpdate ) { #>
+				<# if ( data.hasPackage ) { #>
+					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p></div>
+				<# } else { #>
+					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
+				<# } #>
+			<# } #>
 
-	<# if ( data.hasUpdate ) { #>
-		<# if ( data.hasPackage ) { #>
-			<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p></div>
-		<# } else { #>
-			<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
-		<# } #>
-	<# } #>
-
-	<# if ( data.preferredChildName ) { #>
-		<div class="notice inline notice-info notice-alt"><p><?php printf(
-			/* translators: ClassicPress child theme name */
-			'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-			'{{ data.preferredChildName }}'
-		); ?></p></div>
+			<# if ( data.preferredChildName ) { #>
+				<div class="notice inline notice-info notice-alt"><p><?php printf(
+					/* translators: ClassicPress child theme name */
+					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+					'{{ data.preferredChildName }}'
+				); ?></p></div>
+			<# } #>
+		</div>
 	<# } #>
 
 	<span class="more-details" id="{{ data.id }}-action"><?php _e( 'Theme Details' ); ?></span>

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -265,7 +265,7 @@ foreach ( $themes as $theme ) :
 			<?php if ( $theme['hasUpdate'] ) : ?>
 				<div class="update-message notice inline notice-warning notice-alt">
 				<?php if ( $theme['hasPackage'] ) : ?>
-					<p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p>
+					<p><?php _e( '<span class="cut">New version available. </span><button class="button-link" type="button">Update now</button>' ); ?></p>
 				<?php else : ?>
 					<p><?php _e( 'New version available.' ); ?></p>
 				<?php endif; ?>
@@ -275,7 +275,7 @@ foreach ( $themes as $theme ) :
 			<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 					/* translators: ClassicPress child theme name */
-					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+					__( 'Use the "%s" child theme instead!<span class="cut"> This is a parent theme that says "Powered by WordPress" in its footer.</span>' ),
 					$theme['preferredChildName']
 				); ?></p></div>
 			<?php } ?>
@@ -407,7 +407,7 @@ $can_install = current_user_can( 'install_themes' );
 		<div class="notices">
 			<# if ( data.hasUpdate ) { #>
 				<# if ( data.hasPackage ) { #>
-					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available. <button class="button-link" type="button">Update now</button>' ); ?></p></div>
+					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( '<span class="cut">New version available. </span><button class="button-link" type="button">Update now</button>' ); ?></p></div>
 				<# } else { #>
 					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
 				<# } #>
@@ -416,7 +416,7 @@ $can_install = current_user_can( 'install_themes' );
 			<# if ( data.preferredChildName ) { #>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 					/* translators: ClassicPress child theme name */
-					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
+					__( 'Use the "%s" child theme instead!<span class="cut"> This is a parent theme that says "Powered by WordPress" in its footer.</span>' ),
 					'{{ data.preferredChildName }}'
 				); ?></p></div>
 			<# } #>

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -432,7 +432,7 @@ $can_install = current_user_can( 'install_themes' );
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 						/* translators: %s: ClassicPress child theme name */
 						__('Use the "%s" child theme instead!'),
-						'{{ data.theme.preferredChildName }}'
+						'{{ data.preferredChildName }}'
 					); ?>
 					<span class="cut"><?php
 						/* translators: Advanced part of the notice text, hidden on mobiles */

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -266,9 +266,11 @@ foreach ( $themes as $theme ) :
 				<div class="update-message notice inline notice-warning notice-alt">
 				<?php if ( $theme['hasPackage'] ) : ?>
 					<p><?php
-							/* translators: Notice text */ _e('New version available.');
+						/* translators: Update notice text */
+						_e( 'New version available.' );
 						?> <button class="button-link update-theme" type="button"><?php
-							/* translators: Button text */ _e('Update now');
+							/* translators: Button text */
+							_e( 'Update now' );
 						?></button>
 					</p>
 				<?php else : ?>
@@ -280,12 +282,12 @@ foreach ( $themes as $theme ) :
 			<?php if ( isset( $theme['preferredChildName'] ) ) { ?>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 						/* translators: %s: ClassicPress child theme name */
-						__('Use the "%s" child theme instead!'),
+						__( 'Use the "%s" child theme instead!' ),
 						$theme['preferredChildName']
 					); ?>
 					<span class="cut"><?php
-						/* translators: Advanced part of the notice text, hidden on mobiles */
-						_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+						/* translators: Advanced part of the ClassicPress child theme notice text, hidden on mobiles */
+						_e( 'This is a parent theme that says "Powered by WordPress" in its footer.' );
 					?></span>
 				</p></div>
 			<?php } ?>
@@ -417,12 +419,16 @@ $can_install = current_user_can( 'install_themes' );
 		<div class="notices">
 			<# if ( data.hasUpdate ) { #>
 				<# if ( data.hasPackage ) { #>
-					<div class="update-message notice inline notice-warning notice-alt"><p><?php
-							/* translators: Notice text */ _e('New version available.');
-						?> <button class="button-link update-theme" type="button"><?php
-							/* translators: Button text */ _e('Update now');
-						?></button>
-					</p></div>
+					<div class="update-message notice inline notice-warning notice-alt">
+						<p><?php
+							/* translators: Notice text */
+							_e( 'New version available.' );
+							?> <button class="button-link update-theme" type="button"><?php
+								/* translators: Button text */
+								_e( 'Update now' );
+							?></button>
+						</p>
+					</div>
 				<# } else { #>
 					<div class="update-message notice inline notice-warning notice-alt"><p><?php _e( 'New version available.' ); ?></p></div>
 				<# } #>
@@ -431,12 +437,12 @@ $can_install = current_user_can( 'install_themes' );
 			<# if ( data.preferredChildName ) { #>
 				<div class="notice inline notice-info notice-alt"><p><?php printf(
 						/* translators: %s: ClassicPress child theme name */
-						__('Use the "%s" child theme instead!'),
+						__( 'Use the "%s" child theme instead!' ),
 						'{{ data.preferredChildName }}'
 					); ?>
 					<span class="cut"><?php
-						/* translators: Advanced part of the notice text, hidden on mobiles */
-						_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+						/* translators: Advanced part of the ClassicPress child theme notice text, hidden on mobiles */
+						_e( 'This is a parent theme that says "Powered by WordPress" in its footer.' );
 					?></span>
 				</p></div>
 			<# } #>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -92,21 +92,25 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<div class="notices">
 					<# if ( 'installed' === data.theme.type && data.theme.hasUpdate ) { #>
 						<div class="update-message notice inline notice-warning notice-alt" data-slug="{{ data.theme.id }}">
-							<p>
-								<?php
-								/* translators: %s: "Update now" button */
-								printf( __( 'New version available. %s' ), '<button class="button-link update-theme" type="button">' . __( 'Update now' ) . '</button>' );
-								?>
+							<p><?php /* translators: Notice text */ _e('New version available.');
+								?> <button class="button-link update-theme" type="button"><?php
+									/* translators: Button text */ _e('Update now');
+								?></button>
 							</p>
 						</div>
 					<# } #>
 
 					<# if ( data.theme.preferredChildName ) { #>
 						<div class="notice inline notice-info notice-alt"><p><?php printf(
-							/* translators: ClassicPress child theme name */
-							__( 'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.' ),
-							'{{ data.theme.preferredChildName }}'
-						); ?></p></div>
+								/* translators: %s: ClassicPress child theme name */
+								__('Use the "%s" child theme instead!'),
+								'{{ data.theme.preferredChildName }}'
+							); ?>
+							<span class="cut"><?php
+								/* translators: Advanced part of the notice text, hidden on mobiles */
+								_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+							?></span>
+						</p></div>
 					<# } #>
 				</div>
 			<# } #>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -87,14 +87,19 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				printf( _x( 'By %s', 'theme author' ), '{{ data.theme.author }}' );
 			?></div>
 
-			<# if ( ('installed' === data.theme.type && data.theme.hasUpdate) ||
-					data.theme.preferredChildName ) { #>
+			<# if (
+				( 'installed' === data.theme.type && data.theme.hasUpdate ) ||
+				data.theme.preferredChildName
+			) { #>
 				<div class="notices">
 					<# if ( 'installed' === data.theme.type && data.theme.hasUpdate ) { #>
 						<div class="update-message notice inline notice-warning notice-alt" data-slug="{{ data.theme.id }}">
-							<p><?php /* translators: Notice text */ _e('New version available.');
+							<p><?php
+								/* translators: Notice text */
+								_e( 'New version available.' );
 								?> <button class="button-link update-theme" type="button"><?php
-									/* translators: Button text */ _e('Update now');
+									/* translators: Button text */
+									_e( 'Update now' );
 								?></button>
 							</p>
 						</div>
@@ -103,12 +108,12 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 					<# if ( data.theme.preferredChildName ) { #>
 						<div class="notice inline notice-info notice-alt"><p><?php printf(
 								/* translators: %s: ClassicPress child theme name */
-								__('Use the "%s" child theme instead!'),
+								__( 'Use the "%s" child theme instead!' ),
 								'{{ data.theme.preferredChildName }}'
 							); ?>
 							<span class="cut"><?php
-								/* translators: Advanced part of the notice text, hidden on mobiles */
-								_e('This is a parent theme that says "Powered by WordPress" in its footer.');
+								/* translators: Advanced part of the ClassicPress child theme notice text, hidden on mobiles */
+								_e( 'This is a parent theme that says "Powered by WordPress" in its footer.' );
 							?></span>
 						</p></div>
 					<# } #>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -87,23 +87,28 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				printf( _x( 'By %s', 'theme author' ), '{{ data.theme.author }}' );
 			?></div>
 
-			<# if ( 'installed' === data.theme.type && data.theme.hasUpdate ) { #>
-				<div class="update-message notice inline notice-warning notice-alt" data-slug="{{ data.theme.id }}">
-					<p>
-						<?php
-						/* translators: %s: "Update now" button */
-						printf( __( 'New version available. %s' ), '<button class="button-link update-theme" type="button">' . __( 'Update now' ) . '</button>' );
-						?>
-					</p>
-				</div>
-			<# } #>
+			<# if ( ('installed' === data.theme.type && data.theme.hasUpdate) ||
+					data.theme.preferredChildName ) { #>
+				<div class="notices">
+					<# if ( 'installed' === data.theme.type && data.theme.hasUpdate ) { #>
+						<div class="update-message notice inline notice-warning notice-alt" data-slug="{{ data.theme.id }}">
+							<p>
+								<?php
+								/* translators: %s: "Update now" button */
+								printf( __( 'New version available. %s' ), '<button class="button-link update-theme" type="button">' . __( 'Update now' ) . '</button>' );
+								?>
+							</p>
+						</div>
+					<# } #>
 
-			<# if ( data.theme.preferredChildName ) { #>
-				<div class="notice inline notice-info notice-alt"><p><?php printf(
-					/* translators: ClassicPress child theme name */
-					'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.',
-					'{{ data.theme.preferredChildName }}'
-				); ?></p></div>
+					<# if ( data.theme.preferredChildName ) { #>
+						<div class="notice inline notice-info notice-alt"><p><?php printf(
+							/* translators: ClassicPress child theme name */
+							__( 'Use the "%s" child theme instead! This is a parent theme that says "Powered by WordPress" in its footer.' ),
+							'{{ data.theme.preferredChildName }}'
+						); ?></p></div>
+					<# } #>
+				</div>
 			<# } #>
 
 			<# if ( data.theme.active ) { #>


### PR DESCRIPTION
## Description
1. Wrapped notices with a common "div.notices". Notices now have responsive height and no top margin. External positioning is provided by a wrapper. (According to discussion: https://github.com/ClassicPress/ClassicPress/issues/414#issuecomment-505707842)
2. Wrapped secondary parts of related long messages to hide them on mobile (native breakpoint is 1120px).
3. Added __() to some strings that had no internalization. 

## Motivation and context
Issue, help wanted: https://github.com/ClassicPress/ClassicPress/issues/414
Proposal: https://github.com/ClassicPress/ClassicPress/issues/414#issuecomment-506892952

## How has this been tested?
Visually tested changes in Chrome and Firefox. First at full witdh then decreasing viewport to activate breakpoint. Tested in English and Russian locales + adding hypothetical additional length

## Screenshots (if appropriate):
Desktop, FF:
![image](https://user-images.githubusercontent.com/24218656/60387325-9020ed80-9aa1-11e9-87db-59bdd21f3402.png)
Mobile, Chrome:
![image](https://user-images.githubusercontent.com/24218656/60387333-bc3c6e80-9aa1-11e9-8529-b9bd0e7f4600.png)
Mobile, FF:
![image](https://user-images.githubusercontent.com/24218656/60387344-dbd39700-9aa1-11e9-8b26-143fd3fa5bea.png)

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
