### PR TITLE
WP-r48031: Avoid a PHP notice in several `WP_Filesystem` methods

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -196,15 +196,10 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getpwuid') )
 			return $owneruid;
-<<<<<<< HEAD
-		$ownerarray = posix_getpwuid($owneruid);
-=======
-		}
 		$ownerarray = posix_getpwuid( $owneruid );
 		if ( ! $ownerarray ) {
 			return false;
 		}
->>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $ownerarray['name'];
 	}
 
@@ -232,15 +227,10 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getgrgid') )
 			return $gid;
-<<<<<<< HEAD
-		$grouparray = posix_getgrgid($gid);
-=======
-		}
 		$grouparray = posix_getgrgid( $gid );
 		if ( ! $grouparray ) {
 			return false;
 		}
->>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $grouparray['name'];
 	}
 

--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -196,7 +196,15 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getpwuid') )
 			return $owneruid;
+<<<<<<< HEAD
 		$ownerarray = posix_getpwuid($owneruid);
+=======
+		}
+		$ownerarray = posix_getpwuid( $owneruid );
+		if ( ! $ownerarray ) {
+			return false;
+		}
+>>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $ownerarray['name'];
 	}
 
@@ -224,7 +232,15 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getgrgid') )
 			return $gid;
+<<<<<<< HEAD
 		$grouparray = posix_getgrgid($gid);
+=======
+		}
+		$grouparray = posix_getgrgid( $gid );
+		if ( ! $grouparray ) {
+			return false;
+		}
+>>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $grouparray['name'];
 	}
 

--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -341,15 +341,10 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getpwuid') )
 			return $owneruid;
-<<<<<<< HEAD
-		$ownerarray = posix_getpwuid($owneruid);
-=======
-		}
 		$ownerarray = posix_getpwuid( $owneruid );
 		if ( ! $ownerarray ) {
 			return false;
 		}
->>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $ownerarray['name'];
 	}
 
@@ -373,15 +368,10 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getgrgid') )
 			return $gid;
-<<<<<<< HEAD
-		$grouparray = posix_getgrgid($gid);
-=======
-		}
 		$grouparray = posix_getgrgid( $gid );
 		if ( ! $grouparray ) {
 			return false;
 		}
->>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $grouparray['name'];
 	}
 

--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -341,7 +341,15 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getpwuid') )
 			return $owneruid;
+<<<<<<< HEAD
 		$ownerarray = posix_getpwuid($owneruid);
+=======
+		}
+		$ownerarray = posix_getpwuid( $owneruid );
+		if ( ! $ownerarray ) {
+			return false;
+		}
+>>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $ownerarray['name'];
 	}
 
@@ -365,7 +373,15 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			return false;
 		if ( ! function_exists('posix_getgrgid') )
 			return $gid;
+<<<<<<< HEAD
 		$grouparray = posix_getgrgid($gid);
+=======
+		}
+		$grouparray = posix_getgrgid( $gid );
+		if ( ! $grouparray ) {
+			return false;
+		}
+>>>>>>> d32ec3352b... Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.
 		return $grouparray['name'];
 	}
 


### PR DESCRIPTION
WP-r48031: Filesystem API: Avoid a PHP notice in `WP_Filesystem_Direct::owner()` and `::group()` methods and their `WP_Filesystem_SSH2` counterparts.

Although not officially documented in the PHP manual, `posix_getpwuid()` and `posix_getgrgid()` can return `false` in some circumstances.

WP:Props logig.
Fixes https://core.trac.wordpress.org/ticket/50373.

Conflicts:
- src/wp-admin/includes/class-wp-filesystem-direct.php
- src/wp-admin/includes/class-wp-filesystem-ssh2.php

---

Merges https://core.trac.wordpress.org/changeset/48031 / WordPress/wordpress-develop@d32ec3352b to ClassicPress.

