### PR TITLE
Add check for broken package-lock.json file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -935,7 +935,7 @@ module.exports = function(grunt) {
 				);
 			}
 			grunt.log.writeln( 'The above lines may need to be fixed to https:// manually.' );
-			grunt.log.writeln( 'See: https://github.com/npm/cli/issues/1685' );
+			grunt.log.writeln( 'See: https://github.com/ClassicPress/ClassicPress/pull/711' );
 			grunt.fatal( 'package-lock.json contains invalid lines' );
 		}
 	} );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,8 @@
 /* jshint quotmark:false */
 
 const buildTools = require( './tools/build' );
+const fs = require( 'fs' );
+const path = require( 'path' );
 
 const SOURCE_DIR = 'src/';
 const BUILD_DIR = 'build/';
@@ -785,7 +787,8 @@ module.exports = function(grunt) {
 		'precommit:image',
 		'precommit:emoji',
 		'precommit:php',
-		'precommit:git-conflicts'
+		'precommit:git-conflicts',
+		'precommit:npm-bug'
 	] );
 
     grunt.registerTask(
@@ -856,7 +859,7 @@ module.exports = function(grunt) {
 					.red
 				);
 				grunt.log.writeln();
-				files.forEach( ({yellow}) => grunt.log.writeln( yellow ) );
+				files.forEach( ( { yellow } ) => grunt.log.writeln( yellow ) );
 				grunt.log.writeln();
 				grunt.log.writeln(
 					'Please run `grunt precommit` and commit the results.'
@@ -902,6 +905,39 @@ module.exports = function(grunt) {
 
 			done();
 		} );
+	} );
+
+    grunt.registerTask( 'precommit:npm-bug', function() {
+		// Check for and prevent https://github.com/npm/cli/issues/1685
+		// This just adds needless noise to the npm files which already have a
+		// very large commit history.
+		const lockfileLines = fs.readFileSync(
+			path.join( __dirname, 'package-lock.json' ),
+			'utf8'
+		).split( '\n' );
+		const maxLinesToPrint = 9;
+		let badLines = 0;
+		lockfileLines.forEach( ( line, i ) => {
+			const lineNumber = i + 1;
+			if ( /"http:\/\//.test( line ) ) {
+				if ( badLines < maxLinesToPrint ) {
+					grunt.log.writeln(
+						`package-lock.json line ${lineNumber}: ${line}`.yellow
+					);
+				}
+				badLines++;
+			}
+		} );
+		if ( badLines > 0 ) {
+			if ( badLines > maxLinesToPrint ) {
+				grunt.log.writeln(
+					`... and ${badLines - maxLinesToPrint} more lines`.yellow
+				);
+			}
+			grunt.log.writeln( 'The above lines may need to be fixed to https:// manually.' );
+			grunt.log.writeln( 'See: https://github.com/npm/cli/issues/1685' );
+			grunt.fatal( 'package-lock.json contains invalid lines' );
+		}
 	} );
 
 	grunt.registerTask( 'rollup', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
     },
     "@lodder/grunt-postcss": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.0.1.tgz",
       "integrity": "sha512-boAIrpGJQYxiZ/qI7BRhxNHzNsv6kPlqRpr4XhnTHNjf2RYAqDTL5CMRUcExv8crVduKkhOSSr+pnIQrI3pwYg==",
       "dev": true,
       "requires": {
@@ -22,7 +22,7 @@
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
@@ -32,13 +32,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
     "@rollup/plugin-commonjs": {
       "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz",
       "integrity": "sha512-fj92shhg8luw7XbA0HowAqz90oo7qtLGwqTKbyZ8pmOyH8ui5e+u0wPEgeHLH3djcVma6gUCUrjY6w5R2o1u6g==",
       "dev": true,
       "requires": {
@@ -53,7 +53,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
@@ -69,7 +69,7 @@
     },
     "@rollup/pluginutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
       "dev": true,
       "requires": {
@@ -80,7 +80,7 @@
       "dependencies": {
         "estree-walker": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
           "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
           "dev": true
         }
@@ -88,20 +88,20 @@
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true,
       "optional": true
     },
     "@types/color-name": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/concat-stream": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
       "dev": true,
       "requires": {
@@ -110,13 +110,13 @@
     },
     "@types/estree": {
       "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "resolved": "http://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/form-data": {
       "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "resolved": "http://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
       "dev": true,
       "requires": {
@@ -125,20 +125,20 @@
     },
     "@types/node": {
       "version": "12.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
+      "resolved": "http://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
       "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
       "dev": true
     },
     "@types/q": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true,
       "optional": true
     },
     "@types/qs": {
       "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
     },
     "@lodder/grunt-postcss": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.0.1.tgz",
       "integrity": "sha512-boAIrpGJQYxiZ/qI7BRhxNHzNsv6kPlqRpr4XhnTHNjf2RYAqDTL5CMRUcExv8crVduKkhOSSr+pnIQrI3pwYg==",
       "dev": true,
       "requires": {
@@ -22,7 +22,7 @@
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
       "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
       "dev": true,
       "requires": {
@@ -32,13 +32,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
     "@rollup/plugin-commonjs": {
       "version": "18.0.0",
-      "resolved": "http://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.0.0.tgz",
       "integrity": "sha512-fj92shhg8luw7XbA0HowAqz90oo7qtLGwqTKbyZ8pmOyH8ui5e+u0wPEgeHLH3djcVma6gUCUrjY6w5R2o1u6g==",
       "dev": true,
       "requires": {
@@ -53,7 +53,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.6",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
@@ -69,7 +69,7 @@
     },
     "@rollup/pluginutils": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
       "dev": true,
       "requires": {
@@ -80,7 +80,7 @@
       "dependencies": {
         "estree-walker": {
           "version": "1.0.1",
-          "resolved": "http://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
           "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
           "dev": true
         }
@@ -88,20 +88,20 @@
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
-      "resolved": "http://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true,
       "optional": true
     },
     "@types/color-name": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/concat-stream": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
       "dev": true,
       "requires": {
@@ -110,13 +110,13 @@
     },
     "@types/estree": {
       "version": "0.0.39",
-      "resolved": "http://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/form-data": {
       "version": "0.0.33",
-      "resolved": "http://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
       "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
       "dev": true,
       "requires": {
@@ -125,20 +125,20 @@
     },
     "@types/node": {
       "version": "12.7.9",
-      "resolved": "http://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
       "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==",
       "dev": true
     },
     "@types/q": {
       "version": "1.5.4",
-      "resolved": "http://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true,
       "optional": true
     },
     "@types/qs": {
       "version": "6.5.3",
-      "resolved": "http://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
       "dev": true
     },


### PR DESCRIPTION
This makes sure that we won't commit any package-lock.json changes which suffer from https://github.com/npm/cli/issues/1685, which doesn't seem to break anything but also isn't correct and adds more useless changes to the already noisy package-lock.json file.

## How has this been tested?

Tested locally. I will also push another commit here that will fail this check, and so GitHub Actions should fail the build for that commit.