### PR TITLE
WP-r47181: Posts, Post Types recover orphaned content.

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -205,55 +205,45 @@ function map_meta_cap( $cap, $user_id ) {
 		if ( ! $post ) {
 			$caps[] = 'do_not_allow';
 			break;
-<<<<<<< HEAD
 		}
-=======
-		case 'read_post':
-		case 'read_page':
-			$post = get_post( $args[0] );
+
+		if ( 'revision' == $post->post_type ) {
+			$post = get_post( $post->post_parent );
 			if ( ! $post ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
+		}
 
-			if ( 'revision' == $post->post_type ) {
-				$post = get_post( $post->post_parent );
-				if ( ! $post ) {
-					$caps[] = 'do_not_allow';
-					break;
-				}
-			}
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! $post_type ) {
+			/* translators: 1: Post type, 2: Capability name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+			$caps[] = 'edit_others_posts';
+			break;
+		}
 
-			$post_type = get_post_type_object( $post->post_type );
-			if ( ! $post_type ) {
-				/* translators: 1: Post type, 2: Capability name. */
-				_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
-				$caps[] = 'edit_others_posts';
-				break;
+		if ( ! $post_type->map_meta_cap ) {
+			$caps[] = $post_type->cap->$cap;
+			// Prior to 3.1 we would re-call map_meta_cap here.
+			if ( 'read_post' == $cap ) {
+				$cap = $post_type->cap->$cap;
 			}
+			break;
+		}
 
-			if ( ! $post_type->map_meta_cap ) {
-				$caps[] = $post_type->cap->$cap;
-				// Prior to 3.1 we would re-call map_meta_cap here.
-				if ( 'read_post' == $cap ) {
-					$cap = $post_type->cap->$cap;
-				}
-				break;
-			}
+		$status_obj = get_post_status_object( $post->post_status );
+		if ( ! $status_obj ) {
+			/* translators: 1: Post status, 2: Capability name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post status %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post with that status.' ), $post->post_status, $cap ), '5.4.0' );
+			$caps[] = 'edit_others_posts';
+			break;
+		}
 
-			$status_obj = get_post_status_object( $post->post_status );
-			if ( ! $status_obj ) {
-				/* translators: 1: Post status, 2: Capability name. */
-				_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post status %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post with that status.' ), $post->post_status, $cap ), '5.4.0' );
-				$caps[] = 'edit_others_posts';
-				break;
-			}
-
-			if ( $status_obj->public ) {
-				$caps[] = $post_type->cap->read;
-				break;
-			}
->>>>>>> 6f15251aa4... Posts, Post Types: Fail gracefully when checking mapped cap against unregistered post status.
+		if ( $status_obj->public ) {
+			$caps[] = $post_type->cap->read;
+			break;
+		}
 
 		if ( 'revision' == $post->post_type ) {
 			$post = get_post( $post->post_parent );

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -205,7 +205,55 @@ function map_meta_cap( $cap, $user_id ) {
 		if ( ! $post ) {
 			$caps[] = 'do_not_allow';
 			break;
+<<<<<<< HEAD
 		}
+=======
+		case 'read_post':
+		case 'read_page':
+			$post = get_post( $args[0] );
+			if ( ! $post ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
+			if ( 'revision' == $post->post_type ) {
+				$post = get_post( $post->post_parent );
+				if ( ! $post ) {
+					$caps[] = 'do_not_allow';
+					break;
+				}
+			}
+
+			$post_type = get_post_type_object( $post->post_type );
+			if ( ! $post_type ) {
+				/* translators: 1: Post type, 2: Capability name. */
+				_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post type %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post of that type.' ), $post->post_type, $cap ), '4.4.0' );
+				$caps[] = 'edit_others_posts';
+				break;
+			}
+
+			if ( ! $post_type->map_meta_cap ) {
+				$caps[] = $post_type->cap->$cap;
+				// Prior to 3.1 we would re-call map_meta_cap here.
+				if ( 'read_post' == $cap ) {
+					$cap = $post_type->cap->$cap;
+				}
+				break;
+			}
+
+			$status_obj = get_post_status_object( $post->post_status );
+			if ( ! $status_obj ) {
+				/* translators: 1: Post status, 2: Capability name. */
+				_doing_it_wrong( __FUNCTION__, sprintf( __( 'The post status %1$s is not registered, so it may not be reliable to check the capability "%2$s" against a post with that status.' ), $post->post_status, $cap ), '5.4.0' );
+				$caps[] = 'edit_others_posts';
+				break;
+			}
+
+			if ( $status_obj->public ) {
+				$caps[] = $post_type->cap->read;
+				break;
+			}
+>>>>>>> 6f15251aa4... Posts, Post Types: Fail gracefully when checking mapped cap against unregistered post status.
 
 		if ( 'revision' == $post->post_type ) {
 			$post = get_post( $post->post_parent );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2875,43 +2875,14 @@ class WP_Query {
 		}
 
 		// Check post status to determine if post should be displayed.
-<<<<<<< HEAD
-		if ( !empty($this->posts) && ($this->is_single || $this->is_page) ) {
-			$status = get_post_status($this->posts[0]);
-=======
 		if ( ! empty( $this->posts ) && ( $this->is_single || $this->is_page ) ) {
 			$status = get_post_status( $this->posts[0] );
 
->>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 			if ( 'attachment' === $this->posts[0]->post_type && 0 === (int) $this->posts[0]->post_parent ) {
 				$this->is_page = false;
 				$this->is_single = true;
 				$this->is_attachment = true;
 			}
-<<<<<<< HEAD
-			$post_status_obj = get_post_status_object($status);
-
-			// If the post_status was specifically requested, let it pass through.
-			if ( !$post_status_obj->public && ! in_array( $status, $q_status ) ) {
-
-				if ( ! is_user_logged_in() ) {
-					// User must be logged in to view unpublished posts.
-					$this->posts = array();
-				} else {
-					if  ( $post_status_obj->protected ) {
-						// User must have edit permissions on the draft to preview.
-						if ( ! current_user_can($edit_cap, $this->posts[0]->ID) ) {
-							$this->posts = array();
-						} else {
-							$this->is_preview = true;
-							if ( 'future' != $status )
-								$this->posts[0]->post_date = current_time('mysql');
-						}
-					} elseif ( $post_status_obj->private ) {
-						if ( ! current_user_can($read_cap, $this->posts[0]->ID) )
-							$this->posts = array();
-					} else {
-=======
 
 			// If the post_status was specifically requested, let it pass through.
 			if ( ! in_array( $status, $q_status ) ) {
@@ -2943,7 +2914,6 @@ class WP_Query {
 				} elseif ( ! $post_status_obj ) {
 					// Post status is not registered, assume it's not public.
 					if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) ) {
->>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 						$this->posts = array();
 					}
 				}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2875,13 +2875,20 @@ class WP_Query {
 		}
 
 		// Check post status to determine if post should be displayed.
+<<<<<<< HEAD
 		if ( !empty($this->posts) && ($this->is_single || $this->is_page) ) {
 			$status = get_post_status($this->posts[0]);
+=======
+		if ( ! empty( $this->posts ) && ( $this->is_single || $this->is_page ) ) {
+			$status = get_post_status( $this->posts[0] );
+
+>>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 			if ( 'attachment' === $this->posts[0]->post_type && 0 === (int) $this->posts[0]->post_parent ) {
 				$this->is_page = false;
 				$this->is_single = true;
 				$this->is_attachment = true;
 			}
+<<<<<<< HEAD
 			$post_status_obj = get_post_status_object($status);
 
 			// If the post_status was specifically requested, let it pass through.
@@ -2904,6 +2911,39 @@ class WP_Query {
 						if ( ! current_user_can($read_cap, $this->posts[0]->ID) )
 							$this->posts = array();
 					} else {
+=======
+
+			// If the post_status was specifically requested, let it pass through.
+			if ( ! in_array( $status, $q_status ) ) {
+				$post_status_obj = get_post_status_object( $status );
+
+				if ( $post_status_obj && ! $post_status_obj->public ) {
+					if ( ! is_user_logged_in() ) {
+						// User must be logged in to view unpublished posts.
+						$this->posts = array();
+					} else {
+						if ( $post_status_obj->protected ) {
+							// User must have edit permissions on the draft to preview.
+							if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) ) {
+								$this->posts = array();
+							} else {
+								$this->is_preview = true;
+								if ( 'future' != $status ) {
+									$this->posts[0]->post_date = current_time( 'mysql' );
+								}
+							}
+						} elseif ( $post_status_obj->private ) {
+							if ( ! current_user_can( $read_cap, $this->posts[0]->ID ) ) {
+								$this->posts = array();
+							}
+						} else {
+							$this->posts = array();
+						}
+					}
+				} elseif ( ! $post_status_obj ) {
+					// Post status is not registered, assume it's not public.
+					if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) ) {
+>>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 						$this->posts = array();
 					}
 				}

--- a/tests/phpunit/tests/query/postStatus.php
+++ b/tests/phpunit/tests/query/postStatus.php
@@ -208,6 +208,27 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 		$this->assertEmpty( $q->posts );
 	}
 
+	public function test_single_post_with_nonpublic_status_should_not_be_shown_for_any_user() {
+		register_post_type( 'foo_pt' );
+		register_post_status( 'foo_ps', array( 'public' => false ) );
+		$p = self::factory()->post->create(
+			array(
+				'post_status' => 'foo_ps',
+				'post_author' => self::$author_user_id,
+			)
+		);
+
+		wp_set_current_user( self::$editor_user_id );
+
+		$q = new WP_Query(
+			array(
+				'p' => $p,
+			)
+		);
+
+		$this->assertEmpty( $q->posts );
+	}
+
 	public function test_single_post_with_nonpublic_and_protected_status_should_not_be_shown_for_user_who_cannot_edit_others_posts() {
 		register_post_type( 'foo_pt' );
 		register_post_status( 'foo_ps', array( 'public' => false, 'protected' => true ) );
@@ -264,10 +285,49 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 		$this->assertEquals( array( $p ), wp_list_pluck( $q->posts, 'ID' ) );
 	}
 
-	public function test_single_post_with_nonpublic_and_protected_status_should_not_be_shown_for_any_user() {
+	/**
+	 * @ticket 48653
+	 */
+	public function test_single_post_with_nonexisting_status_should_not_be_shown_for_user_who_cannot_edit_others_posts() {
 		register_post_type( 'foo_pt' );
+<<<<<<< HEAD
 		register_post_status( 'foo_ps', array( 'public' => false ) );
 		$p = self::factory()->post->create( array( 'post_status' => 'foo_ps', 'post_author' => self::$author_user_id ) );
+=======
+		register_post_status( 'foo_ps', array( 'public' => true ) );
+		$p = self::factory()->post->create(
+			array(
+				'post_status' => 'foo_ps',
+				'post_author' => self::$editor_user_id,
+			)
+		);
+		_unregister_post_status( 'foo_ps' );
+
+		wp_set_current_user( self::$author_user_id );
+
+		$q = new WP_Query(
+			array(
+				'p' => $p,
+			)
+		);
+
+		$this->assertEmpty( $q->posts );
+	}
+
+	/**
+	 * @ticket 48653
+	 */
+	public function test_single_post_with_nonexisting_status_should_be_shown_for_user_who_can_edit_others_posts() {
+		register_post_type( 'foo_pt' );
+		register_post_status( 'foo_ps', array( 'public' => true ) );
+		$p = self::factory()->post->create(
+			array(
+				'post_status' => 'foo_ps',
+				'post_author' => self::$author_user_id,
+			)
+		);
+		_unregister_post_status( 'foo_ps' );
+>>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 
 		wp_set_current_user( self::$editor_user_id );
 
@@ -275,7 +335,7 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 			'p' => $p,
 		) );
 
-		$this->assertEmpty( $q->posts );
+		$this->assertEquals( array( $p ), wp_list_pluck( $q->posts, 'ID' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/postStatus.php
+++ b/tests/phpunit/tests/query/postStatus.php
@@ -290,10 +290,7 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 	 */
 	public function test_single_post_with_nonexisting_status_should_not_be_shown_for_user_who_cannot_edit_others_posts() {
 		register_post_type( 'foo_pt' );
-<<<<<<< HEAD
-		register_post_status( 'foo_ps', array( 'public' => false ) );
-		$p = self::factory()->post->create( array( 'post_status' => 'foo_ps', 'post_author' => self::$author_user_id ) );
-=======
+
 		register_post_status( 'foo_ps', array( 'public' => true ) );
 		$p = self::factory()->post->create(
 			array(
@@ -327,7 +324,6 @@ class Tests_Query_PostStatus extends WP_UnitTestCase {
 			)
 		);
 		_unregister_post_status( 'foo_ps' );
->>>>>>> 5e8563eb6b... Posts, Post Types: Fail gracefully when checking whether a single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.
 
 		wp_set_current_user( self::$editor_user_id );
 

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1658,9 +1658,6 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	/**
-<<<<<<< HEAD
-	 * @see https://core.trac.wordpress.org/ticket/17253
-=======
 	 * @ticket 48653
 	 * @expectedIncorrectUsage map_meta_cap
 	 */
@@ -1684,8 +1681,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 17253
->>>>>>> 6f15251aa4... Posts, Post Types: Fail gracefully when checking mapped cap against unregistered post status.
+	 * @see https://core.trac.wordpress.org/ticket/17253
 	 */
 	function test_cpt_with_page_capability_type() {
 

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1658,7 +1658,34 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * @see https://core.trac.wordpress.org/ticket/17253
+=======
+	 * @ticket 48653
+	 * @expectedIncorrectUsage map_meta_cap
+	 */
+	function test_require_edit_others_posts_if_post_status_doesnt_exist() {
+		register_post_status( 'existed' );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'existed' ) );
+		_unregister_post_status( 'existed' );
+
+		$subscriber_id = self::$users['subscriber']->ID;
+		$editor_id     = self::$users['editor']->ID;
+
+		foreach ( array( 'read_post', 'read_page' ) as $cap ) {
+			wp_set_current_user( $subscriber_id );
+			$this->assertSame( array( 'edit_others_posts' ), map_meta_cap( $cap, $subscriber_id, $post_id ) );
+			$this->assertFalse( current_user_can( $cap, $post_id ) );
+
+			wp_set_current_user( $editor_id );
+			$this->assertSame( array( 'edit_others_posts' ), map_meta_cap( $cap, $editor_id, $post_id ) );
+			$this->assertTrue( current_user_can( $cap, $post_id ) );
+		}
+	}
+
+	/**
+	 * @ticket 17253
+>>>>>>> 6f15251aa4... Posts, Post Types: Fail gracefully when checking mapped cap against unregistered post status.
 	 */
 	function test_cpt_with_page_capability_type() {
 


### PR DESCRIPTION
Single post with an unregistered post status should be displayed in `WP_Query::get_posts()`.

If the post status is not registered, assume it's not public, but still allow access to users with edit permissions (same as for a protected post status, e.g. `draft`), so that they could recover orphaned content.

- Add unit tests.

Follow-up to https://core.trac.wordpress.org/changeset/47178.

WP:Props roytanck, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/48653.

Conflicts:
  src/wp-includes/class-wp-query.php
  tests/phpunit/tests/query/postStatus.php
----
Merges https://core.trac.wordpress.org/changeset/47181 / WordPress/wordpress-develop@5e8563eb6b to ClassicPress.