### PR TITLE
WP-r48134: Quick/Bulk Edit: Ensure the proper actions is triggered wh…

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -443,7 +443,7 @@ class WP_List_Table {
 
 		echo "</select>\n";
 
-		submit_button( __( 'Apply' ), 'action', '', false, array( 'id' => "doaction$two" ) );
+		submit_button( __( 'Apply' ), 'action', "doaction$two", false, array( 'id' => "doaction$two" ) );
 		echo "\n";
 	}
 
@@ -461,7 +461,7 @@ class WP_List_Table {
 		if ( isset( $_REQUEST['action'] ) && -1 != $_REQUEST['action'] )
 			return $_REQUEST['action'];
 
-		if ( isset( $_REQUEST['action2'] ) && -1 != $_REQUEST['action2'] )
+		if ( isset( $_REQUEST['doaction2'] ) && isset( $_REQUEST['action2'] ) && -1 != $_REQUEST['action2'] )
 			return $_REQUEST['action2'];
 
 		return false;


### PR DESCRIPTION
…en using the bulk updater.

If a user selects the top option, then chooses a different option, the top selection takes precedence. This update gives a new name to the bottom action, ensuring the proper update is carried out.

Fixes 46872.

WP:Props clayray, garrett-eclipse, subrataemfluence.

Conflicts:
- src/wp-admin/includes/class-wp-list-table.php

---

Merges https://core.trac.wordpress.org/changeset/48134 / WordPress/wordpress-develop@c9ac809611 to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
Backport of upstream patch

## Motivation and context
This fixes unexpected behaviour is 2 different Bulk Actions are selected in an admin table.

## How has this been tested?
See original ticket, no unit tests are included with the commit.

## Types of changes
- Bug fix
