### PR TITLE
WP-r50355: Filesystem API: Make sure to only call `fread()` on non-em…

### DIFF
--- a/src/wp-admin/includes/class-pclzip.php
+++ b/src/wp-admin/includes/class-pclzip.php
@@ -3884,7 +3884,12 @@
 
 
             // ----- Read the compressed file in a buffer (one shot)
-            $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+            if ( $p_entry['compressed_size'] > 0 ) {
+              $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+            }
+            else {
+              $v_buffer = false;
+            }
 
             // ----- Decompress the file
             $v_file_content = @gzinflate($v_buffer);
@@ -4096,7 +4101,12 @@
         if ($p_entry['compressed_size'] == $p_entry['size']) {
 
           // ----- Read the file in a buffer (one shot)
-          $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+          if ( $p_entry['compressed_size'] > 0 ) {
+            $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+          }
+          else {
+            $v_buffer = false;
+          }
 
           // ----- Send the file to the output
           echo $v_buffer;
@@ -4105,7 +4115,12 @@
         else {
 
           // ----- Read the compressed file in a buffer (one shot)
-          $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+          if ( $p_entry['compressed_size'] > 0 ) {
+            $v_buffer = @fread($this->zip_fd, $p_entry['compressed_size']);
+          }
+          else {
+            $v_buffer = false;
+          }
 
           // ----- Decompress the file
           $v_file_content = gzinflate($v_buffer);
@@ -4209,12 +4224,22 @@
         if ($p_entry['compression'] == 0) {
 
           // ----- Reading the file
-          $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+          if ( $p_entry['compressed_size'] > 0 ) {
+            $p_string = @fread($this->zip_fd, $p_entry['compressed_size']);
+          }
+          else {
+            $p_string = false;
+          }
         }
         else {
 
           // ----- Reading the file
-          $v_data = @fread($this->zip_fd, $p_entry['compressed_size']);
+          if ( $p_entry['compressed_size'] > 0 ) {
+            $v_data = @fread($this->zip_fd, $p_entry['compressed_size']);
+          }
+          else {
+            $v_data = false;
+          }
 
           // ----- Decompress the file
           if (($p_string = @gzinflate($v_data)) === FALSE) {


### PR DESCRIPTION
 # Issue
Software fallback for unpacking ZIP archives gives fatal error with PHP 8.0

To replicate:

    Install WordPress 5.6 with PHP 8.0.0
    Disable "zip" PHP extension
    Upload plugin in a zip archive (Installing from dashboard will work, file upload will give fatal) 

Trace:

```
FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught ValueError: fread(): Argument #2 ($length) must be greater than 0 in /sandbox/sandbox4/wp-admin/includes/class-pclzip.php:4212
Stack trace:
#0 /sandbox/sandbox4/wp-admin/includes/class-pclzip.php(4212): fread(Resource id #138, 0)
#1 /sandbox/sandbox4/wp-admin/includes/class-pclzip.php(3518): PclZip->privExtractFileAsString(Array, '', Array)
#2 /sandbox/sandbox4/wp-admin/includes/class-pclzip.php(811): PclZip->privExtractByRule(Array, './', '', false, Array)
#3 /sandbox/sandbox4/wp-admin/includes/file.php(1639): PclZip->extract(77006)
#4 /sandbox/sandbox4/wp-admin/includes/file.php(1476): _unzip_file_pclzip('/sandbox/sandbo...', '/sandbox/sandbo...', Array)
#5 /sandbox/sandbox4/wp-admin/includes/class-wp-upgrader.php(328): unzip_file('/sandbox/sandbo...', '/sandbox/sandbo...')
#6 /sandbox/sandbox4/wp-admin/includes/class-wp-upgrader.php(779): WP_Upgrader->unpack_package('/sandbox/sandbo...', false)
#7 /sandbox/sandbox4/wp-admin/includes/class-plugin-upgrader"

```

# Backport solution
…pty files in the PclZip library.

This avoids a fatal error on PHP 8 caused by passing a zero value to `fread()` as the `$length` argument, which must be greater than zero.

WP:Props yakimun, fierevere, jrf, DavidAnderson, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/52018.

Make some advancement to #687 for PHP8 support