### PR TITLE
Change the Configuration notices wording

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -424,7 +424,7 @@ function network_step2( $errors = false ) {
 ?>
 		<ol>
 			<li><p><?php printf(
-				/* translators: 1: wp-config.php 2: location of wp-config file, 3: translated version of "That's all, stop editing! Happy blogging." */
+				/* translators: 1: wp-config.php 2: location of wp-config file, 3: translated version of "TEND custom settings. Any edit below this line may lead to unwanted errors." */
 				__( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ),
 				'<code>wp-config.php</code>',
 				'<code>' . $location_of_wp_config . '</code>',
@@ -433,7 +433,7 @@ function network_step2( $errors = false ) {
 				 * You can check the localized release package or
 				 * https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
 				 */
-				'<code>/* ' . __( 'That&#8217;s all, stop editing! Happy blogging.' ) . ' */</code>'
+				'<code>/* ' . __( 'END custom settings. Any edit below this line may lead to unwanted errors.' ) . ' */</code>'
 			); ?></p>
 				<textarea class="code" readonly="readonly" cols="100" rows="7">
 define('MULTISITE', true);

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -424,7 +424,7 @@ function network_step2( $errors = false ) {
 ?>
 		<ol>
 			<li><p><?php printf(
-				/* translators: 1: wp-config.php 2: location of wp-config file, 3: translated version of "TEND custom settings. Any edit below this line may lead to unwanted errors." */
+				/* translators: 1: wp-config.php 2: location of wp-config file, 3: translated version of "END custom settings. Any edit below this line may lead to unwanted errors." */
 				__( 'Add the following to your %1$s file in %2$s <strong>above</strong> the line reading %3$s:' ),
 				'<code>wp-config.php</code>',
 				'<code>' . $location_of_wp_config . '</code>',

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -18,6 +18,8 @@
  * @package ClassicPress
  */
 
+/* START custom settings. */
+
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for ClassicPress */
 define('DB_NAME', 'database_name_here');
@@ -79,7 +81,10 @@ $table_prefix  = 'cp_';
  */
 define('WP_DEBUG', false);
 
-/* That's all, stop editing! Happy blogging. */
+/** 
+ * END custom settings.
+ * Any edit below this line may lead to unwanted errors. 
+ */
 
 /** Absolute path to the ClassicPress directory. */
 if ( !defined('ABSPATH') )


### PR DESCRIPTION
Issue shared by @invisnet via Slack https://classicpress.slack.com/archives/CCCF22HG8/p1565050415029700

Help: just finished resolving a support request that boiled down to `/* That's all, stop editing! Happy blogging. */`

The code comment above can be confusing so this PR is aimed to give direction to the user on where to place their Config settings in the `wp-config.php` file.

## Description
<!--
Describe your changes in detail.
-->
Change the text 

> That's all, stop editing! Happy blogging.

 to 

> END custom settings. Any edit below this line may lead to unwanted errors.

## Motivation and context
It's an enhancement. It makes it easier for users with English as a 2nd language to receive a better notice to avoid breaking their config file.

## Screenshots (if appropriate):

## Types of changes
<!--
What types of changes does your code introduce? Put an `x` in all the boxes
that apply:
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
