### PR TITLE
Lock Ubuntu version for PHPUnit tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -31,7 +31,7 @@ jobs:
   # - Set up a Memcached server if needed.
   # - Run PHPUnit Tests.
   test-php:
-    name: PHP Unit Tests - ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }} on ${{ matrix.os }}
+    name: PHP Unit Tests - ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -37,11 +37,11 @@ jobs:
     strategy:
       matrix:
         php: [ '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-18.04 ]
         memcached: [ false ]
         include:
           - php: '7.2'
-            os: ubuntu-latest
+            os: ubuntu-18.04
             memcached: true
       fail-fast: false
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -31,7 +31,7 @@ jobs:
   # - Set up a Memcached server if needed.
   # - Run PHPUnit Tests.
   test-php:
-    name: PHP Unit Tests - ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}
+    name: PHP ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}
     runs-on: ${{ matrix.os }}
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:


### PR DESCRIPTION
## Description

Ubuntu 20.04 now installs MySQL 8 as default which is causing the tests to fail. As a workaround while this can be fully fixed, drop back to `ubuntu-18.04` which includes MySQL 5.7.