### PR TITLE
Remove angle brackets from password reset URL in emails

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1904,7 +1904,7 @@ function wp_new_user_notification( $user_id, $deprecated = null, $notify = '' ) 
 	/* translators: %s: user login */
 	$message = sprintf(__('Username: %s'), $user->user_login) . "\r\n\r\n";
 	$message .= __('To set your password, visit the following address:') . "\r\n\r\n";
-	$message .= '<' . network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user->user_login), 'login') . ">\r\n\r\n";
+	$message .= network_site_url("wp-login.php?action=rp&key=$key&login=" . rawurlencode($user->user_login), 'login') . "\r\n\r\n";
 
 	$message .= wp_login_url() . "\r\n";
 


### PR DESCRIPTION
## Description

WP-r47086: Mail: Remove angle brackets from password reset URL in emails sent by `retrieve_password()` and `wp_new_user_notification()`.

The brackets were originally added in https://core.trac.wordpress.org/changeset/16285 per W3C recommendation in https://www.w3.org/Addressing/URL/5.1_Wrappers.html to avoid wrapping the URL across multiple lines in plain text in older email clients.

This doesn't seem like a common issue in modern email clients, and the current implementation causes more issues than it solves. Since the URL is on a line by itself, it should not require any delimiters.

The URL in recovery mode email introduced in https://core.trac.wordpress.org/changeset/44973 doesn't have angle brackets, so it's time to retire them in password reset email too if they're not used consistently.

WP:Props donmhico, Otto42, sproutchris, iandunn, dd32, DaveWP196, sebastian.pisula, tommix, sablednah, julian.kimmig, Rahe, clayisland, arenddeboer, nicole2292, nagoke, squarecandy, eatingrules, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/21095, https://core.trac.wordpress.org/ticket/23578, https://core.trac.wordpress.org/ticket/44589.

Conflicts:
  src/wp-includes/pluggable.php
----
Merges https://core.trac.wordpress.org/changeset/47086 / WordPress/wordpress-develop@480b5c88c3 to ClassicPress.
## Motivation and context
Additional backport for closed ticket #467

## How has this been tested?
This is partial backport.

## Types of changes
- Bug fix
