### PR TITLE
Add "Custom Login Image" JS to the script loader

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -24,11 +24,7 @@ $timezone_format = _x('Y-m-d H:i:s', 'timezone date format');
 add_action('admin_head', 'options_general_add_js');
 // New (1.2.0, custom login image) options-general JS
 wp_enqueue_media();
-wp_enqueue_script( 'options-general', admin_url( '/js/options-general.js' ), array( 'jquery' ), '1.2.0' );
-wp_localize_script( 'options-general', 'cpOptionsGeneralStrings', array(
-	'selectAnImage' => __( 'Select an image' ),
-	'useThisImage'  => __( 'Use this image' ),
-) );
+wp_enqueue_script( 'cp-options-general' );
 
 $options_help = '<p>' . __('The fields on this screen determine some of the basics of your site setup.') . '</p>' .
 	'<p>' . __('Most themes display the site title at the top of every page, in the title bar of the browser, and as the identifying name for syndicated feeds. The tagline is also displayed by many themes.') . '</p>';

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -940,6 +940,12 @@ function wp_default_scripts( &$scripts ) {
 		$scripts->add( 'media-gallery', "/wp-admin/js/media-gallery$suffix.js", array('jquery'), false, 1 );
 
 		$scripts->add( 'svg-painter', '/wp-admin/js/svg-painter.js', array( 'jquery' ), false, 1 );
+
+		$scripts->add( 'cp-options-general', admin_url( "/js/options-general$suffix.js" ), array( 'jquery' ), false, 1 );
+		did_action( 'init' ) && $scripts->localize( 'cp-options-general', 'cpOptionsGeneralStrings', array(
+			'selectAnImage' => __( 'Select an image' ),
+			'useThisImage'  => __( 'Use this image' ),
+		) );
 	}
 }
 


### PR DESCRIPTION
This is consistent with the way other built-in script files are declared and managed.

### Testing

- [x] Dev install or with WP_DEBUG enabled - should load non-minified script
- [x] Custom build using the migration plugin on live site: https://nylen.io/ClassicPress-v1.1.4+PR.609.zip - should load minified script