### PR TITLE
Update wp-config-sample.php

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -13,7 +13,7 @@
  * * Database table prefix
  * * ABSPATH
  *
- * @link https://codex.wordpress.org/Editing_wp-config.php
+ * @link https://wordpress.org/support/article/editing-wp-config-php/
  *
  * @package ClassicPress
  */


### PR DESCRIPTION

## Description
Changed the link in wp-config-sample.php to https://wordpress.org/support/article/editing-wp-config-php/

## Motivation and context
The old link lead to a broken page: https://codex.wordpress.org/Editing_wp-config.php

## How has this been tested?
Tested quickly. Low chance of conflict elsewhere.

## Screenshots

### Before
Old destination:
![Schermafbeelding 2019-09-16 om 10 30 54](https://user-images.githubusercontent.com/52501540/64943868-1f51cc00-d86d-11e9-80a9-b086c9dcf376.png)

### After
New destination:
![Schermafbeelding 2019-09-16 om 10 31 06](https://user-images.githubusercontent.com/52501540/64943880-2547ad00-d86d-11e9-8867-61b49a6ab71f.png)

## Types of changes
- Bug fix

