### PR TITLE
Add rel="noopener noreferrer" to plugins screen links

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -651,11 +651,11 @@ function install_plugin_information() {
 					}
 					?></li>
 			<?php } if ( ! empty( $api->slug ) && empty( $api->external ) ) { ?>
-				<li><a target="_blank" href="<?php echo __( 'https://wordpress.org/plugins/' ) . $api->slug; ?>/"><?php _e( 'WordPress.org Plugin Page &#187;' ); ?></a></li>
+				<li><a target="_blank" rel="noopener noreferrer" href="<?php echo __( 'https://wordpress.org/plugins/' ) . $api->slug; ?>/"><?php _e( 'WordPress.org Plugin Page &#187;' ); ?></a></li>
 			<?php } if ( ! empty( $api->homepage ) ) { ?>
-				<li><a target="_blank" href="<?php echo esc_url( $api->homepage ); ?>"><?php _e( 'Plugin Homepage &#187;' ); ?></a></li>
+				<li><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $api->homepage ); ?>"><?php _e( 'Plugin Homepage &#187;' ); ?></a></li>
 			<?php } if ( ! empty( $api->donate_link ) && empty( $api->contributors ) ) { ?>
-				<li><a target="_blank" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a></li>
+				<li><a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a></li>
 			<?php } ?>
 		</ul>
 		<?php if ( ! empty( $api->rating ) ) { ?>


### PR DESCRIPTION
## Description
Add rel="noopener noreferrer" to plugins links. See attached screenshot.
![Screenshot 2019-12-25 at 11 47 03](https://user-images.githubusercontent.com/7713923/71439943-a0dab500-270c-11ea-9dd8-9b42359c6ed0.png)

This page a couple of JavaScript files running which leaves the website owner vulnerable. It is a common link click area.

When you open another page using target="_blank", the other page may run on the same process as your page, unless Site Isolation is enabled. If the other page is running a lot of JavaScript, your page's performance may also suffer. 

Ref: https://developers.google.com/web/tools/lighthouse/audits/noopener
