### PR TITLE
Backport script: Several updates

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -185,7 +185,7 @@ perl -w <<PL
 	my \$was_blank_line = 0;
 	while (<MSG_R>) {
 		s,\[(\d+)\],https://core.trac.wordpress.org/changeset/\$1,g;
-		s#\[(\d+)-(\d+)\]#join ', ', map { "https://core.trac.wordpress.org/changeset/\$_" } \$1 .. \$2#ge;
+		s,\[(\d+)-(\d+)\],https://core.trac.wordpress.org/log/?revs=\$1-\$2,g;
 		s,#(\d+)\b,https://core.trac.wordpress.org/ticket/\$1,g;
 		s,^# Conflicts:,Conflicts:,;
 		s,^#\t,- ,;

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -185,6 +185,7 @@ perl -w <<PL
 	my \$was_blank_line = 0;
 	while (<MSG_R>) {
 		s,\[(\d+)\],https://core.trac.wordpress.org/changeset/\$1,g;
+		s#\[(\d+)-(\d+)\]#join ', ', map { "https://core.trac.wordpress.org/changeset/\$_" } \$1 .. \$2#ge;
 		s,#(\d+)\b,https://core.trac.wordpress.org/ticket/\$1,g;
 		s,^# Conflicts:,Conflicts:,;
 		s,^#\t,- ,;

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -246,7 +246,8 @@ else
 	echo "${color_bold_red}=======${color_reset}"
 	echo "${color_bold_red}WARNING: Conflict detected!${color_reset}"
 	echo "Fix and commit the files that contain <<""<< or >>"">> conflict markers:"
-	git log -n 1 | grep -P '^\s+- \S'
+	git log -n 1 \
+		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
 	echo "${color_bold_red}=======${color_reset}"
 	echo
 	echo "If you're not sure how to do this, just push your changes to GitHub"

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -110,8 +110,16 @@ cmd git fetch "$cp_remote"
 commit_hash=""
 # Find the changeset in the WP git log
 # Only need to search after branch points, or after ClassicPress was forked
-# See: https://github.com/ClassicPress/ClassicPress-Bots/blob/755f43e2/app/Http/Controllers/UpstreamCommitsList.php#L12-L45
-for range in 'd7b6719f:4.9' '5d477aa7:5.0' '3ec31001:5.1' 'ff6114f8:master'; do
+# See: https://github.com/ClassicPress/ClassicPress-backports/blob/e8de096b3/app/Http/Controllers/UpstreamCommitsList.php#L23-L74
+for range in \
+	'd7b6719f:4.9' \
+	'5d477aa7:5.0' \
+	'3ec31001:5.1' \
+	'dc512708:5.2' \
+	'c67b47c66:5.3' \
+	'66f510bda:5.4' \
+	'ff6114f8:master'
+do
 	start_commit=$(echo "$range" | cut -d: -f1)
 	search_branch=$(echo "$range" | cut -d: -f2)
 	log_range="$start_commit..$wp_remote/$search_branch"


### PR DESCRIPTION
This PR makes several improvements to the [WP backport script](https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md#backporting-changes-from-wordpress).

These improvements will be used to help backport the WP 4.9.15 changes from https://github.com/WordPress/wordpress-develop/commit/aa08e63c74de39fcb3f6dfd8d03321739c2ab3f1.

## Add the WP 5.3 and 5.4 branches to the script

Self-explanatory. See also https://github.com/ClassicPress/ClassicPress-backports/commit/e8de096b3f1d2b5947c4167c3a036894d5aefd8c

## Expand changeset ranges in commit messages

Before:

```
Merges [47948-47951] to the 4.9  branch.
```

After:

```
Merges https://core.trac.wordpress.org/log/?revs=47948-47951 to the 4.9  branch.
```

## Fix the "conflicting files" detection in the backport script's output

Before:

```
=======
WARNING: Conflict detected!
Fix and commit the files that contain <<<< or >>>> conflict markers:
    - Editor: Prevent HTML decoding on by setting the proper editor context.
    - Formatting: Ensure that wp_validate_redirect() sanitizes a wider variety of characters.
    - Themes: Ensure a broken theme name is returned properly.
    - Administration: Add a new filter to extend set-screen-option.
    - src/wp-admin/includes/misc.php
=======
```

After:

```
=======
WARNING: Conflict detected!
Fix and commit the files that contain <<<< or >>>> conflict markers:
    - src/wp-admin/includes/misc.php
=======
```