### PR TITLE
Improve changelog version headings on About page

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -98,10 +98,15 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				); ?>
 			</p>
 			<h3><?php _e( 'ClassicPress changelogs' ); ?></h3>
+			<h4><?php printf(
+				/* translators: current ClassicPress version */
+				__( 'ClassicPress 1.0.1 - %s' ),
+				classicpress_version()
+			); ?></h4>
 			<p>
 				<?php printf(
 					/* translators: link to ClassicPress release announcements subforum */
-					__( 'The changes and new features included in each version of ClassicPress can be found in our <a href="%s"><strong>Release Announcements subforum</strong></a>.' ),
+					__( 'The changes and new features included in recent versions of ClassicPress can be found in our <a href="%s"><strong>Release Announcements subforum</strong></a>.' ),
 					'https://forums.classicpress.net/c/announcements/release-notes'
 				);
 				?>


### PR DESCRIPTION
This PR attempts to make the "changelog" section of the About page easier to read.

### Before

![2019-10-24T04-04-43Z](https://user-images.githubusercontent.com/227022/67453582-9cafef80-f616-11e9-8ee7-5a996a3f7528.png)

### After

![2019-10-24T04-10-32Z](https://user-images.githubusercontent.com/227022/67453579-9cafef80-f616-11e9-8632-9048f858c775.png)