### PR TITLE
WP-r48241: Administration: Pass the result of `set-screen-option` fil…

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -717,6 +717,8 @@ function set_screen_options() {
 					return;
 				break;
 			default:
+				$screen_option = false;
+
 				if ( '_page' === substr( $option, -5 ) || 'layout_columns' === $option ) {
 					/**
 					 * Filters a screen option value before it is set.
@@ -732,12 +734,12 @@ function set_screen_options() {
 					 *
 					 * @see set_screen_options()
 					 *
-					 * @param bool   $keep   Whether to save or skip saving the screen option value.
-					 *                       Default false.
-					 * @param string $option The option name.
-					 * @param int    $value  The number of rows to use.
+					 * @param mixed  $screen_option The value to save instead of the option value.
+					 *                              Default false (to skip saving the current option).
+					 * @param string $option        The option name.
+					 * @param int    $value         The option value.
 					 */
-					$value = apply_filters( 'set-screen-option', false, $option, $value ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+					$screen_option = apply_filters( 'set-screen-option', $screen_option, $option, $value ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 				}
 
 				/**
@@ -751,12 +753,12 @@ function set_screen_options() {
 				 *
 				 * @see set_screen_options()
 				 *
-				 * @param bool   $keep   Whether to save or skip saving the screen option value.
-				 *                       Default false.
-				 * @param string $option The option name.
-				 * @param int    $value  The number of rows to use.
+				 * @param mixed   $screen_option The value to save instead of the option value.
+				 *                               Default false (to skip saving the current option).
+				 * @param string  $option        The option name.
+				 * @param int     $value         The option value.
 				 */
-				$value = apply_filters( "set_screen_option_{$option}", false, $option, $value );
+				$value = apply_filters( "set_screen_option_{$option}", $screen_option, $option, $value );
 
 				if ( false === $value )
 					return;


### PR DESCRIPTION
…ter to the new `set_screen_option_{$option}` filter to ensure backward compatibility.

Rename the `$keep` parameter of both filters to `$screen_option` for clarity, update the documentation to better reflect its purpose.

WP:Props Chouby, sswells, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/50392.

---

Merges https://core.trac.wordpress.org/changeset/48241 / WordPress/wordpress-develop@48f0e74279 to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
Backport of upstream fix

## Motivation and context
Fix for upstream ticket 50392

## How has this been tested?
Backported through all supported branched of WP

## Types of changes
- Bug fix
