### PR TITLE
Use the correct checksums when updating

### DIFF
--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -141,37 +141,14 @@ class Core_Upgrader extends WP_Upgrader {
 
 		$wp_dir = trailingslashit($wp_filesystem->abspath());
 
-		$partial = true;
-		if ( $parsed_args['do_rollback'] )
-			$partial = false;
-		elseif ( $parsed_args['pre_check_md5'] && ! $this->check_files() )
-			$partial = false;
-
-		/*
-		 * If partial update is returned from the API, use that, unless we're doing
-		 * a reinstallation. If we cross the new_bundled version number, then use
-		 * the new_bundled zip. Don't though if the constant is set to skip bundled items.
-		 * If the API returns a no_content zip, go with it. Finally, default to the full zip.
-		 */
-		if ( $parsed_args['do_rollback'] && $current->packages->rollback )
-			$to_download = 'rollback';
-		elseif ( $current->packages->partial && 'reinstall' != $current->response && $wp_version == $current->partial_version && $partial )
-			$to_download = 'partial';
-		elseif ( $current->packages->new_bundled && version_compare( $wp_version, $current->new_bundled, '<' )
-			&& ( ! defined( 'CORE_UPGRADE_SKIP_NEW_BUNDLED' ) || ! CORE_UPGRADE_SKIP_NEW_BUNDLED ) )
-			$to_download = 'new_bundled';
-		elseif ( $current->packages->no_content )
-			$to_download = 'no_content';
-		else
-			$to_download = 'full';
-
 		// Lock to prevent multiple Core Updates occurring
 		$lock = WP_Upgrader::create_lock( 'core_updater', 15 * MINUTE_IN_SECONDS );
 		if ( ! $lock ) {
 			return new WP_Error( 'locked', $this->strings['locked'] );
 		}
 
-		$download = $this->download_package( $current->packages->$to_download );
+		// ClassicPress only supports the "full" upgrade package.
+		$download = $this->download_package( $current->packages->full );
 		if ( is_wp_error( $download ) ) {
 			WP_Upgrader::release_lock( 'core_updater' );
 			return $download;

--- a/src/wp-admin/includes/class-core-upgrader.php
+++ b/src/wp-admin/includes/class-core-upgrader.php
@@ -594,16 +594,25 @@ class Core_Upgrader extends WP_Upgrader {
 	 * Compare the disk file checksums against the expected checksums.
 	 *
 	 * @since WP-3.7.0
+	 * @since 1.3.0 Correctly uses the checksums for the current ClassicPress
+	 * version, not the equivalent WordPress version. This function is no
+	 * longer used during the core update process.
 	 *
-	 * @global string $wp_version
-	 * @global string $wp_local_package
+	 * @global string $cp_version
 	 *
 	 * @return bool True if the checksums match, otherwise false.
 	 */
 	public function check_files() {
-		global $wp_version, $wp_local_package;
+		global $cp_version;
 
-		$checksums = get_core_checksums( $wp_version, isset( $wp_local_package ) ? $wp_local_package : 'en_US' );
+		if ( version_compare( $cp_version, '1.3.0-rc1', '<' ) ) {
+			// This version of ClassicPress has a `get_core_checksums()`
+			// function which incorrectly expects a WordPress version, so there
+			// is no point in continuing.
+			return false;
+		}
+
+		$checksums = get_core_checksums( $cp_version, 'en_US' );
 
 		if ( ! is_array( $checksums ) )
 			return false;

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -242,9 +242,6 @@ function update_core($from, $to) {
 
 		$checksums = cp_get_core_checksums( $cp_version );
 
-		if ( is_array( $checksums ) && isset( $checksums[ $cp_version ] ) )
-			$checksums = $checksums[ $cp_version ]; // Compat code for 3.7-beta2
-
 		if ( is_array( $checksums ) ) {
 			foreach ( $checksums as $file => $checksum ) {
 				if ( 'wp-content' == substr( $file, 0, 10 ) )

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -233,7 +233,9 @@ function update_core($from, $to) {
 	$skip = array( 'wp-content', 'wp-includes/version.php' );
 	$check_is_writable = array();
 
-	// Check to see which files don't really need updating - only available for 3.7 and higher
+	// Check to see which files don't really need updating.  The
+	// function_exists check is not necessary, but we'll keep it to preserve
+	// the code structure.
 	if ( function_exists( 'cp_get_core_checksums' ) ) {
 		// Find the local version of the working directory
 		$working_dir_local = WP_CONTENT_DIR . '/upgrade/' . basename( $from ) . $distro;
@@ -499,16 +501,18 @@ function update_core($from, $to) {
 }
 
 /**
- * Gets and caches the checksums for the given version of ClassicPress.
- * This uses the ClassicPress checksum API, not the WordPress API
+ * Gets the checksums for the given version of ClassicPress.
  *
- * @since CP-1.3.0
+ * This function is a duplicate copy of `get_core_checksums()` to ensure the
+ * new code is loaded and used when updating from a pre-1.3.0 version.
+ *
+ * @since 1.3.0
  *
  * @param string $version Version string to query.
  * @return bool|array False on failure. An array of checksums on success.
  */
-function cp_get_core_checksums( $version) {
-	$url = 'https://api-v1-test.classicpress.net/checksums/' . $version . '.json';
+function cp_get_core_checksums( $version ) {
+	$url = 'https://api-v1.classicpress.net/checksums/md5/' . $version . '.json';
 
 	$options = array(
 		'timeout' => wp_doing_cron() ? 30 : 3,
@@ -537,8 +541,13 @@ function cp_get_core_checksums( $version) {
 	$body = trim( wp_remote_retrieve_body( $response ) );
 	$body = json_decode( $body, true );
 
-	if ( ! is_array( $body ) || ! isset( $body['checksums'] ) || ! is_array( $body['checksums'] ) )
+	if (
+		! is_array( $body ) ||
+		! isset( $body['checksums'] ) ||
+		! is_array( $body['checksums'] )
+	) {
 		return false;
+	}
 
 	return $body['checksums'];
 }


### PR DESCRIPTION
Fixes #679 (an issue where the incorrect checksums were being used when upgrading ClassicPress, leading to some files not being upgraded correctly). Supersedes #681. See those links for more information.