### PR TITLE
Improve messages that point to the phpunit tests documentation

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -25,7 +25,7 @@ $config_file_path .= '/wp-tests-config.php';
 global $wpdb, $current_site, $current_blog, $wp_rewrite, $shortcode_tags, $wp, $phpmailer, $wp_theme_directories;
 
 if ( ! is_readable( $config_file_path ) ) {
-	echo "ERROR: wp-tests-config.php is missing! Please use wp-tests-config-sample.php to create a config file.\n";
+	echo "ERROR: wp-tests-config.php is missing! Please see wp-tests-config-sample.php for setup instructions.\n";
 	exit( 1 );
 }
 require_once $config_file_path;

--- a/wp-tests-config-sample.php
+++ b/wp-tests-config-sample.php
@@ -1,6 +1,16 @@
 <?php
 
-/* Path to the ClassicPress codebase you'd like to test. Add a forward slash in the end. */
+/*
+ * This is a template configuration file for the ClassicPress phpunit automated
+ * tests.  For full instructions on how to set up the automated tests, see:
+ *
+ * https://github.com/ClassicPress/ClassicPress/tree/develop/tests/phpunit
+ */
+
+/*
+ * Path to the ClassicPress codebase you'd like to test. If you need to modify
+ * this, make sure there is a forward slash at the end.
+ */
 define( 'ABSPATH', dirname( __FILE__ ) . '/src/' );
 
 /*


### PR DESCRIPTION
When you run `phpunit` (or a command that runs `phpunit`) and you haven't set up the automated tests yet, you get a message like the following:

```
$ grunt precommit
[...]
Running "phpunit:wp-api-client-fixtures" (phpunit) task
ERROR: wp-tests-config.php is missing! Please use wp-tests-config-sample.php to create a config file.
```

This PR changes the error message to be a bit clearer:

```
ERROR: wp-tests-config.php is missing! Please see wp-tests-config-sample.php for setup instructions.
```

And it also adds a link from `wp-tests-config-sample.php` to our phpunit testing documentation: https://github.com/ClassicPress/ClassicPress/tree/develop/tests/phpunit