### PR TITLE
Fix get comment 8 0

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -454,8 +454,14 @@ class WP_Comment_Query {
 		 */
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
+<<<<<<< HEAD
 		// Convert to WP_Comment instances
 		$comments = array_map( 'get_comment', $_comments );
+=======
+		// Convert to WP_Comment instances.
+		array_walk( $_comments, 'get_comment' );
+		$comments = $_comments;
+>>>>>>> 29bfc56ca2... Code Modernization: Fix PHP 8 "argument must be passed by reference, value given" error in `WP_Comment_Query::get_comments()`.
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -455,8 +455,7 @@ class WP_Comment_Query {
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
 		// Convert to WP_Comment instances.
-		array_walk( $_comments, 'get_comment' );
-		$comments = $_comments;
+		$comments = array_map( 'get_comment', $_comments );
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -454,14 +454,9 @@ class WP_Comment_Query {
 		 */
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
-<<<<<<< HEAD
-		// Convert to WP_Comment instances
-		$comments = array_map( 'get_comment', $_comments );
-=======
 		// Convert to WP_Comment instances.
 		array_walk( $_comments, 'get_comment' );
 		$comments = $_comments;
->>>>>>> 29bfc56ca2... Code Modernization: Fix PHP 8 "argument must be passed by reference, value given" error in `WP_Comment_Query::get_comments()`.
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -174,7 +174,7 @@ function get_approved_comments( $post_id, $args = array() ) {
  *                                       a WP_Comment object, an associative array, or a numeric array, respectively. Default OBJECT.
  * @return WP_Comment|array|null Depends on $output value.
  */
-function get_comment( &$comment = null, $output = OBJECT ) {
+function get_comment( $comment = null, $output = OBJECT ) {
 	if ( empty( $comment ) && isset( $GLOBALS['comment'] ) ) {
 		$comment = $GLOBALS['comment'];
 	}


### PR DESCRIPTION
Pr fixes the PHP 8.0 compatibility issues and closes #713 (Issue is detailed)

PR constains Merge conflicts and Backport changesets 
- [x] [48838](https://core.trac.wordpress.org/changeset/48838)
- [x] [48961](https://core.trac.wordpress.org/changeset/48961) 

as [#comment:2](https://core.trac.wordpress.org/ticket/51957#comment:2) suggests.

## How is tested?
After the patch, my admin area has not issue as in screenshot.
![Screenshot 2021-04-25 at 20 07 21](https://user-images.githubusercontent.com/7713923/116002339-f9bca500-a601-11eb-8dc4-6977a78ba28f.png)

Yet pre-patch, we had 
![Screenshot 2021-04-25 at 18 05 38](https://user-images.githubusercontent.com/7713923/115998668-084e9080-a5f1-11eb-90ce-7933e30e614b.png)
