### PR TITLE
Remove invalid Travis config key: 'on_start'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
 
 notifications:
   slack:
-    on_start: never
     on_failure: always
     on_success: change
     on_pull_requests: false


### PR DESCRIPTION
Travis mentions this config key once in their [notifications documentation page](https://docs.travis-ci.com/user/notifications), but their [config validator](https://travis-ci.com/ClassicPress/ClassicPress/builds/149741243/config) doesn't like it:

![2020-02-20T01-33-59Z](https://user-images.githubusercontent.com/227022/74892305-2a130e80-5381-11ea-802f-3b2df67b58da.png)
