### PR TITLE
Strip more build metadata from classicpress_version_short()

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -97,7 +97,7 @@ if ( ! function_exists( 'classicpress_version' ) ) {
 if ( ! function_exists( 'classicpress_version_short' ) ) {
 	function classicpress_version_short() {
 		global $cp_version;
-		return strtok( $cp_version, '-' );
+		return preg_replace( '#[+-].*$#', '', $cp_version );
 	}
 }
 


### PR DESCRIPTION
This PR updates the `classicpress_version_short()` function that is used internally to print or log the version number in a couple of places.

Previously, build metadata like `1.1.1+dev` or `1.1.1+migration.20191018` would be included here.

After this PR, this metadata will be stripped and the function will behave as expected, returning e.g. just `1.1.1`.