### PR TITLE
WP-r44405: Accessibility: Insert Link modal: Improve keyboard interaction.

### DIFF
--- a/src/wp-includes/js/wplink.js
+++ b/src/wp-includes/js/wplink.js
@@ -559,7 +559,7 @@ var wpLink;
 			}
 
 			// Up Arrow and Down Arrow keys.
-			if ( 38 !== event.keyCode && 40 !== event.keyCode ) {
+			if ( event.shiftKey || ( 38 !== event.keyCode && 40 !== event.keyCode ) ) {
 				return;
 			}
 


### PR DESCRIPTION

Avoids change the selected link when using the Shift + Up/Down arrow keys
to select text in the form fields.

WP:Props afercia.

Merges https://core.trac.wordpress.org/changeset/42807 to the 5.0 branch.
Fixes https://core.trac.wordpress.org/ticket/43253.

---

Merges https://core.trac.wordpress.org/changeset/44405 / WordPress/wordpress-develop@3f6df95e64 to ClassicPress.

