### PR TITLE
Adds disable_theme_update_notification mu-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ wp-tests-config.php
 # Files and folders that get created in wp-content
 /src/wp-content/blogs.dir
 /src/wp-content/languages
-/src/wp-content/mu-plugins
+/src/wp-content/mu-plugins/*
+!/src/wp-content/mu-plugins/cp_disable_theme_update_notification.php
 /src/wp-content/plugins
 /src/wp-content/themes/*
 !/src/wp-content/themes/twentyfifteen

--- a/src/wp-content/mu-plugins/cp_disable_theme_update_notification.php
+++ b/src/wp-content/mu-plugins/cp_disable_theme_update_notification.php
@@ -1,0 +1,20 @@
+<?php
+/*
+Plugin Name: Disable theme update notification
+Plugin URI: http://www.classicpress.net
+Description: Disables update notifications for WP parent themes shipped with ClassicPress
+Author: ClassicPress
+Version: 1.0
+Author URI: http://www.classicpress.net
+*/
+
+
+function cp_disable_theme_update_notification( $value ) {
+	if ( ! empty( $value ) && is_object( $value ) && is_array( $value->response ) ) {
+		unset( $value->response['twentyfifteen'] );
+		unset( $value->response['twentysixteen'] );
+		unset( $value->response['twentyseventeen'] );
+	}
+	return $value;
+}
+add_filter( 'site_transient_update_themes', 'cp_disable_theme_update_notification' );


### PR DESCRIPTION
### Disables theme update notifications for twentyfifteen, twentysixteen and twentyseventeen.

## Description
The WP themes `twentyfifteen`, `twentysixteen` and `twentyseventeen` are packaged by default with ClassicPress.

As these themes get updated, update notifications will appear in CP admin.

This mu-plugin disables these notifications.

## Motivation and context
1. It may look unprofessional to provide outdated themes with new versions of CP.
2. Users may be tempted to update which may cause unforeseen compatibility issues with the CP child themes.

## How has this been tested?

Tested on two development machines. Results shown in screenshots below.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/4199514/74231170-dbe57780-4cbd-11ea-95fb-b60bd24cf9d3.png)

### After

![image](https://user-images.githubusercontent.com/4199514/74231223-020b1780-4cbe-11ea-89ae-3122f1c1597b.png)


## Types of changes

- New feature
- Improvement

