### PR TITLE
Fix the HTTP tests

### DIFF
--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -256,7 +256,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 
 	function test_file_stream() {
 		$url = $this->fileStreamUrl;
-		$size = 5461;
+		$size = 5764;
 		$res = wp_remote_request( $url, array( 'stream' => true, 'timeout' => 30 ) ); //Auto generate the filename.
 
 		// Cleanup before we assert, as it'll return early.


### PR DESCRIPTION
The size of https://www.classicpress.net/wp-content/uploads/2019/02/celebrating-six-months-150x150.jpg has changed with the move of our site to a new server. This file is used in the HTTP tests during our build, so we need to update the size there.

A full solution to this issue is outlined in #25 but this will do for now.