### PR TITLE
Fix the admin bar logo position with the Twenty Twenty theme

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -483,7 +483,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	height: 18px;
 	margin: 7px 2px 6px 1px;
 	vertical-align: top;
-	display: inline;
+	display: inline-block;
 }
 
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item {
@@ -500,7 +500,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	vertical-align: top;
 	padding-top: 4px;
 	margin-left: -2px;
-	display: inline;
+	display: inline-block;
 }
 
 #wpadminbar #wp-admin-bar-appearance {

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -483,6 +483,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	height: 18px;
 	margin: 7px 2px 6px 1px;
 	vertical-align: top;
+	display: inline;
 }
 
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item {
@@ -493,12 +494,13 @@ html:lang(he-il) .rtl #wpadminbar *  {
  * My Sites & Site Title
  */
 #wp-admin-bar-my-sites-list .ab-item img.cp-logo {
-    width: 18px;
-    height: 18px;
-    margin-right: 6px;
-    vertical-align: top;
-    padding-top: 4px;
-    margin-left: -2px;
+	width: 18px;
+	height: 18px;
+	margin-right: 6px;
+	vertical-align: top;
+	padding-top: 4px;
+	margin-left: -2px;
+	display: inline;
 }
 
 #wpadminbar #wp-admin-bar-appearance {


### PR DESCRIPTION
When running ClassicPress with the Twenty Twenty theme from WordPress, the pop-out menu from the ClassicPress logo in the admin bar is positioned incorrectly:

<img src="https://user-images.githubusercontent.com/227022/72199121-70df2180-342f-11ea-9375-e45be597f799.png" width="450">

This happens because Twenty Twenty contains the following CSS rule:
`img { display: block }`

To fix the issue we set the display of these images to `inline` in the admin bar CSS:

<img src="https://user-images.githubusercontent.com/227022/72199123-83595b00-342f-11ea-8671-f173211e8a5f.png" width="450">

A similar issue exists in the sites menu for multisite installations, and the fix is the same.