### PR TITLE
Ignore new versions of uglify-js

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
 	"labels": [
 		"bot"
 	],
-	"commitMessagePrefix": "Renovate[bot]:"
+	"commitMessagePrefix": "Renovate[bot]:",
+	"ignoreDeps": [
+		"uglify-js"
+	]
 }


### PR DESCRIPTION
This library has had major issues in the past, that went unaddressed for a while. For example: https://github.com/mishoo/UglifyJS2/compare/v3.4.8...v3.5.3 and https://github.com/mishoo/UglifyJS2/issues/3245.

This PR will stop @renovate-bot from sending us new PRs for `uglify-js`, like #132, #402, #409, and #507.