### PR TITLE
Guard against duplicate MIME-Version header in emails

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -447,10 +447,13 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	 */
 	$phpmailer->CharSet = apply_filters( 'wp_mail_charset', $charset );
 
-	// Set custom headers
-	if ( !empty( $headers ) ) {
+	// Set custom headers.
+	if ( ! empty( $headers ) ) {
 		foreach ( (array) $headers as $name => $content ) {
-			$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+			// Only add custom headers not added automatically by PHPMailer.
+			if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer') ) ) {
+				$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+			}
 		}
 
 		if ( false !== stripos( $content_type, 'multipart' ) && ! empty($boundary) )

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -451,7 +451,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	if ( ! empty( $headers ) ) {
 		foreach ( (array) $headers as $name => $content ) {
 			// Only add custom headers not added automatically by PHPMailer.
-			if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer') ) ) {
+			if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer' ) ) ) {
 				$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
 			}
 		}

--- a/tests/phpunit/tests/mail.php
+++ b/tests/phpunit/tests/mail.php
@@ -274,6 +274,22 @@ class Tests_Mail extends WP_UnitTestCase {
 		$this->assertTrue( strpos( $mailer->get_sent()->header, $expected ) > 0 );
 	}
 
+	/**
+	 * @ticket 43542
+	 */
+	public function test_wp_mail_does_not_duplicate_mime_version_header() {
+		$to       = 'user@example.com';
+		$subject  = 'Test email with a MIME-Version header';
+		$message  = 'The MIME-Version header should not be duplicated.';
+		$headers  = 'MIME-Version: 1.0';
+		$expected = 'MIME-Version: 1.0';
+
+		wp_mail( $to, $subject, $message, $headers );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertEquals( 1, substr_count( $mailer->get_sent()->header, $expected ) );
+	}
+
 	function wp_mail_quoted_printable( $mailer ) {
 		$mailer->Encoding = 'quoted-printable';
 	}

--- a/tests/phpunit/tests/mail.php
+++ b/tests/phpunit/tests/mail.php
@@ -275,7 +275,7 @@ class Tests_Mail extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 43542
+	 * @see https://core.trac.wordpress.org/ticket/43542
 	 */
 	public function test_wp_mail_does_not_duplicate_mime_version_header() {
 		$to       = 'user@example.com';


### PR DESCRIPTION
Fixes Issue #495 

## Description
Backport of 3 upstream change sets
https://core.trac.wordpress.org/changeset/46115
https://core.trac.wordpress.org/changeset/46116
https://core.trac.wordpress.org/changeset/46118

## Motivation and context
Fixes issue described in Issue #495

## How has this been tested?
Unit tests are part of patch

## Types of changes
- Bug fix
