### PR TITLE
Invalidate the PHP opcache when files are upgraded

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1333,6 +1333,22 @@ function copy_dir($from, $to, $skip_list = array() ) {
 				if ( ! $wp_filesystem->copy($from . $filename, $to . $filename, true, FS_CHMOD_FILE) )
 					return new WP_Error( 'copy_failed_copy_dir', __( 'Could not copy file.' ), $to . $filename );
 			}
+			if (
+				'.php' === strtolower( substr( $filename, -4 ) ) &&
+				function_exists( 'opcache_invalidate' ) &&
+				/**
+				 * Filters whether to invalidate a file in the PHP opcache
+				 * after it is written during an upgrade.
+				 *
+				 * @since 1.3.0
+				 *
+				 * @param bool $invalidate Whether to invalidate. Default true.
+				 * @param string $filename The PHP filename that was just copied.
+				 */
+				apply_filters( 'wp_opcache_invalidate_file', true, $to . $filename )
+			) {
+				opcache_invalidate( $to . $filename );
+			}
 		} elseif ( 'd' == $fileinfo['type'] ) {
 			if ( !$wp_filesystem->is_dir($to . $filename) ) {
 				if ( !$wp_filesystem->mkdir($to . $filename, FS_CHMOD_DIR) )

--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -1302,8 +1302,9 @@ function _unzip_file_pclzip($file, $to, $needed_dirs = array()) {
 }
 
 /**
- * Copies a directory from one location to another via the ClassicPress Filesystem Abstraction.
- * Assumes that WP_Filesystem() has already been called and setup.
+ * Copies a directory from one location to another via the ClassicPress
+ * Filesystem Abstraction. Assumes that WP_Filesystem() has already been called
+ * and set up.
  *
  * @since WP-2.5.0
  *

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -587,6 +587,14 @@ function _copy_dir($from, $to, $skip_list = array() ) {
 				if ( ! $wp_filesystem->copy($from . $filename, $to . $filename, true, FS_CHMOD_FILE) )
 					return new WP_Error( 'copy_failed__copy_dir', __( 'Could not copy file.' ), $to . $filename );
 			}
+			if (
+				'.php' === strtolower( substr( $filename, -4 ) ) &&
+				function_exists( 'opcache_invalidate' ) &&
+				/** This filter is documented in wp-admin/includes/file.php */
+				apply_filters( 'wp_opcache_invalidate_file', true, $to . $filename )
+			) {
+				opcache_invalidate( $to . $filename );
+			}
 		} elseif ( 'd' == $fileinfo['type'] ) {
 			if ( !$wp_filesystem->is_dir($to . $filename) ) {
 				if ( !$wp_filesystem->mkdir($to . $filename, FS_CHMOD_DIR) )

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -550,11 +550,13 @@ function cp_get_update_directory_root( $working_dir ) {
 }
 
 /**
- * Copies a directory from one location to another via the ClassicPress Filesystem Abstraction.
- * Assumes that WP_Filesystem() has already been called and setup.
+ * Copies a directory from one location to another via the ClassicPress
+ * Filesystem Abstraction. Assumes that WP_Filesystem() has already been called
+ * and set up.
  *
- * This is a temporary function for the 3.1 -> 3.2 upgrade, as well as for those upgrading to
- * 3.7+
+ * This is a standalone copy of this function that is used to upgrade the core
+ * files. It is placed here so that the version of this function from the *new*
+ * ClassicPress version will be called.
  *
  * @ignore
  * @since WP-3.2.0


### PR DESCRIPTION
## Description

When a core upgrade occurs (especially a migration from WP->CP or CP->WP, since these replace almost every file), outdated versions of files may be loaded from the PHP opcache causing fatal errors. This can happen under the following conditions:

- the `opcache.revalidate_freq` setting is set to a value higher than 0 (or `opcache.validate_timestamps` is disabled)
- the upgrade completes before some updated PHP files have a chance to expire from the cache
- one or more of these files contains incompatible changes such as new functions, which are used on the subsequent page load after the upgrade.

Fixes #288. This PR also includes some corrections to the documentation for the `copy_dir` and `_copy_dir` upgrade-related functions.

The plugin and theme editors already contain calls to `opcache_invalidate`, added in https://core.trac.wordpress.org/changeset/41560. These calls set the optional argument `$force = true`, but nothing in my reading of the opcache documentation indicates that this should be necessary.

See also:

- https://www.php.net/manual/en/opcache.configuration.php
- https://forums.classicpress.net/t/blank-screen-when-using-the-migration-plugin/2158
- https://core.trac.wordpress.org/ticket/36455

## How has this been tested?

Initial testing using the [migration plugin](https://github.com/ClassicPress/ClassicPress-Migration-Plugin) and the [custom build below](https://nylen.io/ClassicPress-v1.1.2+PR.567.zip) indicates this works well, but there are still more server configurations to try, for example:

- opcache disabled
- opcache enabled under default settings
- opcache enabled with a longer value than the default for `opcache.revalidate_freq`
- opcache enabled with `opcache.validate_timestamps` disabled
- opcache enabled but `opcache.restrict_api` set (we can't fix the issue in this case, but we can make sure the `@` operator swallows the resulting PHP warning)

`opcache_invalidate` may also fail in other circumstances: https://www.php.net/manual/en/function.opcache-invalidate.php#124420

## Types of changes

- Bug fix