### PR TITLE
Update first section of About page

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -35,7 +35,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 		<div class="wp-badge"></div>
 
 		<h2 class="nav-tab-wrapper wp-clearfix">
-			<a href="about.php" class="nav-tab nav-tab-active"><?php _e( 'What&#8217;s New' ); ?></a>
+			<a href="about.php" class="nav-tab nav-tab-active"><?php _e( 'About' ); ?></a>
 			<a href="credits.php" class="nav-tab"><?php _e( 'Credits' ); ?></a>
 			<a href="freedoms.php" class="nav-tab"><?php _e( 'Freedoms' ); ?></a>
 			<a href="freedoms.php?privacy-notice" class="nav-tab"><?php _e( 'Privacy' ); ?></a>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -53,11 +53,13 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				</p>
 			<?php } ?>
 
-			<h3><?php _e( 'Introducing ClassicPress' ); ?></h3>
+			<h3><?php _e( 'About ClassicPress' ); ?></h3>
 
 			<p>
-				<?php _e(
-					'ClassicPress is a fork of the WordPress 4.9 branch, including the battle-tested and proven classic editor interface using TinyMCE.'
+				<?php printf(
+					/* translators: link to ClassicPress site */
+					__( '<a href="%s"><strong>ClassicPress</strong></a> is a fork of the WordPress 4.9 branch, including the battle-tested and proven classic editor interface using TinyMCE.' ),
+					'https://www.classicpress.net'
 				); ?>
 			</p>
 			<p>

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -34,7 +34,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 <div class="wp-badge"></div>
 
 <h2 class="nav-tab-wrapper wp-clearfix">
-	<a href="about.php" class="nav-tab"><?php _e( 'What&#8217;s New' ); ?></a>
+	<a href="about.php" class="nav-tab"><?php _e( 'About' ); ?></a>
 	<a href="credits.php" class="nav-tab nav-tab-active"><?php _e( 'Credits' ); ?></a>
 	<a href="freedoms.php" class="nav-tab"><?php _e( 'Freedoms' ); ?></a>
 	<a href="freedoms.php?privacy-notice" class="nav-tab"><?php _e( 'Privacy' ); ?></a>

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -37,7 +37,7 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 <div class="wp-badge"></div>
 
 <h2 class="nav-tab-wrapper wp-clearfix">
-	<a href="about.php" class="nav-tab"><?php _e( 'What&#8217;s New' ); ?></a>
+	<a href="about.php" class="nav-tab"><?php _e( 'About' ); ?></a>
 	<a href="credits.php" class="nav-tab"><?php _e( 'Credits' ); ?></a>
 	<a href="freedoms.php" class="nav-tab<?php if ( ! $is_privacy_notice ) { echo ' nav-tab-active'; } ?>"><?php _e( 'Freedoms' ); ?></a>
 	<a href="freedoms.php?privacy-notice" class="nav-tab<?php if ( $is_privacy_notice ) { echo ' nav-tab-active'; } ?>"><?php _e( 'Privacy' ); ?></a>


### PR DESCRIPTION
Since we've been around for a year now, this PR changes the "Introducing ClassicPress" heading on the About page to "About ClassicPress", and adds a link to the main ClassicPress website.

### Before

![2019-10-24T04-21-22Z](https://user-images.githubusercontent.com/227022/67453673-eef11080-f616-11e9-956d-449c4e4e0333.png)

### After

![2019-10-24T04-21-07Z](https://user-images.githubusercontent.com/227022/67453674-eef11080-f616-11e9-8c8a-164818f9c5ff.png)