### PR TITLE
Semantic elements for non-link links: class-wp-posts-list-table.php

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -588,7 +588,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		if ( 'spam' !== $the_comment_status && 'trash' !== $the_comment_status ) {
 			$actions['edit'] = "<a href='comment.php?action=editcomment&amp;c={$comment->comment_ID}' aria-label='" . esc_attr__( 'Edit this comment' ) . "'>". __( 'Edit' ) . '</a>';
 
-			$format = '<a data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s" aria-label="%s" href="#">%s</a>';
+			$format = '<button type="button" data-comment-id="%d" data-post-id="%d" data-action="%s" class="%s button-link" aria-expanded="false" aria-label="%s">%s</button>';
 
 			$actions['quickedit'] = sprintf( $format, $comment->comment_ID, $comment->comment_post_ID, 'edit', 'vim-q comment-inline', esc_attr__( 'Quick edit this comment inline' ), __( 'Quick&nbsp;Edit' ) );
 

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1238,7 +1238,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 				__( 'Edit' )
 			);
 			$actions['inline hide-if-no-js'] = sprintf(
-				'<a href="#" class="editinline" aria-label="%s">%s</a>',
+				'<button type="button" class="button-link editinline" aria-label="%s" aria-expanded="false">%s</button>',
 				/* translators: %s: post title */
 				esc_attr( sprintf( __( 'Quick edit &#8220;%s&#8221; inline' ), $title ) ),
 				__( 'Quick&nbsp;Edit' )

--- a/src/wp-admin/includes/class-wp-terms-list-table.php
+++ b/src/wp-admin/includes/class-wp-terms-list-table.php
@@ -437,7 +437,7 @@ class WP_Terms_List_Table extends WP_List_Table {
 				__( 'Edit' )
 			);
 			$actions['inline hide-if-no-js'] = sprintf(
-				'<a href="#" class="editinline aria-button-if-js" aria-label="%s">%s</a>',
+				'<button type="button" class="button-link editinline" aria-label="%s" aria-expanded="false">%s</button>',
 				/* translators: %s: taxonomy term name */
 				esc_attr( sprintf( __( 'Quick edit &#8220;%s&#8221; inline' ), $tag->name ) ),
 				__( 'Quick&nbsp;Edit' )

--- a/src/wp-admin/js/edit-comments.js
+++ b/src/wp-admin/js/edit-comments.js
@@ -632,15 +632,37 @@ commentReply = {
 	},
 
 	close : function() {
-		var c, replyrow = $('#replyrow');
+		var commentRow = $(),
+			replyRow = $( '#replyrow' );
 
 		// replyrow is not showing?
-		if ( replyrow.parent().is('#com-reply') )
+		if ( replyRow.parent().is( '#com-reply' ) ) {
 			return;
+		}
 
-		if ( this.cid && this.act == 'edit-comment' ) {
-			c = $('#comment-' + this.cid);
-			c.fadeIn(300, function(){ c.show(); }).css('backgroundColor', '');
+		if ( this.cid ) {
+			commentRow = $( '#comment-' + this.cid );
+		}
+
+		/*
+		 * When closing the Quick Edit form, show the comment row and move focus
+		 * back to the Quick Edit button.
+		 */
+		if ( 'edit-comment' === this.act ) {
+			commentRow.fadeIn( 300, function() {
+				commentRow
+					.show()
+					.find( '.vim-q' )
+						.attr( 'aria-expanded', 'false' )
+						.focus();
+			} ).css( 'backgroundColor', '' );
+		}
+
+		// When closing the Reply form, move focus back to the Reply button.
+		if ( 'replyto-comment' === this.act ) {
+			commentRow.find( '.vim-r' )
+				.attr( 'aria-expanded', 'false' )
+				.focus();
 		}
 
 		// reset the Quicktags buttons
@@ -649,14 +671,14 @@ commentReply = {
 
 		$('#add-new-comment').css('display', '');
 
-		replyrow.hide();
-		$('#com-reply').append( replyrow );
+		replyRow.hide();
+		$( '#com-reply' ).append( replyRow );
 		$('#replycontent').css('height', '').val('');
 		$('#edithead input').val('');
-		$( '.notice-error', replyrow )
+		$( '.notice-error', replyRow )
 			.addClass( 'hidden' )
 			.find( '.error' ).empty();
-		$( '.spinner', replyrow ).removeClass( 'is-active' );
+		$( '.spinner', replyRow ).removeClass( 'is-active' );
 
 		this.cid = '';
 		this.originalContent = '';
@@ -960,8 +982,7 @@ $(document).ready(function(){
 	}
 
 	// Quick Edit and Reply have an inline comment editor.
-	$( '#the-comment-list' ).on( 'click', '.comment-inline', function (e) {
-		e.preventDefault();
+	$( '#the-comment-list' ).on( 'click', '.comment-inline', function() {
 		var $el = $( this ),
 			action = 'replyto';
 
@@ -969,6 +990,7 @@ $(document).ready(function(){
 			action = $el.data( 'action' );
 		}
 
+		$( this ).attr( 'aria-expanded', 'true' );
 		commentReply.open( $el.data( 'commentId' ), $el.data( 'postId' ), action );
 	} );
 });

--- a/src/wp-admin/js/edit-comments.js
+++ b/src/wp-admin/js/edit-comments.js
@@ -615,7 +615,7 @@ commentReply = {
 
 	toggle : function(el) {
 		if ( 'none' !== $( el ).css( 'display' ) && ( $( '#replyrow' ).parent().is('#com-reply') || window.confirm( adminCommentsL10n.warnQuickEdit ) ) ) {
-			$( el ).find( 'a.vim-q' ).click();
+			$( el ).find( 'button.vim-q' ).click();
 		}
 	},
 

--- a/src/wp-admin/js/inline-edit-post.js
+++ b/src/wp-admin/js/inline-edit-post.js
@@ -120,11 +120,11 @@ var inlineEditPost;
 		});
 
 		/**
-		 * @summary Bind click event to the .editinline link which opens the quick editor.
+		 * @summary Bind click event to the .editinline button which opens the quick editor.
 		 */
-		$('#the-list').on( 'click', 'a.editinline', function( e ) {
-			e.preventDefault();
-			inlineEditPost.edit(this);
+		$( '#the-list' ).on( 'click', '.editinline', function() {
+			$( this ).attr( 'aria-expanded', 'true' );
+			inlineEditPost.edit( this );
 		});
 
 		$('#bulk-edit').find('fieldset:first').after(
@@ -424,8 +424,10 @@ var inlineEditPost;
 						$(inlineEditPost.what+id).siblings('tr.hidden').addBack().remove();
 						$('#edit-'+id).before(r).remove();
 						$( inlineEditPost.what + id ).hide().fadeIn( 400, function() {
-							// Move focus back to the Quick Edit link. $( this ) is the row being animated.
-							$( this ).find( '.editinline' ).focus();
+							// Move focus back to the Quick Edit button. $( this ) is the row being animated.
+							$( this ).find( '.editinline' )
+								.attr( 'aria-expanded', 'false' )
+								.focus();
 							wp.a11y.speak( inlineEditL10n.saved );
 						});
 					} else {
@@ -479,8 +481,10 @@ var inlineEditPost;
 				$('#'+id).siblings('tr.hidden').addBack().remove();
 				id = id.substr( id.lastIndexOf('-') + 1 );
 
-				// Show the post row and move focus back to the Quick Edit link.
-				$( this.what + id ).show().find( '.editinline' ).focus();
+				// Show the post row and move focus back to the Quick Edit button.
+				$( this.what + id ).show().find( '.editinline' )
+					.attr( 'aria-expanded', 'false' )
+					.focus();
 			}
 		}
 

--- a/src/wp-admin/js/inline-edit-tax.js
+++ b/src/wp-admin/js/inline-edit-tax.js
@@ -37,9 +37,9 @@ inlineEditTax = {
 		t.type = $('#the-list').attr('data-wp-lists').substr(5);
 		t.what = '#'+t.type+'-';
 
-		$('#the-list').on('click', 'a.editinline', function(){
-			inlineEditTax.edit(this);
-			return false;
+		$( '#the-list' ).on( 'click', '.editinline', function() {
+			$( this ).attr( 'aria-expanded', 'true' );
+			inlineEditTax.edit( this );
 		});
 
 		/*
@@ -220,8 +220,10 @@ inlineEditTax = {
 						$( '#parent' ).find( 'option[value=' + option_value + ']' ).text( row.find( '.row-title' ).text() );
 
 						row.hide().fadeIn( 400, function() {
-							// Move focus back to the Quick Edit link.
-							row.find( '.editinline' ).focus();
+							// Move focus back to the Quick Edit button.
+							row.find( '.editinline' )
+								.attr( 'aria-expanded', 'false' )
+								.focus();
 							wp.a11y.speak( inlineEditL10n.saved );
 						});
 
@@ -263,8 +265,10 @@ inlineEditTax = {
 			$('#'+id).siblings('tr.hidden').addBack().remove();
 			id = id.substr( id.lastIndexOf('-') + 1 );
 
-			// Show the taxonomy row and move focus back to the Quick Edit link.
-			$( this.what + id ).show().find( '.editinline' ).focus();
+			// Show the taxonomy row and move focus back to the Quick Edit button.
+			$( this.what + id ).show().find( '.editinline' )
+				.attr( 'aria-expanded', 'false' )
+				.focus();
 		}
 	},
 


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
<!--
Describe your changes in detail.
-->

This adds these 4 related changesets in one batch:

- https://core.trac.wordpress.org/changeset/42725
- https://core.trac.wordpress.org/changeset/42727
- https://core.trac.wordpress.org/changeset/42767
- https://core.trac.wordpress.org/changeset/45553

## Motivation and context
<!--
Why is this change required? What problem does it solve?

If it fixes an open issue, please link to the issue here.
-->

This improves the semantics for the inline actions in the Posts table. Conceptually, these are buttons, and should also be exposed to screen readers as such, not as links (as is the case now). More context can be found in this ticket: https://core.trac.wordpress.org/ticket/38677

## How has this been tested?
<!--
Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to see how
your change affects other areas of the code, etc.

Please include automated tests with new or changed code, if applicable.
-->

It's been on WP since version 5.1, and the regression was fixed in 5.3, which I rolled up into the above set of changes.

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

N/A

### Before
<!--
Insert screenshot(s) of the current behavior (before your changes) here.
-->

Screenshots not available, to sighted people this should not make a difference. For screen reader users, the Edit, Quick Edit etc. elements were spoken as links.

### After
<!--
Insert screenshot(s) of the new, proposed behavior (after your changes) here.
-->

Now, they're spoken as "buttons", clearly indicating that this will cause an action to take place, and not a shift to a new page.

## Types of changes
<!--
What types of changes does your code introduce?  Most PRs are one of the following:

- Bug fix
- New feature
- Breaking change
-->

bug fix.
