### PR TITLE
WP-r45928: https://core.trac.wordpress.org/ticket/43590: Use robots m…

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1306,6 +1306,8 @@ function do_feed_atom( $for_comments ) {
  * robots.txt file.
  *
  * @since WP-2.1.0
+ * @since WP-5.3.0 Remove the "Disallow: /" output if search engine visiblity is
+ *              discouraged in favor of robots meta HTML tag in wp_no_robots().
  */
 function do_robots() {
 	header( 'Content-Type: text/plain; charset=utf-8' );
@@ -1319,14 +1321,11 @@ function do_robots() {
 
 	$output = "User-agent: *\n";
 	$public = get_option( 'blog_public' );
-	if ( '0' == $public ) {
-		$output .= "Disallow: /\n";
-	} else {
-		$site_url = parse_url( site_url() );
-		$path = ( !empty( $site_url['path'] ) ) ? $site_url['path'] : '';
-		$output .= "Disallow: $path/wp-admin/\n";
-		$output .= "Allow: $path/wp-admin/admin-ajax.php\n";
-	}
+
+	$site_url = parse_url( site_url() );
+	$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+	$output  .= "Disallow: $path/wp-admin/\n";
+	$output  .= "Allow: $path/wp-admin/admin-ajax.php\n";
 
 	/**
 	 * Filters the robots.txt output.
@@ -2404,7 +2403,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		} else {
 			if ( $type !== $real_mime ) {
 				/*
-				 * Everything else including image/* and application/*: 
+				 * Everything else including image/* and application/*:
 				 * If the real content type doesn't match the file extension, assume it's dangerous.
 				 */
 				$type = $ext = false;
@@ -2413,7 +2412,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		}
 	}
 
-	// The mime type must be allowed 
+	// The mime type must be allowed
 	if ( $type ) {
 		$allowed = get_allowed_mime_types();
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2403,7 +2403,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		} else {
 			if ( $type !== $real_mime ) {
 				/*
-				 * Everything else including image/* and application/*:
+				 * Everything else including image/* and application/*: 
 				 * If the real content type doesn't match the file extension, assume it's dangerous.
 				 */
 				$type = $ext = false;
@@ -2412,7 +2412,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		}
 	}
 
-	// The mime type must be allowed
+	// The mime type must be allowed 
 	if ( $type ) {
 		$allowed = get_allowed_mime_types();
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2804,12 +2804,18 @@ function noindex() {
  * Display a noindex meta tag.
  *
  * Outputs a noindex meta tag that tells web robots not to index the page content.
- * Typical usage is as a wp_head callback. add_action( 'wp_head', 'wp_no_robots' );
+ * Typical usage is as a {@see 'wp_head'} callback. add_action( 'wp_head', 'wp_no_robots' );
  *
  * @since WP-3.3.0
+ * @since WP-5.3.0 Echo "noindex,nofollow" if search engine visibility is discouraged.
  */
 function wp_no_robots() {
-	echo "<meta name='robots' content='noindex,follow' />\n";
+	if ( get_option( 'blog_public' ) ) {
+		echo "<meta name='robots' content='noindex,follow' />\n";
+		return;
+	}
+
+	echo "<meta name='robots' content='noindex,nofollow' />\n";
 }
 
 /**

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -611,4 +611,19 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $result );
 	}
+
+	/**
+	 * @ticket 43590
+	 */
+	function test_wp_no_robots() {
+		// Simulate private site (search engines discouraged).
+		update_option( 'blog_public', '0' );
+		$actual_private = get_echo( 'wp_no_robots' );
+		$this->assertSame( "<meta name='robots' content='noindex,nofollow' />\n", $actual_private );
+
+		// Simulate public site.
+		update_option( 'blog_public', '1' );
+		$actual_public = get_echo( 'wp_no_robots' );
+		$this->assertSame( "<meta name='robots' content='noindex,follow' />\n", $actual_public );
+	}
 }

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -613,7 +613,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 43590
+	 * @see https://core.trac.wordpress.org/ticket/43590
 	 */
 	function test_wp_no_robots() {
 		// Simulate private site (search engines discouraged).


### PR DESCRIPTION
## Description

This changes the "discourage search engines" option to output a `noindex, nofollow` robots meta tag. `Disallow: /` is removed from the `robots.txt` to allow search engines to discover they are requested not to index the site.

Disallowing search engines from accessing a site in the `robots.txt` file can result in search engines listing a site with a fragment (a listing without content).

WP:Props donmhico, jonoaldersonwp.
Fixes https://core.trac.wordpress.org/ticket/43590.

Conflicts:
  src/wp-includes/functions.php
  src/wp-includes/general-template.php
----
Merges https://core.trac.wordpress.org/changeset/45928 / WordPress/wordpress-develop@122cb2864b to ClassicPress.


## Motivation and context
Fixes #474 

## How has this been tested?
Backport and has unit test

## Types of changes
- Bug fix
- Backport
