### PR TITLE
Update comment-template.php with rel="ugc"

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -221,7 +221,7 @@ function get_comment_author_link( $comment_ID = 0 ) {
 	if ( empty( $url ) || 'http://' == $url )
 		$return = $author;
 	else
-		$return = "<a href='$url' rel='external nofollow' class='url'>$author</a>";
+		$return = "<a href='$url' rel='external nofollow ugc' class='url'>$author</a>";
 
 	/**
 	 * Filters the comment author's link for display.


### PR DESCRIPTION
## Description 
Updated as described in https://github.com/ClassicPress/ClassicPress/issues/482

This fix only works for the website entered by people, to edit links in the comment itself, a deeper dive is needed.

## Motivation and context
Google released an update to how it uses nofollow. It advices  user generated content like comments to use a rel="ucg" 

## How has this been tested?
Tested on http://twentyseventeen.hellenique.eu/2019/06/17/hello-world/

## Screenshots
![Schermafbeelding 2019-09-12 om 17 17 36](https://user-images.githubusercontent.com/52501540/64797180-3f3d7300-d581-11e9-892f-6a6fa673b292.png)

## Types of changes
-Existing feature expansion
