### PR TITLE
Add missing rel=noopener noreferrer to target=_blank

### DIFF
--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -50,7 +50,7 @@ if ( isset($_REQUEST['attachment_id']) && ($id = intval($_REQUEST['attachment_id
 		case 3 :
 			if ( $thumb_url = wp_get_attachment_image_src( $id, 'thumbnail', true ) )
 				echo '<img class="pinkynail" src="' . esc_url( $thumb_url[0] ) . '" alt="" />';
-			echo '<a class="edit-attachment" href="' . esc_url( get_edit_post_link( $id ) ) . '" target="_blank">' . _x( 'Edit', 'media item' ) . '</a>';
+			echo '<a class="edit-attachment" href="' . esc_url( get_edit_post_link( $id ) ) . '" target="_blank" rel="noopener noreferrer">' . _x( 'Edit', 'media item' ) . '</a>';
 
 			// Title shouldn't ever be empty, but use filename just in case.
 			$file = get_attached_file( $post->ID );

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -103,13 +103,13 @@ $viewable = is_post_type_viewable( $post_type_object );
 if ( $viewable ) {
 
 	// Preview post link.
-	$preview_post_link_html = sprintf( ' <a target="_blank" href="%1$s">%2$s</a>',
+	$preview_post_link_html = sprintf( ' <a target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
 		esc_url( $preview_url ),
 		__( 'Preview post' )
 	);
 
 	// Scheduled post preview link.
-	$scheduled_post_link_html = sprintf( ' <a target="_blank" href="%1$s">%2$s</a>',
+	$scheduled_post_link_html = sprintf( ' <a target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
 		esc_url( $permalink ),
 		__( 'Preview post' )
 	);
@@ -121,13 +121,13 @@ if ( $viewable ) {
 	);
 
 	// Preview page link.
-	$preview_page_link_html = sprintf( ' <a target="_blank" href="%1$s">%2$s</a>',
+	$preview_page_link_html = sprintf( ' <a target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
 		esc_url( $preview_url ),
 		__( 'Preview page' )
 	);
 
 	// Scheduled page preview link.
-	$scheduled_page_link_html = sprintf( ' <a target="_blank" href="%1$s">%2$s</a>',
+	$scheduled_page_link_html = sprintf( ' <a target="_blank" rel="noopener noreferrer" href="%1$s">%2$s</a>',
 		esc_url( $permalink ),
 		__( 'Preview page' )
 	);

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1454,7 +1454,7 @@ function cp_dashboard_petitions_output( $widget_id, $feeds ) {
 
 	?>
 	<div class="sub">
-		<a href="<?php echo esc_url( $response->link ); ?>" target="_blank" class="cp_petitions_link"><?php esc_html_e( 'Your voice counts, create and vote on petitions.' ); ?><span class="screen-reader-text"><?php esc_html_e( '(opens in a new window)' ); ?></span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>
+		<a href="<?php echo esc_url( $response->link ); ?>" target="_blank" rel="noopener noreferrer" class="cp_petitions_link"><?php esc_html_e( 'Your voice counts, create and vote on petitions.' ); ?><span class="screen-reader-text"><?php esc_html_e( '(opens in a new window)' ); ?></span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>
 	</div>
 
 	<ul class="petitions-tabs">
@@ -1503,7 +1503,7 @@ function cp_dashboard_petitions_output( $widget_id, $feeds ) {
 						<td class="votes-count"><?php echo esc_html( $petition->votesCount ); ?></td>
 
 						<td class="petition">
-							<a target="_blank" href="<?php echo esc_url( $petition->link ) ?>"><?php echo esc_html( $petition->title )?><span class="screen-reader-text"><?php esc_html_e( '(opens in a new window)' ); ?></span></a>
+							<a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $petition->link ) ?>"><?php echo esc_html( $petition->title )?><span class="screen-reader-text"><?php esc_html_e( '(opens in a new window)' ); ?></span></a>
 							<?php
 								if ( 'open' === $petition->status ){
 									echo esc_html__( ' - ' ) . ' ' . sprintf( __( '%s ago' ), human_time_diff( strtotime( $petition->createdAt ), current_time( 'timestamp' ) ) );

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2688,7 +2688,7 @@ function media_upload_max_image_resize() {
 	$a = $end = '';
 
 	if ( current_user_can( 'manage_options' ) ) {
-		$a = '<a href="' . esc_url( admin_url( 'options-media.php' ) ) . '" target="_blank">';
+		$a = '<a href="' . esc_url( admin_url( 'options-media.php' ) ) . '" target="_blank" rel="noopener noreferrer">';
 		$end = '</a>';
 	}
 ?>

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -938,7 +938,7 @@ function link_submit_meta_box($link) {
 <div id="minor-publishing-actions">
 <div id="preview-action">
 <?php if ( !empty($link->link_id) ) { ?>
-	<a class="preview button" href="<?php echo $link->link_url; ?>" target="_blank"><?php _e('Visit Link'); ?></a>
+	<a class="preview button" href="<?php echo $link->link_url; ?>" target="_blank" rel="noopener noreferrer"><?php _e('Visit Link'); ?></a>
 <?php } ?>
 </div>
 <div class="clear"></div>

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1663,7 +1663,7 @@ final class WP_Privacy_Policy_Content {
 			printf(
 				__( 'Need help putting together your new Privacy Policy page? <a href="%1$s" %2$s>Check out our guide%3$s</a> for recommendations on what content to include, along with policies suggested by your plugins and theme.' ),
 				admin_url( 'tools.php?wp-privacy-policy-guide=1' ),
-				'target="_blank"',
+				'target="_blank" rel="noopener noreferrer"',
 				sprintf(
 					'<span class="screen-reader-text"> %s</span>',
 					/* translators: accessibility text */

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -679,7 +679,7 @@ function install_plugin_information() {
 				?>
 				<div class="counter-container">
 						<span class="counter-label"><a href="https://wordpress.org/support/plugin/<?php echo $api->slug; ?>/reviews/?filter=<?php echo $key; ?>"
-						                               target="_blank" aria-label="<?php echo $aria_label; ?>"><?php printf( _n( '%d star', '%d stars', $key ), $key ); ?></a></span>
+						                               target="_blank" rel="noopener noreferrer" aria-label="<?php echo $aria_label; ?>"><?php printf( _n( '%d star', '%d stars', $key ), $key ); ?></a></span>
 						<span class="counter-back">
 							<span class="counter-bar" style="width: <?php echo 92 * $_rating; ?>px;"></span>
 						</span>
@@ -709,7 +709,7 @@ function install_plugin_information() {
 				?>
 			</ul>
 			<?php if ( ! empty( $api->donate_link ) ) { ?>
-				<a target="_blank" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a>
+				<a target="_blank" rel="noopener noreferrer" href="<?php echo esc_url( $api->donate_link ); ?>"><?php _e( 'Donate to this plugin &#187;' ); ?></a>
 			<?php } ?>
 		<?php } ?>
 	</div>

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1365,7 +1365,7 @@ function get_sample_permalink_html( $id, $new_title = null, $new_slug = null ) {
 
 		// Encourage a pretty permalink setting
 		if ( '' == get_option( 'permalink_structure' ) && current_user_can( 'manage_options' ) && !( 'page' == get_option('show_on_front') && $id == get_option('page_on_front') ) ) {
-			$return .= '<span id="change-permalinks"><a href="options-permalink.php" class="button button-small" target="_blank">' . __('Change Permalinks') . "</a></span>\n";
+			$return .= '<span id="change-permalinks"><a href="options-permalink.php" class="button button-small" target="_blank" rel="noopener noreferrer">' . __('Change Permalinks') . "</a></span>\n";
 		}
 	} else {
 		if ( mb_strlen( $post_name ) > 34 ) {

--- a/src/wp-admin/security.php
+++ b/src/wp-admin/security.php
@@ -63,7 +63,7 @@ switch ( $active_tab ) :
 		<?php
 		printf(
 			/* translators: canonical link to security forum */
-			__( 'Watch this page and the ClassicPress <a href="%s" rel="noopener" target="_blank">Security forum</a> for more news as development continues.' ),
+			__( 'Watch this page and the ClassicPress <a href="%s" target="_blank" rel="noopener noreferrer">Security forum</a> for more news as development continues.' ),
 			'https://link.classicpress.net/forum/security'
 		);
 		?>
@@ -103,7 +103,7 @@ switch ( $active_tab ) :
 		echo '<p>';
 		printf(
 			/* translators: link that describes how to contact plugin authors about the ClassicPress security page */
-			__( 'If you have plugins installed and activated with security-related settings that aren&#8217;t appearing here, <a href="%s" rel="noopener" target="_blank">contact the authors</a> and ask them to add support for the ClassicPress security page.' ),
+			__( 'If you have plugins installed and activated with security-related settings that aren&#8217;t appearing here, <a href="%s" target="_blank" rel="noopener noreferrer">contact the authors</a> and ask them to add support for the ClassicPress security page.' ),
 			'https://link.classicpress.net/security-page/contact-plugin-authors'
 		);
 		echo "</p>\n";
@@ -213,8 +213,8 @@ switch ( $active_tab ) :
 						<div class="inside">
 							<p>
 								<ul>
-									<li><a href="https://link.classicpress.net/support/security-page" rel="noopener" target="_blank"><?php _e( 'Security Page forum' ); ?></a></li>
-									<li><a href="https://link.classicpress.net/security-page" rel="noopener" target="_blank"><?php _e( 'Documentation' ); ?></a></li>
+									<li><a href="https://link.classicpress.net/support/security-page" target="_blank" rel="noopener noreferrer"><?php _e( 'Security Page forum' ); ?></a></li>
+									<li><a href="https://link.classicpress.net/security-page" target="_blank" rel="noopener noreferrer"><?php _e( 'Documentation' ); ?></a></li>
 								</ul>
 							</p>
 						</div>

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -59,7 +59,7 @@ if ( ! $config_file ) {
 	echo '<h1>' . __( 'Sample Config File Missing' ) . '</h1>';
 	echo '<p>' . sprintf(
 		/* translators: 1: wp-config-sample.php, 2: link to the contents of this file */
-		__( 'A %s file was not found. Please upload it to the root of your ClassicPress installation, or one level higher, and then try again. Need a <a href="%s" target="_blank" rel="noopener">fresh copy</a>?' ),
+		__( 'A %s file was not found. Please upload it to the root of your ClassicPress installation, or one level higher, and then try again. Need a <a href="%s" target="_blank" rel="noopener noreferrer">fresh copy</a>?' ),
 		'<code>wp-config-sample.php</code>',
 		esc_url( 'https://raw.githubusercontent.com/ClassicPress/ClassicPress-release/master/wp-config-sample.php' )
 	) . '</p>';
@@ -149,7 +149,7 @@ switch ( $step ) {
 		// Description.
 		echo '<p>' .  sprintf(
 			/* translators: link to support forums for more help */
-			__( 'To get started, fill in your database information. If you don&#8217;t have this information, it can be requested from your web host. Need more <a href="%s" target="_blank" rel="noopener">help</a>?' ),
+			__( 'To get started, fill in your database information. If you don&#8217;t have this information, it can be requested from your web host. Need more <a href="%s" target="_blank" rel="noopener noreferrer">help</a>?' ),
 			'https://forums.classicpress.net/c/support'
 		) . '</p>';
 
@@ -175,7 +175,7 @@ switch ( $step ) {
 		echo '		<th scope="row"><label for="prefix">' . __( 'Table Prefix' ) . '</label></th>';
 		echo '		<td><input name="prefix" id="prefix" type="text" value="cp_" size="25" /> ' .
 			sprintf(
-				'<a href="%s" target="_blank" rel="noopener">' . __( 'Learn More' ) . '</a>',
+				'<a href="%s" target="_blank" rel="noopener noreferrer">' . __( 'Learn More' ) . '</a>',
 				esc_url('https://docs.classicpress.net/installing-classicpress/#installation-steps')
 			) .
 			'</td>';

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -290,7 +290,7 @@ endif; // $_wp_admin_css_colors
 if ( !( IS_PROFILE_PAGE && !$user_can_edit ) ) : ?>
 <tr class="user-comment-shortcuts-wrap">
 <th scope="row"><?php _e( 'Keyboard Shortcuts' ); ?></th>
-<td><label for="comment_shortcuts"><input type="checkbox" name="comment_shortcuts" id="comment_shortcuts" value="true" <?php if ( ! empty( $profileuser->comment_shortcuts ) ) checked( 'true', $profileuser->comment_shortcuts ); ?> /> <?php _e('Enable keyboard shortcuts for comment moderation.'); ?></label> <?php _e('<a href="https://codex.wordpress.org/Keyboard_Shortcuts" target="_blank">More information</a>'); ?></td>
+<td><label for="comment_shortcuts"><input type="checkbox" name="comment_shortcuts" id="comment_shortcuts" value="true" <?php if ( ! empty( $profileuser->comment_shortcuts ) ) checked( 'true', $profileuser->comment_shortcuts ); ?> /> <?php _e('Enable keyboard shortcuts for comment moderation.'); ?></label> <?php _e('<a href="https://codex.wordpress.org/Keyboard_Shortcuts" target="_blank" rel="noopener noreferrer">More information</a>'); ?></td>
 </tr>
 <?php endif; ?>
 <tr class="show-admin-bar user-admin-bar-front-wrap">

--- a/src/wp-includes/class-wp-admin-bar.php
+++ b/src/wp-includes/class-wp-admin-bar.php
@@ -154,6 +154,15 @@ class WP_Admin_Bar {
 			'my-blogs'               => array( 'my-sites',   '3.3' ),
 		);
 
+		if ( isset( $args['meta'], $args['meta']['target'] ) && '_blank' === strtolower( $args['meta']['target'] ) ) {
+			$rel = 'noopener noreferrer';
+			
+			if ( isset( $args['meta']['rel'] ) ) {
+				$rel .= ' ' . $args['meta']['rel'];
+			}
+			$args['meta']['rel'] = $rel;
+		}
+
 		if ( isset( $back_compat_parents[ $args['parent'] ] ) ) {
 			list( $new_parent, $version ) = $back_compat_parents[ $args['parent'] ];
 			_deprecated_argument( __METHOD__, $version, sprintf( 'Use <code>%s</code> as the parent for the <code>%s</code> admin bar node instead of <code>%s</code>.', $new_parent, $args['id'], $args['parent'] ) );

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5260,7 +5260,7 @@ final class WP_Customize_Manager {
 		$section_description = '<p>';
 		$section_description .= __( 'Add your own CSS code here to customize the appearance and layout of your site.' );
 		$section_description .= sprintf(
-			' <a href="%1$s" class="external-link" target="_blank">%2$s<span class="screen-reader-text"> %3$s</span></a>',
+			' <a href="%1$s" class="external-link" target="_blank" rel="noopener noreferrer">%2$s<span class="screen-reader-text"> %3$s</span></a>',
 			esc_url( __( 'https://codex.wordpress.org/CSS' ) ),
 			__( 'Learn more about CSS' ),
 			/* translators: accessibility text */
@@ -5281,7 +5281,7 @@ final class WP_Customize_Manager {
 				/* translators: 1: link to user profile, 2: additional link attributes, 3: accessibility text */
 				__( 'The edit field automatically highlights code syntax. You can disable this in your <a href="%1$s" %2$s>user profile%3$s</a> to work in plain text mode.' ),
 				esc_url( get_edit_profile_url() ),
-				'class="external-link" target="_blank"',
+				'class="external-link" target="_blank" rel="noopener noreferrer"',
 				sprintf( '<span class="screen-reader-text"> %s</span>',
 					/* translators: accessibility text */
 					__( '(opens in a new window)' )

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-locations-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-locations-control.php
@@ -50,7 +50,7 @@ class WP_Customize_Nav_Menu_Locations_Control extends WP_Customize_Control {
 									/* translators: 1: Codex URL, 2: additional link attributes, 3: accessibility text */
 									_x( '(If you plan to use a menu <a href="%1$s" %2$s>widget%3$s</a>, skip this step.)', 'menu locations' ),
 									__( 'https://codex.wordpress.org/WordPress_Widgets' ),
-									' class="external-link" target="_blank"',
+									' class="external-link" target="_blank" rel="noopener noreferrer"',
 									sprintf( '<span class="screen-reader-text"> %s</span>',
 										/* translators: accessibility text */
 										__( '(opens in a new window)' )

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5399,7 +5399,7 @@ function wp_auth_check_html() {
 	?>
 	<div class="wp-auth-fallback">
 		<p><b class="wp-auth-fallback-expired" tabindex="0"><?php _e('Session expired'); ?></b></p>
-		<p><a href="<?php echo esc_url( $login_url ); ?>" target="_blank"><?php _e('Please log in again.'); ?></a>
+		<p><a href="<?php echo esc_url( $login_url ); ?>" target="_blank" rel="noopener noreferrer"><?php _e('Please log in again.'); ?></a>
 		<?php _e('The login page will open in a new window. After logging in you can close it and return to this page.'); ?></p>
 	</div>
 	</div>

--- a/src/wp-includes/js/tinymce/plugins/wplink/plugin.js
+++ b/src/wp-includes/js/tinymce/plugins/wplink/plugin.js
@@ -4,7 +4,7 @@
 		renderHtml: function() {
 			return (
 				'<div id="' + this._id + '" class="wp-link-preview">' +
-					'<a href="' + this.url + '" target="_blank" rel="noopener" tabindex="-1">' + this.url + '</a>' +
+					'<a href="' + this.url + '" target="_blank" rel="noopener noreferrer" tabindex="-1">' + this.url + '</a>' +
 				'</div>'
 			);
 		},

--- a/src/wp-includes/js/tinymce/themes/modern/theme.js
+++ b/src/wp-includes/js/tinymce/themes/modern/theme.js
@@ -1201,7 +1201,7 @@ var modern = (function () {
       };
     }
     if (hasStatusbar(editor)) {
-      var linkHtml = '<a href="https://www.tinymce.com/?utm_campaign=editor_referral&amp;utm_medium=poweredby&amp;utm_source=tinymce" rel="noopener" target="_blank" role="presentation" tabindex="-1">tinymce</a>';
+      var linkHtml = '<a href="https://www.tinymce.com/?utm_campaign=editor_referral&amp;utm_medium=poweredby&amp;utm_source=tinymce" target="_blank" rel="noopener noreferrer" role="presentation" tabindex="-1">tinymce</a>';
       var html = global$5.translate([
         'Powered by {0}',
         linkHtml

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -525,7 +525,7 @@ function wp_print_media_templates() {
 					<# } #>
 
 					<# if ( data.can.save && data.sizes ) { #>
-						<a class="edit-attachment" href="{{ data.editLink }}&amp;image-editor" target="_blank"><?php _e( 'Edit Image' ); ?></a>
+						<a class="edit-attachment" href="{{ data.editLink }}&amp;image-editor" target="_blank" rel="noopener noreferrer"><?php _e( 'Edit Image' ); ?></a>
 					<# } #>
 				<# } #>
 

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -475,7 +475,7 @@ function ms_not_installed( $domain, $path ) {
 	}
 	$msg .= '<p><strong>' . __( 'What do I do now?' ) . '</strong> ';
 	/* translators: %s: Codex URL */
-	$msg .= sprintf( __( 'Read the <a href="%s" target="_blank">bug report</a> page. Some of the guidelines there may help you figure out what went wrong.' ),
+	$msg .= sprintf( __( 'Read the <a href="%s" target="_blank" rel="noopener noreferrer">bug report</a> page. Some of the guidelines there may help you figure out what went wrong.' ),
 		__( 'https://codex.wordpress.org/Debugging_a_WordPress_Network' )
 	);
 	$msg .= ' ' . __( 'If you&#8217;re still stuck with this message, then check that your database contains the following tables:' ) . '</p><ul>';

--- a/src/wp-includes/widgets/class-wp-widget-custom-html.php
+++ b/src/wp-includes/widgets/class-wp-widget-custom-html.php
@@ -298,7 +298,7 @@ class WP_Widget_Custom_HTML extends WP_Widget {
 				/* translators: 1: link to user profile, 2: additional link attributes, 3: accessibility text */
 				__( 'The edit field automatically highlights code syntax. You can disable this in your <a href="%1$s" %2$s>user profile%3$s</a> to work in plain text mode.' ),
 				esc_url( get_edit_profile_url() ),
-				'class="external-link" target="_blank"',
+				'class="external-link" target="_blank" rel="noopener noreferrer"',
 				sprintf( '<span class="screen-reader-text"> %s</span>',
 					/* translators: accessibility text */
 					__( '(opens in a new window)' )

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -250,7 +250,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				$link .= sprintf( ' rel="%s"', esc_attr( $instance['link_rel'] ) );
 			}
 			if ( ! empty( $instance['link_target_blank'] ) ) {
-				$link .= ' target="_blank"';
+				$link .= ' target="_blank" rel="noopener noreferrer"';
 			}
 			$link .= '>';
 			$link .= $image;

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -235,11 +235,11 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 					<p><?php _e( 'Unable to preview media due to an unknown error.' ); ?></p>
 				</div>
 			<# } else if ( data.is_oembed && data.model.poster ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link">
+				<a href="{{ data.model.src }}" target="_blank" rel="noopener noreferrer" class="media-widget-video-link">
 					<img src="{{ data.model.poster }}" />
 				</a>
 			<# } else if ( data.is_oembed ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
+				<a href="{{ data.model.src }}" target="_blank" rel="noopener noreferrer" class="media-widget-video-link no-poster">
 					<span class="dashicons dashicons-format-video"></span>
 				</a>
 			<# } else if ( data.model.src ) { #>

--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -71,6 +71,55 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @see https://core.trac.wordpress.org/ticket/37941
+	 */
+	public function test_it_adds_rel_to_target_blank_links() {
+		$admin_bar = new WP_Admin_Bar;
+		
+		$admin_bar->add_node(
+			array(
+				'id'   => 'test-node',
+				'meta' => [ 'target' => '_blank' ],
+			)
+		);
+		
+		$test_node = $admin_bar->get_node( 'test-node' );
+		
+		$this->assertEquals(
+			[ 'target' => '_blank', 'rel' => 'noopener noreferrer' ],
+			$test_node->meta
+		);
+		
+		$admin_bar->add_node(
+			array(
+				'id'   => 'test-node-2',
+				'meta' => [ 'target' => '_BLANK' ],
+			)
+		);
+
+		$test_node_2 = $admin_bar->get_node( 'test-node-2' );
+
+		$this->assertEquals(
+			[ 'target' => '_BLANK', 'rel' => 'noopener noreferrer' ],
+			$test_node_2->meta
+		);
+
+		$admin_bar->add_node(
+			array(
+				'id'   => 'test-node-3',
+				'meta' => [ 'target' => '_blank', 'rel' => 'nofollow' ],
+			)
+		);
+
+		$test_node_3 = $admin_bar->get_node( 'test-node-3' );
+
+		$this->assertEquals(
+			[ 'target' => '_blank', 'rel' => 'noopener noreferrer nofollow' ],
+			$test_node_3->meta
+		);
+	}
+
+	/**
 	 * @see https://core.trac.wordpress.org/ticket/25162
 	 * @group ms-excluded
 	 */

--- a/tests/phpunit/tests/formatting/LinksAddTarget.php
+++ b/tests/phpunit/tests/formatting/LinksAddTarget.php
@@ -14,19 +14,19 @@ class Tests_Formatting_LinksAddTarget extends WP_UnitTestCase {
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC">LINK</a> HERE </div> END TEXT',
 				null,
 				null,
-				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC" target="_blank">LINK</a> HERE </div> END TEXT'
+				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC" target="_blank" rel="noopener noreferrer">LINK</a> HERE </div> END TEXT'
 			),
 			array (
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <A href="XYZ" src="ABC">LINK</A> HERE </div> END TEXT',
 				null,
 				null,
-				'MY CONTENT <div> SOME ADDITIONAL TEXT <A href="XYZ" src="ABC" target="_blank">LINK</A> HERE </div> END TEXT'
+				'MY CONTENT <div> SOME ADDITIONAL TEXT <A href="XYZ" src="ABC" target="_blank" rel="noopener noreferrer">LINK</A> HERE </div> END TEXT'
 			),
 			array (
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC">LINK</a> HERE </div> <a href="XYZ"  >LINK</a>END TEXT',
 				null,
 				null,
-				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC" target="_blank">LINK</a> HERE </div> <a href="XYZ"   target="_blank">LINK</a>END TEXT'
+				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC" target="_blank" rel="noopener noreferrer">LINK</a> HERE </div> <a href="XYZ" target="_blank" rel="noopener noreferrer">LINK</a>END TEXT'
 			),
 			array (
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC">LINK</a> HERE </div> <span>END TEXT</span>',

--- a/tests/phpunit/tests/formatting/LinksAddTarget.php
+++ b/tests/phpunit/tests/formatting/LinksAddTarget.php
@@ -23,7 +23,7 @@ class Tests_Formatting_LinksAddTarget extends WP_UnitTestCase {
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <A href="XYZ" src="ABC" target="_blank" rel="noopener noreferrer">LINK</A> HERE </div> END TEXT'
 			),
 			array (
-				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC">LINK</a> HERE </div> <a href="XYZ"  >LINK</a>END TEXT',
+				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC">LINK</a> HERE </div> <a href="XYZ">LINK</a>END TEXT',
 				null,
 				null,
 				'MY CONTENT <div> SOME ADDITIONAL TEXT <a href="XYZ" src="ABC" target="_blank" rel="noopener noreferrer">LINK</a> HERE </div> <a href="XYZ" target="_blank" rel="noopener noreferrer">LINK</a>END TEXT'

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -928,9 +928,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			array(
 				// Raw values.
 				array(
-					'title'   => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
-					'description' => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
-					'caption' => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
+					'title'   => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
+					'description' => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
+					'caption' => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
 				),
 				// Expected returned values.
 				array(
@@ -939,12 +939,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 						'rendered' => '<a href="#">link</a>',
 					),
 					'description' => array(
-						'raw'      => '<a href="#" target="_blank">link</a>',
-						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+						'raw'      => '<a href="#" target="_blank" rel="noopener noreferrer">link</a>',
+						'rendered' => '<p><a href="#" target="_blank" rel="noopener noreferrer">link</a></p>',
 					),
 					'caption' => array(
-						'raw'      => '<a href="#" target="_blank">link</a>',
-						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+						'raw'      => '<a href="#" target="_blank" rel="noopener noreferrer">link</a>',
+						'rendered' => '<p><a href="#" target="_blank" rel="noopener noreferrer">link</a></p>',
 					),
 				)
 			),

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2855,9 +2855,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 			array(
 				// Raw values.
 				array(
-					'title'   => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
-					'content' => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
-					'excerpt' => '<a href="#" target="_blank" data-unfiltered=true>link</a>',
+					'title'   => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
+					'content' => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
+					'excerpt' => '<a href="#" target="_blank" rel="noopener noreferrer" data-unfiltered=true>link</a>',
 				),
 				// Expected returned values.
 				array(
@@ -2866,12 +2866,12 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 						'rendered' => '<a href="#">link</a>',
 					),
 					'content' => array(
-						'raw'      => '<a href="#" target="_blank">link</a>',
-						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+						'raw'      => '<a href="#" target="_blank" rel="noopener noreferrer">link</a>',
+						'rendered' => '<p><a href="#" target="_blank" rel="noopener noreferrer">link</a></p>',
 					),
 					'excerpt' => array(
-						'raw'      => '<a href="#" target="_blank">link</a>',
-						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+						'raw'      => '<a href="#" target="_blank" rel="noopener noreferrer">link</a>',
+						'rendered' => '<p><a href="#" target="_blank" rel="noopener noreferrer">link</a></p>',
 					),
 				)
 			),

--- a/tests/phpunit/tests/widgets/media-image-widget.php
+++ b/tests/phpunit/tests/widgets/media-image-widget.php
@@ -423,7 +423,7 @@ class Test_WP_Widget_Media_Image extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertContains( '<a href="https://example.org"', $output );
-		$this->assertContains( 'target="_blank"', $output );
+		$this->assertContains( 'target="_blank" rel="noopener noreferrer"', $output );
 
 		// Populate caption in attachment.
 		wp_update_post( array(

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -661,11 +661,11 @@
 					<p>Unable to preview media due to an unknown error.</p>
 				</div>
 			<# } else if ( data.is_hosted_embed && data.model.poster ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link">
+				<a href="{{ data.model.src }}" target="_blank" rel="noopener noreferrer" class="media-widget-video-link">
 					<img src="{{ data.model.poster }}" />
 				</a>
 			<# } else if ( data.is_hosted_embed ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
+				<a href="{{ data.model.src }}" target="_blank" rel="noopener noreferrer" class="media-widget-video-link no-poster">
 					<span class="dashicons dashicons-format-video"></span>
 				</a>
 			<# } else if ( data.model.src ) { #>
@@ -1268,7 +1268,7 @@
 					<# } #>
 
 					<# if ( data.can.save && data.sizes ) { #>
-						<a class="edit-attachment" href="{{ data.editLink }}&amp;image-editor" target="_blank">Edit Image</a>
+						<a class="edit-attachment" href="{{ data.editLink }}&amp;image-editor" target="_blank" rel="noopener noreferrer">Edit Image</a>
 					<# } #>
 				<# } #>
 


### PR DESCRIPTION
This PR seeks to close #537 as a follow up to #532 (Doing the same job.)

Only one piece of the code from [Ticket #37941](https://core.trac.wordpress.org/ticket/37941) still is not introduced. I am suggesting a different PR for it. 

It has to do with [Ticket #37941: 37941.2.diff](https://core.trac.wordpress.org/attachment/ticket/37941/37941.2.diff) that solves the missing rel=noopener noreferrer to target=_blank for the Admin Bar.