### PR TITLE
Fix backport script on OS X

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -882,7 +882,7 @@ module.exports = function(grunt) {
 
 		grunt.util.spawn( {
 			cmd: 'bash',
-			args: [ '-c', "git ls-files -z | xargs -0 grep -P -C3 -n --binary-files=without-match '(<<" + "<<|^=======(\\s|$)|>>" + ">>)'" ]
+			args: [ '-c', "git ls-files -z | xargs -0 grep -E -C3 -n --binary-files=without-match '(<<" + "<<|^=======(\\s|$)|>>" + ">>)'" ]
 		}, ( error, { stdout, stderr }, code ) => {
 			// Ignore error because it is populated for non-zero exit codes:
 			// https://gruntjs.com/api/grunt.util#grunt.util.spawn

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -222,12 +222,12 @@ git status --porcelain
 echo
 
 # Add "both modified" or "added by us/them" files
-git status --porcelain | grep -P '^[AU][AU] ' | cut -c4- | while read i; do
+git status --porcelain | grep -E '^[AU][AU] ' | cut -c4- | while read i; do
 	cmd git add "$i"
 done
 
 # Remove "deleted by us" or "deleted by them" files
-git status --porcelain | grep -P '^[DU][DU] ' | cut -c4- | while read i; do
+git status --porcelain | grep -E '^[DU][DU] ' | cut -c4- | while read i; do
 	cmd git rm "$i"
 done
 


### PR DESCRIPTION
Issue reported by @bahiirwa:

```
$ bin/backport-wp-commit.sh -c 42832
Found git remote 'wp' for WordPress/wordpress-develop
Found git remote 'origin' for ClassicPress/ClassicPress
Updating repositories from GitHub: WordPress...
Updating repositories from GitHub: ClassicPress...
Searching for r42832 in WP git: wp/4.9
Searching for r42832 in WP git: wp/5.0
Searching for r42832 in WP git: wp/5.1
Searching for r42832 in WP git: wp/5.2
Searching for r42832 in WP git: wp/5.3
Searching for r42832 in WP git: wp/5.4
Searching for r42832 in WP git: wp/master

Found commit: 5f56921131 on wp/master branch

Backporting commit using git cherry-pick
Modifying commit message

git status before:
UU src/wp-admin/css/dashboard.css
UU src/wp-admin/includes/dashboard.php
UU src/wp-includes/capabilities.php
UU tests/phpunit/tests/user/capabilities.php

usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]

git status after:
UU src/wp-admin/css/dashboard.css
UU src/wp-admin/includes/dashboard.php
UU src/wp-includes/capabilities.php
UU tests/phpunit/tests/user/capabilities.php

+ git commit --no-edit --allow-empty --author=Felix Arntz <flixos90@git.wordpress.org>
> error: Committing is not possible because you have unmerged files.
> hint: Fix them up in the work tree, and then use 'git add/rm <file>'
> hint: as appropriate to mark resolution and make a commit.
> fatal: Exiting because of an unresolved conflict.
> U     src/wp-admin/css/dashboard.css
> U     src/wp-admin/includes/dashboard.php
> U     src/wp-includes/capabilities.php
> U     tests/phpunit/tests/user/capabilities.php
```

OS X `grep` supports `-E` but not `-P`: https://ss64.com/osx/grep.html

The same issue exists in the Gruntfile for `grunt precommit:git-conflicts` so this PR should fix that too.