### PR TITLE
WP-r42790: Accessibility: Make the Widgets screen "Enable accessibili…

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -490,6 +490,11 @@ div#widgets-right .closed .widgets-sortables {
 }
 
 /* Accessibility Mode */
+.widget-access-link {
+	float: right;
+	margin: -5px 0 10px 10px;
+}
+
 .widgets_access #widgets-left .widget .widget-top {
 	cursor: auto;
 }
@@ -787,6 +792,11 @@ ul.CodeMirror-hints {
 	div.widget {
 		margin: 0 auto !important;
 		max-width: 480px;
+	}
+
+	.widget-access-link {
+		float: none;
+		margin: 15px 0 0 0;
 	}
 }
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -897,20 +897,13 @@ final class WP_Screen {
 
 		$show_screen = ! empty( $wp_meta_boxes[ $this->id ] ) || $columns || $this->get_option( 'per_page' );
 
-		switch ( $this->base ) {
-			case 'widgets':
-				$nonce = wp_create_nonce( 'widgets-access' );
-				$this->_screen_settings = '<p><a id="access-on" href="widgets.php?widgets-access=on&_wpnonce=' . urlencode( $nonce ) . '">' . __('Enable accessibility mode') . '</a><a id="access-off" href="widgets.php?widgets-access=off&_wpnonce=' . urlencode( $nonce ) . '">' . __('Disable accessibility mode') . "</a></p>\n";
-				break;
-			case 'post' :
-				$expand = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
-				$expand .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
-				$expand .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
-				$this->_screen_settings = $expand;
-				break;
-			default:
-				$this->_screen_settings = '';
-				break;
+		$this->_screen_settings = '';
+
+		if ( 'post' === $this->base ) {
+			$expand                 = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
+			$expand                .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
+			$expand                .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
+			$this->_screen_settings = $expand;
 		}
 
 		/**

--- a/src/wp-admin/widgets.php
+++ b/src/wp-admin/widgets.php
@@ -364,7 +364,12 @@ if ( current_user_can( 'customize' ) ) {
 		__( 'Manage with Live Preview' )
 	);
 }
+
+$nonce = wp_create_nonce( 'widgets-access' );
 ?>
+<div class="widget-access-link">
+	<a id="access-on" href="widgets.php?widgets-access=on&_wpnonce=<?php echo urlencode( $nonce ); ?>"><?php _e( 'Enable accessibility mode' ); ?></a><a id="access-off" href="widgets.php?widgets-access=off&_wpnonce=<?php echo urlencode( $nonce ); ?>"><?php _e( 'Disable accessibility mode' ); ?></a>
+</div>
 
 <hr class="wp-header-end">
 


### PR DESCRIPTION
…ty mode" link more discoverable.

For a number of years, the link to the Widgets screen "Accessibility mode" lived
in the Screen Options panel, hidden by default. Many users, including assistive
technologies users, weren't able to find it or even aware it existed. By bringing
the link in the main screen, visible by default, this change makes the
"Accessibility mode" easily discoverable for everyone.

WP:Props chetan200891, antonioeatgoat.
Fixes https://core.trac.wordpress.org/ticket/42778.

---

Merges https://core.trac.wordpress.org/changeset/42790 / WordPress/wordpress-develop@1a03159d26 to ClassicPress.

