### PR TITLE
Improve error handling for media and AJAX tests

### DIFF
--- a/tests/phpunit/includes/factory/class-wp-unittest-factory-for-attachment.php
+++ b/tests/phpunit/includes/factory/class-wp-unittest-factory-for-attachment.php
@@ -35,6 +35,9 @@ class WP_UnitTest_Factory_For_Attachment extends WP_UnitTest_Factory_For_Post {
 		$contents = file_get_contents($file);
 		$upload = wp_upload_bits(basename($file), null, $contents);
 
+		if ( ! empty( $upload['error'] ) ) {
+			throw new ErrorException( $upload['error'] );
+		}
 		$type = '';
 		if ( ! empty($upload['type']) ) {
 			$type = $upload['type'];

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -724,6 +724,16 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 		}
 	}
 
+	public function assertAttachmentMetaHasSizes( $meta ) {
+		if ( ! isset( $meta['sizes'] ) ) {
+			throw new ErrorException(
+				"No 'sizes' attribute for attachment metadata:"
+				. "\n" . json_encode( $meta )
+				. "\n\nTry installing the `imagick` or `gd` extensions for PHP."
+			);
+		}
+	}
+
 	function unlink( $file ) {
 		$exists = is_file( $file );
 		if ( $exists && ! in_array( $file, self::$ignore_files ) ) {
@@ -835,6 +845,9 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	function _make_attachment($upload, $parent_post_id = 0) {
+		if ( ! empty( $upload['error'] ) ) {
+			throw new ErrorException( $upload['error'] );
+		}
 		$type = '';
 		if ( !empty($upload['type']) ) {
 			$type = $upload['type'];

--- a/tests/phpunit/tests/ajax/MediaEdit.php
+++ b/tests/phpunit/tests/ajax/MediaEdit.php
@@ -43,12 +43,12 @@ class Tests_Ajax_MediaEdit extends WP_Ajax_UnitTestCase {
 		$_REQUEST['history'] = '[{"c":{"x":5,"y":8,"w":289,"h":322}}]';
 
 		$media_meta = wp_get_attachment_metadata($id);
-		$this->assertArrayHasKey('sizes', $media_meta, 'attachment should have size data');
+		$this->assertAttachmentMetaHasSizes( $media_meta );
 		$this->assertArrayHasKey('medium', $media_meta['sizes'], 'attachment should have data for medium size');
 		$ret = wp_save_image($id);
 
 		$media_meta = wp_get_attachment_metadata($id);
-		$this->assertArrayHasKey('sizes', $media_meta, 'cropped attachment should have size data');
+		$this->assertAttachmentMetaHasSizes( $media_meta );
 		$this->assertArrayHasKey('medium', $media_meta['sizes'], 'cropped attachment should have data for medium size');
 	}
 
@@ -76,6 +76,7 @@ class Tests_Ajax_MediaEdit extends WP_Ajax_UnitTestCase {
 		$ret = wp_save_image( $id );
 
 		$media_meta = wp_get_attachment_metadata( $id );
+		$this->assertAttachmentMetaHasSizes( $media_meta );
 		$sizes1 = $media_meta['sizes'];
 
 		$_REQUEST['history'] = '[{"c":{"x":5,"y":8,"w":189,"h":322}}]';
@@ -83,6 +84,7 @@ class Tests_Ajax_MediaEdit extends WP_Ajax_UnitTestCase {
 		$ret = wp_save_image( $id );
 
 		$media_meta = wp_get_attachment_metadata( $id );
+		$this->assertAttachmentMetaHasSizes( $media_meta );
 		$sizes2 = $media_meta['sizes'];
 
 		$file_path = dirname( get_attached_file( $id ) );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1299,6 +1299,7 @@ EOF;
 
 		$year_month = date('Y/m');
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$uploads_dir_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/';
 
 		// Set up test cases for all expected size names.
@@ -1345,6 +1346,7 @@ EOF;
 		$id = self::factory()->attachment->create_upload_object( $filename );
 
 		$image_meta = wp_get_attachment_metadata( $id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$uploads_dir_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/';
 
 		// Set up test cases for all expected size names.
@@ -1387,6 +1389,7 @@ EOF;
 		// For this test we're going to mock metadata changes from an edit.
 		// Start by getting the attachment metadata.
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$image_url = wp_get_attachment_image_url( self::$large_id, 'medium' );
 		$size_array = $this->_get_image_size_array_from_meta( $image_meta, 'medium' );
 
@@ -1421,6 +1424,7 @@ EOF;
 
 		$year_month = date('Y/m');
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$uploads_dir_url = 'http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/';
 
 		// Set up test cases for all expected size names.
@@ -1696,6 +1700,7 @@ EOF;
 		$_wp_additional_image_sizes = wp_get_additional_image_sizes();
 
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$size_array = array( 1600, 1200 ); // full size
 
 		$srcset = wp_get_attachment_image_srcset( self::$large_id, $size_array, $image_meta );
@@ -1786,6 +1791,7 @@ EOF;
 		// Test sizes against the default WP sizes.
 		$intermediates = array( 'thumbnail', 'medium', 'medium_large', 'large' );
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 
 		// Make sure themes aren't filtering the sizes array.
 		remove_all_filters( 'wp_calculate_image_sizes' );
@@ -1807,6 +1813,7 @@ EOF;
 	 */
 	function test_wp_make_content_images_responsive() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$size_array = $this->_get_image_size_array_from_meta( $image_meta, 'medium' );
 
 		$srcset = sprintf( 'srcset="%s"', wp_get_attachment_image_srcset( self::$large_id, $size_array, $image_meta ) );
@@ -1940,6 +1947,7 @@ EOF;
 	 */
 	function test_wp_make_content_images_responsive_schemes() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
 		$size_array = $this->_get_image_size_array_from_meta( $image_meta, 'medium' );
 
 		$srcset = sprintf( 'srcset="%s"', wp_get_attachment_image_srcset( self::$large_id, $size_array, $image_meta ) );
@@ -2092,6 +2100,10 @@ EOF;
 	 * @see https://core.trac.wordpress.org/ticket/36246
 	 */
 	function test_wp_get_attachment_image_should_use_wp_get_attachment_metadata() {
+		// Do this check before the filter which will add $meta['sizes']['testsize']
+		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$this->assertAttachmentMetaHasSizes( $image_meta );
+
 		add_filter( 'wp_get_attachment_metadata', array( $this, '_filter_36246' ), 10, 2 );
 
 		remove_all_filters( 'wp_calculate_image_sizes' );


### PR DESCRIPTION
When running the following PHPUnit tests without the `imagick` or `gd` extensions installed, or with incorrect file permissions in the `wp-content/uploads` directory, running the automated tests will generate some cryptic errors:

```
phpunit --group ajax
phpunit --filter Tests_Media
```

### Before

Example error messages for missing image extensions:

```
1) Tests_Media::test_wp_calculate_image_srcset
Undefined index: sizes

1) Tests_Ajax_MediaEdit::testCropImageThumbnail
attachment should have size data
Failed asserting that an array has the key 'sizes'.
```

And for incorrect filesystem permissions:

```
1) Tests_Ajax_Attachments::test_wp_ajax_send_attachment_to_editor_should_return_an_image
Undefined index: file

1) Tests_Media::test_wp_get_attachment_image_defaults
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<img width="0" height="0" src="" class="attachment-thumbnail size-thumbnail" alt="" />'
+''

1) Tests_Media::test_media_handle_upload_sets_post_excerpt
mysqli_real_escape_string() expects parameter 2 to be string, object given
```

### After

Error messages for at least these two groups of tests are consistent when image extensions are missing:

```
1) Tests_Ajax_MediaEdit::testCropImageThumbnail
ErrorException: No 'sizes' attribute for attachment metadata:
{"width":640,"height":480,"file":"2019\/09\/canola-1.jpg","image_meta":{"aperture":"0","credit":"",camera":"","caption":"","created_timestamp":"0","copyright":"","focal_length":"0","iso":"0","shutte_speed":"0","title":"","orientation":"0","keywords":[]}}

Try installing the `imagick` or `gd` extensions for PHP.
```

And when filesystem permissions are incorrect:

```
1) Tests_Media
ErrorException: Unable to create directory wp-content/uploads/2019/09. Is its parent directory writa
ble by the server? in .../tests/phpunit/includes/factory/class-wp-unittest-fact
ory-for-attachment.php:39

1) Tests_Ajax_Attachments::test_wp_ajax_send_attachment_to_editor_should_return_an_image
ErrorException: Unable to create directory wp-content/uploads/2019/09. Is its parent directory writable by the server?

1) Tests_Ajax_Attachments::test_wp_ajax_send_attachment_to_editor_should_return_an_image
ErrorException: Could not write file .../ClassicPress/src/wp-content/uploads/2019/09/canola.jpg
```