### PR TITLE
WP-r49397: General WordPress updates (backport from from WP 4.9.16)

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -75,13 +75,13 @@ wp_enqueue_script( 'svg-painter' );
 $admin_body_class = preg_replace('/[^a-z0-9_-]+/i', '-', $hook_suffix);
 ?>
 <script type="text/javascript">
-addLoadEvent = function(func){if(typeof jQuery!="undefined")jQuery(document).ready(func);else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
-	pagenow = '<?php echo $current_screen->id; ?>',
-	typenow = '<?php echo $current_screen->post_type; ?>',
-	adminpage = '<?php echo $admin_body_class; ?>',
-	thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
-	decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
+addLoadEvent = function(func){if(typeof jQuery!=='undefined')jQuery(document).ready(func);else if(typeof wpOnload!=='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
+var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
+	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',
+	typenow = '<?php echo esc_js( $current_screen->post_type ); ?>',
+	adminpage = '<?php echo esc_js( $admin_body_class ); ?>',
+	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
+	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
 	isRtl = <?php echo (int) is_rtl(); ?>;
 </script>
 <meta name="viewport" content="width=device-width,initial-scale=1.0">

--- a/src/wp-admin/custom-background.php
+++ b/src/wp-admin/custom-background.php
@@ -541,6 +541,7 @@ if ( current_theme_supports( 'custom-background', 'default-color' ) )
 	 * @deprecated WP-3.5.0
 	 */
 	public function wp_set_background_image() {
+		check_ajax_referer( 'custom-background' );
 		if ( ! current_user_can('edit_theme_options') || ! isset( $_POST['attachment_id'] ) ) exit;
 		$attachment_id = absint($_POST['attachment_id']);
 		/** This filter is documented in wp-admin/includes/media.php */

--- a/src/wp-admin/custom-header.php
+++ b/src/wp-admin/custom-header.php
@@ -322,7 +322,7 @@ class Custom_Image_Header {
 		?>
 <script type="text/javascript">
 (function($){
-	var default_color = '<?php echo $default_color; ?>',
+	var default_color = '<?php echo esc_js( $default_color ); ?>',
 		header_text_fields;
 
 	function pickColor(color) {

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -473,7 +473,7 @@ wp_enqueue_style( 'ie' );
 ?>
 <script type="text/javascript">
 addLoadEvent = function(func){if(typeof jQuery!="undefined")jQuery(document).ready(func);else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
-var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',
+var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>', pagenow = 'media-upload-popup', adminpage = 'media-upload-popup',
 isRtl = <?php echo (int) is_rtl(); ?>;
 </script>
 <?php

--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -745,7 +745,7 @@ function can_edit_network( $network_id ) {
 function _thickbox_path_admin_subfolder() {
 ?>
 <script type="text/javascript">
-var tb_pathToImage = "<?php echo includes_url( 'js/thickbox/loadingAnimation.gif', 'relative' ); ?>";
+var tb_pathToImage = "<?php echo esc_js( includes_url( 'js/thickbox/loadingAnimation.gif', 'relative' ) ); ?>";
 </script>
 <?php
 }

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1641,12 +1641,12 @@ wp_enqueue_style( 'colors' );
 <script type="text/javascript">
 addLoadEvent = function(func){if(typeof jQuery!="undefined")jQuery(document).ready(func);else if(typeof wpOnload!='function'){wpOnload=func;}else{var oldonload=wpOnload;wpOnload=function(){oldonload();func();}}};
 function tb_close(){var win=window.dialogArguments||opener||parent||top;win.tb_remove();}
-var ajaxurl = '<?php echo admin_url( 'admin-ajax.php', 'relative' ); ?>',
-	pagenow = '<?php echo $current_screen->id; ?>',
-	typenow = '<?php echo $current_screen->post_type; ?>',
-	adminpage = '<?php echo $admin_body_class; ?>',
-	thousandsSeparator = '<?php echo addslashes( $wp_locale->number_format['thousands_sep'] ); ?>',
-	decimalPoint = '<?php echo addslashes( $wp_locale->number_format['decimal_point'] ); ?>',
+var ajaxurl = '<?php echo esc_js( admin_url( 'admin-ajax.php', 'relative' ) ); ?>',
+	pagenow = '<?php echo esc_js( $current_screen->id ); ?>',
+	typenow = '<?php echo esc_js( $current_screen->post_type ); ?>',
+	adminpage = '<?php echo esc_js( $admin_body_class ); ?>',
+	thousandsSeparator = '<?php echo esc_js( $wp_locale->number_format['thousands_sep'] ); ?>',
+	decimalPoint = '<?php echo esc_js( $wp_locale->number_format['decimal_point'] ); ?>',
 	isRtl = <?php echo (int) is_rtl(); ?>;
 </script>
 <?php

--- a/src/wp-admin/js/custom-background.js
+++ b/src/wp-admin/js/custom-background.js
@@ -122,11 +122,13 @@
 			frame.on( 'select', function() {
 				// Grab the selected attachment.
 				var attachment = frame.state().get('selection').first();
+				var nonceValue = $( '#_wpnonce' ).val() || '';
 
 				// Run an AJAX request to set the background image.
 				$.post( ajaxurl, {
 					action: 'set-background-image',
 					attachment_id: attachment.id,
+					_ajax_nonce: nonceValue,
 					size: 'full'
 				}).done( function() {
 					// When the request completes, reload the window.

--- a/src/wp-admin/js/media-gallery.js
+++ b/src/wp-admin/js/media-gallery.js
@@ -9,7 +9,7 @@ jQuery(function($) {
 	 * Adds a click event handler to the element with a 'wp-gallery' class.
 	 */
 	$( 'body' ).bind( 'click.wp-gallery', function(e) {
-		var target = $( e.target ), id, img_size;
+		var target = $( e.target ), id, img_size, nonceValue;
 
 		if ( target.hasClass( 'wp-set-header' ) ) {
 			// Opens the image to preview it full size.
@@ -19,6 +19,7 @@ jQuery(function($) {
 			// Sets the image as background of the theme.
 			id = target.data( 'attachment-id' );
 			img_size = $( 'input[name="attachments[' + id + '][image-size]"]:checked').val();
+			nonceValue = $( '#_wpnonce' ).val() && '';
 
 			/**
 			 * This AJAX action has been deprecated since WP-3.5.0, see custom-background.php
@@ -26,6 +27,7 @@ jQuery(function($) {
 			jQuery.post(ajaxurl, {
 				action: 'set-background-image',
 				attachment_id: id,
+				_ajax_nonce: nonceValue,
 				size: img_size
 			}, function() {
 				var win = window.dialogArguments || opener || parent || top;

--- a/src/wp-admin/media-new.php
+++ b/src/wp-admin/media-new.php
@@ -72,9 +72,9 @@ if ( get_user_setting('uploader') || isset( $_GET['browser-uploader'] ) )
 	<?php media_upload_form(); ?>
 
 	<script type="text/javascript">
-	var post_id = <?php echo $post_id; ?>, shortform = 3;
+	var post_id = <?php echo absint( $post_id ); ?>, shortform = 3;
 	</script>
-	<input type="hidden" name="post_id" id="post_id" value="<?php echo $post_id; ?>" />
+	<input type="hidden" name="post_id" id="post_id" value="<?php echo absint( $post_id ); ?>" />
 	<?php wp_nonce_field('media-form'); ?>
 	<div id="media-items" class="hide-if-no-js"></div>
 	</form>

--- a/src/wp-admin/network/site-users.php
+++ b/src/wp-admin/network/site-users.php
@@ -211,7 +211,7 @@ if ( ! wp_is_large_network( 'users' ) && apply_filters( 'show_network_site_users
 require( ABSPATH . 'wp-admin/admin-header.php' ); ?>
 
 <script type="text/javascript">
-var current_site_id = <?php echo $id; ?>;
+var current_site_id = <?php echo absint( $id ); ?>;
 </script>
 
 

--- a/src/wp-includes/Requests/Utility/FilteredIterator.php
+++ b/src/wp-includes/Requests/Utility/FilteredIterator.php
@@ -42,4 +42,5 @@ class Requests_Utility_FilteredIterator extends ArrayIterator {
 		$value = call_user_func($this->callback, $value);
 		return $value;
 	}
+
 }

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -3654,6 +3654,21 @@ class wp_xmlrpc_server extends IXR_Server {
 			return new IXR_Error( 403, __( 'Comment is required.' ) );
 		}
 
+		if (
+			'publish' === get_post_status( $post_id ) &&
+			! current_user_can( 'edit_post', $post_id ) &&
+			post_password_required( $post_id )
+		) {
+			return new IXR_Error( 403, __( 'Sorry, you are not allowed to comment on this post.' ) );
+		}
+
+		if (
+			'private' === get_post_status( $post_id ) &&
+			! current_user_can( 'read_post', $post_id )
+		) {
+			return new IXR_Error( 403, __( 'Sorry, you are not allowed to comment on this post.' ) );
+		}
+
 		$comment = array(
 			'comment_post_ID' => $post_id,
 			'comment_content' => $content_struct['content'],
@@ -4039,8 +4054,10 @@ class wp_xmlrpc_server extends IXR_Server {
 		/** This action is documented in wp-includes/class-wp-xmlrpc-server.php */
 		do_action( 'xmlrpc_call', 'wp.getMediaItem' );
 
-		if ( ! $attachment = get_post($attachment_id) )
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
 			return new IXR_Error( 404, __( 'Invalid attachment ID.' ) );
+		}
 
 		return $this->_prepare_media_item( $attachment );
 	}

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -1094,7 +1094,12 @@ function wp_filter_pre_oembed_result( $result, $url, $args ) {
 		$sites = get_sites( $qv );
 		$site  = reset( $sites );
 
-		if ( $site && (int) $site->blog_id !== get_current_blog_id() ) {
+		// Do not allow embeds for deleted/archived/spam sites.
+		if ( ! empty( $site->deleted ) || ! empty( $site->spam ) || ! empty( $site->archived ) ) {
+			return false;
+		}
+
+		if ( $site && get_current_blog_id() !== (int) $site->blog_id ) {
 			switch_to_blog( $site->blog_id );
 			$switched_blog = true;
 		}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1090,9 +1090,9 @@ function wp_check_invalid_utf8( $string, $strip = false ) {
  * @return string String with Unicode encoded for URI.
  */
 function utf8_uri_encode( $utf8_string, $length = 0 ) {
-	$unicode = '';
-	$values = array();
-	$num_octets = 1;
+	$unicode        = '';
+	$values         = array();
+	$num_octets     = 1;
 	$unicode_length = 0;
 
 	mbstring_binary_safe_encoding();
@@ -1104,9 +1104,10 @@ function utf8_uri_encode( $utf8_string, $length = 0 ) {
 		$value = ord( $utf8_string[ $i ] );
 
 		if ( $value < 128 ) {
-			if ( $length && ( $unicode_length >= $length ) )
+			if ( $length && ( $unicode_length >= $length ) ) {
 				break;
-			$unicode .= chr($value);
+			}
+			$unicode .= chr( $value );
 			$unicode_length++;
 		} else {
 			if ( count( $values ) == 0 ) {
@@ -2007,7 +2008,7 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 		if (function_exists('mb_strtolower')) {
 			$title = mb_strtolower($title, 'UTF-8');
 		}
-		$title = utf8_uri_encode($title, 200);
+		$title = utf8_uri_encode( $title, 200 );
 	}
 
 	$title = strtolower($title);

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -927,8 +927,9 @@ function _get_meta_table($type) {
  *                               term, or user).
  * @return bool True if the key is protected, false otherwise.
  */
-function is_protected_meta( $meta_key, $meta_type = null ) {
-	$protected = ( '_' == $meta_key[0] );
+function is_protected_meta( $meta_key, $meta_type = '' ) {
+	$sanitized_key = preg_replace( "/[^\x20-\x7E\p{L}]/", '', $meta_key );
+	$protected     = strlen( $sanitized_key ) > 0 && ( '_' === $sanitized_key[0] );
 
 	/**
 	 * Filters whether a meta key is protected.

--- a/tests/phpunit/tests/formatting/Utf8UriEncode.php
+++ b/tests/phpunit/tests/formatting/Utf8UriEncode.php
@@ -12,7 +12,7 @@ class Tests_Formatting_Utf8UriEncode extends WP_UnitTestCase {
 	 * @dataProvider data
 	 */
 	function test_percent_encodes_non_reserved_characters( $utf8, $urlencoded ) {
-		$this->assertEquals($urlencoded, utf8_uri_encode( $utf8 ) );
+		$this->assertEquals( $urlencoded, utf8_uri_encode( $utf8 ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/meta/isProtectedMeta.php
+++ b/tests/phpunit/tests/meta/isProtectedMeta.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @group meta
+ * @covers ::is_protected_meta
+ */
+class Tests_Meta_isProtectedMeta extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider protected_data
+	 */
+	public function test_protected( $key ) {
+		$this->assertTrue( is_protected_meta( $key ) );
+	}
+
+	public function protected_data() {
+		$protected_keys = array(
+			array( '_wp_attachment' ),
+		);
+		for ( $i = 0, $max = 31; $i < $max; $i ++ ) {
+			$protected_keys[] = array( chr( $i ) . '_wp_attachment' );
+		}
+		for ( $i = 127, $max = 159; $i <= $max; $i ++ ) {
+			$protected_keys[] = array( chr( $i ) . '_wp_attachment' );
+		}
+		$protected_keys[] = array( chr( 95 ) . '_wp_attachment' );
+
+		return $protected_keys;
+	}
+
+	/**
+	 * @dataProvider unprotected_data
+	 */
+	public function test_unprotected( $key ) {
+		$this->assertFalse( is_protected_meta( $key ) );
+	}
+
+	public function unprotected_data() {
+		$unprotected_keys = array(
+			array( 'singleword' ),
+			array( 'two_words' ),
+			array( 'ąŌ_not_so_protected_meta' ),
+		);
+
+		for ( $i = 32, $max = 94; $i <= $max; $i ++ ) {
+			$unprotected_keys[] = array( chr( $i ) . '_wp_attachment' );
+		}
+		for ( $i = 96, $max = 126; $i <= $max; $i ++ ) {
+			$unprotected_keys[] = array( chr( $i ) . '_wp_attachment' );
+		}
+
+		return $unprotected_keys;
+	}
+
+}

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -445,6 +445,36 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		remove_action( 'make_ham_blog', array( $this, '_action_counter_cb' ), 10 );
 	}
 
+	function test_content_from_spam_blog_is_not_available() {
+		$spam_blog_id = self::factory()->blog->create();
+		switch_to_blog( $spam_blog_id );
+		$post_data      = array(
+			'post_title'   => 'Hello World!',
+			'post_content' => 'Hello world content',
+		);
+		$post_id        = self::factory()->post->create( $post_data );
+		$post           = get_post( $post_id );
+		$spam_permalink = site_url() . '/?p=' . $post->ID;
+		$spam_embed_url = get_post_embed_url( $post_id );
+
+		restore_current_blog();
+		$this->assertNotEmpty( $spam_permalink );
+		$this->assertEquals( $post_data['post_title'], $post->post_title );
+
+		update_blog_status( $spam_blog_id, 'spam', 1 );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => "\n $spam_permalink \n",
+			)
+		);
+		$post    = get_post( $post_id );
+		$content = apply_filters( 'the_content', $post->post_content );
+
+		$this->assertNotContains( $post_data['post_title'], $content );
+		$this->assertNotContains( "src=\"{$spam_embed_url}#?", $content );
+	}
+
 	function test_update_blog_status_make_spam_blog_action() {
 		global $test_action_counter;
 		$test_action_counter = 0;


### PR DESCRIPTION
* XML-RPC: Improve error messages for unprivileged users.
* External Libraries: Disable deserialization in Requests_Utility_FilteredIterator
* Embeds: Disable embeds on deactivated Multisite sites.
* Coding standards: Modify escaping functions to avoid potential false positives.
* XML-RPC: Return error message if attachment ID is incorrect.
* Upgrade/install: Improve logic check when determining installation status.
* Meta: Sanitize meta key before checking protection status.
* Themes: Ensure that only privileged users can set a background image when a theme is using the deprecated custom background page.

Backport from WP 4.9.16. 

Brings the changes from [49380,49382-49388] to the 4.9 branch.

WP:Props xknown, zieladam, peterwilsoncc, whyisjake, desrosj, dd32.

---

Merges https://core.trac.wordpress.org/changeset/49397 / WordPress/wordpress-develop@5cc8ee9838 to ClassicPress.
