### PR TITLE
Improve backport script commit messages

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -187,7 +187,7 @@ edit_merge_msg() {
 			s,\[(\d+)\],https://core.trac.wordpress.org/changeset/\$1,g;
 			s,#(\d+)\b,https://core.trac.wordpress.org/ticket/\$1,g;
 			s,^# Conflicts:,Conflicts:,;
-			s,^#\t,  ,;
+			s,^#\t,- ,;
 			s,\b(Props|Unprops)(\s*),WP:\$1\$2,g;
 			if (/\S/) {
 				if (!/^git-svn-id:/) {
@@ -199,7 +199,7 @@ edit_merge_msg() {
 				\$was_blank_line = 1;
 			}
 		}
-		print MSG_W "----\n";
+		print MSG_W "\n---\n\n";
 		print MSG_W "Merges https://core.trac.wordpress.org/changeset/$wp_changeset / WordPress/wordpress-develop\@$commit_short to ClassicPress.\n";
 		close MSG_R;
 		close MSG_W;


### PR DESCRIPTION
This PR seeks to improve the output when a WP commit is backported to ClassicPress and the resulting commit message is copied into GitHub:

![2020-02-17T05-45-11Z](https://user-images.githubusercontent.com/227022/74626863-036a9300-5149-11ea-896c-fc9e3452462d.png)

This is the default behavior when submitting a PR.  The new output should look like this:

---

WP:Props donmhico, jonoaldersonwp.
Fixes https://core.trac.wordpress.org/ticket/43590.

Conflicts:
- src/wp-includes/functions.php
- src/wp-includes/general-template.php

---

Merges https://core.trac.wordpress.org/changeset/45928 / WordPress/wordpress-develop@122cb2864b to ClassicPress.