### PR TITLE
Add inverse arg to get_term_parents_list()

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1271,6 +1271,7 @@ function get_the_term_list( $id, $taxonomy, $before = '', $sep = '', $after = ''
  *     @type string $separator Separator for between the terms. Default '/'.
  *     @type bool   $link      Whether to format as a link. Default true.
  *     @type bool   $inclusive Include the term to get the parents for. Default true.
+ *     @type bool   $inverse   Wether to reverse the hierarchical order of the Terms on output. Default true.
  * }
  * @return string|WP_Error A list of term parents on success, WP_Error or empty string on failure.
  */
@@ -1293,6 +1294,7 @@ function get_term_parents_list( $term_id, $taxonomy, $args = array() ) {
 		'separator' => '/',
 		'link'      => true,
 		'inclusive' => true,
+		'inverse'   => true,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -1306,8 +1308,12 @@ function get_term_parents_list( $term_id, $taxonomy, $args = array() ) {
 	if ( $args['inclusive'] ) {
 		array_unshift( $parents, $term_id );
 	}
+	
+	if( $args['inverse'] ){
+ 		$parents = array_reverse( $parents );
+ 	}
 
-	foreach ( array_reverse( $parents ) as $term_id ) {
+	foreach ( $parents as $term_id ) {
 		$parent = get_term( $term_id, $taxonomy );
 		$name   = ( 'slug' === $args['format'] ) ? $parent->slug : $parent->name;
 


### PR DESCRIPTION
## Description
Add @type bool   $inverse   Wether to reverse the hierarchical order of the Terms on output, Default true, to get_term_parents_list() method.
See also https://core.trac.wordpress.org/ticket/53319 original commit to WP.

## Motivation and context
Recently I used get_term_parents_list() to create a list of hierarchical terms.
I noticed that by default the function outputs the terms like so:
Parent Category/Child Category/Grandchild Category

I could not find any argument or way to invert that order, with the goal to display the terms like so:
Grandchild Category/Child Category/Parent Category

This is useful for example if we have Geographic zones and the utmost parent is a Country, the utmost child an area. In that case we may want to display Area/Region/Country which looks like an address structure rather than the opposed which is the default

I don't think it should be too hard adding this new argument to the function.
I have uploaded a file with the modified function and updated code comment to the ticket.

I also tested my changes on a existing install and can confirm this introduced no unexpected issues. 

It would be awesome to see if we can add this tiny change in future release.

## How has this been tested?
Local install, as well as online client install (with modified WP)

### Before
function outputs `Parent Category/Child Category/Grandchild Category`

### After
function outputs by default `Parent Category/Child Category/Grandchild Category`
new arg `inverse` can be set to false so the function will output `Grandchild Category/Child Category/Parent Category`

## Types of changes
- Feature enhancement, not breaking

