### PR TITLE
Add classes to H2 tags in user-edit.php

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -266,15 +266,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-      "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "agent-base": {
@@ -11183,14 +11177,14 @@
       }
     },
     "terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.0.2.tgz",
-      "integrity": "sha512-IWLuJqTvx97KP3uTYkFVn93cXO+EtlzJu8TdJylq+H0VBDlPMIfQA9MBS5Vc5t3xTEUG1q0hIfHMpAP2R+gWTw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.1.2.tgz",
+      "integrity": "sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       },
       "dependencies": {
         "commander": {
@@ -11868,17 +11862,16 @@
       }
     },
     "webpack": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.2.tgz",
-      "integrity": "sha512-TZAmorNymV4q66gAM/h90cEjG+N3627Q2MnkSgKlX/z3DlNVKUtqy57lz1WmZU2+FUZwzM+qm7cGaO95PyrX5A==",
+      "version": "4.35.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.35.3.tgz",
+      "integrity": "sha512-xggQPwr9ILlXzz61lHzjvgoqGU08v5+Wnut19Uv3GaTtzN4xBTcwnobodrXE142EL1tOiS5WVEButooGzcQzTA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
         "@webassemblyjs/wasm-edit": "1.8.5",
         "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.0.5",
-        "acorn-dynamic-import": "^4.0.0",
+        "acorn": "^6.2.0",
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0",
         "chrome-trace-event": "^1.0.0",
@@ -11900,9 +11893,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+          "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ink-docstrap": "1.3.2",
     "matchdep": "2.0.0",
     "uglify-js": "3.4.8",
-    "webpack": "4.35.2",
+    "webpack": "4.35.3",
     "webpack-dev-server": "3.7.2"
   },
   "dependencies": {


### PR DESCRIPTION
Adds classes to the &lt;h2&gt; tags on the profile editing page so they can be more carefully targeted with CSS selectors. Fixes #440.

## Description
Updated several h2 tags with unique classes.

## Motivation and context
The current h2 tags lack classes which make them difficult to select with CSS unless they are selected wholesale. This is not ideal when you're only trying to remove a section or two. Using nth-child selectors can work in some cases, but, that method quickly degrades if a plugin or theme adds custom sections and skews the element count.

## How has this been tested?
Inspecting the source; visually in a browser.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
