### PR TITLE
Show a bit more info when listing Twemoji files fails

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -720,10 +720,18 @@ module.exports = function(grunt) {
                                 grunt.log.writeln( 'Fetching list of Twemoji files...' );
 
                                 // Fetch a list of the files that Twemoji supplies
-                                files = spawn( 'svn', [ 'ls', 'https://github.com/twitter/twemoji/branches/gh-pages/2/svg' ] );
+                                const svnArgs = [ 'ls', 'https://github.com/twitter/twemoji/branches/gh-pages/2/svg' ];
+                                files = spawn( 'svn', svnArgs );
                                 if ( 0 !== files.status ) {
-									grunt.fatal( 'Unable to fetch Twemoji file list' );
-								}
+                                    grunt.log.writeln(
+                                        'Command FAILED, try running it manually:'.yellow
+                                    );
+                                    grunt.log.writeln(
+                                        ( 'svn ' + svnArgs.join( ' ' ) ).yellow
+                                    );
+                                    grunt.log.writeln();
+                                    grunt.fatal( 'Unable to fetch Twemoji file list' );
+                                }
 
                                 entities = files.stdout.toString();
 


### PR DESCRIPTION
This helps track down the error more easily if someone is trying to run `grunt precommit` without `svn` installed.

See also #447 for another future improvement here.

### Before

```
Running "replace:emojiRegex" (replace) task
Fetching list of Twemoji files...
Fatal error: Unable to fetch Twemoji file list
```

### After

```
Running "replace:emojiRegex" (replace) task
Fetching list of Twemoji files...
Command FAILED, try running it manually:
svn ls https://github.com/twitter/twemoji/branches/gh-pages/2/svg

Fatal error: Unable to fetch Twemoji file list
```