### PR TITLE
WP-r42785: Accessibility: Change the "Show / Hide dismissed updates" …

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1565,6 +1565,15 @@ ul#dismissed-updates {
 	display: none;
 }
 
+#dismissed-updates li > p {
+	margin-top: 0;
+}
+
+#dismiss,
+#undismiss {
+	margin-left: 0.5em;
+}
+
 form.upgrade {
 	margin-top: 8px;
 }

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -127,15 +127,14 @@ function dismissed_updates() {
 		$hide_text = esc_js(__('Hide hidden updates'));
 	?>
 	<script type="text/javascript">
-
-		jQuery(function($) {
-			$('dismissed-updates').show();
-			$('#show-dismissed').toggle(function(){$(this).text('<?php echo $hide_text; ?>');}, function() {$(this).text('<?php echo $show_text; ?>')});
-			$('#show-dismissed').click(function() { $('#dismissed-updates').toggle('slow');});
+		jQuery(function( $ ) {
+			$( 'dismissed-updates' ).show();
+			$( '#show-dismissed' ).toggle( function() { $( this ).text( '<?php echo $hide_text; ?>' ).attr( 'aria-expanded', 'true' ); }, function() { $( this ).text( '<?php echo $show_text; ?>' ).attr( 'aria-expanded', 'false' ); } );
+			$( '#show-dismissed' ).click( function() { $( '#dismissed-updates' ).toggle( 'fast' ); } );
 		});
 	</script>
 	<?php
-		echo '<p class="hide-if-no-js"><a id="show-dismissed" href="#">'.__('Show hidden updates').'</a></p>';
+		echo '<p class="hide-if-no-js"><button type="button" class="button" id="show-dismissed" aria-expanded="false">' . __( 'Show hidden updates' ) . '</button></p>';
 		echo '<ul id="dismissed-updates" class="core-updates dismissed">';
 		foreach ( (array) $dismissed as $update) {
 			echo '<li>';


### PR DESCRIPTION
…link to a button.

For better accessibility and semantics, user interface controls that perform an
action should be buttons. Links should exclusively be used for navigation.
Also, adds an `aria-expanded` attribute to communicate the expandable panel state
and improves the buttons spacing.

WP:Props Cheffheid, audrasjb, afercia.
Fixes https://core.trac.wordpress.org/ticket/38674.

---

Merges https://core.trac.wordpress.org/changeset/42785 / WordPress/wordpress-develop@0a63e2ed96 to ClassicPress.

