### PR TITLE
WP-r42440: Accessibility: use `aria-current` for the paginated post l…

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -809,7 +809,7 @@ function post_password_required( $post = null ) {
  * Displays page links for paginated posts (i.e. includes the <!--nextpage-->.
  * Quicktag one or more times). This tag must be within The Loop.
  *
- * @since WP-1.2.0
+ * @since WP-5.0.0 Added the `aria_current` argument.
  *
  * @global int $page
  * @global int $numpages
@@ -825,6 +825,8 @@ function post_password_required( $post = null ) {
  *                                          Also prepended to the current item, which is not linked. Default empty.
  *     @type string       $link_after       HTML or text to append to each Pages link inside the `<a>` tag.
  *                                          Also appended to the current item, which is not linked. Default empty.
+ *     @type string       $aria_current     The value for the aria-current attribute. Possible values are 'page',
+ *                                          'step', 'location', 'date', 'time', 'true', 'false'. Default is 'page'.
  *     @type string       $next_or_number   Indicates whether page numbers should be used. Valid values are number
  *                                          and next. Default is 'number'.
  *     @type string       $separator        Text between pagination links. Default is ' '.
@@ -841,10 +843,11 @@ function wp_link_pages( $args = '' ) {
 	global $page, $numpages, $multipage, $more;
 
 	$defaults = array(
-		'before'           => '<p>' . __( 'Pages:' ),
+		'before'           => '<p class="post-nav-links">' . __( 'Pages:' ),
 		'after'            => '</p>',
 		'link_before'      => '',
 		'link_after'       => '',
+		'aria_current'     => 'page',
 		'next_or_number'   => 'number',
 		'separator'        => ' ',
 		'nextpagelink'     => __( 'Next page' ),
@@ -872,6 +875,8 @@ function wp_link_pages( $args = '' ) {
 				$link = $r['link_before'] . str_replace( '%', $i, $r['pagelink'] ) . $r['link_after'];
 				if ( $i != $page || ! $more && 1 == $page ) {
 					$link = _wp_link_page( $i ) . $link . '</a>';
+				} elseif ( $i === $page ) {
+					$link = '<span class="post-page-numbers current" aria-current="' . esc_attr( $r['aria_current'] ) . '">' . $link . '</span>';
 				}
 				/**
 				 * Filters the HTML output of individual page number links.
@@ -964,7 +969,7 @@ function _wp_link_page( $i ) {
 		$url = get_preview_post_link( $post, $query_args, $url );
 	}
 
-	return '<a href="' . esc_url( $url ) . '">';
+	return '<a href="' . esc_url( $url ) . '" class="post-page-numbers">';
 }
 
 //

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -809,6 +809,7 @@ function post_password_required( $post = null ) {
  * Displays page links for paginated posts (i.e. includes the <!--nextpage-->.
  * Quicktag one or more times). This tag must be within The Loop.
  *
+ * @since WP-1.2.0
  * @since WP-5.0.0 Added the `aria_current` argument.
  *
  * @global int $page

--- a/tests/phpunit/tests/post/template.php
+++ b/tests/phpunit/tests/post/template.php
@@ -14,31 +14,6 @@ class Tests_Post_Template extends WP_UnitTestCase {
 
 		setup_postdata( get_post( $post_id ) );
 
-<<<<<<< HEAD
-		$permalink = sprintf( '<a href="%s">', get_permalink() );
-		$page2 = _wp_link_page( 2 );
-		$page3 = _wp_link_page( 3 );
-
-		$expected = "<p>Pages: 1 {$page2}2</a> {$page3}3</a></p>";
-		$output = wp_link_pages( array( 'echo' => 0 ) );
-
-		$this->assertEquals( $expected, $output );
-
-		$before_after = " 1 {$page2}2</a> {$page3}3</a>";
-		$output = wp_link_pages( array( 'echo' => 0, 'before' => '', 'after' => '' ) );
-
-		$this->assertEquals( $before_after, $output );
-
-		$separator = " 1{$page2}2</a>{$page3}3</a>";
-		$output = wp_link_pages( array( 'echo' => 0, 'before' => '', 'after' => '', 'separator' => '' ) );
-
-		$this->assertEquals( $separator, $output );
-
-		$link = " <em>1</em>{$page2}<em>2</em></a>{$page3}<em>3</em></a>";
-		$output = wp_link_pages( array( 'echo' => 0, 'before' => '', 'after' => '', 'separator' => '',
-			'link_before' => '<em>', 'link_after' => '</em>'
-		) );
-=======
 		$permalink = sprintf( '<a href="%s" class="post-page-numbers">', get_permalink() );
 		$page2     = _wp_link_page( 2 );
 		$page3     = _wp_link_page( 3 );
@@ -82,7 +57,6 @@ class Tests_Post_Template extends WP_UnitTestCase {
 				'link_after'  => '</em>',
 			)
 		);
->>>>>>> 1258d1d9d2... Accessibility: use `aria-current` for the paginated post links output by `wp_link_pages()`.
 
 		$this->assertEquals( $link, $output );
 
@@ -109,17 +83,6 @@ class Tests_Post_Template extends WP_UnitTestCase {
 		$this->assertEquals( $next_prev_link, $output );
 
 		$GLOBALS['page'] = 1;
-<<<<<<< HEAD
-		$separator = "<p>Pages: 1 | {$page2}2</a> | {$page3}3</a></p>";
-		$output = wp_link_pages( array( 'echo' => 0, 'separator' => ' | ' ) );
-
-		$this->assertEquals( $separator, $output );
-
-		$pagelink = " Page 1 | {$page2}Page 2</a> | {$page3}Page 3</a>";
-		$output = wp_link_pages( array( 'echo' => 0, 'separator' => ' | ', 'before' => '', 'after' => '',
-			'pagelink' => 'Page %'
-		) );
-=======
 		$separator       = "<p class=\"post-nav-links\">Pages: <span class=\"post-page-numbers current\" aria-current=\"page\">1</span> | {$page2}2</a> | {$page3}3</a></p>";
 		$output          = wp_link_pages(
 			array(
@@ -140,7 +103,6 @@ class Tests_Post_Template extends WP_UnitTestCase {
 				'pagelink'  => 'Page %',
 			)
 		);
->>>>>>> 1258d1d9d2... Accessibility: use `aria-current` for the paginated post links output by `wp_link_pages()`.
 
 		$this->assertEquals( $pagelink, $output );
 	}

--- a/tests/phpunit/tests/post/template.php
+++ b/tests/phpunit/tests/post/template.php
@@ -14,6 +14,7 @@ class Tests_Post_Template extends WP_UnitTestCase {
 
 		setup_postdata( get_post( $post_id ) );
 
+<<<<<<< HEAD
 		$permalink = sprintf( '<a href="%s">', get_permalink() );
 		$page2 = _wp_link_page( 2 );
 		$page3 = _wp_link_page( 3 );
@@ -37,6 +38,51 @@ class Tests_Post_Template extends WP_UnitTestCase {
 		$output = wp_link_pages( array( 'echo' => 0, 'before' => '', 'after' => '', 'separator' => '',
 			'link_before' => '<em>', 'link_after' => '</em>'
 		) );
+=======
+		$permalink = sprintf( '<a href="%s" class="post-page-numbers">', get_permalink() );
+		$page2     = _wp_link_page( 2 );
+		$page3     = _wp_link_page( 3 );
+
+		$expected = '<p class="post-nav-links">Pages: <span class="post-page-numbers current" aria-current="page">1</span> ' . $page2 . '2</a> ' . $page3 . '3</a></p>';
+		$output   = wp_link_pages( array( 'echo' => 0 ) );
+
+		$this->assertEquals( $expected, $output );
+
+		$before_after = " <span class=\"post-page-numbers current\" aria-current=\"page\">1</span> {$page2}2</a> {$page3}3</a>";
+		$output       = wp_link_pages(
+			array(
+				'echo'   => 0,
+				'before' => '',
+				'after'  => '',
+			)
+		);
+
+		$this->assertEquals( $before_after, $output );
+
+		$separator = " <span class=\"post-page-numbers current\" aria-current=\"page\">1</span>{$page2}2</a>{$page3}3</a>";
+		$output    = wp_link_pages(
+			array(
+				'echo'      => 0,
+				'before'    => '',
+				'after'     => '',
+				'separator' => '',
+			)
+		);
+
+		$this->assertEquals( $separator, $output );
+
+		$link   = " <span class=\"post-page-numbers current\" aria-current=\"page\"><em>1</em></span>{$page2}<em>2</em></a>{$page3}<em>3</em></a>";
+		$output = wp_link_pages(
+			array(
+				'echo'        => 0,
+				'before'      => '',
+				'after'       => '',
+				'separator'   => '',
+				'link_before' => '<em>',
+				'link_after'  => '</em>',
+			)
+		);
+>>>>>>> 1258d1d9d2... Accessibility: use `aria-current` for the paginated post links output by `wp_link_pages()`.
 
 		$this->assertEquals( $link, $output );
 
@@ -63,6 +109,7 @@ class Tests_Post_Template extends WP_UnitTestCase {
 		$this->assertEquals( $next_prev_link, $output );
 
 		$GLOBALS['page'] = 1;
+<<<<<<< HEAD
 		$separator = "<p>Pages: 1 | {$page2}2</a> | {$page3}3</a></p>";
 		$output = wp_link_pages( array( 'echo' => 0, 'separator' => ' | ' ) );
 
@@ -72,6 +119,28 @@ class Tests_Post_Template extends WP_UnitTestCase {
 		$output = wp_link_pages( array( 'echo' => 0, 'separator' => ' | ', 'before' => '', 'after' => '',
 			'pagelink' => 'Page %'
 		) );
+=======
+		$separator       = "<p class=\"post-nav-links\">Pages: <span class=\"post-page-numbers current\" aria-current=\"page\">1</span> | {$page2}2</a> | {$page3}3</a></p>";
+		$output          = wp_link_pages(
+			array(
+				'echo'      => 0,
+				'separator' => ' | ',
+			)
+		);
+
+		$this->assertEquals( $separator, $output );
+
+		$pagelink = " <span class=\"post-page-numbers current\" aria-current=\"page\">Page 1</span> | {$page2}Page 2</a> | {$page3}Page 3</a>";
+		$output   = wp_link_pages(
+			array(
+				'echo'      => 0,
+				'separator' => ' | ',
+				'before'    => '',
+				'after'     => '',
+				'pagelink'  => 'Page %',
+			)
+		);
+>>>>>>> 1258d1d9d2... Accessibility: use `aria-current` for the paginated post links output by `wp_link_pages()`.
 
 		$this->assertEquals( $pagelink, $output );
 	}


### PR DESCRIPTION
…inks output by `wp_link_pages()`.

Continues the introduction in core of the aria-current attribute after https://core.trac.wordpress.org/changeset/41683, https://core.trac.wordpress.org/changeset/41359, and https://core.trac.wordpress.org/changeset/41371.

- changes the `wp_link_pages()` (see the `nextpage` quicktag) output to use an `aria-current` attribute on the current item
- adds `post-nav-links` and `post-page-numbers` CSS classes to help themes style these links
- updates the related tests

WP:Props antonioeatgoat, alexstine.
Fixes https://core.trac.wordpress.org/ticket/41859.

Conflicts:
- tests/phpunit/tests/post/template.php

---

Merges https://core.trac.wordpress.org/changeset/42440 / WordPress/wordpress-develop@1258d1d9d2 to ClassicPress.

Also adds the bit from https://core.trac.wordpress.org/changeset/44411 that cortrected the fact that due to the awkward branching of WP 5.0, this change was eventually part of WP 5.1 instead.

