### PR TITLE
fix #445 - Update tweemoji url in gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -729,7 +729,7 @@ module.exports = function(grunt) {
 								grunt.log.writeln( 'Fetching list of Twemoji files...' );
 
 								// Fetch a list of the files that Twemoji supplies
-								files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji.git/branches/gh-pages/2/svg' ] );
+								files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji/branches/gh-pages/2/svg' ] );
 								if ( 0 !== files.status ) {
 									grunt.fatal( 'Unable to fetch Twemoji file list' );
 								}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -737,7 +737,7 @@ module.exports = function(grunt) {
 								entities = files.stdout.toString();
 
 								// Tidy up the file list
-								entities = entities.replace( /\.ai/g, '' );
+								entities = entities.replace( /\.svg/g, '' );
 								entities = entities.replace( /^$/g, '' );
 
 								// Convert the emoji entities to HTML entities

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -729,7 +729,7 @@ module.exports = function(grunt) {
 								grunt.log.writeln( 'Fetching list of Twemoji files...' );
 
 								// Fetch a list of the files that Twemoji supplies
-								files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji.git/branches/gh-pages/2/assets' ] );
+								files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji.git/branches/gh-pages/2/svg' ] );
 								if ( 0 !== files.status ) {
 									grunt.fatal( 'Unable to fetch Twemoji file list' );
 								}


### PR DESCRIPTION
## Description
Fix #445

## Motivation and context
The url is in 404 because the project changed the way how to manage assets

## How has this been tested?
Locally the grunt task is not getting any issue anymore. Require further testing to see if the there are other errors.

## Screenshots (if appropriate):
![Screenshot_20190711_124143](https://user-images.githubusercontent.com/403283/61044608-4ad1b980-a3d9-11e9-9f90-673508941f9a.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

