### PR TITLE
WP-r44750: Accessibility: Fix a regression in the old media modal pagtion links.

### DIFF
--- a/src/wp-admin/css/deprecated-media.css
+++ b/src/wp-admin/css/deprecated-media.css
@@ -206,6 +206,22 @@ span.required {
 	margin: 8px 0;
 }
 
+#media-upload .tablenav-pages a,
+#media-upload .tablenav-pages .current {
+	display: inline-block;
+	padding: 4px 5px 6px;
+	font-size: 16px;
+	line-height: 1;
+	text-align: center;
+	text-decoration: none;
+}
+
+#media-upload .tablenav-pages a {
+	min-width: 17px;
+	border: 1px solid #ccc;
+	background: #f7f7f7;
+}
+
 #filter .tablenav select {
 	border-style: solid;
 	border-width: 1px;


### PR DESCRIPTION


https://core.trac.wordpress.org/changeset/43019 improved the table pagination link styling, but introduced a regression in the old media dialog.

Merges https://core.trac.wordpress.org/changeset/44747 to the 5.1 branch.

WP:Props afercia, joneiseman.
Fixes https://core.trac.wordpress.org/ticket/41858.

---

Merges https://core.trac.wordpress.org/changeset/44750 / WordPress/wordpress-develop@67384779e5 to ClassicPress.

