### PR TITLE
Update build scripts

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,11 @@
+# Supported browsers
+> 1%,
+ie >= 11
+last 1 Android versions
+last 1 ChromeAndroid versions
+last 2 Chrome versions
+Firefox >= 60
+last 2 Safari versions
+last 2 iOS versions
+last 2 Edge versions
+last 2 Opera versions

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -738,9 +738,9 @@ module.exports = function(grunt) {
                                 entities = entities.replace( /-/g, '' );
 
                                 // Sort the entities list by length, so the longest emoji will be found first
-								emojiArray = entities.split( '\n' ).sort( ( a, b ) => {
-									return b.length - a.length;
-								} );
+                                emojiArray = entities.split( '\n' ).sort( ( a, b ) => {
+                                    return b.length - a.length;
+                                } );
 
                                 // Convert the entities list to PHP array syntax
                                 entities = `'${emojiArray.filter( val => val.length >= 8 ? val : false ).join( '\', \'' )}'`;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,46 +2,34 @@
 /* jshint es3:false */
 /* jshint esversion:6 */
 /* globals Set */
-var webpackConfig = require( './webpack.config.prod' );
-var webpackDevConfig = require( './webpack.config.dev' );
+const webpackConfig = require( './webpack.config.prod' );
+const webpackDevConfig = require( './webpack.config.dev' );
+const path = require('path');
+
+const spawn = require( 'child_process' ).spawnSync;
+const SOURCE_DIR = 'src/';
+const BUILD_DIR = 'build/';
+const BANNER_TEXT = '/*! This file is auto-generated */';
+const autoprefixer = require( 'autoprefixer' );
 
 module.exports = function(grunt) {
-	var path = require('path'),
-		spawn = require( 'child_process' ).spawnSync,
-		SOURCE_DIR = 'src/',
-		BUILD_DIR = 'build/',
- 		BANNER_TEXT = '/*! This file is auto-generated */',
-		autoprefixer = require( 'autoprefixer' );
-
-	var puppeteerOptions = {};
-	if (process.env.TRAVIS) {
+    const puppeteerOptions = {};
+    if (process.env.TRAVIS) {
 		// Avoid error: Failed to launch chrome! No usable sandbox!
 		puppeteerOptions.args = [ '--no-sandbox' ];
 	}
 
-	// Load tasks.
-	require('matchdep').filterDev(['grunt-*', '!grunt-legacy-util']).forEach( grunt.loadNpmTasks );
-	// Load legacy utils
-	grunt.util = require('grunt-legacy-util');
+    // Load tasks.
+    require('matchdep').filterDev(['grunt-*', '!grunt-legacy-util']).forEach( grunt.loadNpmTasks );
+    // Load legacy utils
+    grunt.util = require('grunt-legacy-util');
 
-	// Project configuration.
-	grunt.initConfig({
+    // Project configuration.
+    grunt.initConfig({
 		postcss: {
 			options: {
 				processors: [
 					autoprefixer({
-						browsers: [
-							'> 1%',
-							'ie >= 11',
-							'last 1 Android versions',
-							'last 1 ChromeAndroid versions',
-							'last 2 Chrome versions',
-							'Firefox >= 60',
-							'last 2 Safari versions',
-							'last 2 iOS versions',
-							'last 2 Edge versions',
-							'last 2 Opera versions'
-						],
 						cascade: false
 					})
 				]
@@ -72,9 +60,9 @@ module.exports = function(grunt) {
 			},
 			files: {
 				src: [
-					BUILD_DIR + 'wp-admin/css/*.min.css',
-					BUILD_DIR + 'wp-includes/css/*.min.css',
-					BUILD_DIR + 'wp-admin/css/colors/*/*.css'
+					`${BUILD_DIR}wp-admin/css/*.min.css`,
+					`${BUILD_DIR}wp-includes/css/*.min.css`,
+					`${BUILD_DIR}wp-admin/css/colors/*/*.css`
 				]
 			}
 		},
@@ -126,33 +114,33 @@ module.exports = function(grunt) {
 			},
 			'wp-admin-css-compat-rtl': {
 				options: {
-					processContent: function( src ) {
+					processContent(src) {
 						return src.replace( /\.css/g, '-rtl.css' );
 					}
 				},
-				src: SOURCE_DIR + 'wp-admin/css/wp-admin.css',
-				dest: BUILD_DIR + 'wp-admin/css/wp-admin-rtl.css'
+				src: `${SOURCE_DIR}wp-admin/css/wp-admin.css`,
+				dest: `${BUILD_DIR}wp-admin/css/wp-admin-rtl.css`
 			},
 			'wp-admin-css-compat-min': {
 				options: {
-					processContent: function( src ) {
+					processContent(src) {
 						return src.replace( /\.css/g, '.min.css' );
 					}
 				},
 				files: [
 					{
-						src: SOURCE_DIR + 'wp-admin/css/wp-admin.css',
-						dest: BUILD_DIR + 'wp-admin/css/wp-admin.min.css'
+						src: `${SOURCE_DIR}wp-admin/css/wp-admin.css`,
+						dest: `${BUILD_DIR}wp-admin/css/wp-admin.min.css`
 					},
 					{
-						src:  BUILD_DIR + 'wp-admin/css/wp-admin-rtl.css',
-						dest: BUILD_DIR + 'wp-admin/css/wp-admin-rtl.min.css'
+						src:  `${BUILD_DIR}wp-admin/css/wp-admin-rtl.css`,
+						dest: `${BUILD_DIR}wp-admin/css/wp-admin-rtl.min.css`
 					}
 				]
 			},
 			'script-loader-impl': {
 				options: {
-					processContent: function( src ) {
+					processContent(src) {
 						return src.replace( /\$default_version = 'cp_' \. .*;/m, () => {
 							const hash = grunt.config.get( 'dev.git-version' );
 							if ( ! hash ) {
@@ -162,17 +150,17 @@ module.exports = function(grunt) {
 								grunt.fatal( 'grunt.config dev.git-version not set' );
 							}
 							/* jshint quotmark: true */
-							return "$default_version = 'cp_" + hash.substr( 0, 8 ) + "';";
+							return `$default_version = 'cp_${hash.substr( 0, 8 )}';`;
 						} );
 					}
 				},
-				src: SOURCE_DIR + 'wp-includes/script-loader.php',
-				dest: BUILD_DIR + 'wp-includes/script-loader.php'
+				src: `${SOURCE_DIR}wp-includes/script-loader.php`,
+				dest: `${BUILD_DIR}wp-includes/script-loader.php`
 			},
 			version: {
 				options: {
-					processContent: function( src ) {
-						return src.replace( /^\$cp_version = '(.+?)';/m, function( str, version ) {
+					processContent(src) {
+						return src.replace( /^\$cp_version = '(.+?)';/m, (str, version) => {
 							if ( process.env.CLASSICPRESS_RELEASE ) {
 								// This is an official build that will receive auto-updates to newer
 								// official builds.  Remove the '+dev' suffix from the source tree.
@@ -182,28 +170,28 @@ module.exports = function(grunt) {
 								// to newer official nightly builds.  Replace the '+dev' suffix from
 								// the source tree with e.g.  '+nightly.20181019'.  Use yesterday's
 								// date - nightly builds are baked at midnight UTC.
-								var d = new Date();
+								const d = new Date();
 								d.setDate( d.getDate() - 1 );
 								version = version.replace(
 									/\+dev$/,
-									'+nightly.' + grunt.template.date( d, 'yyyymmdd' )
+									`+nightly.${grunt.template.date( d, 'yyyymmdd' )}`
 								);
 							} else {
 								// This is another type of build, probably someone generating one
 								// for their own purposes.  Use e.g. '+build.20181020'.
 								version = version.replace(
 									/\+dev$/,
-									'+build.' + grunt.template.today( 'yyyymmdd' )
+									`+build.${grunt.template.today( 'yyyymmdd' )}`
 								);
 							}
 
 							/* jshint quotmark: true */
-							return "$cp_version = '" + version + "';";
+							return `$cp_version = '${version}';`;
 						});
 					}
 				},
-				src: SOURCE_DIR + 'wp-includes/version.php',
-				dest: BUILD_DIR + 'wp-includes/version.php'
+				src: `${SOURCE_DIR}wp-includes/version.php`,
+				dest: `${BUILD_DIR}wp-includes/version.php`
 			},
 			dynamic: {
 				dot: true,
@@ -216,11 +204,9 @@ module.exports = function(grunt) {
 				src: 'tests/qunit/index.html',
 				dest: 'tests/qunit/compiled.html',
 				options: {
-					processContent: function( src ) {
-						return src.replace( /(\".+?\/)src(\/.+?)(?:.min)?(.js\")/g , function( match, $1, $2, $3 ) {
-							// Don't add `.min` to files that don't have it.
-							return $1 + 'build' + $2 + ( /jquery$/.test( $2 ) ? '' : '.min' ) + $3;
-						} );
+					processContent(src) {
+						return src.replace( /(\".+?\/)src(\/.+?)(?:.min)?(.js\")/g , (match, $1, $2, $3) => // Don't add `.min` to files that don't have it.
+                        `${$1}build${$2}${/jquery$/.test( $2 ) ? '' : '.min'}${$3}` );
 					}
 				}
 			}
@@ -307,7 +293,7 @@ module.exports = function(grunt) {
 						processors: [
 							{
 								expr: /content/im,
-								action: function( prop, value ) {
+								action(prop, value) {
 									if ( value === '"\\f141"' ) { // dashicons-arrow-left
 										value = '"\\f139"';
 									} else if ( value === '"\\f340"' ) { // dashicons-arrow-left-alt
@@ -321,7 +307,7 @@ module.exports = function(grunt) {
 									} else if ( value === '"\\f345"' ) { // dashicons-arrow-right-alt2
 										value = '"\\f341"';
 									}
-									return { prop: prop, value: value };
+									return { prop, value };
 								}
 							}
 						]
@@ -375,7 +361,7 @@ module.exports = function(grunt) {
 			},
 			themes: {
 				expand: true,
-				cwd: SOURCE_DIR + 'wp-content/themes',
+				cwd: `${SOURCE_DIR}wp-content/themes`,
 				src: [
 					'twenty*/**/*.js',
 					'!twenty{eleven,twelve,thirteen}/**',
@@ -387,7 +373,7 @@ module.exports = function(grunt) {
 			},
 			media: {
 				src: [
-					SOURCE_DIR + 'wp-includes/js/media/**/*.js'
+					`${SOURCE_DIR}wp-includes/js/media/**/*.js`
 				]
 			},
 			core: {
@@ -433,29 +419,30 @@ module.exports = function(grunt) {
 				//
 				//    grunt jshint:core --file=path/to/filename.js
 				//
-				filter: function( filepath ) {
-					var index, file = grunt.option( 'file' );
+				filter(filepath) {
+                    let index;
+                    const file = grunt.option( 'file' );
 
-					// Don't filter when no target file is specified
-					if ( ! file ) {
+                    // Don't filter when no target file is specified
+                    if ( ! file ) {
 						return true;
 					}
 
-					// Normalize filepath for Windows
-					filepath = filepath.replace( /\\/g, '/' );
-					index = filepath.lastIndexOf( '/' + file );
+                    // Normalize filepath for Windows
+                    filepath = filepath.replace( /\\/g, '/' );
+                    index = filepath.lastIndexOf( `/${file}` );
 
-					// Match only the filename passed from cli
-					if ( filepath === file || ( -1 !== index && index === filepath.length - ( file.length + 1 ) ) ) {
+                    // Match only the filename passed from cli
+                    if ( filepath === file || ( -1 !== index && index === filepath.length - ( file.length + 1 ) ) ) {
 						return true;
 					}
 
-					return false;
-				}
+                    return false;
+                }
 			},
 			plugins: {
 				expand: true,
-				cwd: SOURCE_DIR + 'wp-content/plugins',
+				cwd: `${SOURCE_DIR}wp-content/plugins`,
 				src: [
 					'**/*.js',
 					'!**/*.min.js'
@@ -464,24 +451,25 @@ module.exports = function(grunt) {
 				//
 				//    grunt jshint:plugins --dir=foldername
 				//
-				filter: function( dirpath ) {
-					var index, dir = grunt.option( 'dir' );
+				filter(dirpath) {
+                    let index;
+                    const dir = grunt.option( 'dir' );
 
-					// Don't filter when no target folder is specified
-					if ( ! dir ) {
+                    // Don't filter when no target folder is specified
+                    if ( ! dir ) {
 						return true;
 					}
 
-					dirpath = dirpath.replace( /\\/g, '/' );
-					index = dirpath.lastIndexOf( '/' + dir );
+                    dirpath = dirpath.replace( /\\/g, '/' );
+                    index = dirpath.lastIndexOf( `/${dir}` );
 
-					// Match only the folder name passed from cli
-					if ( -1 !== index ) {
+                    // Match only the folder name passed from cli
+                    if ( -1 !== index ) {
 						return true;
 					}
 
-					return false;
-				}
+                    return false;
+                }
 			}
 		},
 		jsdoc : {
@@ -508,9 +496,9 @@ module.exports = function(grunt) {
 				options: {
 					port: 8008,
 					base: '.',
-					middleware: function( connect, options, middlewares ) {
-						middlewares.unshift( function( req, res, next ) {
-							if (req.method === 'POST') { // admin-ajax.php
+					middleware(connect, options, middlewares) {
+						middlewares.unshift( ({method}, res, next) => {
+							if (method === 'POST') { // admin-ajax.php
 								// The 'connect' web server will return HTTP
 								// 405 (Method Not Allowed) here.
 								return res.end('');
@@ -628,12 +616,12 @@ module.exports = function(grunt) {
 					// Preserve comments that start with a bang.
 					preserveComments: /^!/
 				},
-				src: SOURCE_DIR + 'wp-includes/js/jquery/jquery.masonry.js',
-				dest: SOURCE_DIR + 'wp-includes/js/jquery/jquery.masonry.min.js'
+				src: `${SOURCE_DIR}wp-includes/js/jquery/jquery.masonry.js`,
+				dest: `${SOURCE_DIR}wp-includes/js/jquery/jquery.masonry.min.js`
 			},
 			imgareaselect: {
-				src: SOURCE_DIR + 'wp-includes/js/imgareaselect/jquery.imgareaselect.js',
-				dest: SOURCE_DIR + 'wp-includes/js/imgareaselect/jquery.imgareaselect.min.js'
+				src: `${SOURCE_DIR}wp-includes/js/imgareaselect/jquery.imgareaselect.js`,
+				dest: `${SOURCE_DIR}wp-includes/js/imgareaselect/jquery.imgareaselect.min.js`
 			}
 		},
 		webpack: {
@@ -644,29 +632,29 @@ module.exports = function(grunt) {
 			tinymce: {
 				options: {
 					separator: '\n',
-					process: function( src, filepath ) {
-						return '// Source: ' + filepath.replace( BUILD_DIR, '' ) + '\n' + src;
+					process(src, filepath) {
+						return `// Source: ${filepath.replace( BUILD_DIR, '' )}\n${src}`;
 					}
 				},
 				src: [
-					BUILD_DIR + 'wp-includes/js/tinymce/tinymce.min.js',
-					BUILD_DIR + 'wp-includes/js/tinymce/themes/modern/theme.min.js',
-					BUILD_DIR + 'wp-includes/js/tinymce/plugins/*/plugin.min.js'
+					`${BUILD_DIR}wp-includes/js/tinymce/tinymce.min.js`,
+					`${BUILD_DIR}wp-includes/js/tinymce/themes/modern/theme.min.js`,
+					`${BUILD_DIR}wp-includes/js/tinymce/plugins/*/plugin.min.js`
 				],
-				dest: BUILD_DIR + 'wp-includes/js/tinymce/wp-tinymce.js'
+				dest: `${BUILD_DIR}wp-includes/js/tinymce/wp-tinymce.js`
 			},
 			emoji: {
 				options: {
 					separator: '\n',
-					process: function( src, filepath ) {
-						return '// Source: ' + filepath.replace( BUILD_DIR, '' ) + '\n' + src;
+					process(src, filepath) {
+						return `// Source: ${filepath.replace( BUILD_DIR, '' )}\n${src}`;
 					}
 				},
 				src: [
-					BUILD_DIR + 'wp-includes/js/twemoji.min.js',
-					BUILD_DIR + 'wp-includes/js/wp-emoji.min.js'
+					`${BUILD_DIR}wp-includes/js/twemoji.min.js`,
+					`${BUILD_DIR}wp-includes/js/wp-emoji.min.js`
 				],
-				dest: BUILD_DIR + 'wp-includes/js/wp-emoji-release.min.js'
+				dest: `${BUILD_DIR}wp-includes/js/wp-emoji-release.min.js`
 			}
 		},
 		compress: {
@@ -676,7 +664,7 @@ module.exports = function(grunt) {
 					level: 9
 				},
 				src: '<%= concat.tinymce.dest %>',
-				dest: BUILD_DIR + 'wp-includes/js/tinymce/wp-tinymce.js.gz'
+				dest: `${BUILD_DIR}wp-includes/js/tinymce/wp-tinymce.js.gz`
 			}
 		},
 		jsvalidate:{
@@ -688,8 +676,8 @@ module.exports = function(grunt) {
 			build: {
 				files: {
 					src: [
-						BUILD_DIR + 'wp-{admin,includes}/**/*.js',
-						BUILD_DIR + 'wp-content/themes/twenty*/**/*.js'
+						`${BUILD_DIR}wp-{admin,includes}/**/*.js`,
+						`${BUILD_DIR}wp-content/themes/twenty*/**/*.js`
 					]
 				}
 			}
@@ -707,11 +695,11 @@ module.exports = function(grunt) {
 		},
 		includes: {
 			emoji: {
-				src: BUILD_DIR + 'wp-includes/formatting.php',
+				src: `${BUILD_DIR}wp-includes/formatting.php`,
 				dest: '.'
 			},
 			embed: {
-				src: BUILD_DIR + 'wp-includes/embed.php',
+				src: `${BUILD_DIR}wp-includes/embed.php`,
 				dest: '.'
 			}
 		},
@@ -721,59 +709,56 @@ module.exports = function(grunt) {
 					patterns: [
 						{
 							match: /\/\/ START: emoji arrays[\S\s]*\/\/ END: emoji arrays/g,
-							replacement: function () {
-								var regex, files,
-									partials, partialsSet,
-									entities, emojiArray;
+							replacement() {
+                                let regex;
+                                let files;
+                                let partials;
+                                let partialsSet;
+                                let entities;
+                                let emojiArray;
 
-								grunt.log.writeln( 'Fetching list of Twemoji files...' );
+                                grunt.log.writeln( 'Fetching list of Twemoji files...' );
 
-								// Fetch a list of the files that Twemoji supplies
-								files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji/branches/gh-pages/2/svg' ] );
-								if ( 0 !== files.status ) {
+                                // Fetch a list of the files that Twemoji supplies
+                                files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji/branches/gh-pages/2/svg' ] );
+                                if ( 0 !== files.status ) {
 									grunt.fatal( 'Unable to fetch Twemoji file list' );
 								}
 
-								entities = files.stdout.toString();
+                                entities = files.stdout.toString();
 
-								// Tidy up the file list
-								entities = entities.replace( /\.svg/g, '' );
-								entities = entities.replace( /^$/g, '' );
+                                // Tidy up the file list
+                                entities = entities.replace( /\.svg/g, '' );
+                                entities = entities.replace( /^$/g, '' );
 
-								// Convert the emoji entities to HTML entities
-								partials = entities = entities.replace( /([a-z0-9]+)/g, '&#x$1;' );
+                                // Convert the emoji entities to HTML entities
+                                partials = entities = entities.replace( /([a-z0-9]+)/g, '&#x$1;' );
 
-								// Remove the hyphens between the HTML entities
-								entities = entities.replace( /-/g, '' );
+                                // Remove the hyphens between the HTML entities
+                                entities = entities.replace( /-/g, '' );
 
-								// Sort the entities list by length, so the longest emoji will be found first
-								emojiArray = entities.split( '\n' ).sort( function ( a, b ) {
-									return b.length - a.length;
-								} );
+                                // Sort the entities list by length, so the longest emoji will be found first
+                                emojiArray = entities.split( '\n' ).sort( ({length}, {length}) => length - length );
 
-								// Convert the entities list to PHP array syntax
-								entities = '\'' + emojiArray.filter( function( val ) {
-									return val.length >= 8 ? val : false ;
-								} ).join( '\', \'' ) + '\'';
+                                // Convert the entities list to PHP array syntax
+                                entities = `'${emojiArray.filter( val => val.length >= 8 ? val : false ).join( '\', \'' )}'`;
 
-								// Create a list of all characters used by the emoji list
-								partials = partials.replace( /-/g, '\n' );
+                                // Create a list of all characters used by the emoji list
+                                partials = partials.replace( /-/g, '\n' );
 
-								// Set automatically removes duplicates
-								partialsSet = new Set( partials.split( '\n' ) );
+                                // Set automatically removes duplicates
+                                partialsSet = new Set( partials.split( '\n' ) );
 
-								// Convert the partials list to PHP array syntax
-								partials = '\'' + Array.from( partialsSet ).filter( function( val ) {
-									return val.length >= 8 ? val : false ;
-								} ).join( '\', \'' ) + '\'';
+                                // Convert the partials list to PHP array syntax
+                                partials = `'${Array.from( partialsSet ).filter( val => val.length >= 8 ? val : false ).join( '\', \'' )}'`;
 
-								regex = '// START: emoji arrays\n';
-								regex += '\t$entities = array( ' + entities + ' );\n';
-								regex += '\t$partials = array( ' + partials + ' );\n';
-								regex += '\t// END: emoji arrays';
+                                regex = '// START: emoji arrays\n';
+                                regex += `\t$entities = array( ${entities} );\n`;
+                                regex += `\t$partials = array( ${partials} );\n`;
+                                regex += '\t// END: emoji arrays';
 
-								return regex;
-							}
+                                return regex;
+                            }
 						}
 					]
 				},
@@ -782,9 +767,9 @@ module.exports = function(grunt) {
 						expand: true,
 						flatten: true,
 						src: [
-							SOURCE_DIR + 'wp-includes/formatting.php'
+							`${SOURCE_DIR}wp-includes/formatting.php`
 						],
-						dest: SOURCE_DIR + 'wp-includes/'
+						dest: `${SOURCE_DIR}wp-includes/`
 					}
 				]
 			}
@@ -792,10 +777,10 @@ module.exports = function(grunt) {
 		_watch: {
 			all: {
 				files: [
-					SOURCE_DIR + '**',
-					'!' + SOURCE_DIR + 'wp-includes/js/media/**',
+					`${SOURCE_DIR}**`,
+					`!${SOURCE_DIR}wp-includes/js/media/**`,
 					// Ignore version control directories.
-					'!' + SOURCE_DIR + '**/.{svn,git}/**'
+					`!${SOURCE_DIR}**/.{svn,git}/**`
 				],
 				tasks: ['clean:dynamic', 'copy:dynamic'],
 				options: {
@@ -812,13 +797,13 @@ module.exports = function(grunt) {
 				]
 			},
 			colors: {
-				files: [SOURCE_DIR + 'wp-admin/css/colors/**'],
+				files: [`${SOURCE_DIR}wp-admin/css/colors/**`],
 				tasks: ['sass:colors']
 			},
 			rtl: {
 				files: [
-					SOURCE_DIR + 'wp-admin/css/*.css',
-					SOURCE_DIR + 'wp-includes/css/*.css'
+					`${SOURCE_DIR}wp-admin/css/*.css`,
+					`${SOURCE_DIR}wp-includes/css/*.css`
 				],
 				tasks: ['rtlcss:dynamic'],
 				options: {
@@ -836,31 +821,32 @@ module.exports = function(grunt) {
 		}
 	});
 
-	// Allow builds to be minimal
-	if( grunt.option( 'minimal-copy' ) ) {
-		var copyFilesOptions = grunt.config.get( 'copy.files.files' );
+    // Allow builds to be minimal
+    if( grunt.option( 'minimal-copy' ) ) {
+		const copyFilesOptions = grunt.config.get( 'copy.files.files' );
 		copyFilesOptions[0].src.push( '!wp-content/plugins/**' );
 		copyFilesOptions[0].src.push( '!wp-content/themes/!(twenty*)/**' );
 		grunt.config.set( 'copy.files.files', copyFilesOptions );
 	}
 
 
-	// Register tasks.
+    // Register tasks.
+    grunt.loadNpmTasks('@lodder/grunt-postcss');
 
-	// Webpack task.
-	grunt.loadNpmTasks( 'grunt-webpack' );
+    // Webpack task.
+    grunt.loadNpmTasks( 'grunt-webpack' );
 
-	// Connect task (local server for QUnit tests).
-	grunt.loadNpmTasks( 'grunt-contrib-connect' );
+    // Connect task (local server for QUnit tests).
+    grunt.loadNpmTasks( 'grunt-contrib-connect' );
 
-	// RTL task.
-	grunt.registerTask('rtl', ['rtlcss:core', 'rtlcss:colors']);
+    // RTL task.
+    grunt.registerTask('rtl', ['rtlcss:core', 'rtlcss:colors']);
 
-	// Color schemes task.
-	grunt.registerTask('colors', ['sass:colors', 'postcss:colors']);
+    // Color schemes task.
+    grunt.registerTask('colors', ['sass:colors', 'postcss:colors']);
 
-	// JSHint task.
-	grunt.registerTask( 'jshint:corejs', [
+    // JSHint task.
+    grunt.registerTask( 'jshint:corejs', [
 		'jshint:grunt',
 		'jshint:tests',
 		'jshint:themes',
@@ -868,46 +854,46 @@ module.exports = function(grunt) {
 		'jshint:media'
 	] );
 
-	grunt.registerTask( 'restapi-jsclient', [
+    grunt.registerTask( 'restapi-jsclient', [
 		'phpunit:restapi-jsclient',
 		'qunit:compiled'
 	] );
 
-	grunt.renameTask( 'watch', '_watch' );
+    grunt.renameTask( 'watch', '_watch' );
 
-	grunt.registerTask( 'watch', function() {
-		if ( ! this.args.length || this.args.indexOf( 'webpack' ) > -1 ) {
+    grunt.registerTask( 'watch', function() {
+		if ( ! this.args.length || this.args.includes('webpack') ) {
 
 			grunt.task.run( 'webpack:dev' );
 		}
 
-		grunt.task.run( '_' + this.nameArgs );
+		grunt.task.run( `_${this.nameArgs}` );
 	} );
 
-	grunt.registerTask( 'precommit:image', [
+    grunt.registerTask( 'precommit:image', [
 		'imagemin:core'
 	] );
 
-	grunt.registerTask( 'precommit:js', [
+    grunt.registerTask( 'precommit:js', [
 		'webpack:prod',
 		'jshint:corejs',
 		'uglify:masonry',
 		'uglify:imgareaselect'
 	] );
 
-	grunt.registerTask( 'precommit:css', [
+    grunt.registerTask( 'precommit:css', [
 		'postcss:core'
 	] );
 
-	grunt.registerTask( 'precommit:php', [
+    grunt.registerTask( 'precommit:php', [
 		'phpunit:wp-api-client-fixtures'
 	] );
 
-	grunt.registerTask( 'precommit:emoji', [
+    grunt.registerTask( 'precommit:emoji', [
 		'replace:emojiRegex'
 	] );
 
-	grunt.registerTask( 'precommit', [
+    grunt.registerTask( 'precommit', [
 		'precommit:js',
 		'precommit:css',
 		'precommit:image',
@@ -915,7 +901,7 @@ module.exports = function(grunt) {
 		'precommit:php'
 	] );
 
-	grunt.registerTask(
+    grunt.registerTask(
 		'precommit:verify',
 		'Run precommit checks and verify no changed files.  Commit everything before running!',
 		[
@@ -924,16 +910,15 @@ module.exports = function(grunt) {
 		]
 	);
 
-	grunt.registerTask( 'dev:git-version', function() {
-		var done = this.async();
+    grunt.registerTask( 'dev:git-version', function() {
+		const done = this.async();
 
 		if (
 			process.env.CLASSICPRESS_GIT_VERSION &&
 			/^[a-f0-9]{8}/.test( process.env.CLASSICPRESS_GIT_VERSION )
 		) {
 			grunt.log.ok(
-				'Using git version from env var: ' +
-				process.env.CLASSICPRESS_GIT_VERSION.substr( 0, 8 )
+				`Using git version from env var: ${process.env.CLASSICPRESS_GIT_VERSION.substr( 0, 8 )}`
 			);
 			grunt.config.set( 'dev.git-version', process.env.CLASSICPRESS_GIT_VERSION );
 			done();
@@ -943,42 +928,41 @@ module.exports = function(grunt) {
 		grunt.util.spawn( {
 			cmd: 'git',
 			args: [ 'rev-parse', 'HEAD' ]
-		}, function( error, result, code ) {
+		}, (error, {stdout}, code) => {
 			if ( error ) {
 				throw error;
 			}
 			if ( code !== 0 ) {
-				throw new Error( 'git rev-parse failed: code ' + code );
+				throw new Error( `git rev-parse failed: code ${code}` );
 			}
-			var hash = result.stdout.trim();
+			const hash = stdout.trim();
 			if ( ! hash || hash.length !== 40 ) {
-				throw new Error( 'git rev-parse returned invalid value: ' + hash );
+				throw new Error( `git rev-parse returned invalid value: ${hash}` );
 			}
 			grunt.config.set( 'dev.git-version', hash );
 			grunt.log.ok(
-				'Using git version from `git rev-parse`: ' +
-				hash.substr( 0, 8 )
+				`Using git version from \`git rev-parse\`: ${hash.substr( 0, 8 )}`
 			);
 			done();
 		} );
 	} );
 
-	grunt.registerTask( 'precommit:check-for-changes', function() {
+    grunt.registerTask( 'precommit:check-for-changes', function() {
 		grunt.task.requires( 'precommit' );
 
-		var done = this.async();
+		const done = this.async();
 
 		grunt.util.spawn( {
 			cmd: 'git',
 			args: [ 'ls-files', '-m' ]
-		}, function( error, result, code ) {
+		}, (error, {stdout}, code) => {
 			if ( error ) {
 				throw error;
 			}
 			if ( code !== 0 ) {
-				throw new Error( 'git ls-files failed: code ' + code );
+				throw new Error( `git ls-files failed: code ${code}` );
 			}
-			var files = result.stdout.split( '\n' )
+			const files = stdout.split( '\n' )
 				.map( f => f.trim() )
 				.filter( f => f !== '' )
 				.filter( f => f !== 'package-lock.json' );
@@ -988,7 +972,7 @@ module.exports = function(grunt) {
 					.red
 				);
 				grunt.log.writeln();
-				files.forEach( f => grunt.log.writeln( f.yellow ) );
+				files.forEach( ({yellow}) => grunt.log.writeln( yellow ) );
 				grunt.log.writeln();
 				grunt.log.writeln(
 					'Please run `grunt precommit` and commit the results.'
@@ -1005,12 +989,12 @@ module.exports = function(grunt) {
 		} );
 	} );
 
-	grunt.registerTask( 'copy:script-loader', [
+    grunt.registerTask( 'copy:script-loader', [
 		'dev:git-version',
 		'copy:script-loader-impl'
 	] );
 
-	grunt.registerTask( 'copy:all', [
+    grunt.registerTask( 'copy:all', [
 		'copy:files',
 		'copy:wp-admin-css-compat-rtl',
 		'copy:wp-admin-css-compat-min',
@@ -1018,7 +1002,7 @@ module.exports = function(grunt) {
 		'copy:version'
 	] );
 
-	grunt.registerTask( 'build', [
+    grunt.registerTask( 'build', [
 		'clean:all',
 		'copy:all',
 		'cssmin:core',
@@ -1039,15 +1023,15 @@ module.exports = function(grunt) {
 		'jsvalidate:build'
 	] );
 
-	grunt.registerTask( 'prerelease', [
+    grunt.registerTask( 'prerelease', [
 		'precommit:php',
 		'precommit:js',
 		'precommit:css',
 		'precommit:image'
 	] );
 
-	// Testing tasks.
-	grunt.registerMultiTask('phpunit', 'Runs PHPUnit tests, including the ajax, external-http, and multisite tests.', function() {
+    // Testing tasks.
+    grunt.registerMultiTask('phpunit', 'Runs PHPUnit tests, including the ajax, external-http, and multisite tests.', function() {
 		grunt.util.spawn({
 			cmd: this.data.cmd,
 			args: this.data.args,
@@ -1055,16 +1039,16 @@ module.exports = function(grunt) {
 		}, this.async());
 	});
 
-	grunt.registerTask('qunit:local', 'Runs QUnit tests with a local server.',
+    grunt.registerTask('qunit:local', 'Runs QUnit tests with a local server.',
 		['connect', 'qunit']);
 
-	grunt.registerTask('qunit:compiled', 'Runs QUnit tests on compiled as well as uncompiled scripts.',
+    grunt.registerTask('qunit:compiled', 'Runs QUnit tests on compiled as well as uncompiled scripts.',
 		['build', 'copy:qunit', 'qunit:local']);
 
-	grunt.registerTask('test', 'Runs all QUnit and PHPUnit tasks.', ['qunit:compiled', 'phpunit']);
+    grunt.registerTask('test', 'Runs all QUnit and PHPUnit tasks.', ['qunit:compiled', 'phpunit']);
 
-	// Travis CI tasks.
-	grunt.registerTask(
+    // Travis CI tasks.
+    grunt.registerTask(
 		'travis:precommit-and-js',
 		'Runs precommit checks and JavaScript tests on Travis CI.',
 		[
@@ -1072,29 +1056,29 @@ module.exports = function(grunt) {
 			'qunit:compiled'
 		]
 	);
-	grunt.registerTask(
+    grunt.registerTask(
 		'travis:phpunit',
 		'Runs PHPUnit tests on Travis CI.',
 		'phpunit'
 	);
 
-	// Patch task.
-	grunt.renameTask('patch_wordpress', 'patch');
+    // Patch task.
+    grunt.renameTask('patch_wordpress', 'patch');
 
-	// Add an alias `apply` of the `patch` task name.
-	grunt.registerTask('apply', 'patch');
+    // Add an alias `apply` of the `patch` task name.
+    grunt.registerTask('apply', 'patch');
 
-	// Default task.
-	grunt.registerTask('default', ['build']);
+    // Default task.
+    grunt.registerTask('default', ['build']);
 
-	/*
+    /*
 	 * Automatically updates the `:dynamic` configurations
 	 * so that only the changed files are updated.
 	 */
-	grunt.event.on('watch', function( action, filepath, target ) {
-		var src;
+    grunt.event.on('watch', (action, filepath, target) => {
+		let src;
 
-		if ( [ 'all', 'rtl', 'webpack' ].indexOf( target ) === -1 ) {
+		if ( ![ 'all', 'rtl', 'webpack' ].includes(target) ) {
 			return;
 		}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -738,7 +738,9 @@ module.exports = function(grunt) {
                                 entities = entities.replace( /-/g, '' );
 
                                 // Sort the entities list by length, so the longest emoji will be found first
-                                emojiArray = entities.split( '\n' ).sort( ({length}, {length}) => length - length );
+								emojiArray = entities.split( '\n' ).sort( ( a, b ) => {
+									return b.length - a.length;
+								} );
 
                                 // Convert the entities list to PHP array syntax
                                 entities = `'${emojiArray.filter( val => val.length >= 8 ? val : false ).join( '\', \'' )}'`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,26 @@
       "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
       "dev": true
     },
+    "@lodder/grunt-postcss": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-1.0.9.tgz",
+      "integrity": "sha512-20Dqp1/2Wk24tuJWIjt88H0OVKy6O7/X6lyWYaK4nc3YWDeiDeogxqIRofin6rC0doFGfk93vx0tP62kFX0fdg==",
+      "dev": true,
+      "requires": {
+        "diff": "^4.0.1",
+        "kleur": "^3.0.2",
+        "maxmin": "^2.1.0",
+        "postcss": "^7.0.14"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        }
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1278,7 +1298,6 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -1419,8 +1438,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1779,7 +1797,6 @@
       "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "get-proxy": "^2.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -2046,7 +2063,6 @@
       "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-readlink": ">= 1.0.0"
       }
@@ -2143,7 +2159,6 @@
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
@@ -2227,8 +2242,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
@@ -2564,7 +2578,6 @@
       "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.0.0",
         "decompress-tarbz2": "^4.0.0",
@@ -2581,7 +2594,6 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
-      "optional": true,
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -2591,7 +2603,6 @@
       "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-type": "^5.2.0",
         "is-stream": "^1.1.0",
@@ -2602,8 +2613,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2612,7 +2622,6 @@
       "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.0",
         "file-type": "^6.1.0",
@@ -2625,8 +2634,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
           "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2635,7 +2643,6 @@
       "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "decompress-tar": "^4.1.1",
         "file-type": "^5.2.0",
@@ -2646,8 +2653,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -2656,7 +2662,6 @@
       "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
-      "optional": true,
       "requires": {
         "file-type": "^3.8.0",
         "get-stream": "^2.2.0",
@@ -2668,15 +2673,13 @@
           "version": "3.9.0",
           "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
           "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
-          "optional": true,
           "requires": {
             "object-assign": "^4.0.1",
             "pinkie-promise": "^2.0.0"
@@ -2757,7 +2760,6 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2916,12 +2918,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
-      "dev": true
-    },
-    "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -3088,8 +3084,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "duplexify": {
       "version": "3.6.0",
@@ -3210,7 +3205,6 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -3224,7 +3218,6 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3369,7 +3362,6 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
@@ -3385,7 +3377,6 @@
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -3397,7 +3388,6 @@
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -3622,7 +3612,6 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "mime-db": "^1.28.0"
       }
@@ -3632,7 +3621,6 @@
       "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "ext-list": "^2.0.0",
         "sort-keys-length": "^1.0.0"
@@ -3822,7 +3810,6 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -3859,15 +3846,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
       "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "filenamify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "filename-reserved-regex": "^2.0.0",
         "strip-outer": "^1.0.0",
@@ -4212,8 +4197,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4330,8 +4314,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4373,7 +4356,6 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4392,7 +4374,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4493,7 +4474,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4579,8 +4559,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4616,7 +4595,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4680,14 +4658,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4713,8 +4689,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -4749,7 +4724,6 @@
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "npm-conf": "^1.1.0"
       }
@@ -4763,8 +4737,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -4993,8 +4966,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "grunt": {
       "version": "1.0.4",
@@ -5607,71 +5579,6 @@
         }
       }
     },
-    "grunt-postcss": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.9.0.tgz",
-      "integrity": "sha512-lglLcVaoOIqH0sFv7RqwUKkEFGQwnlqyAKbatxZderwZGV1nDyKHN7gZS9LUiTx1t5GOvRBx0BEalHMyVwFAIA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.1.0",
-        "diff": "^3.0.0",
-        "postcss": "^6.0.11"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "grunt-replace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/grunt-replace/-/grunt-replace-1.0.1.tgz",
@@ -5760,7 +5667,6 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -5783,22 +5689,19 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
       "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -6505,8 +6408,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -6521,8 +6423,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6610,8 +6511,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-number": {
       "version": "3.0.0",
@@ -6635,8 +6535,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-path-cwd": {
       "version": "2.1.0",
@@ -6666,8 +6565,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6704,7 +6602,6 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -6713,8 +6610,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -6737,7 +6633,6 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -6790,7 +6685,6 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
@@ -6994,6 +6888,12 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -7158,8 +7058,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lpad-align": {
       "version": "1.1.2",
@@ -7616,8 +7515,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
@@ -7788,8 +7686,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -8345,7 +8242,6 @@
       "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "config-chain": "^1.1.11",
         "pify": "^3.0.0"
@@ -8355,8 +8251,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8437,8 +8332,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
       "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -8705,7 +8599,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
       "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
       "dev": true,
-      "optional": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -9129,8 +9022,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -10229,7 +10121,6 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "dev": true,
-      "optional": true,
       "requires": {
         "commander": "~2.8.1"
       }
@@ -10603,7 +10494,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
       }
@@ -10613,7 +10503,6 @@
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
-      "optional": true,
       "requires": {
         "sort-keys": "^1.0.0"
       }
@@ -10995,7 +10884,6 @@
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-natural-number": "^4.0.1"
       }
@@ -11025,7 +10913,6 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -11162,15 +11049,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
       "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "tempfile": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "temp-dir": "^1.0.0",
         "uuid": "^3.0.1"
@@ -11253,8 +11138,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "timers-browserify": {
       "version": "2.0.10",
@@ -11405,7 +11289,6 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
-      "optional": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
@@ -11450,7 +11333,6 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -11535,7 +11417,6 @@
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.1.tgz",
       "integrity": "sha512-fIZnvdjblYs7Cru/xC6tCPVhz7JkYcVQQkePwMLyQELzYTds2Xn8QefPVnvdVhhZqubxNA1cASXEH5wcK0Bucw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer": "^3.0.1",
         "through": "^2.3.6"
@@ -11545,15 +11426,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
           "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer": {
           "version": "3.6.0",
           "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "base64-js": "0.0.8",
             "ieee754": "^1.1.4",
@@ -11758,8 +11637,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "use": {
       "version": "3.1.1",
@@ -12307,7 +12185,6 @@
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -12326,7 +12203,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -12420,7 +12296,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -12506,8 +12381,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12613,8 +12487,7 @@
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -12999,7 +12872,6 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
-      "optional": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-jsvalidate": "0.2.2",
     "grunt-legacy-util": "1.1.1",
     "grunt-patch-wordpress": "1.0.0",
-    "grunt-postcss": "0.9.0",
+    "@lodder/grunt-postcss": "1.0.9",
     "grunt-replace": "1.0.1",
     "grunt-rtlcss": "2.0.1",
     "grunt-sass": "3.0.2",
@@ -39,6 +39,18 @@
     "webpack": "4.35.3",
     "webpack-dev-server": "3.7.2"
   },
+  "browserslist": [
+    "> 1%",
+    "ie >= 11",
+    "last 1 Android versions",
+    "last 1 ChromeAndroid versions",
+    "last 2 Chrome versions",
+    "Firefox >= 60",
+    "last 2 Safari versions",
+    "last 2 iOS versions",
+    "last 2 Edge versions",
+    "last 2 Opera versions"
+  ],
   "dependencies": {
     "node-sass": "4.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,18 +39,6 @@
     "webpack": "4.35.3",
     "webpack-dev-server": "3.7.2"
   },
-  "browserslist": [
-    "> 1%",
-    "ie >= 11",
-    "last 1 Android versions",
-    "last 1 ChromeAndroid versions",
-    "last 2 Chrome versions",
-    "Firefox >= 60",
-    "last 2 Safari versions",
-    "last 2 iOS versions",
-    "last 2 Edge versions",
-    "last 2 Opera versions"
-  ],
   "dependencies": {
     "node-sass": "4.12.0"
   },

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,14 +1,14 @@
-var path         = require( 'path' ),
-	SOURCE_DIR   = 'src/',
-	mediaConfig  = {},
-	mediaBuilds  = [ 'audiovideo', 'grid', 'models', 'views' ],
-	webpack      = require( 'webpack' );
+const path         = require( 'path' );
+const SOURCE_DIR   = 'src/';
+const mediaConfig  = {};
+const mediaBuilds  = [ 'audiovideo', 'grid', 'models', 'views' ];
+const webpack      = require( 'webpack' );
 
 
-mediaBuilds.forEach( function ( build ) {
-	var path = SOURCE_DIR + 'wp-includes/js/media';
-	mediaConfig[ build ] = './' + path + '/' + build + '.manifest.js';
-} );
+mediaBuilds.forEach( build => {
+	const path = `${SOURCE_DIR}wp-includes/js/media`;
+	mediaConfig[ build ] = `./${path}/${build}.manifest.js`;
+});
 
 module.exports = {
 	mode: 'development',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,13 +1,13 @@
-var path         = require( 'path' ),
-	SOURCE_DIR   = 'src/',
-	mediaConfig  = {},
-	mediaBuilds  = [ 'audiovideo', 'grid', 'models', 'views' ],
-	webpack      = require( 'webpack' );
+const path         = require( 'path' );
+const SOURCE_DIR   = 'src/';
+const mediaConfig  = {};
+const mediaBuilds  = [ 'audiovideo', 'grid', 'models', 'views' ];
+const webpack      = require( 'webpack' );
 
 
 mediaBuilds.forEach(( build ) => {
-	var path = SOURCE_DIR + 'wp-includes/js/media';
-	mediaConfig[ build ] = './' + path + '/' + build + '.manifest.js';
+	const path = `${SOURCE_DIR}wp-includes/js/media`;
+	mediaConfig[ build ] = `./${path}/${build}.manifest.js`;
 });
 
 module.exports = {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -5,10 +5,10 @@ var path         = require( 'path' ),
 	webpack      = require( 'webpack' );
 
 
-mediaBuilds.forEach( function ( build ) {
+mediaBuilds.forEach(( build ) => {
 	var path = SOURCE_DIR + 'wp-includes/js/media';
 	mediaConfig[ build ] = './' + path + '/' + build + '.manifest.js';
-} );
+});
 
 module.exports = {
 	mode: 'production',


### PR DESCRIPTION
Just some updates to the build scripts:

1. Convert to ES6
2. Replace `grunt-postcss` with `@lodder/grunt-postcss` (see note below)
3. Move browser list to `.browserslistrc` in conjunction with the PostCSS update

Point 2 is not at all supposed to be any form of personal endorsement. I forked the original `grunt-postcss` package and took on maintanence.