### PR TITLE
WP-r45042: Adds support for the `wp_body_open()` hook introduced in WP5.2.0.

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2631,6 +2631,22 @@ function wp_footer() {
 }
 
 /**
+ * Fire the wp_body_open action.
+ *
+ * * See {@see 'wp_body_open'}.
+ *
+ * @since 5.2.0
+ */
+function wp_body_open() {
+	/**
+	 * Triggered after the opening <body> tag.
+	 *
+	 * @since 5.2.0
+	 */
+	do_action( 'wp_body_open' );
+}
+
+/**
  * Display the links to the general feeds.
  *
  * @since WP-2.8.0


### PR DESCRIPTION
## Description
This is a backport from https://core.trac.wordpress.org/changeset/45042/. 
Merges https://core.trac.wordpress.org/changeset/45042 / WordPress/wordpress-develop@01882f477b to ClassicPress.
Closes #646

**Description from WP:**

> Bundled Theme: trigger a new `wp_body_open` action immediately after the opening `body` tag.
> 
> - Enables inserting (asynchronous) JavaScript right after the opening `body` tag.
> - Add a `wp_body_open` helper function that triggers the `wp_body_open` action.
> - Call `wp_body_open` in core themes immediately after the opening `body` tag. 


---

## Notes
1. One file changed: `src/wp-includes/general-template.php`
2. Other files were intentionally omitted from this PR. Such files include:

   - src/wp-content/themes/twentyfifteen/header.php
   - src/wp-content/themes/twentyseventeen/header.php
   - src/wp-content/themes/twentysixteen/header.php

    and other, theme-specific files.

3. Separate WP changesets ([47221](https://core.trac.wordpress.org/changeset/47221) and [47455](https://core.trac.wordpress.org/changeset/47455)) also reference `wp_body_open` but these are related to the loading of the admin toolbar on the frontend. These are not included in this PR.

---

## Motivation and context
Provides a fix for `PHP Fatal error:  Uncaught Error: Call to undefined function wp_body_open() in .../wp-content/themes/twentytwentyone/header.php:24` error.

`wp_body_open()` is found in themes (not just Twenty Twenty-One) bundled with WP5.6 and other themes such as Underscores (_s).

The main issue is during migration from WP to CP which will cause the site to break if the site is using:

- WP 5.2+
- any theme using the `wp_body_open()` hook

This backport should improve the migration process for many people. It will avoid the need for users to downgrade their theme to an earlier, CP-compatible version pre-migration and it will prevent site breakages post-migration.

---

## How has this been tested?
1. Copy Twenty Twenty-One (as bundled with WP 5.6) to a CP 1.2.0 installation.
2. Activate Twenty Twenty-One.
3. Refresh frontend. It will then display the `Call to undefined function wp_body_open()` error.

---

## Types of changes
- New feature (WP theme compatibility)

---

## References
https://core.trac.wordpress.org/ticket/12563
https://core.trac.wordpress.org/changeset/45042
https://github.com/ClassicPress/ClassicPress/issues/646
