### PR TITLE
Merge/wp r44353: Administration: Update default fallback color for SVG icons.

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1015,7 +1015,15 @@ function wp_color_scheme_settings() {
 		$icon_colors = $_wp_admin_css_colors['fresh']->icon_colors;
 	} else {
 		// Fall back to the default set of icon colors if the default scheme is missing.
+<<<<<<< HEAD
 		$icon_colors = array( 'base' => '#82878c', 'focus' => '#00a0d2', 'current' => '#fff' );
+=======
+		$icon_colors = array(
+			'base'    => '#a0a5aa',
+			'focus'   => '#00a0d2',
+			'current' => '#fff',
+		);
+>>>>>>> 96a6ed10dc... Administration: Update default fallback color for SVG icons.
 	}
 
 	echo '<script type="text/javascript">var _wpColorScheme = ' . wp_json_encode( array( 'icons' => $icon_colors ) ) . ";</script>\n";

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1015,15 +1015,7 @@ function wp_color_scheme_settings() {
 		$icon_colors = $_wp_admin_css_colors['fresh']->icon_colors;
 	} else {
 		// Fall back to the default set of icon colors if the default scheme is missing.
-<<<<<<< HEAD
-		$icon_colors = array( 'base' => '#82878c', 'focus' => '#00a0d2', 'current' => '#fff' );
-=======
-		$icon_colors = array(
-			'base'    => '#a0a5aa',
-			'focus'   => '#00a0d2',
-			'current' => '#fff',
-		);
->>>>>>> 96a6ed10dc... Administration: Update default fallback color for SVG icons.
+		$icon_colors = array( 'base' => ''#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' );
 	}
 
 	echo '<script type="text/javascript">var _wpColorScheme = ' . wp_json_encode( array( 'icons' => $icon_colors ) ) . ";</script>\n";

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1015,7 +1015,7 @@ function wp_color_scheme_settings() {
 		$icon_colors = $_wp_admin_css_colors['fresh']->icon_colors;
 	} else {
 		// Fall back to the default set of icon colors if the default scheme is missing.
-		$icon_colors = array( 'base' => ''#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' );
+		$icon_colors = array( 'base' => '#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' );
 	}
 
 	echo '<script type="text/javascript">var _wpColorScheme = ' . wp_json_encode( array( 'icons' => $icon_colors ) ) . ";</script>\n";

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3923,15 +3923,7 @@ function register_admin_color_schemes() {
 	wp_admin_css_color( 'fresh', _x( 'Default', 'admin color scheme' ),
 		false,
 		array( '#222', '#333', '#0073aa', '#00a0d2' ),
-<<<<<<< HEAD
-		array( 'base' => '#82878c', 'focus' => '#00a0d2', 'current' => '#fff' )
-=======
-		array(
-			'base'    => '#a0a5aa',
-			'focus'   => '#00a0d2',
-			'current' => '#fff',
-		)
->>>>>>> 96a6ed10dc... Administration: Update default fallback color for SVG icons.
+		array( 'base' => ''#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' )
 	);
 
 	// Other color schemes are not available when running out of src

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3923,7 +3923,15 @@ function register_admin_color_schemes() {
 	wp_admin_css_color( 'fresh', _x( 'Default', 'admin color scheme' ),
 		false,
 		array( '#222', '#333', '#0073aa', '#00a0d2' ),
+<<<<<<< HEAD
 		array( 'base' => '#82878c', 'focus' => '#00a0d2', 'current' => '#fff' )
+=======
+		array(
+			'base'    => '#a0a5aa',
+			'focus'   => '#00a0d2',
+			'current' => '#fff',
+		)
+>>>>>>> 96a6ed10dc... Administration: Update default fallback color for SVG icons.
 	);
 
 	// Other color schemes are not available when running out of src

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3923,7 +3923,7 @@ function register_admin_color_schemes() {
 	wp_admin_css_color( 'fresh', _x( 'Default', 'admin color scheme' ),
 		false,
 		array( '#222', '#333', '#0073aa', '#00a0d2' ),
-		array( 'base' => ''#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' )
+		array( 'base' => '#a0a5aa', 'focus' => '#00a0d2', 'current' => '#fff' )
 	);
 
 	// Other color schemes are not available when running out of src


### PR DESCRIPTION
Currently, when an SVG is used as a menu icon, the color is inconsistent with the other, default dashicons and the contrast ratio does not meet the minimum requirement for accessibility. This updates the base color for the default `fresh` color scheme to ensure consistency and proper contrast.

Props swift, dschalk.

Fixes [44209](https://core.trac.wordpress.org/ticket/44209).