### PR TITLE
Updating wp-config-sample.php's second link.

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -75,7 +75,7 @@ $table_prefix  = 'cp_';
  * For information on other constants that can be used for debugging,
  * visit the Codex.
  *
- * @link https://codex.wordpress.org/Debugging_in_WordPress
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
  */
 define('WP_DEBUG', false);
 


### PR DESCRIPTION
## Description
Changed the second link in wp-config-sample.php to https://wordpress.org/support/article/debugging-in-wordpress/

## Motivation and context
After making a PR for https://github.com/ClassicPress/ClassicPress/pull/488 I decided to look at the other links in the root files of CP and found another one. Once again in wp-config-sample.php:
https://codex.wordpress.org/Debugging_in_WordPress

## How has this been tested?
Tested quickly. Low chance of conflict elsewhere.

## Screenshots

### Before
Old destination:
![Schermafbeelding 2019-09-18 om 13 52 47](https://user-images.githubusercontent.com/52501540/65146934-4fd86800-da1d-11e9-96de-55624e7395eb.png)

### After
New destination:
![Schermafbeelding 2019-09-18 om 13 53 00](https://user-images.githubusercontent.com/52501540/65146941-5666df80-da1d-11e9-84ff-06a1ba3b8bb6.png)

## Types of changes
- Bug fix

