### PR TITLE
Comments: Add rel="nofollow ugc" attribute 

### DIFF
--- a/tests/phpunit/tests/formatting/MakeClickable.php
+++ b/tests/phpunit/tests/formatting/MakeClickable.php
@@ -374,13 +374,8 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	}
 
 	/**
-<<<<<<< HEAD
-	 * @dataProvider data_script_and_style_tags
 	 * @see https://core.trac.wordpress.org/ticket/30162
-=======
-	 * @ticket 30162
 	 * @dataProvider data_script_and_style_tags
->>>>>>> 1f7f0a1357... Comments: Add `rel="nofollow ugc"` attribute when converting plain URLs to `<a>` tags in comments via `make_clickable()`.
 	 */
 	public function test_dont_link_script_and_style_tags( $tag ) {
 		$this->assertEquals( $tag, make_clickable( $tag ) );

--- a/tests/phpunit/tests/formatting/MakeClickable.php
+++ b/tests/phpunit/tests/formatting/MakeClickable.php
@@ -374,8 +374,13 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * @dataProvider data_script_and_style_tags
 	 * @see https://core.trac.wordpress.org/ticket/30162
+=======
+	 * @ticket 30162
+	 * @dataProvider data_script_and_style_tags
+>>>>>>> 1f7f0a1357... Comments: Add `rel="nofollow ugc"` attribute when converting plain URLs to `<a>` tags in comments via `make_clickable()`.
 	 */
 	public function test_dont_link_script_and_style_tags( $tag ) {
 		$this->assertEquals( $tag, make_clickable( $tag ) );
@@ -394,6 +399,37 @@ class Tests_Formatting_MakeClickable extends WP_UnitTestCase {
 			),
 			array(
 				'<style type="text/css">http://wordpress.org</style>',
+			),
+		);
+	}
+
+	/**
+	 * @ticket 48022
+	 * @dataProvider data_add_rel_ugc_in_comments
+	 */
+	public function test_add_rel_ugc_in_comments( $content, $expected ) {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_content' => $content,
+			)
+		);
+
+		ob_start();
+		comment_text( $comment_id );
+		$comment_text = ob_get_clean();
+
+		$this->assertContains( $expected, make_clickable( $comment_text ) );
+	}
+
+	public function data_add_rel_ugc_in_comments() {
+		return array(
+			array(
+				'http://wordpress.org',
+				'<a href="http://wordpress.org" rel="nofollow ugc">http://wordpress.org</a>',
+			),
+			array(
+				'www.wordpress.org',
+				'<p><a href="http://www.wordpress.org" rel="nofollow ugc">http://www.wordpress.org</a>',
 			),
 		);
 	}


### PR DESCRIPTION
Comments: Add rel="nofollow ugc" attribute when converting plain URLs to <a> tags in comments via make_clickable().

Closes #482 

Introduce make_clickable_rel filter for the rel value that is added to URL matches converted to links.

This is a follow-up to [46349], which added the rel="nofollow ugc" attribute to existing <a> tags in comments via wp_rel_ugc().

UGC stands for User Generated Content, and the ugc attribute value is recommended for links within user generated content, such as comments and forum posts.

See https://webmasters.googleblog.com/2019/09/evolving-nofollow-new-ways-to-identify.html.

Props: blogginglife, SergeyBiryukov.
Reviewed by desrosj, audrasjb.
Fixes [48022](https://core.trac.wordpress.org/ticket/48022).