### PR TITLE
Document and verify KSES functions as accepting arrays

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -515,6 +515,7 @@ if ( ! CUSTOM_TAGS ) {
  * @return string                         Filtered content with only allowed HTML elements
  */
 function wp_kses( $string, $allowed_html, $allowed_protocols = array() ) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	if ( empty( $allowed_protocols ) )
 		$allowed_protocols = wp_allowed_protocols();
 	$string = wp_kses_no_null( $string, array( 'slash_zero' => 'keep' ) );
@@ -689,6 +690,7 @@ function wp_kses_allowed_html( $context = '' ) {
  * @return string                         Filtered content through {@see 'pre_kses'} hook.
  */
 function wp_kses_hook( $string, $allowed_html, $allowed_protocols ) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	/**
 	 * Filters content to be run through kses.
 	 *
@@ -728,6 +730,7 @@ function wp_kses_version() {
  * @return string                         Content with fixed HTML tags
  */
 function wp_kses_split( $string, $allowed_html, $allowed_protocols ) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	global $pass_allowed_html, $pass_allowed_protocols;
 	$pass_allowed_html = $allowed_html;
 	$pass_allowed_protocols = $allowed_protocols;
@@ -1305,6 +1308,7 @@ function wp_kses_bad_protocol($string, $allowed_protocols) {
  * @return string
  */
 function wp_kses_no_null( $string, $options = null ) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	if ( ! isset( $options['slash_zero'] ) ) {
 		$options = array( 'slash_zero' => 'remove' );
 	}
@@ -1330,6 +1334,7 @@ function wp_kses_no_null( $string, $options = null ) {
  * @return string              Fixed string with quoted slashes
  */
 function wp_kses_stripslashes($string) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return preg_replace('%\\\\"%', '"', $string);
 }
 
@@ -1369,6 +1374,7 @@ function wp_kses_array_lc($inarray) {
  * @return string
  */
 function wp_kses_html_error($string) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return preg_replace('/^("[^"]*("|$)|\'[^\']*(\'|$)|\S)*\s*/', '', $string);
 }
 
@@ -1447,6 +1453,7 @@ function wp_kses_bad_protocol_once2( $string, $allowed_protocols ) {
  * @return string              Content with normalized entities
  */
 function wp_kses_normalize_entities($string) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	// Disarm all entities by converting & to &amp;
 	$string = str_replace('&', '&amp;', $string);
 
@@ -1556,6 +1563,7 @@ function valid_unicode($i) {
  * @return string              Content after decoded entities
  */
 function wp_kses_decode_entities($string) {
+	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	$string = preg_replace_callback('/&#([0-9]+);/', '_wp_kses_decode_entities_chr', $string);
 	$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+);/', '_wp_kses_decode_entities_chr_hexdec', $string);
 
@@ -1607,6 +1615,7 @@ function wp_filter_kses( $data ) {
  * @return string            Filtered content
  */
 function wp_kses_data( $data ) {
+	if ( is_array( $data ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return wp_kses( $data, current_filter() );
 }
 
@@ -1637,6 +1646,7 @@ function wp_filter_post_kses( $data ) {
  * @return string            Filtered post content with allowed HTML tags and attributes intact.
  */
 function wp_kses_post( $data ) {
+	if ( is_array( $data ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return wp_kses( $data, 'post' );
 }
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -515,7 +515,6 @@ if ( ! CUSTOM_TAGS ) {
  * @return string                         Filtered content with only allowed HTML elements
  */
 function wp_kses( $string, $allowed_html, $allowed_protocols = array() ) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	if ( empty( $allowed_protocols ) )
 		$allowed_protocols = wp_allowed_protocols();
 	$string = wp_kses_no_null( $string, array( 'slash_zero' => 'keep' ) );
@@ -690,7 +689,6 @@ function wp_kses_allowed_html( $context = '' ) {
  * @return string                         Filtered content through {@see 'pre_kses'} hook.
  */
 function wp_kses_hook( $string, $allowed_html, $allowed_protocols ) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	/**
 	 * Filters content to be run through kses.
 	 *
@@ -730,7 +728,6 @@ function wp_kses_version() {
  * @return string                         Content with fixed HTML tags
  */
 function wp_kses_split( $string, $allowed_html, $allowed_protocols ) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	global $pass_allowed_html, $pass_allowed_protocols;
 	$pass_allowed_html = $allowed_html;
 	$pass_allowed_protocols = $allowed_protocols;
@@ -1308,7 +1305,6 @@ function wp_kses_bad_protocol($string, $allowed_protocols) {
  * @return string
  */
 function wp_kses_no_null( $string, $options = null ) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	if ( ! isset( $options['slash_zero'] ) ) {
 		$options = array( 'slash_zero' => 'remove' );
 	}
@@ -1334,7 +1330,6 @@ function wp_kses_no_null( $string, $options = null ) {
  * @return string              Fixed string with quoted slashes
  */
 function wp_kses_stripslashes($string) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return preg_replace('%\\\\"%', '"', $string);
 }
 
@@ -1374,7 +1369,6 @@ function wp_kses_array_lc($inarray) {
  * @return string
  */
 function wp_kses_html_error($string) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return preg_replace('/^("[^"]*("|$)|\'[^\']*(\'|$)|\S)*\s*/', '', $string);
 }
 
@@ -1453,7 +1447,6 @@ function wp_kses_bad_protocol_once2( $string, $allowed_protocols ) {
  * @return string              Content with normalized entities
  */
 function wp_kses_normalize_entities($string) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	// Disarm all entities by converting & to &amp;
 	$string = str_replace('&', '&amp;', $string);
 
@@ -1563,7 +1556,6 @@ function valid_unicode($i) {
  * @return string              Content after decoded entities
  */
 function wp_kses_decode_entities($string) {
-	if ( is_array( $string ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	$string = preg_replace_callback('/&#([0-9]+);/', '_wp_kses_decode_entities_chr', $string);
 	$string = preg_replace_callback('/&#[Xx]([0-9A-Fa-f]+);/', '_wp_kses_decode_entities_chr_hexdec', $string);
 
@@ -1615,7 +1607,6 @@ function wp_filter_kses( $data ) {
  * @return string            Filtered content
  */
 function wp_kses_data( $data ) {
-	if ( is_array( $data ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return wp_kses( $data, current_filter() );
 }
 
@@ -1646,7 +1637,6 @@ function wp_filter_post_kses( $data ) {
  * @return string            Filtered post content with allowed HTML tags and attributes intact.
  */
 function wp_kses_post( $data ) {
-	if ( is_array( $data ) && getenv( 'KSES_ARRAY_TEST' ) === __FUNCTION__ ) throw new ErrorException( 'KSES function passed array: ' . __FUNCTION__ );
 	return wp_kses( $data, 'post' );
 }
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -509,10 +509,10 @@ if ( ! CUSTOM_TAGS ) {
  *
  * @since WP-1.0.0
  *
- * @param string $string            Content to filter through kses
- * @param array  $allowed_html      List of allowed HTML elements
- * @param array  $allowed_protocols Optional. Allowed protocol in links.
- * @return string Filtered content with only allowed HTML elements
+ * @param string|array $string            Content to filter through kses
+ * @param array        $allowed_html      List of allowed HTML elements
+ * @param array        $allowed_protocols Optional. Allowed protocol in links.
+ * @return string                         Filtered content with only allowed HTML elements
  */
 function wp_kses( $string, $allowed_html, $allowed_protocols = array() ) {
 	if ( empty( $allowed_protocols ) )
@@ -683,10 +683,10 @@ function wp_kses_allowed_html( $context = '' ) {
  *
  * @since WP-1.0.0
  *
- * @param string $string            Content to filter through kses
- * @param array  $allowed_html      List of allowed HTML elements
- * @param array  $allowed_protocols Allowed protocol in links
- * @return string Filtered content through {@see 'pre_kses'} hook.
+ * @param string|array $string            Content to filter through kses
+ * @param array        $allowed_html      List of allowed HTML elements
+ * @param array        $allowed_protocols Allowed protocol in links
+ * @return string                         Filtered content through {@see 'pre_kses'} hook.
  */
 function wp_kses_hook( $string, $allowed_html, $allowed_protocols ) {
 	/**
@@ -694,9 +694,9 @@ function wp_kses_hook( $string, $allowed_html, $allowed_protocols ) {
 	 *
 	 * @since WP-2.3.0
 	 *
-	 * @param string $string            Content to run through kses.
-	 * @param array  $allowed_html      Allowed HTML elements.
-	 * @param array  $allowed_protocols Allowed protocol in links.
+	 * @param string|array $string            Content to run through kses.
+	 * @param array        $allowed_html      Allowed HTML elements.
+	 * @param array        $allowed_protocols Allowed protocol in links.
 	 */
 	return apply_filters( 'pre_kses', $string, $allowed_html, $allowed_protocols );
 }
@@ -722,10 +722,10 @@ function wp_kses_version() {
  * @global array $pass_allowed_html
  * @global array $pass_allowed_protocols
  *
- * @param string $string            Content to filter
- * @param array  $allowed_html      Allowed HTML elements
- * @param array  $allowed_protocols Allowed protocols to keep
- * @return string Content with fixed HTML tags
+ * @param string|array $string            Content to filter
+ * @param array        $allowed_html      Allowed HTML elements
+ * @param array        $allowed_protocols Allowed protocols to keep
+ * @return string                         Content with fixed HTML tags
  */
 function wp_kses_split( $string, $allowed_html, $allowed_protocols ) {
 	global $pass_allowed_html, $pass_allowed_protocols;
@@ -1300,8 +1300,8 @@ function wp_kses_bad_protocol($string, $allowed_protocols) {
  *
  * @since WP-1.0.0
  *
- * @param string $string
- * @param array $options Set 'slash_zero' => 'keep' when '\0' is allowed. Default is 'remove'.
+ * @param string|array $string
+ * @param array        $options Set 'slash_zero' => 'keep' when '\0' is allowed. Default is 'remove'.
  * @return string
  */
 function wp_kses_no_null( $string, $options = null ) {
@@ -1326,8 +1326,8 @@ function wp_kses_no_null( $string, $options = null ) {
  *
  * @since WP-1.0.0
  *
- * @param string $string String to strip slashes
- * @return string Fixed string with quoted slashes
+ * @param string|array $string String to strip slashes
+ * @return string              Fixed string with quoted slashes
  */
 function wp_kses_stripslashes($string) {
 	return preg_replace('%\\\\"%', '"', $string);
@@ -1365,7 +1365,7 @@ function wp_kses_array_lc($inarray) {
  *
  * @since WP-1.0.0
  *
- * @param string $string
+ * @param string|array $string
  * @return string
  */
 function wp_kses_html_error($string) {
@@ -1443,8 +1443,8 @@ function wp_kses_bad_protocol_once2( $string, $allowed_protocols ) {
  *
  * @since WP-1.0.0
  *
- * @param string $string Content to normalize entities
- * @return string Content with normalized entities
+ * @param string|array $string Content to normalize entities
+ * @return string              Content with normalized entities
  */
 function wp_kses_normalize_entities($string) {
 	// Disarm all entities by converting & to &amp;
@@ -1552,8 +1552,8 @@ function valid_unicode($i) {
  *
  * @since WP-1.0.0
  *
- * @param string $string Content to change entities
- * @return string Content after decoded entities
+ * @param string|array $string Content to change entities
+ * @return string              Content after decoded entities
  */
 function wp_kses_decode_entities($string) {
 	$string = preg_replace_callback('/&#([0-9]+);/', '_wp_kses_decode_entities_chr', $string);
@@ -1603,8 +1603,8 @@ function wp_filter_kses( $data ) {
  *
  * @since WP-2.9.0
  *
- * @param string $data Content to filter, expected to not be escaped
- * @return string Filtered content
+ * @param string|array $data Content to filter, expected to not be escaped
+ * @return string            Filtered content
  */
 function wp_kses_data( $data ) {
 	return wp_kses( $data, current_filter() );
@@ -1633,8 +1633,8 @@ function wp_filter_post_kses( $data ) {
  *
  * @since WP-2.9.0
  *
- * @param string $data Post content to filter
- * @return string Filtered post content with allowed HTML tags and attributes intact.
+ * @param string|array $data Post content to filter
+ * @return string            Filtered post content with allowed HTML tags and attributes intact.
  */
 function wp_kses_post( $data ) {
 	return wp_kses( $data, 'post' );

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -755,4 +755,32 @@ EOF;
 
 		$this->assertEquals( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => false ), array() ) );
 	}
+
+	function test_wp_kses_array() {
+		global $allowedposttags;
+
+		$attributes = array(
+			'class'  => 'classname',
+			'id'     => 'id',
+			'style'  => 'color: red;',
+			'title'  => 'title',
+			'href'   => 'http://example.com',
+			'rel'    => 'related',
+			'rev'    => 'revision',
+			'name'   => 'name',
+			'target' => '_blank',
+		);
+
+		$input           = [];
+		$output_expected = [];
+		$output_actual   = [];
+
+		foreach ( $attributes as $name => $value ) {
+			$input[]           = "<a $name='$value'>I link this</a>";
+			$output_expected[] = "<a $name='" . trim( $value, ';' ) . "'>I link this</a>";
+		}
+
+		$output_actual = wp_kses( $input, $allowedposttags );
+		$this->assertEquals( $output_expected, $output_actual );
+	}
 }


### PR DESCRIPTION
Related: https://core.trac.wordpress.org/ticket/48955

Some of the changes in WordPress 5.3.1 broke long-standing but undocumented behavior of the KSES functions: many of them, including the main functions like `wp_kses`, accepted an array of data in addition to just a string.

ClassicPress 1.1.2 adopted a related patch from the WP 4.9.13 release, but it does not break passing an array to `wp_kses`.

Since some plugins depend on this behavior (see WP Trac link above for details), this PR is intended to document the KSES functions that can accept arrays, and also add automated tests to make sure this continues working in the future.