### PR TITLE
Welcome new Contributors

### DIFF
--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -21,9 +21,7 @@ jobs:
 
             It looks like this is your first pull request. We appreciate and value your contribution!
             
-            Please read our [Contributers guide](https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-) to find out how you can be more involved.
+            Please read our [contribution guide](https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md) to find out how you can be more involved.
 
             Thank you,
-
             ClassicPress Core Team.

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -8,8 +8,6 @@ jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress' }}
-
     steps:
       - uses: bubkoo/welcome-action@8dbbac2540d155744c90e4e37da6b05ffc9c5e2c # v1.0.3
         with:

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -1,0 +1,29 @@
+name: Welcome New Contributors
+
+on:
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  # Comments on a pull request when the author is a new contributor.
+  post-welcome-message:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' }}
+
+    steps:
+      - uses: bubkoo/welcome-action@8dbbac2540d155744c90e4e37da6b05ffc9c5e2c # v1.0.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FIRST_PR_COMMENT: >
+            Hi @{{ author }}! 👋
+
+            Thank you for your contribution to ClassicPress! 💖
+
+            It looks like this is your first pull request. We appreciate and value your contribution!
+            
+            Please read our [Contributers guide](https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
+) to find out how you can be more involved.
+
+            Thank you,
+
+            ClassicPress Core Team.


### PR DESCRIPTION
Closes #730 

I think, it will be of great value to add an automation to welcome new contributors like we do on the forums.

If this is accepted, we would need to have a `GITHUB_TOKEN` to run the bot.

It auto responds to the PR and also sends an email to the new contributor welcoming them like the image below.

![Screenshot 2021-05-08 at 11 52 12](https://user-images.githubusercontent.com/7713923/117533165-f9ee7480-aff3-11eb-9190-e59c0106392a.png)
