### PR TITLE
Update jQuery version after security patch

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -227,8 +227,8 @@ function wp_default_scripts( &$scripts ) {
 	$scripts->add( 'cropper', '/wp-includes/js/crop/cropper.js', array('scriptaculous-dragdrop') );
 
 	// jQuery
-	$scripts->add( 'jquery', false, array( 'jquery-core', 'jquery-migrate' ), '1.12.4' );
-	$scripts->add( 'jquery-core', '/wp-includes/js/jquery/jquery.js', array(), '1.12.4' );
+	$scripts->add( 'jquery', false, array( 'jquery-core', 'jquery-migrate' ), '1.12.4-wp' );
+	$scripts->add( 'jquery-core', '/wp-includes/js/jquery/jquery.js', array(), '1.12.4-wp' );
 	$scripts->add( 'jquery-migrate', "/wp-includes/js/jquery/jquery-migrate$suffix.js", array(), '1.4.1' );
 
 	// full jQuery UI


### PR DESCRIPTION
## Description
Fixes #476 

## Motivation and context
This updates the jQuery version after applying the latest security fix from WP. The security fix has already been applied in ClassicPress 1.0.1. See #476 for more details.

## How has this been tested?
Tested and integrated upstream

## Screenshots
N/A

## Types of changes
Simple update to jquery version numbers to enable browsers to download fixed versions sooner than current cache expiry.