### PR TITLE
Fix for issue #404 (https://github.com/ClassicPress/ClassicPress/issu…

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2583,7 +2583,7 @@ function _navigation_markup( $links, $class = 'posts-navigation', $screen_reader
 	}
 
 	$template = '
-	<nav class="navigation %1$s" role="navigation">
+	<nav class="navigation %1$s">
 		<h2 class="screen-reader-text">%2$s</h2>
 		<div class="nav-links">%3$s</div>
 	</nav>';


### PR DESCRIPTION
Removed "role" tag for valid HTML5 markup

## Description

Removed "role" tag for valid HTML5 markup, this changed was made in the file ./wp-includes/link-template.php at line 2586 

## Motivation and context

It's a fix for issue #404 

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
