### PR TITLE
New Dashboard Widget: Upgrade PHP prompt

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -970,6 +970,7 @@ a.rsswidget {
 	font-size: 16px;
 }
 
+<<<<<<< HEAD
 /* ---------------------------------------------------------
 	Dashboard Petitions Widget
 ------------------------------------------------------------*/
@@ -1088,6 +1089,22 @@ table.cp_petitions span.started {
 	padding: 2px 4px;
 }
 
+=======
+/* PHP Nag */
+#dashboard_php_nag h2.hndle {
+	border-left: 4px solid #dc3232;
+}
+
+#dashboard_php_nag h3 {
+	font-weight: 600;
+}
+
+#dashboard_php_nag .button.button-hero {
+	display: block;
+	text-align: center;
+}
+
+>>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 /* =Media Queries
 -------------------------------------------------------------- */
 

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1089,17 +1089,25 @@ table.cp_petitions span.started {
 }
 
 /* PHP Nag */
-#dashboard_php_nag h2.hndle {
-	border-left: 4px solid #dc3232;
+#dashboard_php_nag .dashicons-warning {
+	color: #ffb900;
+	padding-right: 6px;
+}
+
+#dashboard_php_nag.php-insecure .dashicons-warning {
+	color: #df3232;
+}
+
+#dashboard_php_nag p {
+	margin: 12px 0;
 }
 
 #dashboard_php_nag h3 {
 	font-weight: 600;
 }
 
-#dashboard_php_nag .button.button-hero {
-	display: block;
-	text-align: center;
+#dashboard_php_nag .button .dashicons-external {
+	line-height: 25px;
 }
 
 /* =Media Queries

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -970,7 +970,6 @@ a.rsswidget {
 	font-size: 16px;
 }
 
-<<<<<<< HEAD
 /* ---------------------------------------------------------
 	Dashboard Petitions Widget
 ------------------------------------------------------------*/
@@ -1089,7 +1088,6 @@ table.cp_petitions span.started {
 	padding: 2px 4px;
 }
 
-=======
 /* PHP Nag */
 #dashboard_php_nag h2.hndle {
 	border-left: 4px solid #dc3232;
@@ -1104,7 +1102,6 @@ table.cp_petitions span.started {
 	text-align: center;
 }
 
->>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 /* =Media Queries
 -------------------------------------------------------------- */
 

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -613,11 +613,6 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 					_e( 'This plugin doesn&#8217;t work with your version of PHP or support ClassicPress. ' );
 					if ( current_user_can( 'update_php' ) ) {
 						printf(
-<<<<<<< HEAD
-							/* translators: %s: "Update PHP" page URL */
-							__( '<a href="%s">Learn more about updating PHP</a>.' ),
-							esc_url( wp_get_update_php_url() )
-=======
 							/* translators: 1: "Update WordPress" screen URL, 2: "Updating PHP" page URL */
 							__( '<a href="%1$s">Please update WordPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
 							self_admin_url( 'update-core.php' ),
@@ -628,7 +623,6 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 							/* translators: %s: "Updating PHP" page URL */
 							__( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( __( 'https://wordpress.org/support/update-php/' ) )
->>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
 						);
 						wp_update_php_annotation();
 					}
@@ -640,11 +634,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 						printf(
 							/* translators: %s: "Update PHP" page URL */
 							__( '<a href="%s">Learn more about updating PHP</a>.' ),
-<<<<<<< HEAD
-							esc_url( wp_get_update_php_url() )
-=======
-						esc_url( __( 'https://wordpress.org/support/update-php/' ) )
->>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
+							esc_url( __( 'https://wordpress.org/support/update-php/' ) )
 						);
 						wp_update_php_annotation();
 					}

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -613,9 +613,22 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 					_e( 'This plugin doesn&#8217;t work with your version of PHP or support ClassicPress. ' );
 					if ( current_user_can( 'update_php' ) ) {
 						printf(
+<<<<<<< HEAD
 							/* translators: %s: "Update PHP" page URL */
 							__( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( wp_get_update_php_url() )
+=======
+							/* translators: 1: "Update WordPress" screen URL, 2: "Updating PHP" page URL */
+							__( '<a href="%1$s">Please update WordPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( __( 'https://wordpress.org/support/update-php/' ) )
+						);
+					} else {
+						printf(
+							/* translators: %s: "Updating PHP" page URL */
+							__( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( __( 'https://wordpress.org/support/update-php/' ) )
+>>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
 						);
 						wp_update_php_annotation();
 					}
@@ -627,7 +640,11 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 						printf(
 							/* translators: %s: "Update PHP" page URL */
 							__( '<a href="%s">Learn more about updating PHP</a>.' ),
+<<<<<<< HEAD
 							esc_url( wp_get_update_php_url() )
+=======
+						esc_url( __( 'https://wordpress.org/support/update-php/' ) )
+>>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
 						);
 						wp_update_php_annotation();
 					}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1401,9 +1401,9 @@ function wp_check_browser_version() {
 }
 
 /**
- * Displays the PHP upgrade nag.
+ * Displays the PHP update nag.
  *
- * @since 5.0.0
+ * @since 5.1.0
  */
 function wp_dashboard_php_nag() {
 	$response = wp_check_php_version();
@@ -1418,6 +1418,9 @@ function wp_dashboard_php_nag() {
 		$msg = __( 'WordPress has detected that your site is running on an outdated version of PHP.' );
 	}
 
+	$update_url  = wp_get_update_php_url();
+	$default_url = wp_get_default_update_php_url();
+
 	?>
 	<p><?php echo $msg; ?></p>
 
@@ -1428,7 +1431,7 @@ function wp_dashboard_php_nag() {
 		<?php
 			printf(
 				'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-				esc_url( _x( 'https://wordpress.org/support/update-php/', 'localized PHP upgrade information page' ) ),
+			esc_url( $update_url ),
 				__( 'Learn more about updating PHP' ),
 				/* translators: accessibility text */
 				__( '(opens in a new tab)' )
@@ -1436,12 +1439,26 @@ function wp_dashboard_php_nag() {
 		?>
 	</p>
 	<?php
+
+	if ( $update_url !== $default_url ) {
+		?>
+		<p class="description">
+			<?php
+			printf(
+				/* translators: %s: default Update PHP page URL */
+				__( 'This resource is provided by your web host, and is specific to your site. For more information, <a href="%s" target="_blank">see the official WordPress documentation</a>.' ),
+				esc_url( $default_url )
+			);
+			?>
+		</p>
+		<?php
+	}
 }
 
 /**
  * Adds an additional class to the PHP nag if the current version is insecure.
  *
- * @since 5.0.0
+ * @since 5.1.0
  *
  * @param array $classes Metabox classes.
  * @return array Modified metabox classes.
@@ -1457,9 +1474,9 @@ function dashboard_php_nag_class( $classes ) {
 }
 
 /**
- * Checks if the user needs to upgrade PHP.
+ * Checks if the user needs to update PHP.
  *
- * @since 5.0.0
+ * @since 5.1.0
  *
  * @return array|false $response Array of PHP version data. False on failure.
  */

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1413,16 +1413,21 @@ function wp_dashboard_php_nag() {
 	}
 
 	if ( isset( $response['is_secure'] ) && ! $response['is_secure'] ) {
-		$msg = __( 'WordPress has detected that your site is running on an insecure version of PHP.' );
+		printf(
+			__( 'WordPress has detected that your site is running on an insecure version of PHP (%s).' ),
+			phpversion()
+		);
 	} else {
-		$msg = __( 'WordPress has detected that your site is running on an outdated version of PHP.' );
+		printf(
+			__( 'WordPress has detected that your site is running on an outdated version of PHP (%s).' ),
+			phpversion()
+		);
 	}
 
 	$update_url  = wp_get_update_php_url();
 	$default_url = wp_get_default_update_php_url();
 
 	?>
-	<p><?php echo $msg; ?></p>
 
 	<h3><?php _e( 'What is PHP and how does it affect my site?' ); ?></h3>
 	<p><?php _e( 'PHP is the programming language we use to build and maintain WordPress. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site’s performance.' ); ?></p>
@@ -1486,7 +1491,7 @@ function wp_check_php_version() {
 
 	$response = get_site_transient( 'php_check_' . $key );
 	if ( false === $response ) {
-		$url = 'http://api.wordpress.org/core/serve-happy/1.0/';
+		$url = 'https://api-v1.classicpress.net/core/support-check/1.0/';
 		if ( wp_http_supports( array( 'ssl' ) ) ) {
 			$url = set_url_scheme( $url, 'https' );
 		}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -35,6 +35,13 @@ function wp_dashboard_setup() {
 		}
 	}
 
+	// PHP Version
+	$response = wp_check_php_version();
+	if ( $response && ! $response['is_acceptable'] && current_user_can( 'upgrade_php' ) ) {
+		$title = $response['is_secure'] ? __( 'Your site could be much faster!' ) : __( 'Your site could be much faster and more secure!' );
+		wp_add_dashboard_widget( 'dashboard_php_nag', $title, 'wp_dashboard_php_nag' );
+	}
+
 	// Right Now
 	if ( is_blog_admin() && current_user_can( 'edit_posts' ) ) {
 		wp_add_dashboard_widget( 'dashboard_right_now', __( 'At a Glance' ), 'wp_dashboard_right_now' );
@@ -181,8 +188,10 @@ function wp_add_dashboard_widget( $widget_id, $widget_name, $callback, $control_
 		$location = 'side';
 	}
 
+	$high_priority_widgets = array( 'dashboard_browser_nag', 'dashboard_php_nag' );
+
 	$priority = 'core';
-	if ( 'dashboard_browser_nag' === $widget_id ) {
+	if ( in_array( $widget_id, $high_priority_widgets, true ) ) {
 		$priority = 'high';
 	}
 
@@ -1386,6 +1395,91 @@ function wp_check_browser_version() {
 		}
 
 		set_site_transient( 'browser_' . $key, $response, WEEK_IN_SECONDS );
+	}
+
+	return $response;
+}
+
+/**
+ * Displays the PHP upgrade nag.
+ *
+ * @since 5.0.0
+ */
+function wp_dashboard_php_nag() {
+	$response = wp_check_php_version();
+
+	if ( ! $response ) {
+		return;
+	}
+
+	$information_url = _x( 'https://wordpress.org/support/upgrade-php/', 'localized PHP upgrade information page' );
+
+	$msg = __( 'Hi, it&#8217;s your friends at WordPress here.' );
+	if ( ! $response['is_secure'] ) {
+		$msg .= ' ' . __( 'We noticed that your site is running on an insecure version of PHP, which is why we&#8217;re showing you this notice.' );
+	} else {
+		$msg .= ' ' . __( 'We noticed that your site is running on an outdated version of PHP, which is why we&#8217;re showing you this notice.' );
+	}
+
+	?>
+	<p><?php echo $msg; ?></p>
+
+	<h3><?php _e( 'What is PHP and why should I care?' ); ?></h3>
+	<p><?php _e( 'PHP is the programming language that WordPress is built on. Newer versions of PHP are both faster and more secure, so upgrading is better for your site, and better for the people who are building WordPress.' ); ?></p>
+	<p><?php _e( 'If you want to know exactly how PHP works and why it is important, continue reading.' ); ?></p>
+
+	<h3><?php _e( 'Okay, how do I update?' ); ?></h3>
+	<p><?php _e( 'The button below will take you to a page with more details on what PHP is, how to upgrade your PHP version, and what to do if it turns out you can&#8217;t.' ); ?></p>
+	<p>
+		<a class="button button-primary button-hero" href="<?php echo esc_url( $information_url ); ?>"><?php _e( 'Show me how to upgrade my PHP' ); ?></a>
+	</p>
+
+	<h3><?php _e( 'Thank you for taking the time to read this!' ); ?></h3>
+	<p><?php _e( 'If you carefully follow the instructions we&#8217;ve provided, upgrading shouldn&#8217;t take more than a few minutes, and it is generally very safe to do.' ); ?></p>
+	<p><?php _e( 'Good luck and happy blogging!' ); ?></p>
+	<?php
+}
+
+/**
+ * Checks if the user needs to upgrade PHP.
+ *
+ * @since 5.0.0
+ *
+ * @return array Array of PHP version data.
+ */
+function wp_check_php_version() {
+	$version = phpversion();
+	$key     = md5( $version );
+
+	$response = get_site_transient( 'php_check_' . $key );
+	if ( false === $response ) {
+		$url = 'http://api.wordpress.org/core/serve-happy/1.0/';
+		if ( wp_http_supports( array( 'ssl' ) ) ) {
+			$url = set_url_scheme( $url, 'https' );
+		}
+
+		$url = add_query_arg( 'php_version', $version, $url );
+
+		$response = wp_remote_get( $url );
+
+		if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		/**
+		 * Response should be an array with:
+		 *  'recommended_version' - string - The PHP version recommended by WordPress
+		 *  'is_supported' - boolean - Whether the PHP version is actively supported
+		 *  'is_secure' - boolean - Whether the PHP version receives security updates
+		 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for WordPress
+		 */
+		$response = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $response ) ) {
+			return false;
+		}
+
+		set_site_transient( 'php_check_' . $key, $response, WEEK_IN_SECONDS );
 	}
 
 	return $response;

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1414,11 +1414,10 @@ function wp_dashboard_php_nag() {
 
 	$information_url = _x( 'https://wordpress.org/support/upgrade-php/', 'localized PHP upgrade information page' );
 
-	$msg = __( 'Hi, it&#8217;s your friends at WordPress here.' );
 	if ( ! $response['is_secure'] ) {
-		$msg .= ' ' . __( 'We noticed that your site is running on an insecure version of PHP, which is why we&#8217;re showing you this notice.' );
+		$msg = __( 'WordPress has detected that your site is running on an insecure version of PHP, which is why we&#8217;re showing you this notice.' );
 	} else {
-		$msg .= ' ' . __( 'We noticed that your site is running on an outdated version of PHP, which is why we&#8217;re showing you this notice.' );
+		$msg = __( 'WordPress has detected that your site is running on an outdated version of PHP, which is why we&#8217;re showing you this notice.' );
 	}
 
 	?>
@@ -1428,15 +1427,13 @@ function wp_dashboard_php_nag() {
 	<p><?php _e( 'PHP is the programming language that WordPress is built on. Newer versions of PHP are both faster and more secure, so upgrading is better for your site, and better for the people who are building WordPress.' ); ?></p>
 	<p><?php _e( 'If you want to know exactly how PHP works and why it is important, continue reading.' ); ?></p>
 
-	<h3><?php _e( 'Okay, how do I update?' ); ?></h3>
+	<h3><?php _e( 'How can I upgrade my PHP version?' ); ?></h3>
 	<p><?php _e( 'The button below will take you to a page with more details on what PHP is, how to upgrade your PHP version, and what to do if it turns out you can&#8217;t.' ); ?></p>
 	<p>
 		<a class="button button-primary button-hero" href="<?php echo esc_url( $information_url ); ?>"><?php _e( 'Show me how to upgrade my PHP' ); ?></a>
 	</p>
 
-	<h3><?php _e( 'Thank you for taking the time to read this!' ); ?></h3>
-	<p><?php _e( 'If you carefully follow the instructions we&#8217;ve provided, upgrading shouldn&#8217;t take more than a few minutes, and it is generally very safe to do.' ); ?></p>
-	<p><?php _e( 'Good luck and happy blogging!' ); ?></p>
+	<p><?php _e( 'Upgrading usually takes only a few minutes and should be safe if you follow the provided instructions.' ); ?></p>
 	<?php
 }
 

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1403,7 +1403,7 @@ function wp_check_browser_version() {
 /**
  * Displays the PHP update nag.
  *
- * @since 5.1.0
+ * @since WP-5.1.0
  */
 function wp_dashboard_php_nag() {
 	$response = wp_check_php_version();
@@ -1458,7 +1458,7 @@ function wp_dashboard_php_nag() {
 /**
  * Adds an additional class to the PHP nag if the current version is insecure.
  *
- * @since 5.1.0
+ * @since WP-5.1.0
  *
  * @param array $classes Metabox classes.
  * @return array Modified metabox classes.
@@ -1476,7 +1476,7 @@ function dashboard_php_nag_class( $classes ) {
 /**
  * Checks if the user needs to update PHP.
  *
- * @since 5.1.0
+ * @since WP-5.1.0
  *
  * @return array|false $response Array of PHP version data. False on failure.
  */

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -35,11 +35,11 @@ function wp_dashboard_setup() {
 		}
 	}
 
-	// PHP Version
+	// PHP Version.
 	$response = wp_check_php_version();
-	if ( $response && ! $response['is_acceptable'] && current_user_can( 'upgrade_php' ) ) {
-		$title = $response['is_secure'] ? __( 'Your site could be much faster!' ) : __( 'Your site could be much faster and more secure!' );
-		wp_add_dashboard_widget( 'dashboard_php_nag', $title, 'wp_dashboard_php_nag' );
+	if ( $response && isset( $response['is_acceptable'] ) && ! $response['is_acceptable'] && current_user_can( 'upgrade_php' ) ) {
+		add_filter( 'postbox_classes_dashboard_dashboard_php_nag', 'dashboard_php_nag_class' );
+		wp_add_dashboard_widget( 'dashboard_php_nag', __( 'PHP Update Required' ), 'wp_dashboard_php_nag' );
 	}
 
 	// Right Now
@@ -1412,29 +1412,48 @@ function wp_dashboard_php_nag() {
 		return;
 	}
 
-	$information_url = _x( 'https://wordpress.org/support/upgrade-php/', 'localized PHP upgrade information page' );
-
-	if ( ! $response['is_secure'] ) {
-		$msg = __( 'WordPress has detected that your site is running on an insecure version of PHP, which is why we&#8217;re showing you this notice.' );
+	if ( isset( $response['is_secure'] ) && ! $response['is_secure'] ) {
+		$msg = __( 'WordPress has detected that your site is running on an insecure version of PHP.' );
 	} else {
-		$msg = __( 'WordPress has detected that your site is running on an outdated version of PHP, which is why we&#8217;re showing you this notice.' );
+		$msg = __( 'WordPress has detected that your site is running on an outdated version of PHP.' );
 	}
 
 	?>
 	<p><?php echo $msg; ?></p>
 
-	<h3><?php _e( 'What is PHP and why should I care?' ); ?></h3>
-	<p><?php _e( 'PHP is the programming language that WordPress is built on. Newer versions of PHP are both faster and more secure, so upgrading is better for your site, and better for the people who are building WordPress.' ); ?></p>
-	<p><?php _e( 'If you want to know exactly how PHP works and why it is important, continue reading.' ); ?></p>
+	<h3><?php _e( 'What is PHP and how does it affect my site?' ); ?></h3>
+	<p><?php _e( 'PHP is the programming language we use to build and maintain WordPress. Newer versions of PHP are both faster and more secure, so updating will have a positive effect on your site’s performance.' ); ?></p>
 
-	<h3><?php _e( 'How can I upgrade my PHP version?' ); ?></h3>
-	<p><?php _e( 'The button below will take you to a page with more details on what PHP is, how to upgrade your PHP version, and what to do if it turns out you can&#8217;t.' ); ?></p>
-	<p>
-		<a class="button button-primary button-hero" href="<?php echo esc_url( $information_url ); ?>"><?php _e( 'Show me how to upgrade my PHP' ); ?></a>
+	<p class="button-container">
+		<?php
+			printf(
+				'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+				esc_url( _x( 'https://wordpress.org/support/upgrade-php/', 'localized PHP upgrade information page' ) ),
+				__( 'Learn more about updating PHP' ),
+				/* translators: accessibility text */
+				__( '(opens in a new tab)' )
+			);
+		?>
 	</p>
-
-	<p><?php _e( 'Upgrading usually takes only a few minutes and should be safe if you follow the provided instructions.' ); ?></p>
 	<?php
+}
+
+/**
+ * Adds an additional class to the PHP nag if the current version is insecure.
+ *
+ * @since 5.0.0
+ *
+ * @param array $classes Metabox classes.
+ * @return array Modified metabox classes.
+ */
+function dashboard_php_nag_class( $classes ) {
+	$response = wp_check_php_version();
+
+	if ( $response && isset( $response['is_secure'] ) && ! $response['is_secure'] ) {
+		$classes[] = 'php-insecure';
+	}
+
+	return $classes;
 }
 
 /**
@@ -1442,7 +1461,7 @@ function wp_dashboard_php_nag() {
  *
  * @since 5.0.0
  *
- * @return array Array of PHP version data.
+ * @return array|false $response Array of PHP version data. False on failure.
  */
 function wp_check_php_version() {
 	$version = phpversion();
@@ -1459,16 +1478,16 @@ function wp_check_php_version() {
 
 		$response = wp_remote_get( $url );
 
-		if ( is_wp_error( $response ) || 200 != wp_remote_retrieve_response_code( $response ) ) {
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return false;
 		}
 
 		/**
 		 * Response should be an array with:
-		 *  'recommended_version' - string - The PHP version recommended by WordPress
-		 *  'is_supported' - boolean - Whether the PHP version is actively supported
-		 *  'is_secure' - boolean - Whether the PHP version receives security updates
-		 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for WordPress
+		 *  'recommended_version' - string - The PHP version recommended by WordPress.
+		 *  'is_supported' - boolean - Whether the PHP version is actively supported.
+		 *  'is_secure' - boolean - Whether the PHP version receives security updates.
+		 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for WordPress.
 		 */
 		$response = json_decode( wp_remote_retrieve_body( $response ), true );
 

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1428,7 +1428,7 @@ function wp_dashboard_php_nag() {
 		<?php
 			printf(
 				'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-				esc_url( _x( 'https://wordpress.org/support/upgrade-php/', 'localized PHP upgrade information page' ) ),
+				esc_url( _x( 'https://wordpress.org/support/update-php/', 'localized PHP upgrade information page' ) ),
 				__( 'Learn more about updating PHP' ),
 				/* translators: accessibility text */
 				__( '(opens in a new tab)' )

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -792,9 +792,15 @@ function install_plugin_information() {
 		_e( '<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>.' );
 		if ( current_user_can( 'update_php' ) ) {
 			printf(
+<<<<<<< HEAD
 				/* translators: %s: "Update PHP" page URL */
 				' ' . __( '<a href="%s" target="_blank">Click here to learn more about updating PHP</a>.' ),
 				esc_url( wp_get_update_php_url() )
+=======
+			/* translators: "Updating PHP" page URL */
+			__( '<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>, so unfortunately you cannot install it. <a href="%s" target="_blank">Click here to learn more about updating PHP</a>.' ),
+			esc_url( __( 'https://wordpress.org/support/update-php/' ) )
+>>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
 			);
 			echo '</p>';
 			wp_update_php_annotation();

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -792,15 +792,9 @@ function install_plugin_information() {
 		_e( '<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>.' );
 		if ( current_user_can( 'update_php' ) ) {
 			printf(
-<<<<<<< HEAD
-				/* translators: %s: "Update PHP" page URL */
-				' ' . __( '<a href="%s" target="_blank">Click here to learn more about updating PHP</a>.' ),
-				esc_url( wp_get_update_php_url() )
-=======
 			/* translators: "Updating PHP" page URL */
 			__( '<strong>Error:</strong> This plugin <strong>requires a newer version of PHP</strong>, so unfortunately you cannot install it. <a href="%s" target="_blank">Click here to learn more about updating PHP</a>.' ),
 			esc_url( __( 'https://wordpress.org/support/update-php/' ) )
->>>>>>> 6d8e3c5864 (Plugins: Use newer "Updating PHP" page URL in the notice displayed when a plugin requires a higher PHP version.)
 			);
 			echo '</p>';
 			wp_update_php_annotation();

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1176,7 +1176,13 @@ function do_meta_boxes( $screen, $context, $object ) {
 						echo '<span class="toggle-indicator" aria-hidden="true"></span>';
 						echo '</button>';
 					}
-					echo "<h2 class='hndle'><span>{$box['title']}</span></h2>\n";
+					echo '<h2 class="hndle">';
+					if ( 'dashboard_php_nag' === $box['id'] ) {
+						echo '<span aria-hidden="true" class="dashicons dashicons-warning"></span>';
+						echo '<span class="screen-reader-text">' . __( 'Warning:' ) . ' </span>';
+					}
+					echo "<span>{$box['title']}</span>";
+					echo "</h2>\n";
 					echo '<div class="inside">' . "\n";
 					call_user_func( $box['callback'], $object, $box );
 					echo "</div>\n";

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -558,10 +558,19 @@ function map_meta_cap( $cap, $user_id ) {
 				$caps[] = 'manage_options';
 			}
 			break;
+<<<<<<< HEAD
 		case 'export_others_personal_data':
 		case 'erase_others_personal_data':
 		case 'manage_privacy_options':
 			$caps[] = is_multisite() ? 'manage_network' : 'manage_options';
+=======
+		case 'upgrade_php':
+			if ( is_multisite() && ! is_super_admin( $user_id ) ) {
+				$caps[] = 'do_not_allow';
+			} else {
+				$caps[] = 'update_core';
+			}
+>>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 			break;
 		default:
 			// Handle meta capabilities for custom post types.

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -558,19 +558,16 @@ function map_meta_cap( $cap, $user_id ) {
 				$caps[] = 'manage_options';
 			}
 			break;
-<<<<<<< HEAD
 		case 'export_others_personal_data':
 		case 'erase_others_personal_data':
 		case 'manage_privacy_options':
 			$caps[] = is_multisite() ? 'manage_network' : 'manage_options';
-=======
 		case 'upgrade_php':
 			if ( is_multisite() && ! is_super_admin( $user_id ) ) {
 				$caps[] = 'do_not_allow';
 			} else {
 				$caps[] = 'update_core';
 			}
->>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 			break;
 		default:
 			// Handle meta capabilities for custom post types.

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -562,6 +562,7 @@ function map_meta_cap( $cap, $user_id ) {
 		case 'erase_others_personal_data':
 		case 'manage_privacy_options':
 			$caps[] = is_multisite() ? 'manage_network' : 'manage_options';
+			break;
 		case 'upgrade_php':
 			if ( is_multisite() && ! is_super_admin( $user_id ) ) {
 				$caps[] = 'do_not_allow';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6680,7 +6680,7 @@ function wp_get_update_php_url() {
  * @return string Default URL to learn more about updating PHP.
  */
 function wp_get_default_update_php_url() {
-	return _x( 'https://wordpress.org/support/update-php/', 'localized PHP upgrade information page' );
+	return _x( 'https://docs.classicpress.net/user-guides/update-php/', 'localized PHP upgrade information page' );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6636,11 +6636,7 @@ function wp_privacy_delete_old_export_files() {
  * default URL being used. Furthermore the page the URL links to should preferably be localized in the
  * site language.
  *
-<<<<<<< HEAD
  * @since WP-5.1.0
-=======
- * @since 5.1.0
->>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
  *
  * @return string URL to learn more about updating PHP.
  */
@@ -6658,11 +6654,7 @@ function wp_get_update_php_url() {
 	 * Providing an empty string is not allowed and will result in the default URL being used. Furthermore
 	 * the page the URL links to should preferably be localized in the site language.
 	 *
-<<<<<<< HEAD
-	 * @since WP-5.1.0
-=======
 	 * @since 5.1.0
->>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
 	 *
 	 * @param string $update_url URL to learn more about updating PHP.
 	 */
@@ -6682,11 +6674,7 @@ function wp_get_update_php_url() {
  * This function does not allow modifying the returned URL, and is only used to compare the actually used URL with the
  * default one.
  *
-<<<<<<< HEAD
- * @since WP-5.1.0
-=======
  * @since 5.1.0
->>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
  * @access private
  *
  * @return string Default URL to learn more about updating PHP.
@@ -6694,7 +6682,6 @@ function wp_get_update_php_url() {
 function wp_get_default_update_php_url() {
 	return _x( 'https://wordpress.org/support/update-php/', 'localized PHP upgrade information page' );
 }
-<<<<<<< HEAD
 
 /**
  * Prints the default annotation for the web host altering the "Update PHP" page URL.
@@ -6830,5 +6817,3 @@ function is_wp_version_compatible( $required ) {
 function is_php_version_compatible( $required ) {
 	return empty( $required ) || version_compare( phpversion(), $required, '>=' );
 }
-=======
->>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6636,7 +6636,11 @@ function wp_privacy_delete_old_export_files() {
  * default URL being used. Furthermore the page the URL links to should preferably be localized in the
  * site language.
  *
+<<<<<<< HEAD
  * @since WP-5.1.0
+=======
+ * @since 5.1.0
+>>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
  *
  * @return string URL to learn more about updating PHP.
  */
@@ -6654,7 +6658,11 @@ function wp_get_update_php_url() {
 	 * Providing an empty string is not allowed and will result in the default URL being used. Furthermore
 	 * the page the URL links to should preferably be localized in the site language.
 	 *
+<<<<<<< HEAD
 	 * @since WP-5.1.0
+=======
+	 * @since 5.1.0
+>>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
 	 *
 	 * @param string $update_url URL to learn more about updating PHP.
 	 */
@@ -6674,7 +6682,11 @@ function wp_get_update_php_url() {
  * This function does not allow modifying the returned URL, and is only used to compare the actually used URL with the
  * default one.
  *
+<<<<<<< HEAD
  * @since WP-5.1.0
+=======
+ * @since 5.1.0
+>>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)
  * @access private
  *
  * @return string Default URL to learn more about updating PHP.
@@ -6682,6 +6694,7 @@ function wp_get_update_php_url() {
 function wp_get_default_update_php_url() {
 	return _x( 'https://wordpress.org/support/update-php/', 'localized PHP upgrade information page' );
 }
+<<<<<<< HEAD
 
 /**
  * Prints the default annotation for the web host altering the "Update PHP" page URL.
@@ -6817,3 +6830,5 @@ function is_wp_version_compatible( $required ) {
 function is_php_version_compatible( $required ) {
 	return empty( $required ) || version_compare( phpversion(), $required, '>=' );
 }
+=======
+>>>>>>> aea4b2765a (General: Make Update PHP notice link customizable.)

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6654,7 +6654,7 @@ function wp_get_update_php_url() {
 	 * Providing an empty string is not allowed and will result in the default URL being used. Furthermore
 	 * the page the URL links to should preferably be localized in the site language.
 	 *
-	 * @since 5.1.0
+	 * @since WP-5.1.0
 	 *
 	 * @param string $update_url URL to learn more about updating PHP.
 	 */
@@ -6674,7 +6674,7 @@ function wp_get_update_php_url() {
  * This function does not allow modifying the returned URL, and is only used to compare the actually used URL with the
  * default one.
  *
- * @since 5.1.0
+ * @since WP-5.1.0
  * @access private
  *
  * @return string Default URL to learn more about updating PHP.

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -236,9 +236,13 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'           => array( 'administrator' ),
 			'update_languages'            => array( 'administrator' ),
 			'deactivate_plugins'          => array( 'administrator' ),
+<<<<<<< HEAD
 			'export_others_personal_data' => array( 'administrator' ),
 			'erase_others_personal_data'  => array( 'administrator' ),
 			'manage_privacy_options'      => array( 'administrator' ),
+=======
+			'upgrade_php'            => array( 'administrator' ),
+>>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 
 			'edit_categories'             => array( 'administrator', 'editor' ),
 			'delete_categories'           => array( 'administrator', 'editor' ),
@@ -270,9 +274,13 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'           => array(),
 			'update_languages'            => array(),
 			'deactivate_plugins'          => array(),
+<<<<<<< HEAD
 			'export_others_personal_data' => array( '' ),
 			'erase_others_personal_data'  => array( '' ),
 			'manage_privacy_options'      => array(),
+=======
+			'upgrade_php'            => array(),
+>>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
 
 			'customize'                   => array( 'administrator' ),
 			'delete_site'                 => array( 'administrator' ),

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -236,13 +236,10 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'           => array( 'administrator' ),
 			'update_languages'            => array( 'administrator' ),
 			'deactivate_plugins'          => array( 'administrator' ),
-<<<<<<< HEAD
 			'export_others_personal_data' => array( 'administrator' ),
 			'erase_others_personal_data'  => array( 'administrator' ),
 			'manage_privacy_options'      => array( 'administrator' ),
-=======
-			'upgrade_php'            => array( 'administrator' ),
->>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
+			'upgrade_php'                 => array( 'administrator' ),
 
 			'edit_categories'             => array( 'administrator', 'editor' ),
 			'delete_categories'           => array( 'administrator', 'editor' ),
@@ -274,13 +271,10 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			'install_languages'           => array(),
 			'update_languages'            => array(),
 			'deactivate_plugins'          => array(),
-<<<<<<< HEAD
 			'export_others_personal_data' => array( '' ),
 			'erase_others_personal_data'  => array( '' ),
 			'manage_privacy_options'      => array(),
-=======
-			'upgrade_php'            => array(),
->>>>>>> 5f56921131 (General: Introduce dashboard widget to inform administrators about outdated PHP versions.)
+			'upgrade_php'                 => array(),
 
 			'customize'                   => array( 'administrator' ),
 			'delete_site'                 => array( 'administrator' ),


### PR DESCRIPTION
Re-opening related to #604  which was erroneously closed by referenced PR #620 and can not be re-opened in the ordinary way.

## Description
Requires to fulfill https://github.com/ClassicPress/ClassicPress/issues/438#issuecomment-670770511

This is a backport of changes for the WP PHP upgrade dashboard notice widget. 
The new widget reminds the site owner to upgrade their version of PHP on the server to meet the minimum upcoming standard for CP.

### Changesets included:
https://core.trac.wordpress.org/changeset/42832
https://core.trac.wordpress.org/changeset/42891
https://core.trac.wordpress.org/changeset/43006
https://core.trac.wordpress.org/changeset/44420
https://core.trac.wordpress.org/changeset/44476
https://core.trac.wordpress.org/changeset/44627

## Challenge
This function mainly depends on `wp_check_php_version()` in `src/wp-admin/includes/dashboard.php` to display a dashboard widget.

The function requires an API with a response:

```
/**
 * Response should be an array with:
 *  'recommended_version' - string - The PHP version recommended by ClassicPress.
 *  'is_supported' - boolean - Whether the PHP version is actively supported.
 *  'is_secure' - boolean - Whether the PHP version receives security updates.
 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for ClassicPress.
 */
```
With the above challenge, there is no screenshot to share since this change was introduced in WP 5.1.0. The dashboard therefore works post WP 5.0.

Closes #438 

## Motivation and context
Better PHP on the server has its joys. Cleaner environment, better security, new tools and faster performance.

## How has this been tested?
Tests are included in the backports.

Passing the right API expected array produces

![Screenshot 2022-07-18 at 20 24 13](https://user-images.githubusercontent.com/7713923/179570184-7f980ba4-33f4-4a1e-b872-1fec1c95ecb5.png)

![Screenshot 2022-07-18 at 20 23 45](https://user-images.githubusercontent.com/7713923/179570199-dd256ee7-c95f-4198-87fe-20e208919bf1.png)

![Screenshot 2022-07-18 at 20 23 28](https://user-images.githubusercontent.com/7713923/179570207-f9b3baad-ce81-4f58-8f51-169f7b6933a3.png)


## Types of changes
- [x] New feature

## New Tasks
- [ ] Add new API https://github.com/ClassicPress/ClassicPress-APIs/pull/51
- [ ] Add new documentation https://github.com/ClassicPress/Documentation-Issue-Tracker/issues/34


