### PR TITLE
Add a setting to limit the number of revisions stored in the database

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -109,6 +109,39 @@ do_settings_fields('writing', 'remote_publishing'); // A deprecated section.
 ?>
 </table>
 
+
+<h2 class="title"><?php _e( 'Revisions' ); ?></h2>
+<?php
+	$rev_hardcoded = cp_is_revisions_option_hardcoded();
+	$rev_num = cp_get_revisions_limit();
+	$rev_attr = $rev_hardcoded ? 'disabled="disabled"' : '';
+?>
+<table class="form-table">
+<tr>
+<th scope="row"><label for="revisions_to_keep"><?php _e('Revisions to keep') ?></label></th>
+<td>
+	<input name="revisions_to_keep"
+		id="revisions_to_keep"
+		value="<?php echo $rev_num; ?>"
+		type="number"
+		step="1"
+		min="-1"
+		class="small-text"
+		<?php echo $rev_attr; ?>
+	/><br />
+	<?php if ( $rev_hardcoded ): ?>
+		<p><?php _e( 'This value is now <strong>hardcoded</strong> in your configuration files. You can remove <strong>WP_POST_REVISIONS</strong> constant definition to enable the field and manage revisions limit right here.' ); ?></p>
+	<?php else: ?>
+	<label for="revisions_to_keep">
+		<kbd>-1</kbd>: <?php _e( 'Store every revision (can bloat the database size).'); ?><br />
+		<kbd>0</kbd>: <?php _e( 'Do not store any revisions (except 1 autosave).'); ?><br />
+		<kbd>&gt; 0</kbd>: <?php _e('Store that many revisions per post (+1 autosave). Old revisions are automatically deleted.'); ?>
+	</label>
+	<?php endif; ?>
+</td>
+</tr>
+</table>
+
 <?php
 /** This filter is documented in wp-admin/options.php */
 if ( apply_filters( 'enable_post_by_email_configuration', true ) ) {

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -144,6 +144,7 @@ $whitelist_options = array(
 		'default_email_category',
 		'default_link_category',
 		'default_post_format',
+		'revisions_to_keep',
 	),
 );
 $whitelist_options['misc'] = $whitelist_options['options'] = $whitelist_options['privacy'] = array();

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4109,6 +4109,10 @@ function sanitize_option( $option, $value ) {
 			$value = absint( $value );
 			break;
 
+		case 'revisions_to_keep':
+			$value = intval( $value );
+			break;
+
 		case 'posts_per_page':
 		case 'posts_per_rss':
 			$value = (int) $value;


### PR DESCRIPTION
## Description
1. Added an input field (type number) to admin page Settings->Writing. Added it to the options whitelist and sanitization in formatting.php.
2. Added a new constant `CP_REVISIONS_OPTION_DISABLE` which is true when WP_POST_REVISIONS is manually defined in wp-config.php and false otherwise. This check fires on hook `'plugins_loaded'` in order to determine if WP_POST_REVISIONS was defined before `default-constants.php` overwrites it.
3. Modified function `wp_revisions_to_keep( $post )` to make it consider new setting. Moved a piece of its logic to a new function `cp_get_revisions_limit()` which swtiches between option and constant values. Changes are not breaking (I suggest :). 
4. Added some contextual logic when field is displayed. If WP_POST_REVISIONS is defined in wp-config.php this input is disbled and its label explains this behvior in a message. Otherwise input is editable and label describes possible values (-1, 0, positive int).

## Motivation and context
Petition: https://petitions.classicpress.net/posts/185/add-a-setting-to-limit-the-number-of-revisions-stored-in-the-database
See Slack discussion: https://classicpress.slack.com/archives/CCNEEH86P/p1562118425031800

## How has this been tested?
All tests were visual (not familiar with phpunit yet).
1. Edit wp-config.php to change WP_POST_REVISIONS const (states: not defined, true, false, -1, 0, positive integers, random 'evil' string);
2. Open Settings page. Matching: input value, input attribute (disabled/enabled), input range (int, > -1, step 1), proper label text.
3. Click update button. Data saved, sanitized.
4. Open page editor, make several updates, check revisions count.

## Screenshots (if appropriate):

Option enabled (constant is not defined in config; option is undefined yet)

![image](https://user-images.githubusercontent.com/24218656/60571945-c9dd4700-9d74-11e9-880f-25ddcc3e8577.png)

Option enabled (constant is not defined in config; option is updated)

![image](https://user-images.githubusercontent.com/24218656/60572272-8d5e1b00-9d75-11e9-9a6f-d710ef8a87ca.png)

Defined in config (false):

![image](https://user-images.githubusercontent.com/24218656/60571987-e11c3480-9d74-11e9-8d12-d47f4e755132.png)

Defined in config (777):

![image](https://user-images.githubusercontent.com/24218656/60572046-07da6b00-9d75-11e9-8cb4-f3ee7062fa1e.png)

Defined in config (true):

![image](https://user-images.githubusercontent.com/24218656/60572154-496b1600-9d75-11e9-979e-b5875a3cf098.png)

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
