### PR TITLE
Add local header-image support for plugins hosted remotely

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -581,6 +581,29 @@ function install_plugin_information() {
 			}
 		</style>
 		<?php
+	} else {
+		
+		// Check for existence of a header image in the plugin itself; for non-WP-repo-hosted plugins.
+
+		$extensions = array( '.jpg', '.png' );
+		$file = 'banner-772x250'; // Regular
+		$path  = 'plugins/' . sanitize_title( $_REQUEST['plugin'] ) . '/images/';
+
+		foreach ( $extensions as $extension ) {
+			if ( file_exists( WP_CONTENT_DIR . '/' . $path . $file . $extension ) ) {
+				$image = WP_CONTENT_URL . '/' . $path . $file . $extension;
+				$_with_banner = 'with-banner';
+				break;
+			}
+		}
+		?>
+		<style type="text/css">
+			#plugin-information-title.with-banner {
+				background: url('<?php echo esc_url( $image ); ?>');
+				background-size:cover;
+			}
+		</style>
+		<?php
 	}
 
 	echo '<div id="plugin-information-scrollable">';


### PR DESCRIPTION
For plugins that are not hosted in the WordPress repository, the dialog that shows additional info about the update seems broken. This is mostly because the header image is missing, but, the tabs are also missing. See first screenshot.

## Description
This pull request extends the functionality that locates the header image for the dialog. A simple `else` clause was added. If there's no w.org-hosted image for the plugin, the code looks in the to-be-updated plugin's directory for a header image in png or jpg format. See second screenshot.

## Motivation and Context
I'm using the f(x) Updater plugin to handle updates before the directory is launched. This plugin creates an endpoint on my site which returns a JSON object containing the details of the latest version of the plugin. If the returned version number is (semantically) greater than the version the user currently has installed, an update is made available to the user through the traditional update experience, with the updated file coming from a remote server (GitHub, in this case). The dialog shown in the screenshots below is the modal that is presented when a user clicks the link to learn more about a given update when they are on the `Dashboard > Updates` page.

## How has this been tested?
Manually.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/12477319/62429284-bb5eb400-b6c1-11e9-84ad-281351212a38.png)

![image](https://user-images.githubusercontent.com/12477319/62429268-86eaf800-b6c1-11e9-9095-07a39389e845.png)

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
