### PR TITLE
Add new tagline - The CMS for Creators. Stable. Secure. Instantly Familiar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="https://www.classicpress.net"><img src="src/wp-admin/images/classicpress-logo-wordmark-gradient-on-transparent.svg" height="60"></a>
 
-**ClassicPress: The business-focused CMS. Powerful. Versatile. Predictable.**
+**ClassicPress: The CMS for Creators. Stable. Secure. Instantly Familiar.**
 
 ClassicPress is a fork of WordPress that serves the CMS-based business website market. We empower the people who create and support these websites, including plugin and theme developers.
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "classicpress/classicpress",
-    "description": "The business-focused CMS. Powerful. Versatile. Predictable. Also known as the WordPress fork.",
+    "description": "The CMS for Creators. Stable. Secure. Instantly Familiar. Also known as the WordPress fork.",
     "keywords": [
         "classicpress"
     ],

--- a/src/readme.html
+++ b/src/readme.html
@@ -10,7 +10,7 @@
 <h1 id="logo">
 	<a href="https://www.classicpress.net/">ClassicPress</a>
 </h1>
-<p style="text-align: center">The business-focused CMS.<br>Powerful. Versatile. Predictable.</p>
+<p style="text-align: center">The CMS for Creators.<br>Stable. Secure. Instantly Familiar.</p>
 
 <h2 id="welcome">Welcome to ClassicPress!</h2>
 <p>You&#8217;ve just become part of a growing community of people who value the firm foundation WordPress 4.9.x provides for websites everywhere. <a href="https://www.classicpress.net/democracy/">Guided by our community</a>, we can leverage our collective expertise to maintain and develop the ClassicPress platform as an excellent choice for business and professional-quality websites worldwide.</p>

--- a/src/readme.html
+++ b/src/readme.html
@@ -13,14 +13,14 @@
 <p style="text-align: center">The CMS for Creators.<br>Stable. Secure. Instantly Familiar.</p>
 
 <h2 id="welcome">Welcome to ClassicPress!</h2>
-<p>You&#8217;ve just become part of a growing community of people who value the firm foundation WordPress 4.9.x provides for websites everywhere. <a href="https://www.classicpress.net/democracy/">Guided by our community</a>, we can leverage our collective expertise to maintain and develop the ClassicPress platform as an excellent choice for business and professional-quality websites worldwide.</p>
-<p>Our purpose is to provide a powerful, versatile, and predictable content management system tailored to the needs of the business website market. We invite you to connect with us and participate in our <a href="#resources">thriving online community</a>.</p>
-<p style="text-align: right">&#8212; The ClassicPress Founding Committee</p>
+<p>You&#8217;ve just become part of a growing community of people who value the firm foundation WordPress 4.9.x provides for websites everywhere. <a href="https://www.classicpress.net/democracy/">Guided by our community</a>, we can leverage our collective expertise to maintain and develop the ClassicPress platform as <em>the</em> content management system of choice for professionals, hobbyists, developers, sole-traders and <em>all</em> website creators worldwide.</p>
+<p>Our purpose is to provide a stable, secure, and instantly familiar content management system driven by the needs of the community. We invite you to connect with us and <a href="#resources">add your voice to the conversation.</a>.</p>
+<p style="text-align: right">&#8212; The ClassicPress Directors</p>
 
 <h2 id="installation">Installation</h2>
 <p>For more information about installing ClassicPress, see our <a href="https://docs.classicpress.net/installing-classicpress/">installation documentation</a>.</p>
 <ol>
-	<li>Download the latest release of ClassicPress from our <a href="https://www.classicpress.net/releases/">releases page</a>.</li>
+	<li>Download the latest release of ClassicPress from our <a href="https://link.classicpress.net/releases/">releases page</a>.</li>
 	<li>Unzip the package in an empty directory and upload all the files to your server using a remote connection method like SSH, SFTP, or FTP.</li>
 	<li>Open <span class="file"><a href="wp-admin/install.php">wp-admin/install.php</a></span> in the browser. It will take you through the process to set up a <code>wp-config.php</code> file with the database connection details.
 		<ol type="a">
@@ -47,7 +47,7 @@
 <p>For more information, see our <a href="https://docs.classicpress.net/updating-classicpress/#updating-classicpress-manually">manual update documentation</a>.</p>
 <ol start="0">
 	<li>Before doing anything, make sure you have a working backup of the entire site as well as the database.</li>
-	<li>Download the latest release of ClassicPress from our <a href="https://www.classicpress.net/releases/">releases page</a>.</li>
+	<li>Download the latest release of ClassicPress from our <a href="https://link.classicpress.net/releases/">releases page</a>.</li>
 	<li>On your <strong>local computer</strong>, unzip the ClassicPress release file into a directory.</li>
 	<li>On your <strong>local computer</strong>, remove the <code>wp-config-sample.php</code> file and the <code>wp-content</code> directory.</li>
 	<li>Upload what’s left over to your server, replacing the existing files (using either SSH or an application that connects over SFTP or FTP).
@@ -80,12 +80,12 @@
 	<dt><a href="https://docs.classicpress.net/">ClassicPress Documentation</a></dt>
 		<dd>Here you'll find up-to-date reference information about ClassicPress.</dd>
 	<dt><a href="https://www.classicpress.net/blog/">ClassicPress Blog</a></dt>
-		<dd>This is where you&#8217;ll find the latest updates and news related to ClassicPress. Recent ClassicPress news appears in your administrative dashboard by default.</dd>
+		<dd>This is where you&#8217;ll find the latest updates and news related to ClassicPress as well as tutorials and other interesting snippets of information. Recent ClassicPress news appears in your administrative dashboard by default.</dd>
 	<dt><a href="https://forums.classicpress.net/c/support">ClassicPress Support Forums</a></dt>
 		<dd>The support forums are a great way to get help from other ClassicPress users. Many community members and ClassicPress leaders are active here.</dd>
 	<dt><a href="https://www.classicpress.net/join-slack/">ClassicPress Slack</a></dt>
 		<dd>There is an active online chat channel that is used for discussion among people who use ClassicPress and plan its further development.</dd>
-	<dt><a href="https://petitions.classicpress.net/">ClassicPress Petitions</a></dt>
+	<dt><a href="https://forums.classicpress.net/c/governance/petitions/77">ClassicPress Petitions</a></dt>
 		<dd>Do you have an idea to make ClassicPress better? Please look for petitions that are similar to your idea, then discuss and vote for what will be included in future versions of ClassicPress.</dd>
 	<dt><a href="https://www.classicpress.net/democracy/">ClassicPress Democracy</a></dt>
 		<dd>Last but not least, read about the ClassicPress governance structure to understand how we do things and how you can help. ClassicPress is a democratic community-led fork of WordPress that enables all stakeholders to shape the direction that the project takes. This page aims to explain how we handle this process to ensure that power doesn’t become centralised and that every voice can be heard.</dd>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -27,7 +27,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<?php printf(
 				/* translators: link to "business-focused CMS" article */
 				__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
-				'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
+				'https://link.classicpress.net/the-cms-for-creators'
 			); ?>
 			<br />
 			<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -26,11 +26,11 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 		<p class="about-text">
 			<?php printf(
 				/* translators: link to "business-focused CMS" article */
-				__( 'Thank you for using ClassicPress, the <a href="%s">business-focused CMS</a>.' ),
+				__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
 				'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
 			); ?>
 			<br />
-			<?php _e( 'Powerful. Versatile. Predictable.' ); ?>
+			<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>
 		</p>
 		<div class="wp-badge"></div>
 

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -24,11 +24,11 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 <p class="about-text">
 	<?php printf(
 		/* translators: link to "business-focused CMS" article */
-		__( 'Thank you for using ClassicPress, the <a href="%s">business-focused CMS</a>.' ),
+		__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
 		'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
 	); ?>
 	<br>
-	<?php _e( 'Powerful. Versatile. Predictable.' ); ?>
+	<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>
 </p>
 
 <div class="wp-badge"></div>

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -25,7 +25,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 	<?php printf(
 		/* translators: link to "business-focused CMS" article */
 		__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
-		'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
+		'https://link.classicpress.net/the-cms-for-creators'
 	); ?>
 	<br>
 	<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -27,11 +27,11 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 <p class="about-text">
 	<?php printf(
 		/* translators: link to "business-focused CMS" article */
-		__( 'Thank you for using ClassicPress, the <a href="%s">business-focused CMS</a>.' ),
+		__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
 		'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
 	); ?>
 	<br>
-	<?php _e( 'Powerful. Versatile. Predictable.' ); ?>
+	<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>
 </p>
 
 <div class="wp-badge"></div>

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -28,7 +28,7 @@ $is_privacy_notice = isset( $_GET['privacy-notice'] );
 	<?php printf(
 		/* translators: link to "business-focused CMS" article */
 		__( 'Thank you for using ClassicPress, the <a href="%s">CMS for Creators</a>.' ),
-		'https://www.classicpress.net/blog/2018/10/29/classicpress-for-business-professional-organization-websites/'
+		'https://link.classicpress.net/the-cms-for-creators'
 	); ?>
 	<br>
 	<?php _e( 'Stable. Secure. Instantly Familiar.' ); ?>


### PR DESCRIPTION
Closes #653

## Description
Chaging the tagline and byline from

```
ClassicPress
A business-focused CMS
Powerful. Versatile. Predictable.
```

 to

```
ClassicPress
The CMS for Creators
Stable. Secure. Instantly Familiar.
```

## How has this been tested?
No tests to write as these are changes to texts. 

Clarity can be made on `tests/phpunit/data/admin/features.json` file. Do we need to rephrase the wording? Many instances of this appear like below.

<img width="1344" alt="Screenshot 2021-01-23 at 19 00 35" src="https://user-images.githubusercontent.com/7713923/105606988-557e5480-5dad-11eb-8f60-9336453c7606.png">

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

### Before
<img width="877" alt="Screenshot 2021-01-23 at 18 57 19" src="https://user-images.githubusercontent.com/7713923/105606880-d426c200-5dac-11eb-9601-25742f96ed0e.png">

<img width="947" alt="Screenshot 2021-01-23 at 18 58 15" src="https://user-images.githubusercontent.com/7713923/105606915-f4ef1780-5dac-11eb-9831-f3fd6c1c25ab.png">

### After
<img width="954" alt="Screenshot 2021-01-23 at 18 54 11" src="https://user-images.githubusercontent.com/7713923/105606798-64183c00-5dac-11eb-9e39-389173bdee47.png">

<img width="980" alt="Screenshot 2021-01-23 at 18 56 29" src="https://user-images.githubusercontent.com/7713923/105606850-b6595d00-5dac-11eb-92a0-f609662d5b16.png">

## Types of changes
- Branding texts
