### PR TITLE
Add workflow_dispatch to GitHub Actions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  workflow_dispatch:
 
 jobs:
   # Runs PHP coding standards checks.

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  workflow_dispatch:
 
 jobs:
   # Runs the QUnit tests for ClassicPress.

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   pull_request:
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
   pull_request:
   # Once weekly On Sundays at 00:00 UTC.
   schedule:


### PR DESCRIPTION
Adds the `workflow_dispatch` event to each GitHub Action `yml` file.

This allows actions to be triggered manually as detailed here:

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch

Once integrated, a ‘Run workflow’ button will appear on the Actions tab.