### PR TITLE
Improve custom login image controls usability

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -919,6 +919,16 @@ table.form-table td .updated p {
 	max-height: 120px;
 }
 
+.options-general-php .wrap .login_custom_image-notice {
+	margin: 3px 0 3px 24px;
+	padding: 3px 6px;
+	/* inside <label> for positioning, but shouldn't advertise as clickable */
+	cursor: default;
+	/* from .description styles */
+	color: #666;
+	font-style: italic;
+}
+
 .form-table.permalink-structure .available-structure-tags li {
 	float: left;
 	margin-right: 5px;

--- a/src/wp-admin/js/options-general.js
+++ b/src/wp-admin/js/options-general.js
@@ -4,6 +4,7 @@
  * @since 1.2.0
  */
 jQuery( document ).ready( function( $ ) {
+	var $row      = $( '#login_custom_image-row' );
 	var $choices  = $( 'input[name=login_custom_image_state]' );
 	var $img      = $( '#login_custom_image-img' );
 	var $controls = $( '#login_custom_image-controls' );
@@ -13,6 +14,10 @@ jQuery( document ).ready( function( $ ) {
 
 	// Show controls for this setting
 	$controls.removeClass( 'hidden' );
+
+	// Enable all choices. An inline notice will be shown if an invalid choice
+	// is selected.
+	$choices.prop( 'disabled', false );
 
 	var uploader = wp.media( {
 		title: window.cpOptionsGeneralStrings.selectAnImage,
@@ -27,30 +32,35 @@ jQuery( document ).ready( function( $ ) {
 	} );
 
 	uploader.on( 'select', function() {
+		$row.find( '.login_custom_image-notice' ).remove();
 		var attachment = uploader.state().get( 'selection' ).first().toJSON();
 		$img.removeClass( 'hidden' );
 		$img.attr( 'src', attachment.url );
 		$img.attr( 'alt', attachment.alt );
 		$img.attr( 'title', attachment.description );
-		$choices.prop( 'disabled', false );
-		$input.attr( 'value', attachment.id );
+		$input.val( attachment.id );
 		if ( $choices.filter( '[value=0]:checked' ).length ) {
 			$choices.filter( '[value=1]' ).prop( 'checked', true );
 		}
 	} );
 
 	$clear.on( 'click', function() {
+		$row.find( '.login_custom_image-notice' ).remove();
 		$img.addClass( 'hidden' );
 		$img.removeAttr( 'src' );
 		$img.removeAttr( 'alt' );
 		$img.removeAttr( 'title' );
-		$input.attr( 'value', '' );
-		$choices.each( function() {
-			if ( this.value === '0' ) {
-				$( this ).prop( 'checked', true );
-			} else {
-				$( this ).prop( 'disabled', true );
-			}
-		} );
+		$input.val( '' );
+		$choices.filter( '[value=0]' ).prop( 'checked', true );
+	} );
+
+	$choices.on( 'click', function() {
+		$row.find( '.login_custom_image-notice' ).remove();
+		var inputVal = $input.val();
+		if ( $( this ).val() !== '0' && ( inputVal === '' || inputVal === '0' ) ) {
+			var $notice = $( '<div class="notice error login_custom_image-notice">' );
+			$notice.text( window.cpOptionsGeneralStrings.chooseAnImageFirst );
+			$( this ).closest( 'label' ).append( $notice );
+		}
 	} );
 } );

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -142,7 +142,7 @@ if ( $login_custom_image_src ) {
 }
 ?>
 
-<tr>
+<tr id="login_custom_image-row">
 <th scope="row"><?php _e( 'Custom Login Image' ) ?></th>
 <td>
 	<fieldset>

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -943,8 +943,9 @@ function wp_default_scripts( &$scripts ) {
 
 		$scripts->add( 'cp-options-general', admin_url( "/js/options-general$suffix.js" ), array( 'jquery' ), false, 1 );
 		did_action( 'init' ) && $scripts->localize( 'cp-options-general', 'cpOptionsGeneralStrings', array(
-			'selectAnImage' => __( 'Select an image' ),
-			'useThisImage'  => __( 'Use this image' ),
+			'selectAnImage'      => __( 'Select an image' ),
+			'useThisImage'       => __( 'Use this image' ),
+			'chooseAnImageFirst' => __( 'Choose an image first!' ),
 		) );
 	}
 }


### PR DESCRIPTION
This PR seeks to improve the usability of the new "custom login image" setting's controls.

Follow-up to #601.

## Before

The two "use my custom image" options are disabled until an image has been selected.

<img src="https://user-images.githubusercontent.com/227022/92153671-2e31e580-ee14-11ea-9360-47b9348b5657.png" width="480">

This has caused some user confusion: https://forums.classicpress.net/t/classicpress-1-2-0-rc1-release-notes/2479/2

## After

These options are clickable but an inline message will be shown when an image has not been chosen yet:

<img src="https://user-images.githubusercontent.com/227022/92153771-4c97e100-ee14-11ea-9f32-24613c58c9ea.png" width="540">