### PR TITLE
WP-r42784: Accessibility: Change the media upload "Dismiss error" lin…

### DIFF
--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -81,9 +81,9 @@ if ( isset( $_REQUEST['post_id'] ) ) {
 $id = media_handle_upload( 'async-upload', $post_id );
 if ( is_wp_error($id) ) {
 	echo '<div class="error-div error">
-	<a class="dismiss" href="#" onclick="jQuery(this).parents(\'div.media-item\').slideUp(200, function(){jQuery(this).remove();});">' . __('Dismiss') . '</a>
-	<strong>' . sprintf(__('&#8220;%s&#8221; has failed to upload.'), esc_html($_FILES['async-upload']['name']) ) . '</strong><br />' .
-	esc_html($id->get_error_message()) . '</div>';
+	<button type="button" class="dismiss button-link" onclick="jQuery(this).parents(\'div.media-item\').slideUp(200, function(){jQuery(this).remove();});">' . __( 'Dismiss' ) . '</button>
+	<strong>' . sprintf( __( '&#8220;%s&#8221; has failed to upload.' ), esc_html( $_FILES['async-upload']['name'] ) ) . '</strong><br />' .
+	esc_html( $id->get_error_message() ) . '</div>';
 	exit;
 }
 

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -211,8 +211,7 @@
 	padding: 10px 0 10px 14px;
 }
 
-.media-item .error-div a.dismiss {
-	display: block;
+.media-item .error-div button.dismiss {
 	float: right;
 	margin: 0 10px 0 15px;
 }


### PR DESCRIPTION
…k to a button.

For better accessibility and semantics, user interface controls that perform an
action should be buttons. Links should exclusively be used for navigation.

WP:Props Cheffheid, audrasjb.
Fixes https://core.trac.wordpress.org/ticket/38671.

---

Merges https://core.trac.wordpress.org/changeset/42784 / WordPress/wordpress-develop@ef84e589d2 to ClassicPress.

