### PR TITLE
WP-r48240: Administration: Always show the filters on media and post …

### DIFF
--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -172,16 +172,14 @@ class WP_Media_List_Table extends WP_List_Table {
 ?>
 		<div class="actions">
 <?php
-		if ( ! is_singular() ) {
-			if ( ! $this->is_trash ) {
-				$this->months_dropdown( 'attachment' );
-			}
-
-			/** This action is documented in wp-admin/includes/class-wp-posts-list-table.php */
-			do_action( 'restrict_manage_posts', $this->screen->post_type, $which );
-
-			submit_button( __( 'Filter' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+		if ( ! $this->is_trash ) {
+			$this->months_dropdown( 'attachment' );
 		}
+
+		/** This action is documented in wp-admin/includes/class-wp-posts-list-table.php */
+		do_action( 'restrict_manage_posts', $this->screen->post_type, $which );
+
+		submit_button( __( 'Filter' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
 
 		if ( $this->is_trash && current_user_can( 'edit_others_posts' ) && $this->has_items() ) {
 			submit_button( __( 'Empty Trash' ), 'apply', 'delete_all', false );

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -454,7 +454,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 ?>
 		<div class="alignleft actions">
 <?php
-		if ( 'top' === $which && !is_singular() ) {
+		if ( 'top' === $which ) {
 			ob_start();
 
 			$this->months_dropdown( $this->screen->post_type );


### PR DESCRIPTION
## Description
…list tables.

Previously, the filters were hidden for single posts or attachments, which could only be achieved by editing the URL manually.

The `is_singular()` check was added long before the list tables were introduced, and appears to no longer serve any purpose in the current code.

As a side effect, this resolves an issue where a non-existing attachment ID in the URL would block further search in Media Library.

WP:Props afercia, tomdude, audrasjb, bencroskery, desrosj, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/38221.

Conflicts:
- src/wp-admin/includes/class-wp-media-list-table.php
- src/wp-admin/includes/class-wp-posts-list-table.php

---

Merges https://core.trac.wordpress.org/changeset/48240 / WordPress/wordpress-develop@b9871a67cb to ClassicPress.

## Motivation and context
Backport of upstream fix

## How has this been tested?
Commit agreed by 2 WP core committers

## Types of changes
- Bug fix
