### PR TITLE
Update privacy policy

### DIFF
--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -46,9 +46,9 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 <?php if ( $is_privacy_notice ) : ?>
 
 <div class="about-wrap-content">
-	<p class="about-description"><?php _e( 'From time to time, your ClassicPress site may send data to ClassicPress.net &#8212; including, but not limited to &#8212; the version of ClassicPress you are using, and a list of installed plugins and themes.' ); ?></p>
+	<p class="about-description"><?php _e( 'From time to time, your ClassicPress site may send anonymous data to ClassicPress.net. Some examples of the kinds of data that may be sent are the version of ClassicPress your site is running and a list of installed plugins and themes.' ); ?></p>
 
-	<p><?php printf( __( 'We take privacy and transparency very seriously. To learn more about what data we collect, and how we use it, please visit <a href="%s">ClassicPress Privacy Policy</a>.' ), 'https://www.iubenda.com/privacy-policy/41030260' ); ?></p>
+	<p><?php printf( __( 'We take privacy and transparency very seriously. To learn more about what data we collect, how we use it, and what precautions we take to ensure site owners&#8217; privacy, please see the <a href="%s">ClassicPress Privacy Policy</a>.' ), 'https://link.classicpress.net/core-privacy-policy/' ); ?></p>
 </div>
 
 <?php else : ?>


### PR DESCRIPTION
This PR updates the privacy policy wording to be a little more clear, and to link to the page that is going to contain the full policy.

The previous link was pointing to iubenda.com which is no longer active and was not very useful anyway. The new link is not live yet, but it is using our redirect server at link.classicpress.net / https://github.com/ClassicPress/subdomain-link so that we can put up a page wherever we want without having to change the core code again.