### PR TITLE
Fix for Ajax Autosave Unit Tests

### DIFF
--- a/tests/phpunit/tests/ajax/Autosave.php
+++ b/tests/phpunit/tests/ajax/Autosave.php
@@ -31,6 +31,7 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 		self::$user_ids[] = self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$user_ids[] = self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 
+<<<<<<< HEAD
 		self::$post_id = $factory->post->create( array( 'post_status' => 'draft' ) );
 		self::$post = get_post( self::$post_id );
 	}
@@ -41,7 +42,13 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		// Set a user so the $post has 'post_author'
+=======
+		// Set a user so the $post has 'post_author'.
+>>>>>>> 570d86da90 (Tests: Correct the test for autosaving a post with Ajax.)
 		wp_set_current_user( self::$admin_id );
+
+		self::$post_id = $factory->post->create( array( 'post_status' => 'draft' ) );
+		self::$post    = get_post( self::$post_id );
 	}
 
 	/**
@@ -59,10 +66,17 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 			'_nonce' => wp_create_nonce( 'heartbeat-nonce' ),
 			'data' => array(
 				'wp_autosave' => array(
+<<<<<<< HEAD
 				    'post_id'       => self::$post_id,
 				    '_wpnonce'      => wp_create_nonce( 'update-post_' . self::$post->ID ),
 				    'post_content'  => self::$post->post_content . PHP_EOL . $md5,
 					'post_type'     => 'post',
+=======
+					'post_id'      => self::$post_id,
+					'_wpnonce'     => wp_create_nonce( 'update-post_' . self::$post_id ),
+					'post_content' => self::$post->post_content . PHP_EOL . $md5,
+					'post_type'    => 'post',
+>>>>>>> 570d86da90 (Tests: Correct the test for autosaving a post with Ajax.)
 				),
 			),
 		);
@@ -83,7 +97,7 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 
 		// Check that the edit happened
 		$post = get_post( self::$post_id );
-		$this->assertGreaterThanOrEqual( 0, strpos( self::$post->post_content, $md5 ) );
+		$this->assertNotFalse( strpos( $post->post_content, $md5 ) );
 	}
 
 	/**
@@ -135,7 +149,7 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 		// Check if the autosave post was created
 		$autosave = wp_get_post_autosave( self::$post_id, get_current_user_id() );
 		$this->assertNotEmpty( $autosave );
-		$this->assertGreaterThanOrEqual( 0, strpos( $autosave->post_content, $md5 ) );
+		$this->assertNotFalse( strpos( $autosave->post_content, $md5 ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/ajax/Autosave.php
+++ b/tests/phpunit/tests/ajax/Autosave.php
@@ -31,20 +31,7 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 		self::$user_ids[] = self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
 		self::$user_ids[] = self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
 
-<<<<<<< HEAD
-		self::$post_id = $factory->post->create( array( 'post_status' => 'draft' ) );
-		self::$post = get_post( self::$post_id );
-	}
-
-	/**
-	 * Set up the test fixture
-	 */
-	public function setUp() {
-		parent::setUp();
-		// Set a user so the $post has 'post_author'
-=======
 		// Set a user so the $post has 'post_author'.
->>>>>>> 570d86da90 (Tests: Correct the test for autosaving a post with Ajax.)
 		wp_set_current_user( self::$admin_id );
 
 		self::$post_id = $factory->post->create( array( 'post_status' => 'draft' ) );
@@ -66,17 +53,10 @@ class Tests_Ajax_Autosave extends WP_Ajax_UnitTestCase {
 			'_nonce' => wp_create_nonce( 'heartbeat-nonce' ),
 			'data' => array(
 				'wp_autosave' => array(
-<<<<<<< HEAD
-				    'post_id'       => self::$post_id,
-				    '_wpnonce'      => wp_create_nonce( 'update-post_' . self::$post->ID ),
-				    'post_content'  => self::$post->post_content . PHP_EOL . $md5,
-					'post_type'     => 'post',
-=======
 					'post_id'      => self::$post_id,
 					'_wpnonce'     => wp_create_nonce( 'update-post_' . self::$post_id ),
 					'post_content' => self::$post->post_content . PHP_EOL . $md5,
 					'post_type'    => 'post',
->>>>>>> 570d86da90 (Tests: Correct the test for autosaving a post with Ajax.)
 				),
 			),
 		);


### PR DESCRIPTION
## Description
This is a backport for changes 51450 and it fixes #752

## Motivation and context
Upstream backport, bug confirmed on develop and fox confirmed in PR

## How has this been tested?
Unit tests and manual `var_dump()`ing of test content to command line.

## Screenshots
N/A

## Types of changes
- Bug fix

