### PR TITLE
Always run 'skipOnAutomatedBranches' tests

### DIFF
--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018 ClassicPress and contributors
+Copyright © 2018-2020 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2018 by the WordPress contributors
+  Copyright 2003-2020 by the WordPress contributors
 
   WordPress is released under the GPL
 

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -181,36 +181,6 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Allow tests to be skipped on some automated runs (i.e. Travis builds
-	 * that aren't running against the main branch).
-	 *
-	 * DISABLED for ClassicPress (we will always run these tests on all
-	 * branches) since we definitely want to know when one of these is failing.
-	 */
-	public function skipOnAutomatedBranches() {
-		// DISABLED for ClassicPress.
-		return false;
-
-		// getenv can be disabled
-		if ( ! function_exists( 'getenv' ) ) {
-			return false;
-		}
-
-		// https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-		$travis_branch       = getenv( 'TRAVIS_BRANCH' );
-		$travis_pull_request = getenv( 'TRAVIS_PULL_REQUEST' );
-
-		if (
-			false !== $travis_pull_request &&
-			'develop' !== $travis_branch
-		) {
-			$this->markTestSkipped(
-				'For automated test runs, this test is only run on the develop branch.'
-			);
-		}
-	}
-
-	/**
 	 * Allow tests to be skipped when Multisite is not in use.
 	 *
 	 * Use in conjunction with the ms-required group.

--- a/tests/phpunit/includes/testcase.php
+++ b/tests/phpunit/includes/testcase.php
@@ -181,13 +181,17 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Allow tests to be skipped on some automated runs
+	 * Allow tests to be skipped on some automated runs (i.e. Travis builds
+	 * that aren't running against the main branch).
 	 *
-	 * For test runs on Travis for something other than trunk/master 
-	 * we want to skip tests that only need to run for master.
+	 * DISABLED for ClassicPress (we will always run these tests on all
+	 * branches) since we definitely want to know when one of these is failing.
 	 */
 	public function skipOnAutomatedBranches() {
-		// gentenv can be disabled
+		// DISABLED for ClassicPress.
+		return false;
+
+		// getenv can be disabled
 		if ( ! function_exists( 'getenv' ) ) {
 			return false;
 		}
@@ -196,8 +200,13 @@ class WP_UnitTestCase extends PHPUnit_Framework_TestCase {
 		$travis_branch       = getenv( 'TRAVIS_BRANCH' );
 		$travis_pull_request = getenv( 'TRAVIS_PULL_REQUEST' );
 
-		if ( false !== $travis_pull_request && 'master' !== $travis_branch ) {
-			$this->markTestSkipped( 'For automated test runs, this test is only run on trunk/master' );
+		if (
+			false !== $travis_pull_request &&
+			'develop' !== $travis_branch
+		) {
+			$this->markTestSkipped(
+				'For automated test runs, this test is only run on the develop branch.'
+			);
 		}
 	}
 

--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -7,7 +7,7 @@
  */
 class Tests_Basic extends WP_UnitTestCase {
 
-	function test_license() {
+	function test_license_wp() {
 		// This test is designed to only run on trunk/master
 		$this->skipOnAutomatedBranches();
 
@@ -15,12 +15,36 @@ class Tests_Basic extends WP_UnitTestCase {
 		$this_year = date( 'Y' );
 
 		// Check WordPress copyright years
-		// TODO: This only applies if we actually pull changes from WP in 2019 or later!
-		preg_match( '#Copyright 2003-(\d+) by the WordPress contributors#', $license, $matches );
-		$this->assertEquals( $this_year, trim( $matches[1] ), "license.txt's year needs to be updated to $this_year." );
+		preg_match(
+			'#Copyright 2003-(\d+) by the WordPress contributors#',
+			$license,
+			$matches
+		);
+		$this->assertEquals(
+			$this_year,
+			trim( $matches[1] ),
+			"license.txt's year needs to be updated to $this_year : \"{$matches[0]}\""
+		);
+	}
 
-		preg_match( '#Copyright © (2018-)?(\d+) ClassicPress and contributors#', $license, $matches );
-		$this->assertEquals( $this_year, trim( $matches[2] ), "license.txt's year needs to be updated to $this_year." );
+	function test_license_cp() {
+		// This test is designed to only run on trunk/master
+		$this->skipOnAutomatedBranches();
+
+		$license = file_get_contents( ABSPATH . 'license.txt' );
+		$this_year = date( 'Y' );
+
+		// Check ClassicPress copyright years
+		preg_match(
+			'#Copyright © 2018-(\d+) ClassicPress and contributors#',
+			$license,
+			$matches
+		);
+		$this->assertEquals(
+			$this_year,
+			trim( $matches[1] ),
+			"license.txt's year needs to be updated to $this_year : \"{$matches[0]}\""
+		);
 	}
 
 	function test_package_json() {

--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -7,7 +7,7 @@
  */
 class Tests_Basic extends WP_UnitTestCase {
 
-	function test_license_wp() {
+	function test_license_wp_copyright_years() {
 		$license = file_get_contents( ABSPATH . 'license.txt' );
 		$this_year = date( 'Y' );
 
@@ -24,7 +24,7 @@ class Tests_Basic extends WP_UnitTestCase {
 		);
 	}
 
-	function test_license_cp() {
+	function test_license_cp_copyright_years() {
 		$license = file_get_contents( ABSPATH . 'license.txt' );
 		$this_year = date( 'Y' );
 

--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -8,9 +8,6 @@
 class Tests_Basic extends WP_UnitTestCase {
 
 	function test_license_wp() {
-		// This test is designed to only run on trunk/master
-		$this->skipOnAutomatedBranches();
-
 		$license = file_get_contents( ABSPATH . 'license.txt' );
 		$this_year = date( 'Y' );
 
@@ -28,9 +25,6 @@ class Tests_Basic extends WP_UnitTestCase {
 	}
 
 	function test_license_cp() {
-		// This test is designed to only run on trunk/master
-		$this->skipOnAutomatedBranches();
-
 		$license = file_get_contents( ABSPATH . 'license.txt' );
 		$this_year = date( 'Y' );
 

--- a/tests/phpunit/tests/basic.php
+++ b/tests/phpunit/tests/basic.php
@@ -17,6 +17,7 @@ class Tests_Basic extends WP_UnitTestCase {
 			$license,
 			$matches
 		);
+		$this->assertNotEmpty( $matches );
 		$this->assertEquals(
 			$this_year,
 			trim( $matches[1] ),
@@ -34,6 +35,7 @@ class Tests_Basic extends WP_UnitTestCase {
 			$license,
 			$matches
 		);
+		$this->assertNotEmpty( $matches );
 		$this->assertEquals(
 			$this_year,
 			trim( $matches[1] ),

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -12,6 +12,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 			$readme,
 			$matches
 		);
+		$this->assertNotEmpty( $matches );
 
 		$response = wp_remote_get(
 			'https://secure.php.net/supported-versions.php'
@@ -26,6 +27,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 			$php,
 			$phpmatches
 		);
+		$this->assertNotEmpty( $phpmatches );
 
 		$this->assertContains(
 			$matches[1],
@@ -42,6 +44,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 			$readme,
 			$matches
 		);
+		$this->assertNotEmpty( $matches );
 
 		$response = wp_remote_get(
 			"https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/"
@@ -56,6 +59,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 			$mysql,
 			$mysqlmatches
 		);
+		$this->assertNotEmpty( $mysqlmatches );
 
 		// Per https://www.mysql.com/support/, Oracle actively supports MySQL
 		// releases for 5 years from GA release

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -5,9 +5,6 @@
 class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 	function test_readme_php() {
-		// This test is designed to only run on trunk/master
-		$this->skipOnAutomatedBranches();
-
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
 		preg_match(
@@ -38,9 +35,6 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 	}
 
 	function test_readme_mysql() {
-		// This test is designed to only run on trunk/master
-		$this->skipOnAutomatedBranches();
-
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
 		preg_match(

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -4,7 +4,7 @@
  */
 class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
-	function test_readme_php() {
+	function test_readme_recommended_php_version() {
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
 		preg_match(
@@ -34,7 +34,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		);
 	}
 
-	function test_readme_mysql() {
+	function test_readme_recommended_mysql_version() {
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
 		preg_match(

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -4,37 +4,73 @@
  */
 class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
-	function test_readme() {
+	function test_readme_php() {
 		// This test is designed to only run on trunk/master
 		$this->skipOnAutomatedBranches();
 
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
-		preg_match( '#Recommendations.*PHP</a> version <strong>([0-9.]*)#s', $readme, $matches );
+		preg_match(
+			'#Recommendations.*PHP</a> version <strong>([0-9.]*)#s',
+			$readme,
+			$matches
+		);
 
-		$response = wp_remote_get( 'https://secure.php.net/supported-versions.php' );
-		if ( 200 != wp_remote_retrieve_response_code( $response ) ) {
+		$response = wp_remote_get(
+			'https://secure.php.net/supported-versions.php'
+		);
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$this->fail( 'Could not contact PHP.net to check versions.' );
 		}
 		$php = wp_remote_retrieve_body( $response );
 
-		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $php, $phpmatches );
+		preg_match_all(
+			'#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
+			$php,
+			$phpmatches
+		);
 
-		$this->assertContains( $matches[1], $phpmatches[1], "readme.html's Recommended PHP version is too old. Remember to update the WordPress.org Requirements page, too." );
+		$this->assertContains(
+			$matches[1],
+			$phpmatches[1],
+			"readme.html's Recommended PHP version is too old."
+		);
+	}
 
-		preg_match( '#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
+	function test_readme_mysql() {
+		// This test is designed to only run on trunk/master
+		$this->skipOnAutomatedBranches();
 
-		$response = wp_remote_get( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
-		if ( 200 != wp_remote_retrieve_response_code( $response ) ) {
-			$this->fail( 'Could not contact dev.MySQL.com to check versions.' );
+		$readme = file_get_contents( ABSPATH . 'readme.html' );
+
+		preg_match(
+			'#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s',
+			$readme,
+			$matches
+		);
+
+		$response = wp_remote_get(
+			"https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/"
+		);
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			$this->fail( 'Could not contact dev.mysql.com to check versions.' );
 		}
 		$mysql = wp_remote_retrieve_body( $response );
 
-		preg_match( '#(\d{4}-\d{2}-\d{2}), General Availability#', $mysql, $mysqlmatches );
+		preg_match(
+			'#(\d{4}-\d{2}-\d{2}), General Availability#',
+			$mysql,
+			$mysqlmatches
+		);
 
-		// Per https://www.mysql.com/support/, Oracle actively supports MySQL releases for 5 years from GA release
+		// Per https://www.mysql.com/support/, Oracle actively supports MySQL
+		// releases for 5 years from GA release
 		$mysql_eol = strtotime( $mysqlmatches[1] . ' +5 years' );
 
-		$this->assertLessThan( $mysql_eol, time(), "readme.html's Recommended MySQL version is too old. Remember to update the WordPress.org Requirements page, too." );
+		$this->assertLessThan(
+			$mysql_eol,
+			time(),
+			"readme.html's Recommended MySQL version is too old."
+		);
 	}
 }

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -25,14 +25,14 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		$php = wp_remote_retrieve_body( $response );
 
 		preg_match_all(
-			'#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
+			'#<tr class="(security|stable)">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
 			$php,
 			$phpmatches
 		);
 
 		$this->assertContains(
 			$matches[1],
-			$phpmatches[1],
+			$phpmatches[2],
 			"readme.html's Recommended PHP version is too old."
 		);
 	}


### PR DESCRIPTION
The following 2 automated tests are not running currently:

https://github.com/ClassicPress/ClassicPress/blob/6a77df7e6cef814e6f15a63a90997ae78d800c58/tests/phpunit/tests/basic.php#L10-L24

https://github.com/ClassicPress/ClassicPress/blob/6a77df7e6cef814e6f15a63a90997ae78d800c58/tests/phpunit/tests/external-http/basic.php#L7-L39

Since we definitely want to know when one of these tests is failing, let's always run them on all branches.