### PR TITLE
WP-r44416: Accessibility: Themes: use `aria-current` for the `Walker_…

### DIFF
--- a/src/wp-includes/class-walker-page.php
+++ b/src/wp-includes/class-walker-page.php
@@ -155,8 +155,9 @@ class Walker_Page extends Walker {
 		$args['link_before'] = empty( $args['link_before'] ) ? '' : $args['link_before'];
 		$args['link_after'] = empty( $args['link_after'] ) ? '' : $args['link_after'];
 
-		$atts = array();
-		$atts['href'] = get_permalink( $page->ID );
+		$atts                 = array();
+		$atts['href']         = get_permalink( $page->ID );
+		$atts['aria-current'] = ( $page->ID == $current_page ) ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a page menu item's anchor element.
@@ -166,7 +167,8 @@ class Walker_Page extends Walker {
 		 * @param array $atts {
 		 *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
 		 *
-		 *     @type string $href The href attribute.
+		 *     @type string $href         The href attribute.
+		 *     @type string $aria_current The aria-current attribute.
 		 * }
 		 * @param WP_Post $page         Page data object.
 		 * @param int     $depth        Depth of page, used for padding.


### PR DESCRIPTION
…Page` current link.

See https://core.trac.wordpress.org/changeset/42808 for `Walker_Nav_Menu`.

The `aria-current` attribute is a simple, effective way to help assistive
technologies users orientate themselves within a list of items. Continues the
introduction in core of `aria-current` after https://core.trac.wordpress.org/changeset/42440, https://core.trac.wordpress.org/changeset/41683, https://core.trac.wordpress.org/changeset/41359, and https://core.trac.wordpress.org/changeset/41371.

WP:Props chetan200891, wpzinc.
Fixes https://core.trac.wordpress.org/ticket/43522.

---

Merges https://core.trac.wordpress.org/changeset/44416 / WordPress/wordpress-develop@cc400e9099 to ClassicPress.

