### PR TITLE
Remove JavaScript and CSS type attributes for HTML5 validity

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -943,7 +943,7 @@ function wp_admin_bar_add_secondary_groups( $wp_admin_bar ) {
  * @since WP-3.1.0
  */
 function wp_admin_bar_header() { ?>
-<style type="text/css" media="print">#wpadminbar { display:none; }</style>
+<style <?php if ( ! current_theme_supports( 'html5' ) ) { echo 'type="text/css" '; } ?> media="print">#wpadminbar { display:none; }</style>
 <?php
 }
 
@@ -952,8 +952,8 @@ function wp_admin_bar_header() { ?>
  *
  * @since WP-3.1.0
  */
-function _admin_bar_bump_cb() { ?>
-<style type="text/css" media="screen">
+function _admin_bar_bump_cb() {?>
+<style <?php if ( ! current_theme_supports( 'html5' ) ) { echo 'type="text/css" '; } ?>media="screen">
 	html { margin-top: 32px !important; }
 	* html body { margin-top: 32px !important; }
 	@media screen and ( max-width: 782px ) {

--- a/src/wp-includes/class.wp-scripts.php
+++ b/src/wp-includes/class.wp-scripts.php
@@ -202,10 +202,16 @@ class WP_Scripts extends WP_Dependencies {
 		if ( !$echo )
 			return $output;
 
-		echo "<script type='text/javascript'>\n"; // CDATA and type='text/javascript' is not needed for HTML 5
-		echo "/* <![CDATA[ */\n";
+		if ( ! current_theme_supports( 'html5' ) ) {
+			echo "<script type='text/javascript'>\n";
+			echo "/* <![CDATA[ */\n";
+		} else {
+			echo "<script>\n"; // CDATA and is not needed for HTML 5
+		}
 		echo "$output\n";
-		echo "/* ]]> */\n";
+		if ( ! current_theme_supports( 'html5' ) ) {
+			echo "/* ]]> */\n";
+		}
 		echo "</script>\n";
 
 		return true;
@@ -261,12 +267,18 @@ class WP_Scripts extends WP_Dependencies {
 		$before_handle = $this->print_inline_script( $handle, 'before', false );
 		$after_handle = $this->print_inline_script( $handle, 'after', false );
 
+		if ( ! current_theme_supports( 'html5' ) ) {
+			$type = " type='text/javascript'";
+		} else {
+			$type = '';
+		}
+
 		if ( $before_handle ) {
-			$before_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $before_handle );
+			$before_handle = sprintf( "<script%s>\n%s\n</script>\n", $type, $before_handle );
 		}
 
 		if ( $after_handle ) {
-			$after_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $after_handle );
+			$after_handle = sprintf( "<script%s>\n%s\n</script>\n", $type, $after_handle );
 		}
 
 		if ( $this->do_concat ) {
@@ -327,7 +339,7 @@ class WP_Scripts extends WP_Dependencies {
 		if ( ! $src )
 			return true;
 
-		$tag = "{$cond_before}{$before_handle}<script type='text/javascript' src='$src'></script>\n{$after_handle}{$cond_after}";
+		$tag = "{$cond_before}{$before_handle}<script{$type} src='$src'></script>\n{$after_handle}{$cond_after}";
 
 		/**
 		 * Filters the HTML script tag of an enqueued script.
@@ -396,8 +408,14 @@ class WP_Scripts extends WP_Dependencies {
 
 		$output = trim( implode( "\n", $output ), "\n" );
 
+		if ( ! current_theme_supports( 'html5' ) ) {
+			$type = " type='text/javascript'";
+		} else {
+			$type = '';
+		}
+
 		if ( $echo ) {
-			printf( "<script type='text/javascript'>\n%s\n</script>\n", $output );
+			printf( "<script%s>\n%s\n</script>\n", $type, $output );
 		}
 
 		return $output;

--- a/src/wp-includes/class.wp-styles.php
+++ b/src/wp-includes/class.wp-styles.php
@@ -158,10 +158,17 @@ class WP_Styles extends WP_Dependencies {
 		else
 			$media = 'all';
 
+		if ( ! current_theme_supports( 'html5' ) ) {
+			$type = " type='text/css'";
+		} else {
+			$type = '';
+		}
+
 		// A single item may alias a set of items, by having dependencies, but no source.
 		if ( ! $obj->src ) {
 			if ( $inline_style = $this->print_inline_style( $handle, false ) ) {
-				$inline_style = sprintf( "<style id='%s-inline-css' type='text/css'>\n%s\n</style>\n", esc_attr( $handle ), $inline_style );
+
+				$inline_style = sprintf( "<style%s id='%s-inline-css'>\n%s\n</style>\n", $type, esc_attr( $handle ), $inline_style );
 				if ( $this->do_concat ) {
 					$this->print_html .= $inline_style;
 				} else {
@@ -191,7 +198,7 @@ class WP_Styles extends WP_Dependencies {
 		 * @param string $href   The stylesheet's source URL.
 		 * @param string $media  The stylesheet's media attribute.
 		 */
-		$tag = apply_filters( 'style_loader_tag', "<link rel='$rel' id='$handle-css' $title href='$href' type='text/css' media='$media' />\n", $handle, $href, $media);
+		$tag = apply_filters( 'style_loader_tag', "<link rel='$rel' id='$handle-css' $title href='$href' media='$media' />\n", $handle, $href, $media);
 		if ( 'rtl' === $this->text_direction && isset($obj->extra['rtl']) && $obj->extra['rtl'] ) {
 			if ( is_bool( $obj->extra['rtl'] ) || 'replace' === $obj->extra['rtl'] ) {
 				$suffix = isset( $obj->extra['suffix'] ) ? $obj->extra['suffix'] : '';
@@ -201,7 +208,7 @@ class WP_Styles extends WP_Dependencies {
 			}
 
 			/** This filter is documented in wp-includes/class.wp-styles.php */
-			$rtl_tag = apply_filters( 'style_loader_tag', "<link rel='$rel' id='$handle-rtl-css' $title href='$rtl_href' type='text/css' media='$media' />\n", $handle, $rtl_href, $media );
+			$rtl_tag = apply_filters( 'style_loader_tag', "<link rel='$rel' id='$handle-rtl-css' $title href='$rtl_href'{$type} media='$media' />\n", $handle, $rtl_href, $media );
 
 			if ( $obj->extra['rtl'] === 'replace' ) {
 				$tag = $rtl_tag;
@@ -220,7 +227,7 @@ class WP_Styles extends WP_Dependencies {
 			$this->print_html .= $conditional_pre;
 			$this->print_html .= $tag;
 			if ( $inline_style = $this->print_inline_style( $handle, false ) ) {
-				$this->print_html .= sprintf( "<style id='%s-inline-css' type='text/css'>\n%s\n</style>\n", esc_attr( $handle ), $inline_style );
+				$this->print_html .= sprintf( "<style%s id='%s-inline-css'>\n%s\n</style>\n", $type, esc_attr( $handle ), $inline_style );
 			}
 			$this->print_html .= $conditional_post;
 		} else {
@@ -280,7 +287,13 @@ class WP_Styles extends WP_Dependencies {
 			return $output;
 		}
 
-		printf( "<style id='%s-inline-css' type='text/css'>\n%s\n</style>\n", esc_attr( $handle ), $output );
+		if ( ! current_theme_supports( 'html5' ) ) {
+			$type = " type='text/css'";
+		} else {
+			$type = '';
+		}
+
+		printf( "<style%s id='%s-inline-css'>\n%s\n</style>\n", $type, esc_attr( $handle ), $output );
 
 		return true;
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4988,7 +4988,7 @@ function print_emoji_styles() {
 
 	$printed = true;
 ?>
-<style type="text/css">
+<style<?php if ( ! current_theme_supports( 'html5' ) ) { echo ' type="text/css"'; } ?>>
 img.wp-smiley,
 img.emoji {
 	display: inline !important;
@@ -5081,7 +5081,7 @@ function _print_emoji_detection_script() {
 		);
 
 		?>
-		<script type="text/javascript">
+		<script<?php if ( ! current_theme_supports( 'html5' ) ) { echo ' type="text/javascript"'; } ?>>
 			window._wpemojiSettings = <?php echo wp_json_encode( $settings ); ?>;
 			<?php readfile( ABSPATH . WPINC . "/js/wp-emoji-loader.js" ); ?>
 		</script>
@@ -5104,7 +5104,7 @@ function _print_emoji_detection_script() {
 		 * and edit wp-emoji-loader.js directly.
 		 */
 		?>
-		<script type="text/javascript">
+		<script<?php if ( ! current_theme_supports( 'html5' ) ) { echo ' type="text/javascript"'; } ?>>
 			window._wpemojiSettings = <?php echo wp_json_encode( $settings ); ?>;
 			include "js/wp-emoji-loader.min.js"
 		</script>

--- a/src/wp-includes/js/wp-emoji-loader.js
+++ b/src/wp-includes/js/wp-emoji-loader.js
@@ -127,7 +127,7 @@
 		var script = document.createElement( 'script' );
 
 		script.src = src;
-		script.defer = script.type = 'text/javascript';
+		script.defer = script.type = '';
 		document.getElementsByTagName( 'head' )[0].appendChild( script );
 	}
 

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -716,6 +716,46 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_style_type_with_html5_in_admin_bar_bump_cb() {
+		ob_start();
+		add_theme_support( 'html5' );
+		_admin_bar_bump_cb();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertFalse( strstr( $output, 'type="text/css') );
+	}
+
+	public function test_style_type_without_html5_in_admin_bar_bump_cb() {
+		ob_start();
+		remove_theme_support( 'html5' );
+		_admin_bar_bump_cb();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertNotFalse( strstr( $output, 'type="text/css') );
+	}
+
+	public function test_style_type_with_html5_in_admin_bar_header() {
+		ob_start();
+		add_theme_support( 'html5' );
+		wp_admin_bar_header();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertFalse( strstr( $output, 'type="text/css') );
+	}
+
+	public function test_style_type_without_html5_in_admin_bar_header() {
+		ob_start();
+		remove_theme_support( 'html5' );
+		wp_admin_bar_header();
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertNotFalse( strstr( $output, 'type="text/css') );
+	}
+
 	private function get_my_sites_network_menu_items() {
 		return array(
 			'my-sites-super-admin' => 'manage_network',

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1226,4 +1226,30 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 			array_keys( $wp_enqueue_code_editor['htmlhint'] )
 		);
 	}
+
+	public function test_javascript_type_with_html5_in_print_inline_script() {
+		wp_enqueue_script( 'test-example', 'example.com', array(), null );
+		wp_add_inline_script( 'test-example', 'console.log("html5");' );
+		add_theme_support( 'html5' );
+		global $wp_scripts;
+		ob_start();
+		$wp_scripts->print_inline_script( 'test-example', 'after' );
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertFalse( strstr( $output, "type='text/javascript'" ) );
+	}
+
+	public function test_javascript_type_without_html5_in_print_inline_script() {
+		wp_enqueue_script( 'test-example', 'example.com', array(), null );
+		wp_add_inline_script( 'test-example', 'console.log("html5");' );
+		remove_theme_support( 'html5' );
+		global $wp_scripts;
+		ob_start();
+		$wp_scripts->print_inline_script( 'test-example', 'after' );
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertNotFalse( strstr( $output, "type='text/javascript'" ) );
+	}
 }

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -29,6 +29,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$this->classicpress_asset_version_calls = array();
 		$GLOBALS['wp_styles'] = new WP_Styles();
 		$GLOBALS['wp_styles']->default_version = self::$asset_version;
+		add_theme_support( 'html5' );
 	}
 
 	function tearDown() {
@@ -68,10 +69,10 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		wp_enqueue_style('no-deps-null-version', 'example.com', array(), null);
 		wp_enqueue_style('no-deps-null-version-print-media', 'example.com', array(), null, 'print');
 		$ver = self::$asset_version;
-		$expected  = "<link rel='stylesheet' id='no-deps-no-version-css'  href='http://example.com?ver=$ver' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-version-css'  href='http://example.com?ver=1.2' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-null-version-css'  href='http://example.com' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-null-version-print-media-css'  href='http://example.com' type='text/css' media='print' />\n";
+		$expected  = "<link rel='stylesheet' id='no-deps-no-version-css'  href='http://example.com?ver=$ver' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-version-css'  href='http://example.com?ver=1.2' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-null-version-css'  href='http://example.com' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-null-version-print-media-css'  href='http://example.com' media='print' />\n";
 
 		$this->assertEquals($expected, get_echo('wp_print_styles'));
 
@@ -111,7 +112,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$ver = 'aaaa';
 		$GLOBALS['wp_styles']->default_version = $ver;
 		wp_enqueue_style( 'override-default-version', 'example.com' );
-		$expected  = "<link rel='stylesheet' id='override-default-version-css'  href='http://example.com?ver=$ver' type='text/css' media='all' />\n";
+		$expected  = "<link rel='stylesheet' id='override-default-version-css'  href='http://example.com?ver=$ver' media='all' />\n";
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
 		$this->assertEquals( array(
 			array(
@@ -128,7 +129,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$GLOBALS['wp_styles']->default_version = 'aaaa';
 		$this->classicpress_asset_version_override = $ver;
 		wp_enqueue_style( 'override-default-version-and-filter', 'example.com' );
-		$expected = "<link rel='stylesheet' id='override-default-version-and-filter-css'  href='http://example.com?ver=$ver' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='override-default-version-and-filter-css'  href='http://example.com?ver=$ver' media='all' />\n";
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
 		$this->assertEquals( array(
 			array(
@@ -144,7 +145,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$ver = 'cccc';
 		$this->classicpress_asset_version_override = $ver;
 		wp_enqueue_style( 'filter-default-version', 'example.com' );
-		$expected = "<link rel='stylesheet' id='filter-default-version-css'  href='http://example.com?ver=$ver' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='filter-default-version-css'  href='http://example.com?ver=$ver' media='all' />\n";
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
 		$this->assertEquals( array(
 			array(
@@ -159,7 +160,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	function test_wp_enqueue_style_filter_declared_version() {
 		$this->classicpress_asset_version_override = 'oooo';
 		wp_enqueue_style( 'filter-declared-version', 'example.com', array(), 'dddd' );
-		$expected = "<link rel='stylesheet' id='filter-declared-version-css'  href='http://example.com?ver=oooo' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='filter-declared-version-css'  href='http://example.com?ver=oooo' media='all' />\n";
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
 		$this->assertEquals( array(
 			array(
@@ -174,7 +175,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	function test_wp_enqueue_style_filter_null_version() {
 		$this->classicpress_asset_version_override = 'oooo';
 		wp_enqueue_style( 'filter-null-version', 'example.com', array(), null );
-		$expected = "<link rel='stylesheet' id='filter-null-version-css'  href='http://example.com?ver=oooo' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='filter-null-version-css'  href='http://example.com?ver=oooo' media='all' />\n";
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
 		$this->assertEquals( array(
 			array(
@@ -201,24 +202,24 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 
 		// Try with an HTTP reference
 		wp_enqueue_style( 'reset-css-http', 'http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected  .= "<link rel='stylesheet' id='reset-css-http-css'  href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected  .= "<link rel='stylesheet' id='reset-css-http-css'  href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with an HTTPS reference
 		wp_enqueue_style( 'reset-css-https', 'http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected  .= "<link rel='stylesheet' id='reset-css-https-css'  href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected  .= "<link rel='stylesheet' id='reset-css-https-css'  href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with an automatic protocol reference (//)
 		wp_enqueue_style( 'reset-css-doubleslash', '//yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected  .= "<link rel='stylesheet' id='reset-css-doubleslash-css'  href='//yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected  .= "<link rel='stylesheet' id='reset-css-doubleslash-css'  href='//yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with a local resource and an automatic protocol reference (//)
 		$url = '//my_plugin/style.css';
 		wp_enqueue_style( 'plugin-style', $url );
-		$expected  .= "<link rel='stylesheet' id='plugin-style-css'  href='$url?ver=$ver' type='text/css' media='all' />\n";
+		$expected  .= "<link rel='stylesheet' id='plugin-style-css'  href='$url?ver=$ver' media='all' />\n";
 
 		// Try with a bad protocol
 		wp_enqueue_style( 'reset-css-ftp', 'ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected  .= "<link rel='stylesheet' id='reset-css-ftp-css'  href='{$wp_styles->base_url}ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected  .= "<link rel='stylesheet' id='reset-css-ftp-css'  href='{$wp_styles->base_url}ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Go!
 		$this->assertEquals( $expected, get_echo( 'wp_print_styles' ) );
@@ -240,8 +241,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= "}";
 
-		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "</style>\n";
 
@@ -268,8 +269,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= "}";
 
-		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "</style>\n";
 
@@ -295,8 +296,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style2 .= "\tbackground: blue;\n";
 		$style2 .= "}";
 
-		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style1\n";
 		$expected .= "$style2\n";
 		$expected .= "</style>\n";
@@ -318,13 +319,13 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 */
 	public function test_plugin_doing_inline_styles_wrong() {
 
-		$style  = "<style id='handle-inline-css' type='text/css'>\n";
+		$style  = "<style id='handle-inline-css'>\n";
 		$style .= ".thing {\n";
 		$style .= "\tbackground: red;\n";
 		$style .= "}\n";
 		$style .= "</style>";
 
-		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
+		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />\n";
 		$expected .= "$style\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
@@ -341,7 +342,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 */
 	public function test_unnecessary_style_tags() {
 
-		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
+		$expected  = "<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
 
@@ -356,8 +357,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	public function test_conditional_inline_styles_are_also_conditional() {
 		$expected = <<<CSS
 <!--[if IE]>
-<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' type='text/css' media='all' />
-<style id='handle-inline-css' type='text/css'>
+<link rel='stylesheet' id='handle-css'  href='http://example.com?ver=1' media='all' />
+<style id='handle-inline-css'>
 a { color: blue; }
 </style>
 <![endif]-->
@@ -386,9 +387,9 @@ CSS;
 	function test_wp_add_inline_style_for_handle_without_source() {
 		$style  = "a { color: blue; }";
 
-		$expected  = "<link rel='stylesheet' id='handle-one-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='handle-two-css'  href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-three-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-one-css'  href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='handle-two-css'  href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-three-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "</style>\n";
 
@@ -409,6 +410,30 @@ CSS;
 	function test_wp_enqueue_style_with_media( $expected, $media ) {
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1, $media );
 		$this->assertContains( $expected, get_echo( 'wp_print_styles' ) );
+	}
+
+	public function test_css_type_with_html5_in_print_inline_script() {
+		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
+		wp_add_inline_style( 'handle', 'a { color: blue;}' );
+		global $wp_styles;
+		ob_start();
+		$wp_styles->print_inline_style( 'handle', 'after' );
+		$output = ob_get_contents();
+		ob_end_clean();
+		$this->assertFalse( strstr( $output, "type='text/css'" ) );
+	}
+
+	public function test_css_type_without_html5_in_print_inline_script() {
+		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
+		wp_add_inline_style( 'handle', 'a { color: blue;}' );
+		remove_theme_support( 'html5' );
+		global $wp_styles;
+		ob_start();
+		$wp_styles->print_inline_style( 'handle', 'after' );
+		$output = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertNotFalse( strstr( $output, "type='text/css'" ) );
 	}
 
 	function data_styles_with_media() {

--- a/tests/phpunit/tests/formatting/Emoji.php
+++ b/tests/phpunit/tests/formatting/Emoji.php
@@ -146,4 +146,36 @@ class Tests_Formatting_Emoji extends WP_UnitTestCase {
 	public function test_wp_staticize_emoji( $emoji, $expected ) {
 		$this->assertSame( $expected, wp_staticize_emoji( $emoji ) );
 	}
+
+	public function test_detecton_script_with_html5() {
+		add_theme_support( 'html5' );
+		$output = get_echo( '_print_emoji_detection_script' );
+
+		$this->assertFalse( strstr( $output, 'type="text/javascript"' ) );
+	}
+
+	public function test_detecton_script_without_html5() {
+		remove_theme_support( 'html5' );
+		$output = get_echo( '_print_emoji_detection_script' );
+
+		$this->assertNotFalse( strstr( $output, 'type="text/javascript"' ) );
+	}
+
+	public function test_print_emoji_styles_with_html5() {
+		add_theme_support( 'html5' );
+		$output = get_echo( 'print_emoji_styles' );
+
+		$this->assertFalse( strstr( $output, 'type="text/css"' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
+	public function test_print_emoji_styles_without_html5() {
+		remove_theme_support( 'html5' );
+		$printed = false;
+		$output = get_echo( 'print_emoji_styles' );
+
+		$this->assertNotFalse( strstr( $output, 'type="text/css"' ) );
+	}
 }

--- a/tests/phpunit/tests/formatting/Emoji.php
+++ b/tests/phpunit/tests/formatting/Emoji.php
@@ -9,6 +9,15 @@ class Tests_Formatting_Emoji extends WP_UnitTestCase {
 	private $png_cdn = 'https://twemoji.classicpress.net/12/72x72/';
 	private $svn_cdn = 'https://twemoji.classicpress.net/12/svg/';
 
+	function setUp() {
+		// This is not done when loading the login page, but parent::setUp()
+		// needs it when WP_TRAVIS_OBJECT_CACHE=true.
+		if ( wp_using_ext_object_cache() ) {
+			wp_cache_init();
+		}
+		parent::setUp();
+	}
+
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/36525
 	 */
@@ -173,8 +182,8 @@ class Tests_Formatting_Emoji extends WP_UnitTestCase {
 	 */
 	public function test_print_emoji_styles_without_html5() {
 		remove_theme_support( 'html5' );
-		$printed = false;
 		$output = get_echo( 'print_emoji_styles' );
+
 
 		$this->assertNotFalse( strstr( $output, 'type="text/css"' ) );
 	}


### PR DESCRIPTION
## Description
PR for #339 This patch updated tests and removes declarations of `type` when enqueuing or in-lining JavaScript and CSS styles

## Motivation and context
HTML5 should be the standard 4 years after release and official recommendation over previous web standards.

## How has this been tested?
Unit tests are both updated and extended.