### PR TITLE
WP-r48839: Code Modernization: Fix PHP 8 "ArgumentCountError: array_m…

### DIFF
--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1157,7 +1157,7 @@ function retrieve_widgets( $theme_changed = false ) {
 	$sidebars_widgets = wp_map_sidebars_widgets( $sidebars_widgets );
 
 	// Find hidden/lost multi-widget instances.
-	$shown_widgets = call_user_func_array( 'array_merge', $sidebars_widgets );
+	$shown_widgets = array_merge( ...array_values( $sidebars_widgets ) );
 	$lost_widgets  = array_diff( $registered_widgets_ids, $shown_widgets );
 
 	foreach ( $lost_widgets as $key => $widget_id ) {


### PR DESCRIPTION
Closes #717 

…erge() does not accept unknown named parameters" fatal error in `retrieve_widgets()`.

As per the documentation of `call_user_func_array()`, the `$param_arr` should be a (numerically) indexed array, not a string-keyed array.

As we can use the spread operator in PHP 5.6+, there isn't really any need to use `call_user_func_array()` anyhow, we can call the `array_merge()` function directly.

The caveat to this is that the spread operator only works on numerically indexed arrays, so we need to wrap the `$sidebars_widgets` variable in a call to `array_values()` when using the spread operator.

Using `array_values()` in the existing `call_user_func_array()` call would also have solved this, but the solution now proposed, has the added benefit of getting rid of the overhead of `call_user_func_array()`.

WP:Props jrf.
See https://core.trac.wordpress.org/ticket/50913.

## How was it tested in CP?
I switched themes and did not have previous fatal error like before in #717 
