### PR TITLE
Begin updating links to use links.classicpress.net

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -71,7 +71,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 					/* translators: 1: link with instructions to join ClassicPress Slack, 2: link to community forums */
 					__( 'For general discussion about ClassicPress, <a href="%1$s"><strong>join our Slack group</strong></a> or our <a href="%2$s"><strong>community forum</strong></a>.' ),
 					'https://www.classicpress.net/join-slack/',
-					'https://forums.classicpress.net/c/support'
+					'https://link.classicpress.net/support'
 				); ?>
 			</p>
 			<p>
@@ -86,7 +86,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 					/* translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum */
 					__( 'If you need help with something else, please see our <a href="%1$s"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
 					'https://link.classicpress.net/faq-support/',
-					'https://forums.classicpress.net/c/support/'
+					'https://link.classicpress.net/support'
 				); ?>
 			</p>
 			<p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -78,7 +78,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				<?php printf(
 					/* translators: link to ClassicPress Petitions site for new features */
 					__( 'Suggestions for improvements to future versions of ClassicPress are welcome at <a href="%s"><strong>our petitions site</strong></a>.' ),
-					'https://petitions.classicpress.net/'
+					'https://link.classicpress.net/petitions'
 				); ?>
 			</p>
 			<p>
@@ -111,7 +111,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				<?php printf(
 					/* translators: link to ClassicPress 1.0.0 changelog */
 					__( 'For a list of new features and other changes from WordPress 4.9.x, see the <a href="%s"><strong>ClassicPress 1.0.0 (Aurora) release notes</strong></a>.' ),
-					'https://forums.classicpress.net/t/classicpress-1-0-0-aurora-release-notes/910'
+					'https://link.classicpress.net/classicpress-1-0-0-aurora-release-notes'
 				);
 				?>
 			</p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -85,7 +85,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				<?php printf(
 					/* translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum */
 					__( 'If you need help with something else, please see our <a href="%1$s"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
-					'https://docs.classicpress.net/faq-support/',
+					'https://link.classicpress.net/faq-support/',
 					'https://forums.classicpress.net/c/support/'
 				); ?>
 			</p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -102,7 +102,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				<?php printf(
 					/* translators: link to ClassicPress release announcements subforum */
 					__( 'The changes and new features included in each version of ClassicPress can be found in our <a href="%s"><strong>Release Announcements subforum</strong></a>.' ),
-					'https://forums.classicpress.net/c/announcements/release-notes'
+					'https://link.classicpress.net/c/announcements/release-notes'
 				);
 				?>
 			</p>

--- a/src/wp-admin/comment.php
+++ b/src/wp-admin/comment.php
@@ -49,7 +49,7 @@ case 'editcomment' :
 	get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Administration_Screens#Comments">Documentation on Comments</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 	);
 
 	wp_enqueue_script('comment');

--- a/src/wp-admin/custom-background.php
+++ b/src/wp-admin/custom-background.php
@@ -95,7 +95,7 @@ class Custom_Background {
 		get_current_screen()->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 			'<p>' . __( '<a href="https://codex.wordpress.org/Appearance_Background_Screen">Documentation on Custom Background</a>' ) . '</p>' .
-			'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+			'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 		);
 
 		wp_enqueue_media();

--- a/src/wp-admin/custom-header.php
+++ b/src/wp-admin/custom-header.php
@@ -121,7 +121,7 @@ class Custom_Image_Header {
 		get_current_screen()->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 			'<p>' . __( '<a href="https://codex.wordpress.org/Appearance_Header_Screen">Documentation on Custom Header</a>' ) . '</p>' .
-			'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+			'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 		);
 	}
 

--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -185,7 +185,7 @@ get_current_screen()->set_help_sidebar(
 	'<p>' . __( '<a href="https://codex.wordpress.org/Administration_Screens#Comments">Documentation on Comments</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Comment_Spam">Documentation on Comment Spam</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Keyboard_Shortcuts">Documentation on Keyboard Shortcuts</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -390,7 +390,7 @@ if ( 'post' == $post_type ) {
 			'<p>' . sprintf(__('You can also create posts with the <a href="%s">Press This bookmarklet</a>.'), 'tools.php') . '</p>' .
 			'<p><strong>' . __('For more information:') . '</strong></p>' .
 			'<p>' . __('<a href="https://codex.wordpress.org/Posts_Add_New_Screen">Documentation on Writing and Editing Posts</a>') . '</p>' .
-			'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+			'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 } elseif ( 'page' == $post_type ) {
 	$about_pages = '<p>' . __('Pages are similar to posts in that they have a title, body text, and associated metadata, but they are different in that they are not part of the chronological blog stream, kind of like permanent posts. Pages are not categorized or tagged, but can have a hierarchy. You can nest pages under other pages by making one the &#8220;Parent&#8221; of the other, creating a group of pages.') . '</p>' .
@@ -406,7 +406,7 @@ if ( 'post' == $post_type ) {
 			'<p><strong>' . __('For more information:') . '</strong></p>' .
 			'<p>' . __('<a href="https://codex.wordpress.org/Pages_Add_New_Screen">Documentation on Adding New Pages</a>') . '</p>' .
 			'<p>' . __('<a href="https://codex.wordpress.org/Pages_Screen#Editing_Individual_Pages">Documentation on Editing Pages</a>') . '</p>' .
-			'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+			'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 } elseif ( 'attachment' == $post_type ) {
 	get_current_screen()->add_help_tab( array(
@@ -422,7 +422,7 @@ if ( 'post' == $post_type ) {
 	get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Media_Add_New_Screen#Edit_Media">Documentation on Edit Media</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 }
 

--- a/src/wp-admin/edit-link-form.php
+++ b/src/wp-admin/edit-link-form.php
@@ -63,7 +63,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Links_Add_New_Screen">Documentation on Creating Links</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 require_once( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/edit-tags.php
+++ b/src/wp-admin/edit-tags.php
@@ -269,7 +269,7 @@ if ( 'category' == $taxonomy || 'link_category' == $taxonomy || 'post_tag' == $t
 	else
 		$help .= '<p>' . __( '<a href="https://codex.wordpress.org/Posts_Tags_Screen">Documentation on Tags</a>' ) . '</p>';
 
-	$help .= '<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>';
+	$help .= '<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>';
 
 	get_current_screen()->set_help_sidebar( $help );
 

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -226,7 +226,7 @@ if ( 'post' == $post_type ) {
 	get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Posts_Screen">Documentation on Managing Posts</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 
 } elseif ( 'page' == $post_type ) {
@@ -247,7 +247,7 @@ if ( 'post' == $post_type ) {
 	get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Pages_Screen">Documentation on Managing Pages</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 
 }

--- a/src/wp-admin/export.php
+++ b/src/wp-admin/export.php
@@ -52,7 +52,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Tools_Export_Screen">Documentation on Export</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 // If the 'download' URL parameter is set, a WXR export file is baked and returned.

--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -27,7 +27,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Tools_Import_Screen">Documentation on Import</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 if ( current_user_can( 'install_plugins' ) ) {

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -686,7 +686,7 @@ class WP_Automatic_Updater {
 		} else {
 			// Add a note about the support forums.
 			$body .= "\n\n" . __( 'If you experience any issues or need support, the volunteers in the ClassicPress.net support forums may be able to help.' );
-			$body .= "\n" . __( 'https://forums.classicpress.net/c/support' );
+			$body .= "\n" . __( 'https://link.classicpress.net/support' );
 		}
 
 		// Updates are important!

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -837,7 +837,7 @@ This debugging email is sent when you are using a development version of Classic
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
  * If you need general support: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://docs.classicpress.net/testing-classicpress/#reporting-bugs
+ * Or, if you're comfortable writing a bug report: https://links.classicpress.net/testing-classicpress/#reporting-bugs
 
 Thanks! -- The ClassicPress Team" ) );
 			$body[] = '';

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -837,7 +837,7 @@ This debugging email is sent when you are using a development version of Classic
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
  * If you need general support: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://links.classicpress.net/testing-classicpress/#reporting-bugs
+ * Or, if you're comfortable writing a bug report: https://link.classicpress.net/testing-classicpress/#reporting-bugs
 
 Thanks! -- The ClassicPress Team" ) );
 			$body[] = '';

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -836,8 +836,8 @@ class WP_Automatic_Updater {
 This debugging email is sent when you are using a development version of ClassicPress.
 
 If you think these failures might be due to a bug in ClassicPress, could you report it?
- * If you need general support: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://link.classicpress.net/testing-classicpress/#reporting-bugs
+ * If you need general support: https://link.classicpress.net/faq-support/
+ * Or, if you're comfortable writing a bug report: https://link.classicpress.net/testing-classicpress/reporting-bugs
 
 Thanks! -- The ClassicPress Team" ) );
 			$body[] = '';

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -994,5 +994,5 @@ function get_site_screen_help_tab_args() {
 function get_site_screen_help_sidebar_content() {
 	return '<p><strong>' . __('For more information:') . '</strong></p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-		'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>';
+		'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>';
 }

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -161,7 +161,7 @@ function plugins_api( $action, $args = array() ) {
 				sprintf(
 					/* translators: %s: support forums URL */
 					__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 				headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 			);
@@ -175,7 +175,7 @@ function plugins_api( $action, $args = array() ) {
 				sprintf(
 					/* translators: %s: support forums URL */
 					__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				),
 				$request->get_error_message()
 			);
@@ -186,7 +186,7 @@ function plugins_api( $action, $args = array() ) {
 					sprintf(
 						/* translators: %s: support forums URL */
 						__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-						__( 'https://forums.classicpress.net/c/support' )
+						__( 'https://link.classicpress.net/support' )
 					),
 					wp_remote_retrieve_body( $request )
 				);

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -461,7 +461,7 @@ function themes_api( $action, $args = array() ) {
 					sprintf(
 						/* translators: %s: support forums URL */
 						__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-						__( 'https://forums.classicpress.net/c/support' )
+						__( 'https://link.classicpress.net/support' )
 					) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 					headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 				);
@@ -476,7 +476,7 @@ function themes_api( $action, $args = array() ) {
 				sprintf(
 					/* translators: %s: support forums URL */
 					__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				),
 				$request->get_error_message()
 			);
@@ -487,7 +487,7 @@ function themes_api( $action, $args = array() ) {
 					sprintf(
 						/* translators: %s: support forums URL */
 						__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-						__( 'https://forums.classicpress.net/c/support' )
+						__( 'https://link.classicpress.net/support' )
 					),
 					wp_remote_retrieve_body( $request )
 				);

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -66,7 +66,7 @@ function translations_api( $type, $args = null ) {
 				sprintf(
 					/* translators: %s: support forums URL */
 					__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 				headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 			);
@@ -80,7 +80,7 @@ function translations_api( $type, $args = null ) {
 				sprintf(
 					/* translators: %s: support forums URL */
 					__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				),
 				$request->get_error_message()
 			);
@@ -91,7 +91,7 @@ function translations_api( $type, $args = null ) {
 					sprintf(
 						/* translators: %s: support forums URL */
 						__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-						__( 'https://forums.classicpress.net/c/support' )
+						__( 'https://link.classicpress.net/support' )
 					),
 					wp_remote_retrieve_body( $request )
 				);

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -110,7 +110,7 @@ function get_core_checksums( $version, $locale ) {
 			sprintf(
 				/* translators: %s: support forums URL */
 				__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-				__( 'https://forums.classicpress.net/c/support' )
+				__( 'https://link.classicpress.net/support' )
 			) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);

--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -87,7 +87,7 @@ unset( $help );
 $screen->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Dashboard_Screen">Documentation on Dashboard</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/link-manager.php
+++ b/src/wp-admin/link-manager.php
@@ -64,7 +64,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Links_Screen">Documentation on Managing Links</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -144,7 +144,7 @@ if ( ! defined( 'WP_ALLOW_REPAIR' ) ) {
 	}
 
 	if ( $problems ) {
-		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors into the <a href="%s">support forum</a> for additional assistance.') . '</p>', __( 'https://forums.classicpress.net/c/support/' ) );
+		printf( '<p>' . __('Some database problems could not be repaired. Please copy-and-paste the following list of errors into the <a href="%s">support forum</a> for additional assistance.') . '</p>', __( 'https://link.classicpress.net/support' ) );
 		$problem_output = '';
 		foreach ( $problems as $table => $problem )
 			$problem_output .= "$table: $problem\n";

--- a/src/wp-admin/media-new.php
+++ b/src/wp-admin/media-new.php
@@ -54,7 +54,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Media_Add_New_Screen">Documentation on Uploading Media Files</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 require_once( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/media.php
+++ b/src/wp-admin/media.php
@@ -81,7 +81,7 @@ case 'edit' :
 	get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Media_Add_New_Screen#Edit_Media">Documentation on Edit Media</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 
 	require( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/my-sites.php
+++ b/src/wp-admin/my-sites.php
@@ -45,7 +45,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Dashboard_My_Sites_Screen">Documentation on My Sites</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 require_once( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -569,7 +569,7 @@ endif;
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Appearance_Menus_Screen">Documentation on Menus</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 // Get the admin header.

--- a/src/wp-admin/network.php
+++ b/src/wp-admin/network.php
@@ -76,7 +76,7 @@ get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Create_A_Network">Documentation on Creating a Network</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Tools_Network_Screen">Documentation on the Network Screen</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/network/index.php
+++ b/src/wp-admin/network/index.php
@@ -48,7 +48,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin">Documentation on the Network Admin</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 wp_dashboard_setup();

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -58,7 +58,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Settings_Screen">Documentation on Network Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 if ( $_POST ) {

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -28,7 +28,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-site' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -40,7 +40,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Sites_Screen">Documentation on Site Management</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -227,7 +227,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Themes_Screen">Documentation on Network Themes</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/network/upgrade.php
+++ b/src/wp-admin/network/upgrade.php
@@ -27,7 +27,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Updates_Screen">Documentation on Upgrade Network</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 require_once( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -24,7 +24,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 if ( isset($_REQUEST['action']) && 'add-user' == $_REQUEST['action'] ) {

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -177,7 +177,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Network_Admin_Users_Screen">Documentation on Network Users</a>') . '</p>' .
-	'<p>' . __('<a href="https://docs.classicpress.net/faq-support/">Support</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/faq-support/">Support</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -26,7 +26,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_Discussion_Screen">Documentation on Discussion Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -43,7 +43,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_General_Screen">Documentation on General Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -32,7 +32,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_Media_Screen">Documentation on Media Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -43,7 +43,7 @@ get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_Permalinks_Screen">Documentation on Permalinks Settings</a>') . '</p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Using_Permalinks">Documentation on Using Permalinks</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 $home_path = get_home_path();

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -36,7 +36,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_Reading_Screen">Documentation on Reading Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -43,7 +43,7 @@ if ( apply_filters( 'enable_update_services_configuration', true ) ) {
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Settings_Writing_Screen">Documentation on Writing Settings</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include( ABSPATH . 'wp-admin/admin-header.php' );

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -134,7 +134,7 @@ if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 		'<p><strong>' . __('For more information:') . '</strong></p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Plugins_Editor_Screen">Documentation on Editing Plugins</a>') . '</p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Writing_a_Plugin">Documentation on Writing Plugins</a>') . '</p>' .
-		'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+		'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 
 	$settings = array(

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -96,7 +96,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Plugins_Add_New_Screen">Documentation on Installing Plugins</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -433,7 +433,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Managing_Plugins#Plugin_Management">Documentation on Managing Plugins</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/revision.php
+++ b/src/wp-admin/revision.php
@@ -118,7 +118,7 @@ get_current_screen()->add_help_tab( array(
 
 $revisions_sidebar  = '<p><strong>' . __( 'For more information:' ) . '</strong></p>';
 $revisions_sidebar .= '<p>' . __( '<a href="https://codex.wordpress.org/Revision_Management">Revisions Management</a>' ) . '</p>';
-$revisions_sidebar .= '<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>';
+$revisions_sidebar .= '<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>';
 
 get_current_screen()->set_help_sidebar( $revisions_sidebar );
 

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -176,7 +176,7 @@ switch ( $step ) {
 		echo '		<td><input name="prefix" id="prefix" type="text" value="cp_" size="25" /> ' .
 			sprintf(
 				'<a href="%s" target="_blank" rel="noopener">' . __( 'Learn More' ) . '</a>',
-				esc_url('https://docs.classicpress.net/installing-classicpress/#installation-steps')
+				esc_url('https://links.classicpress.net/installing-classicpress/#installation-steps')
 			) .
 			'</td>';
 		echo '	</tr>';

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -176,7 +176,7 @@ switch ( $step ) {
 		echo '		<td><input name="prefix" id="prefix" type="text" value="cp_" size="25" /> ' .
 			sprintf(
 				'<a href="%s" target="_blank" rel="noopener">' . __( 'Learn More' ) . '</a>',
-				esc_url('https://link.classicpress.net/installing-classicpress/#installation-steps')
+				esc_url('https://link.classicpress.net/installing-classicpress/installation-steps')
 			) .
 			'</td>';
 		echo '	</tr>';

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -176,7 +176,7 @@ switch ( $step ) {
 		echo '		<td><input name="prefix" id="prefix" type="text" value="cp_" size="25" /> ' .
 			sprintf(
 				'<a href="%s" target="_blank" rel="noopener">' . __( 'Learn More' ) . '</a>',
-				esc_url('https://links.classicpress.net/installing-classicpress/#installation-steps')
+				esc_url('https://link.classicpress.net/installing-classicpress/#installation-steps')
 			) .
 			'</td>';
 		echo '	</tr>';

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -150,7 +150,7 @@ switch ( $step ) {
 		echo '<p>' .  sprintf(
 			/* translators: link to support forums for more help */
 			__( 'To get started, fill in your database information. If you don&#8217;t have this information, it can be requested from your web host. Need more <a href="%s" target="_blank" rel="noopener">help</a>?' ),
-			'https://forums.classicpress.net/c/support'
+			'https://link.classicpress.net/support'
 		) . '</p>';
 
 		// Database settings inputs.

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -46,7 +46,7 @@ get_current_screen()->set_help_sidebar(
 	'<p>' . __('<a href="https://codex.wordpress.org/Using_Themes">Documentation on Using Themes</a>') . '</p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Editing_Files">Documentation on Editing Files</a>') . '</p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Template_Tags">Documentation on Template Tags</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 wp_reset_vars( array( 'action', 'error', 'file', 'theme' ) );
@@ -327,7 +327,7 @@ if ( ! in_array( 'theme_editor_notice', $dismissed_pointers, true ) ) :
 					?>
 				</p>
 				<p><?php _e( 'If you decide to go ahead with direct edits anyway, use a file manager to create a copy with a new name and hang on to the original. That way, you can re-enable a functional version if something goes wrong.' ); ?></p>
-				
+
 			</div>
 			<p>
 				<a class="button file-editor-warning-go-back" href="<?php echo esc_url( $return_url ); ?>"><?php _e( 'Go back' ); ?></a>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -56,7 +56,7 @@ wp_localize_script( 'theme', '_wpThemeSettings', array(
 		'error'               => sprintf(
 			/* translators: %s: support forums URL */
 			__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-			__( 'https://forums.classicpress.net/c/support' )
+			__( 'https://link.classicpress.net/support' )
 		),
 		'tryAgain'            => __( 'Try Again' ),
 		'themesFound'         => __( 'Number of Themes found: %d' ),
@@ -118,7 +118,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Using_Themes#Adding_New_Themes">Documentation on Adding New Themes</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 include(ABSPATH . 'wp-admin/admin-header.php');

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -116,7 +116,7 @@ if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' )
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Using_Themes">Documentation on Using Themes</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 if ( current_user_can( 'switch_themes' ) ) {

--- a/src/wp-admin/tools.php
+++ b/src/wp-admin/tools.php
@@ -31,7 +31,7 @@ if ( $is_privacy_guide ) {
 	get_current_screen()->set_help_sidebar(
 		'<p><strong>' . __('For more information:') . '</strong></p>' .
 		'<p>' . __('<a href="https://codex.wordpress.org/Tools_Screen">Documentation on Tools</a>') . '</p>' .
-		'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+		'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 	);
 }
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -556,7 +556,7 @@ function do_core_upgrade( $reinstall = false ) {
 				show_message( sprintf(
 					/* translators: URL to support forum */
 					__( 'If you see this message after waiting 15 minutes and trying the update again, please make a post on our <a href="%s">support forum</a>.' ),
-					'https://forums.classicpress.net/c/support/'
+					'https://link.classicpress.net/support'
 				) );
 				break;
 
@@ -645,7 +645,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Dashboard_Updates_Screen">Documentation on Updating ClassicPress</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 if ( 'upgrade-core' == $action ) {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -204,7 +204,7 @@ function core_upgrade_preamble() {
 		printf(
 			__( '<strong>Important:</strong> before updating, please <a href="%1$s">back up your database and files</a>. For help with updates, visit the <a href="%2$s">Updating ClassicPress</a> documentation page.' ),
 			'https://codex.wordpress.org/WordPress_Backups',
-			'https://links.classicpress.net/updating-classicpress/'
+			'https://link.classicpress.net/updating-classicpress/'
 		);
 		echo '</p></div>';
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -204,7 +204,7 @@ function core_upgrade_preamble() {
 		printf(
 			__( '<strong>Important:</strong> before updating, please <a href="%1$s">back up your database and files</a>. For help with updates, visit the <a href="%2$s">Updating ClassicPress</a> documentation page.' ),
 			'https://codex.wordpress.org/WordPress_Backups',
-			'https://docs.classicpress.net/updating-classicpress/'
+			'https://links.classicpress.net/updating-classicpress/'
 		);
 		echo '</p></div>';
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -64,7 +64,7 @@ if ( 'grid' === $mode ) {
 	get_current_screen()->set_help_sidebar(
 		'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 		'<p>' . __( '<a href="https://codex.wordpress.org/Media_Library_Screen">Documentation on Media Library</a>' ) . '</p>' .
-		'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+		'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 	);
 
 	$title = __('Media Library');
@@ -210,7 +210,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Media_Library_Screen">Documentation on Media Library</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://link.classicpress.net/support">Support Forums</a>' ) . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -59,7 +59,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wordpress.org/Users_Your_Profile_Screen">Documentation on User Profiles</a>') . '</p>' .
-    '<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+    '<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 $wp_http_referer = remove_query_arg( array( 'update', 'delete_count', 'user_id' ), $wp_http_referer );

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -218,7 +218,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wordpress.org/Users_Add_New_Screen">Documentation on Adding New Users</a>') . '</p>' .
-    '<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+    '<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 wp_enqueue_script('wp-ajax-response');

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -66,7 +66,7 @@ get_current_screen()->set_help_sidebar(
     '<p><strong>' . __('For more information:') . '</strong></p>' .
     '<p>' . __('<a href="https://codex.wordpress.org/Users_Screen">Documentation on Managing Users</a>') . '</p>' .
     '<p>' . __('<a href="https://codex.wordpress.org/Roles_and_Capabilities">Descriptions of Roles and Capabilities</a>') . '</p>' .
-    '<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+    '<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 get_current_screen()->set_screen_reader_content( array(

--- a/src/wp-admin/widgets.php
+++ b/src/wp-admin/widgets.php
@@ -74,7 +74,7 @@ get_current_screen()->add_help_tab( array(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __('For more information:') . '</strong></p>' .
 	'<p>' . __('<a href="https://codex.wordpress.org/Appearance_Widgets_Screen">Documentation on Widgets</a>') . '</p>' .
-	'<p>' . __('<a href="https://forums.classicpress.net/c/support">Support Forums</a>') . '</p>'
+	'<p>' . __('<a href="https://link.classicpress.net/support">Support Forums</a>') . '</p>'
 );
 
 if ( ! current_theme_supports( 'widgets' ) ) {

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -165,7 +165,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		'parent'    => 'wp-logo-external',
 		'id'        => 'support',
 		'title'     => __('Support'),
-		'href'      => __('https://docs.classicpress.net/faq-support/'),
+		'href'      => __('https://link.classicpress.net/faq-support/'),
 	) );
 }
 

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -157,7 +157,7 @@ function wp_admin_bar_wp_menu( $wp_admin_bar ) {
 		'parent'    => 'wp-logo-external',
 		'id'        => 'documentation',
 		'title'     => __('Documentation'),
-		'href'      => __('https://docs.classicpress.net/'),
+		'href'      => __('https://link.classicpress.net/docs'),
 	) );
 
 	// Add support link

--- a/src/wp-includes/customize/class-wp-customize-themes-section.php
+++ b/src/wp-includes/customize/class-wp-customize-themes-section.php
@@ -81,7 +81,7 @@ class WP_Customize_Themes_Section extends WP_Customize_Section {
 						<?php $this->filter_bar_content_template(); ?>
 					</div>
 					<?php $this->filter_drawer_content_template(); ?>
-					<div class="error unexpected-error" style="display: none; "><p><?php _e( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://forums.classicpress.net/c/support">support forums</a>.' ); ?></p></div>
+					<div class="error unexpected-error" style="display: none; "><p><?php _e( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://link.classicpress.net/support">support forums</a>.' ); ?></p></div>
 					<ul class="themes">
 					</ul>
 					<p class="no-themes"><?php _e( 'No themes found. Try a different search.' ); ?></p>

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -155,7 +155,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 			sprintf(
 				/* translators: %s: support forums URL */
 				__( 'An unexpected error occurred. Something may be wrong with ClassicPress.net or this server&#8217;s configuration. If you continue to have problems, please report this issue in our <a href="%s">support forum</a>.' ),
-				'https://forums.classicpress.net/c/support/'
+				'https://link.classicpress.net/support'
 			) . ' ' . __( '(ClassicPress could not establish a secure connection to ClassicPress.net. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
@@ -346,7 +346,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 			sprintf(
 				/* translators: %s: support forums URL */
 				__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-				__( 'https://forums.classicpress.net/c/support' )
+				__( 'https://link.classicpress.net/support' )
 			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
@@ -528,7 +528,7 @@ function wp_update_themes( $extra_stats = array() ) {
 			sprintf(
 				/* translators: %s: support forums URL */
 				__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.' ),
-				__( 'https://forums.classicpress.net/c/support' )
+				__( 'https://link.classicpress.net/support' )
 			) . ' ' . __( '(WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.)' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1059,7 +1059,7 @@ class wpdb {
 				$message .= '<p>' . sprintf(
 					/* translators: %s: support forums URL */
 					__( 'If you don&#8217;t know how to set up a database you should <strong>contact your host</strong>. If all else fails you may find help at the <a href="%s">ClassicPress Support Forums</a>.' ),
-					__( 'https://forums.classicpress.net/c/support' )
+					__( 'https://link.classicpress.net/support' )
 				) . "</p>\n";
 
 				$this->bail( $message, 'db_select_fail' );
@@ -1592,7 +1592,7 @@ class wpdb {
 			$message .= '<p>' . sprintf(
 				/* translators: %s: support forums URL */
 				__( 'If you&#8217;re unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">ClassicPress Support Forums</a>.' ),
-				__( 'https://forums.classicpress.net/c/support' )
+				__( 'https://link.classicpress.net/support' )
 			) . "</p>\n";
 
 			$this->bail( $message, 'db_connect_fail' );
@@ -1750,7 +1750,7 @@ class wpdb {
 		$message .= '<p>' . sprintf(
 			/* translators: %s: support forums URL */
 			__( 'If you&#8217;re unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">ClassicPress Support Forums</a>.' ),
-			__( 'https://forums.classicpress.net/c/support' )
+			__( 'https://link.classicpress.net/support' )
 		) . "</p>\n";
 
 		// We weren't able to reconnect, so we better bail.


### PR DESCRIPTION
## Description
Issue #501 recommends pushing all ClassicPress.net URLs via the `link` subdomain. This is an initial PR covering three simple links to ensure the approach is correct before I scale up the changes.

## Motivation and context
Initial progress towards issue #501

## How has this been tested?
The links have been amended 


## Types of changes
New feature / enhancement
