### PR TITLE
 WP-r47171: Database: Add `ANSI` to the list of incompatible SQL modes

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -528,10 +528,6 @@ class wpdb {
 	 * @since WP-3.9.0
 	 * @var array
 	 */
-<<<<<<< HEAD
-	protected $incompatible_modes = array( 'NO_ZERO_DATE', 'ONLY_FULL_GROUP_BY',
-		'STRICT_TRANS_TABLES', 'STRICT_ALL_TABLES', 'TRADITIONAL' );
-=======
 	protected $incompatible_modes = array(
 		'NO_ZERO_DATE',
 		'ONLY_FULL_GROUP_BY',
@@ -540,7 +536,6 @@ class wpdb {
 		'TRADITIONAL',
 		'ANSI',
 	);
->>>>>>> b26b0ccf8c... Database: Add `ANSI` to the list of incompatible SQL modes.
 
 	/**
 	 * Whether to use mysqli over mysql.

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -528,8 +528,19 @@ class wpdb {
 	 * @since WP-3.9.0
 	 * @var array
 	 */
+<<<<<<< HEAD
 	protected $incompatible_modes = array( 'NO_ZERO_DATE', 'ONLY_FULL_GROUP_BY',
 		'STRICT_TRANS_TABLES', 'STRICT_ALL_TABLES', 'TRADITIONAL' );
+=======
+	protected $incompatible_modes = array(
+		'NO_ZERO_DATE',
+		'ONLY_FULL_GROUP_BY',
+		'STRICT_TRANS_TABLES',
+		'STRICT_ALL_TABLES',
+		'TRADITIONAL',
+		'ANSI',
+	);
+>>>>>>> b26b0ccf8c... Database: Add `ANSI` to the list of incompatible SQL modes.
 
 	/**
 	 * Whether to use mysqli over mysql.


### PR DESCRIPTION
Starting with MySQL 5.7.5, the `ANSI` mode implies `ONLY_FULL_GROUP_BY`, which is already listed in `wpdb` as incompatible per https://core.trac.wordpress.org/changeset/27072.

When `ANSI` is enabled on MySQL 5.7.5+, `ONLY_FULL_GROUP_BY` remains enabled even after being "unset" by `wpdb::set_sql_mode()`.

To prevent this, the `ANSI` mode should also be listed as incompatible. It is not enabled on default MySQL installations.

WP:Props jnylen0.
Fixes https://core.trac.wordpress.org/ticket/48377.

Conflicts:
- src/wp-includes/wp-db.php

---

Merges https://core.trac.wordpress.org/changeset/47171 / WordPress/wordpress-develop@b26b0cc to ClassicPress.