### PR TITLE
Prevent update notices from Twenty * default themes

### DIFF
--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentyfifteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2015 default theme is clean, blog-focused, and designed for clarity. Twenty Fifteen's simple, straightforward typography is readable on a wide variety of screen sizes, and suitable for multiple languages. We designed it using a mobile-first approach, meaning your content takes center-stage, regardless of whether your visitors arrive by smartphone, tablet, laptop, or desktop computer.
-Version: 2.0
+Version: 99.1-upstream2.0
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, two-columns, left-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentyseventeen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
-Version: 1.7
+Version: 99.1-upstream1.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentyseventeen

--- a/src/wp-content/themes/twentysixteen/style.css
+++ b/src/wp-content/themes/twentysixteen/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentysixteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Sixteen is a modernized take on an ever-popular WordPress layout — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites. It has custom color options with beautiful default color schemes, a harmonious fluid grid using a mobile-first approach, and impeccable polish in every detail. Twenty Sixteen will make your WordPress look beautiful everywhere.
-Version: 1.5
+Version: 99.1-upstream1.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-images, flexible-header, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready, blog


### PR DESCRIPTION
Fixes #529. Alternative approach to #545.

>When you install ClassicPress from scratch you immediately get prompted to upgrade the base version of our default themes (Twenty Fifteen through Seventeen from WP). This is worth fixing.

The main reason we don't just ship the latest version of these themes is that they include a lot of Gutenberg files we don't need (see #326), and these will be going away entirely in v2.

This PR fixes this issue in the easiest and simplest way possible: bumping the version numbers of these base themes to something beyond what the WP directory has.

This way, users can still upgrade these themes and keep them up to date if they really want to - they just have to edit the version number back to what it used to be. Other approaches that involve filtering the upgrade data and omitting all upgrades for these themes would not allow this.

The only minor drawbacks I'm aware of are that this will only affect **new** installations, not **existing** sites, and also WP-CLI shows some warnings:

```
$ wp theme update --all
Warning: twentyfifteen: version higher than expected.
Warning: twentyseventeen: version higher than expected.
Warning: twentysixteen: version higher than expected.
Error: No themes updated.
```

Related: https://github.com/wp-cli/extension-command/issues/192

### Screenshot - before

![2020-02-20T02-14-19Z](https://user-images.githubusercontent.com/227022/74894970-4d8d8780-5388-11ea-98ce-a3501f7640e9.png)

### Screenshot - after

![2020-02-20T02-14-53Z](https://user-images.githubusercontent.com/227022/74894969-4cf4f100-5388-11ea-8754-f4276220b59e.png)