### PR TITLE
Update Hello Dolly version for dev environments

### DIFF
--- a/src/wp-content/plugins/hello.php
+++ b/src/wp-content/plugins/hello.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * @package Hello_Dolly
- * @version 1.7
+ * @version 99.0-wp1.7
  */
 /*
 Plugin Name: Hello Dolly
 Plugin URI: http://wordpress.org/plugins/hello-dolly/
 Description: This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.
 Author: Matt Mullenweg
-Version: 1.7
+Version: 99.0-wp1.7
 Author URI: http://ma.tt/
 */
 

--- a/tests/phpunit/tests/ajax/UpdatePlugin.php
+++ b/tests/phpunit/tests/ajax/UpdatePlugin.php
@@ -158,7 +158,7 @@ class Tests_Ajax_Update_Plugin extends WP_Ajax_UnitTestCase {
 				'plugin'       => 'hello.php',
 				'pluginName'   => 'Hello Dolly',
 				'errorMessage' => 'Plugin update failed.',
-				'oldVersion'   => 'Version 1.7',
+				'oldVersion'   => 'Version 99.0-wp1.7',
 				'newVersion'   => '',
 				'debug'        => array( 'The plugin is at the latest version.' ),
 			),


### PR DESCRIPTION
This PR avoids an "update available" notice for the Hello Dolly plugin in ClassicPress sites **installed from the source repository** - our release builds do not contain Hello Dolly so "regular" users will never see this.

## Before

![2019-09-14T12 10 08Z](https://user-images.githubusercontent.com/227022/64907941-e4269000-d6e8-11e9-9e89-3a8189407308.png)

## After

![2019-09-14T12 10 14Z](https://user-images.githubusercontent.com/227022/64907940-e4269000-d6e8-11e9-890e-a92914a6b3f1.png)