### PR TITLE
Upgrade SimplePie

### DIFF
--- a/src/wp-includes/SimplePie/Author.php
+++ b/src/wp-includes/SimplePie/Author.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -114,10 +113,8 @@ class SimplePie_Author
 		{
 			return $this->name;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -131,10 +128,8 @@ class SimplePie_Author
 		{
 			return $this->link;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -148,10 +143,7 @@ class SimplePie_Author
 		{
 			return $this->email;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Cache.php
+++ b/src/wp-includes/SimplePie/Cache.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -62,8 +61,10 @@ class SimplePie_Cache
 	 * @var array
 	 */
 	protected static $handlers = array(
-		'mysql' => 'SimplePie_Cache_MySQL',
-		'memcache' => 'SimplePie_Cache_Memcache',
+		'mysql'     => 'SimplePie_Cache_MySQL',
+		'memcache'  => 'SimplePie_Cache_Memcache',
+		'memcached' => 'SimplePie_Cache_Memcached',
+		'redis'     => 'SimplePie_Cache_Redis'
 	);
 
 	/**

--- a/src/wp-includes/SimplePie/Cache/Base.php
+++ b/src/wp-includes/SimplePie/Cache/Base.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/wp-includes/SimplePie/Cache/DB.php
+++ b/src/wp-includes/SimplePie/Cache/DB.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/wp-includes/SimplePie/Cache/File.php
+++ b/src/wp-includes/SimplePie/Cache/File.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -102,7 +101,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	 */
 	public function save($data)
 	{
-		if (file_exists($this->name) && is_writeable($this->name) || file_exists($this->location) && is_writeable($this->location))
+		if (file_exists($this->name) && is_writable($this->name) || file_exists($this->location) && is_writable($this->location))
 		{
 			if ($data instanceof SimplePie)
 			{
@@ -136,11 +135,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	 */
 	public function mtime()
 	{
-		if (file_exists($this->name))
-		{
-			return filemtime($this->name);
-		}
-		return false;
+		return @filemtime($this->name);
 	}
 
 	/**
@@ -150,11 +145,7 @@ class SimplePie_Cache_File implements SimplePie_Cache_Base
 	 */
 	public function touch()
 	{
-		if (file_exists($this->name))
-		{
-			return touch($this->name);
-		}
-		return false;
+		return @touch($this->name);
 	}
 
 	/**

--- a/src/wp-includes/SimplePie/Cache/Memcache.php
+++ b/src/wp-includes/SimplePie/Cache/Memcache.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -95,10 +94,8 @@ class SimplePie_Cache_Memcache implements SimplePie_Cache_Base
 				'prefix' => 'simplepie_',
 			),
 		);
-		$parsed = SimplePie_Cache::parse_URL($location);
-		$this->options['host'] = empty($parsed['host']) ? $this->options['host'] : $parsed['host'];
-		$this->options['port'] = empty($parsed['port']) ? $this->options['port'] : $parsed['port'];
-		$this->options['extras'] = array_merge($this->options['extras'], $parsed['extras']);
+		$this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
+
 		$this->name = $this->options['extras']['prefix'] . md5("$name:$type");
 
 		$this->cache = new Memcache();
@@ -147,7 +144,7 @@ class SimplePie_Cache_Memcache implements SimplePie_Cache_Base
 
 		if ($data !== false)
 		{
-			// essentially ignore the mtime because Memcache expires on it's own
+			// essentially ignore the mtime because Memcache expires on its own
 			return time();
 		}
 
@@ -165,7 +162,7 @@ class SimplePie_Cache_Memcache implements SimplePie_Cache_Base
 
 		if ($data !== false)
 		{
-			return $this->cache->set($this->name, $data, MEMCACHE_COMPRESSED, (int) $this->duration);
+			return $this->cache->set($this->name, $data, MEMCACHE_COMPRESSED, (int) $this->options['extras']['timeout']);
 		}
 
 		return false;

--- a/src/wp-includes/SimplePie/Cache/Memcached.php
+++ b/src/wp-includes/SimplePie/Cache/Memcached.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * SimplePie
+ *
+ * A PHP-Based RSS and Atom Feed Framework.
+ * Takes the hard work out of managing a complete RSS/Atom solution.
+ *
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 	* Redistributions of source code must retain the above copyright notice, this list of
+ * 	  conditions and the following disclaimer.
+ *
+ * 	* Redistributions in binary form must reproduce the above copyright notice, this list
+ * 	  of conditions and the following disclaimer in the documentation and/or other materials
+ * 	  provided with the distribution.
+ *
+ * 	* Neither the name of the SimplePie Team nor the names of its contributors may be used
+ * 	  to endorse or promote products derived from this software without specific prior
+ * 	  written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS
+ * AND CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @package SimplePie
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
+ * @author Ryan Parman
+ * @author Sam Sneddon
+ * @author Ryan McCue
+ * @link http://simplepie.org/ SimplePie
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+/**
+ * Caches data to memcached
+ *
+ * Registered for URLs with the "memcached" protocol
+ *
+ * For example, `memcached://localhost:11211/?timeout=3600&prefix=sp_` will
+ * connect to memcached on `localhost` on port 11211. All tables will be
+ * prefixed with `sp_` and data will expire after 3600 seconds
+ *
+ * @package    SimplePie
+ * @subpackage Caching
+ * @author     Paul L. McNeely
+ * @uses       Memcached
+ */
+class SimplePie_Cache_Memcached implements SimplePie_Cache_Base
+{
+    /**
+     * Memcached instance
+     * @var Memcached
+     */
+    protected $cache;
+
+    /**
+     * Options
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Cache name
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Create a new cache object
+     * @param string $location Location string (from SimplePie::$cache_location)
+     * @param string $name     Unique ID for the cache
+     * @param string $type     Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     */
+    public function __construct($location, $name, $type) {
+        $this->options = array(
+            'host'   => '127.0.0.1',
+            'port'   => 11211,
+            'extras' => array(
+                'timeout' => 3600, // one hour
+                'prefix'  => 'simplepie_',
+            ),
+        );
+        $this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
+
+        $this->name = $this->options['extras']['prefix'] . md5("$name:$type");
+
+        $this->cache = new Memcached();
+        $this->cache->addServer($this->options['host'], (int)$this->options['port']);
+    }
+
+    /**
+     * Save data to the cache
+     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @return bool Successfulness
+     */
+    public function save($data) {
+        if ($data instanceof SimplePie) {
+            $data = $data->data;
+        }
+
+        return $this->setData(serialize($data));
+    }
+
+    /**
+     * Retrieve the data saved to the cache
+     * @return array Data for SimplePie::$data
+     */
+    public function load() {
+        $data = $this->cache->get($this->name);
+
+        if ($data !== false) {
+            return unserialize($data);
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve the last modified time for the cache
+     * @return int Timestamp
+     */
+    public function mtime() {
+        $data = $this->cache->get($this->name . '_mtime');
+        return (int) $data;
+    }
+
+    /**
+     * Set the last modified time to the current time
+     * @return bool Success status
+     */
+    public function touch() {
+        $data = $this->cache->get($this->name);
+        return $this->setData($data);
+    }
+
+    /**
+     * Remove the cache
+     * @return bool Success status
+     */
+    public function unlink() {
+        return $this->cache->delete($this->name, 0);
+    }
+
+    /**
+     * Set the last modified time and data to Memcached
+     * @return bool Success status
+     */
+    private function setData($data) {
+
+        if ($data !== false) {
+            $this->cache->set($this->name . '_mtime', time(), (int)$this->options['extras']['timeout']);
+            return $this->cache->set($this->name, $data, (int)$this->options['extras']['timeout']);
+        }
+
+        return false;
+    }
+}

--- a/src/wp-includes/SimplePie/Cache/MySQL.php
+++ b/src/wp-includes/SimplePie/Cache/MySQL.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -94,9 +93,11 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 			'path' => '',
 			'extras' => array(
 				'prefix' => '',
+				'cache_purge_time' => 2592000
 			),
 		);
-		$this->options = array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
+
+		$this->options = SimplePie_Misc::array_merge_recursive($this->options, SimplePie_Cache::parse_URL($location));
 
 		// Path is prefixed with a "/"
 		$this->options['dbname'] = substr($this->options['path'], 1);
@@ -130,16 +131,20 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 			$query = $this->mysql->exec('CREATE TABLE `' . $this->options['extras']['prefix'] . 'cache_data` (`id` TEXT CHARACTER SET utf8 NOT NULL, `items` SMALLINT NOT NULL DEFAULT 0, `data` BLOB NOT NULL, `mtime` INT UNSIGNED NOT NULL, UNIQUE (`id`(125)))');
 			if ($query === false)
 			{
+				trigger_error("Can't create " . $this->options['extras']['prefix'] . "cache_data table, check permissions", E_USER_WARNING);
 				$this->mysql = null;
+				return;
 			}
 		}
 
 		if (!in_array($this->options['extras']['prefix'] . 'items', $db))
 		{
-			$query = $this->mysql->exec('CREATE TABLE `' . $this->options['extras']['prefix'] . 'items` (`feed_id` TEXT CHARACTER SET utf8 NOT NULL, `id` TEXT CHARACTER SET utf8 NOT NULL, `data` TEXT CHARACTER SET utf8 NOT NULL, `posted` INT UNSIGNED NOT NULL, INDEX `feed_id` (`feed_id`(125)))');
+			$query = $this->mysql->exec('CREATE TABLE `' . $this->options['extras']['prefix'] . 'items` (`feed_id` TEXT CHARACTER SET utf8 NOT NULL, `id` TEXT CHARACTER SET utf8 NOT NULL, `data` MEDIUMBLOB NOT NULL, `posted` INT UNSIGNED NOT NULL, INDEX `feed_id` (`feed_id`(125)))');
 			if ($query === false)
 			{
+				trigger_error("Can't create " . $this->options['extras']['prefix'] . "items table, check permissions", E_USER_WARNING);
 				$this->mysql = null;
+				return;
 			}
 		}
 	}
@@ -153,6 +158,17 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 	public function save($data)
 	{
 		if ($this->mysql === null)
+		{
+			return false;
+		}
+
+		$query = $this->mysql->prepare('DELETE i, cd FROM `' . $this->options['extras']['prefix'] . 'cache_data` cd, ' .
+			'`' . $this->options['extras']['prefix'] . 'items` i ' .
+			'WHERE cd.id = i.feed_id ' .
+			'AND cd.mtime < (unix_timestamp() - :purge_time)');
+		$query->bindValue(':purge_time', $this->options['extras']['cache_purge_time']);
+
+		if (!$query->execute())
 		{
 			return false;
 		}
@@ -379,10 +395,8 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 		{
 			return $time;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -400,14 +414,8 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 		$query = $this->mysql->prepare('UPDATE `' . $this->options['extras']['prefix'] . 'cache_data` SET `mtime` = :time WHERE `id` = :id');
 		$query->bindValue(':time', time());
 		$query->bindValue(':id', $this->id);
-		if ($query->execute() && $query->rowCount() > 0)
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+
+		return $query->execute() && $query->rowCount() > 0;
 	}
 
 	/**
@@ -426,13 +434,7 @@ class SimplePie_Cache_MySQL extends SimplePie_Cache_DB
 		$query->bindValue(':id', $this->id);
 		$query2 = $this->mysql->prepare('DELETE FROM `' . $this->options['extras']['prefix'] . 'items` WHERE `feed_id` = :id');
 		$query2->bindValue(':id', $this->id);
-		if ($query->execute() && $query2->execute())
-		{
-			return true;
-		}
-		else
-		{
-			return false;
-		}
+
+		return $query->execute() && $query2->execute();
 	}
 }

--- a/src/wp-includes/SimplePie/Cache/Redis.php
+++ b/src/wp-includes/SimplePie/Cache/Redis.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * SimplePie Redis Cache Extension
+ *
+ * @package SimplePie
+ * @author Jan Kozak <galvani78@gmail.com>
+ * @link http://galvani.cz/
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @version 0.2.9
+ */
+
+
+/**
+ * Caches data to redis
+ *
+ * Registered for URLs with the "redis" protocol
+ *
+ * For example, `redis://localhost:6379/?timeout=3600&prefix=sp_&dbIndex=0` will
+ * connect to redis on `localhost` on port 6379. All tables will be
+ * prefixed with `simple_primary-` and data will expire after 3600 seconds
+ *
+ * @package SimplePie
+ * @subpackage Caching
+ * @uses Redis
+ */
+class SimplePie_Cache_Redis implements SimplePie_Cache_Base {
+    /**
+     * Redis instance
+     *
+     * @var \Redis
+     */
+    protected $cache;
+
+    /**
+     * Options
+     *
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Cache name
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Cache Data
+     *
+     * @var type
+     */
+    protected $data;
+
+    /**
+     * Create a new cache object
+     *
+     * @param string $location Location string (from SimplePie::$cache_location)
+     * @param string $name Unique ID for the cache
+     * @param string $type Either TYPE_FEED for SimplePie data, or TYPE_IMAGE for image data
+     */
+    public function __construct($location, $name, $options = null) {
+        //$this->cache = \flow\simple\cache\Redis::getRedisClientInstance();
+        $parsed = SimplePie_Cache::parse_URL($location);
+        $redis = new Redis();
+        $redis->connect($parsed['host'], $parsed['port']);
+        if (isset($parsed['pass'])) {
+            $redis->auth($parsed['pass']);
+        }
+        if (isset($parsed['path'])) {
+            $redis->select((int)substr($parsed['path'], 1));
+        }
+        $this->cache = $redis;
+
+        if (!is_null($options) && is_array($options)) {
+            $this->options = $options;
+        } else {
+            $this->options = array (
+                'prefix' => 'rss:simple_primary:',
+                'expire' => 0,
+            );
+        }
+
+        $this->name = $this->options['prefix'] . $name;
+    }
+
+    /**
+     * @param \Redis $cache
+     */
+    public function setRedisClient(\Redis $cache) {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Save data to the cache
+     *
+     * @param array|SimplePie $data Data to store in the cache. If passed a SimplePie object, only cache the $data property
+     * @return bool Successfulness
+     */
+    public function save($data) {
+        if ($data instanceof SimplePie) {
+            $data = $data->data;
+        }
+        $response = $this->cache->set($this->name, serialize($data));
+        if ($this->options['expire']) {
+            $this->cache->expire($this->name, $this->options['expire']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Retrieve the data saved to the cache
+     *
+     * @return array Data for SimplePie::$data
+     */
+    public function load() {
+        $data = $this->cache->get($this->name);
+
+        if ($data !== false) {
+            return unserialize($data);
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve the last modified time for the cache
+     *
+     * @return int Timestamp
+     */
+    public function mtime() {
+
+        $data = $this->cache->get($this->name);
+
+        if ($data !== false) {
+            return time();
+        }
+
+        return false;
+    }
+
+    /**
+     * Set the last modified time to the current time
+     *
+     * @return bool Success status
+     */
+    public function touch() {
+
+        $data = $this->cache->get($this->name);
+
+        if ($data !== false) {
+            $return = $this->cache->set($this->name, $data);
+            if ($this->options['expire']) {
+                return $this->cache->expire($this->name, $this->ttl);
+            }
+            return $return;
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove the cache
+     *
+     * @return bool Success status
+     */
+    public function unlink() {
+        return $this->cache->set($this->name, null);
+    }
+
+}

--- a/src/wp-includes/SimplePie/Caption.php
+++ b/src/wp-includes/SimplePie/Caption.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -132,10 +131,8 @@ class SimplePie_Caption
 		{
 			return $this->endTime;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -150,10 +147,8 @@ class SimplePie_Caption
 		{
 			return $this->lang;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -167,10 +162,8 @@ class SimplePie_Caption
 		{
 			return $this->startTime;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -184,10 +177,8 @@ class SimplePie_Caption
 		{
 			return $this->text;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -201,10 +192,7 @@ class SimplePie_Caption
 		{
 			return $this->type;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Category.php
+++ b/src/wp-includes/SimplePie/Category.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -57,7 +56,7 @@ class SimplePie_Category
 	/**
 	 * Category identifier
 	 *
-	 * @var string
+	 * @var string|null
 	 * @see get_term
 	 */
 	var $term;
@@ -65,7 +64,7 @@ class SimplePie_Category
 	/**
 	 * Categorization scheme identifier
 	 *
-	 * @var string
+	 * @var string|null
 	 * @see get_scheme()
 	 */
 	var $scheme;
@@ -73,23 +72,36 @@ class SimplePie_Category
 	/**
 	 * Human readable label
 	 *
-	 * @var string
+	 * @var string|null
 	 * @see get_label()
 	 */
 	var $label;
 
 	/**
+	 * Category type
+	 * 
+	 * category for <category>
+	 * subject for <dc:subject>
+	 *
+	 * @var string|null
+	 * @see get_type()
+	 */
+	var $type;
+
+	/**
 	 * Constructor, used to input the data
 	 *
-	 * @param string $term
-	 * @param string $scheme
-	 * @param string $label
+	 * @param string|null $term
+	 * @param string|null $scheme
+	 * @param string|null $label
+	 * @param string|null $type
 	 */
-	public function __construct($term = null, $scheme = null, $label = null)
+	public function __construct($term = null, $scheme = null, $label = null, $type = null)
 	{
 		$this->term = $term;
 		$this->scheme = $scheme;
 		$this->label = $label;
+		$this->type = $type;
 	}
 
 	/**
@@ -110,14 +122,7 @@ class SimplePie_Category
 	 */
 	public function get_term()
 	{
-		if ($this->term !== null)
-		{
-			return $this->term;
-		}
-		else
-		{
-			return null;
-		}
+		return $this->term;
 	}
 
 	/**
@@ -127,31 +132,32 @@ class SimplePie_Category
 	 */
 	public function get_scheme()
 	{
-		if ($this->scheme !== null)
-		{
-			return $this->scheme;
-		}
-		else
-		{
-			return null;
-		}
+		return $this->scheme;
 	}
 
 	/**
 	 * Get the human readable label
 	 *
+	 * @param bool $strict
 	 * @return string|null
 	 */
-	public function get_label()
+	public function get_label($strict = false)
 	{
-		if ($this->label !== null)
-		{
-			return $this->label;
-		}
-		else
+		if ($this->label === null && $strict !== true)
 		{
 			return $this->get_term();
 		}
+		return $this->label;
+	}
+
+	/**
+	 * Get the category type
+	 *
+	 * @return string|null
+	 */
+	public function get_type()
+	{
+		return $this->type;
 	}
 }
 

--- a/src/wp-includes/SimplePie/Content/Type/Sniffer.php
+++ b/src/wp-includes/SimplePie/Content/Type/Sniffer.php
@@ -150,7 +150,7 @@ class SimplePie_Content_Type_Sniffer
 		}
 		elseif (preg_match('/[\x00-\x08\x0E-\x1A\x1C-\x1F]/', $this->file->body))
 		{
-			return 'application/octect-stream';
+			return 'application/octet-stream';
 		}
 
 		return 'text/plain';

--- a/src/wp-includes/SimplePie/Content/Type/Sniffer.php
+++ b/src/wp-includes/SimplePie/Content/Type/Sniffer.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -121,24 +120,18 @@ class SimplePie_Content_Type_Sniffer
 				{
 					return $return;
 				}
-				else
-				{
-					return $official;
-				}
+
+				return $official;
 			}
 			elseif ($official === 'text/html')
 			{
 				return $this->feed_or_html();
 			}
-			else
-			{
-				return $official;
-			}
+
+			return $official;
 		}
-		else
-		{
-			return $this->unknown();
-		}
+
+		return $this->unknown();
 	}
 
 	/**
@@ -159,10 +152,8 @@ class SimplePie_Content_Type_Sniffer
 		{
 			return 'application/octect-stream';
 		}
-		else
-		{
-			return 'text/plain';
-		}
+
+		return 'text/plain';
 	}
 
 	/**
@@ -208,10 +199,8 @@ class SimplePie_Content_Type_Sniffer
 		{
 			return 'image/vnd.microsoft.icon';
 		}
-		else
-		{
-			return $this->text_or_binary();
-		}
+
+		return $this->text_or_binary();
 	}
 
 	/**
@@ -242,10 +231,8 @@ class SimplePie_Content_Type_Sniffer
 		{
 			return 'image/vnd.microsoft.icon';
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -256,7 +243,7 @@ class SimplePie_Content_Type_Sniffer
 	public function feed_or_html()
 	{
 		$len = strlen($this->file->body);
-		$pos = strspn($this->file->body, "\x09\x0A\x0D\x20");
+		$pos = strspn($this->file->body, "\x09\x0A\x0D\x20\xEF\xBB\xBF");
 
 		while ($pos < $len)
 		{
@@ -329,4 +316,3 @@ class SimplePie_Content_Type_Sniffer
 		return 'text/html';
 	}
 }
-

--- a/src/wp-includes/SimplePie/Copyright.php
+++ b/src/wp-includes/SimplePie/Copyright.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -104,10 +103,8 @@ class SimplePie_Copyright
 		{
 			return $this->url;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -121,10 +118,7 @@ class SimplePie_Copyright
 		{
 			return $this->label;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Core.php
+++ b/src/wp-includes/SimplePie/Core.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2009, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/wp-includes/SimplePie/Credit.php
+++ b/src/wp-includes/SimplePie/Credit.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -113,10 +112,8 @@ class SimplePie_Credit
 		{
 			return $this->role;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -130,10 +127,8 @@ class SimplePie_Credit
 		{
 			return $this->scheme;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -147,10 +142,7 @@ class SimplePie_Credit
 		{
 			return $this->name;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Decode/HTML/Entities.php
+++ b/src/wp-includes/SimplePie/Decode/HTML/Entities.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -118,10 +117,8 @@ class SimplePie_Decode_HTML_Entities
 			$this->consumed .= $this->data[$this->position];
 			return $this->data[$this->position++];
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -140,10 +137,8 @@ class SimplePie_Decode_HTML_Entities
 			$this->position += $len;
 			return $data;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -168,7 +163,6 @@ class SimplePie_Decode_HTML_Entities
 		{
 			case "\x09":
 			case "\x0A":
-			case "\x0B":
 			case "\x0B":
 			case "\x0C":
 			case "\x20":
@@ -614,4 +608,3 @@ class SimplePie_Decode_HTML_Entities
 		}
 	}
 }
-

--- a/src/wp-includes/SimplePie/Enclosure.php
+++ b/src/wp-includes/SimplePie/Enclosure.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -283,10 +282,8 @@ class SimplePie_Enclosure
 		{
 			return $this->bitrate;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -302,10 +299,8 @@ class SimplePie_Enclosure
 		{
 			return $captions[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -319,10 +314,8 @@ class SimplePie_Enclosure
 		{
 			return $this->captions;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -338,10 +331,8 @@ class SimplePie_Enclosure
 		{
 			return $categories[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -355,10 +346,8 @@ class SimplePie_Enclosure
 		{
 			return $this->categories;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -372,10 +361,8 @@ class SimplePie_Enclosure
 		{
 			return $this->channels;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -389,10 +376,8 @@ class SimplePie_Enclosure
 		{
 			return $this->copyright;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -408,10 +393,8 @@ class SimplePie_Enclosure
 		{
 			return $credits[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -425,10 +408,8 @@ class SimplePie_Enclosure
 		{
 			return $this->credits;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -442,16 +423,14 @@ class SimplePie_Enclosure
 		{
 			return $this->description;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
 	 * Get the duration of the enclosure
 	 *
-	 * @param string $convert Convert seconds into hh:mm:ss
+	 * @param bool $convert Convert seconds into hh:mm:ss
 	 * @return string|int|null 'hh:mm:ss' string if `$convert` was specified, otherwise integer (or null if none found)
 	 */
 	public function get_duration($convert = false)
@@ -463,15 +442,11 @@ class SimplePie_Enclosure
 				$time = SimplePie_Misc::time_hms($this->duration);
 				return $time;
 			}
-			else
-			{
-				return $this->duration;
-			}
+
+			return $this->duration;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -485,10 +460,8 @@ class SimplePie_Enclosure
 		{
 			return $this->expression;
 		}
-		else
-		{
-			return 'full';
-		}
+
+		return 'full';
 	}
 
 	/**
@@ -520,10 +493,8 @@ class SimplePie_Enclosure
 		{
 			return $this->framerate;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -550,10 +521,8 @@ class SimplePie_Enclosure
 		{
 			return $hashes[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -567,10 +536,8 @@ class SimplePie_Enclosure
 		{
 			return $this->hashes;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -584,10 +551,8 @@ class SimplePie_Enclosure
 		{
 			return $this->height;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -602,10 +567,8 @@ class SimplePie_Enclosure
 		{
 			return $this->lang;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -621,10 +584,8 @@ class SimplePie_Enclosure
 		{
 			return $keywords[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -638,10 +599,8 @@ class SimplePie_Enclosure
 		{
 			return $this->keywords;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -655,10 +614,8 @@ class SimplePie_Enclosure
 		{
 			return $this->length;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -672,10 +629,8 @@ class SimplePie_Enclosure
 		{
 			return urldecode($this->link);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -690,10 +645,8 @@ class SimplePie_Enclosure
 		{
 			return $this->medium;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -708,10 +661,8 @@ class SimplePie_Enclosure
 		{
 			return $this->player;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -727,10 +678,8 @@ class SimplePie_Enclosure
 		{
 			return $ratings[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -744,10 +693,8 @@ class SimplePie_Enclosure
 		{
 			return $this->ratings;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -763,10 +710,8 @@ class SimplePie_Enclosure
 		{
 			return $restrictions[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -780,10 +725,8 @@ class SimplePie_Enclosure
 		{
 			return $this->restrictions;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -797,10 +740,8 @@ class SimplePie_Enclosure
 		{
 			return $this->samplingrate;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -815,10 +756,8 @@ class SimplePie_Enclosure
 		{
 			return round($length/1048576, 2);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -834,10 +773,8 @@ class SimplePie_Enclosure
 		{
 			return $thumbnails[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -851,10 +788,8 @@ class SimplePie_Enclosure
 		{
 			return $this->thumbnails;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -868,10 +803,8 @@ class SimplePie_Enclosure
 		{
 			return $this->title;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -886,10 +819,8 @@ class SimplePie_Enclosure
 		{
 			return $this->type;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -903,10 +834,8 @@ class SimplePie_Enclosure
 		{
 			return $this->width;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -942,7 +871,7 @@ class SimplePie_Enclosure
 	 * - `height` (integer): The height of the embedded media. Accepts any
 	 *    numeric pixel value (such as `360`) or `auto`. Defaults to `auto`,
 	 *    and it is recommended that you use this default.
-	 * - `loop` (boolean): Do you want the media to loop when its done?
+	 * - `loop` (boolean): Do you want the media to loop when it's done?
 	 *    Defaults to `false`.
 	 * - `mediaplayer` (string): The location of the included
 	 *    `mediaplayer.swf` file. This allows for the playback of Flash Video
@@ -1366,15 +1295,10 @@ class SimplePie_Enclosure
 			{
 				return 'mp3';
 			}
-			else
-			{
-				return null;
-			}
+
+			return null;
 		}
-		else
-		{
-			return $type;
-		}
+
+		return $type;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Exception.php
+++ b/src/wp-includes/SimplePie/Exception.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.4-dev
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/wp-includes/SimplePie/File.php
+++ b/src/wp-includes/SimplePie/File.php
@@ -109,11 +109,6 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_REFERER, $url);
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
-				if (!ini_get('open_basedir') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
-				{
-					curl_setopt($fp, CURLOPT_FOLLOWLOCATION, 1);
-					curl_setopt($fp, CURLOPT_MAXREDIRS, $redirects);
-				}
 				foreach ($curl_options as $curl_param => $curl_value) {
 					curl_setopt($fp, $curl_param, $curl_value);
 				}
@@ -148,7 +143,7 @@ class SimplePie_File
 							$this->redirects++;
 							$location = SimplePie_Misc::absolutize_url($this->headers['location'], $url);
 							$previousStatusCode = $this->status_code;
-							$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen);
+							$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options);
 							$this->permanent_url = ($previousStatusCode == 301) ? $location : $url;
 							return;
 						}
@@ -233,7 +228,7 @@ class SimplePie_File
 								$this->redirects++;
 								$location = SimplePie_Misc::absolutize_url($this->headers['location'], $url);
 								$previousStatusCode = $this->status_code;
-								$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen);
+								$this->__construct($location, $timeout, $redirects, $headers, $useragent, $force_fsockopen, $curl_options);
 								$this->permanent_url = ($previousStatusCode == 301) ? $location : $url;
 								return;
 							}

--- a/src/wp-includes/SimplePie/HTTP/Parser.php
+++ b/src/wp-includes/SimplePie/HTTP/Parser.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -156,15 +155,13 @@ class SimplePie_HTTP_Parser
 		{
 			return true;
 		}
-		else
-		{
-			$this->http_version = '';
-			$this->status_code = '';
-			$this->reason = '';
-			$this->headers = array();
-			$this->body = '';
-			return false;
-		}
+
+		$this->http_version = '';
+		$this->status_code = '';
+		$this->reason = '';
+		$this->headers = array();
+		$this->body = '';
+		return false;
 	}
 
 	/**
@@ -496,5 +493,26 @@ class SimplePie_HTTP_Parser
 				return;
 			}
 		}
+	}
+
+	/**
+	 * Prepare headers (take care of proxies headers)
+	 *
+	 * @param string  $headers Raw headers
+	 * @param integer $count   Redirection count. Default to 1.
+	 *
+	 * @return string
+	 */
+	static public function prepareHeaders($headers, $count = 1)
+	{
+		$data = explode("\r\n\r\n", $headers, $count);
+		$data = array_pop($data);
+		if (false !== stripos($data, "HTTP/1.0 200 Connection established\r\n\r\n")) {
+			$data = str_ireplace("HTTP/1.0 200 Connection established\r\n\r\n", '', $data);
+		}
+		if (false !== stripos($data, "HTTP/1.1 200 Connection established\r\n\r\n")) {
+			$data = str_ireplace("HTTP/1.1 200 Connection established\r\n\r\n", '', $data);
+		}
+		return $data;
 	}
 }

--- a/src/wp-includes/SimplePie/Item.php
+++ b/src/wp-includes/SimplePie/Item.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -122,7 +121,7 @@ class SimplePie_Item
 	 */
 	public function __destruct()
 	{
-		if ((version_compare(PHP_VERSION, '5.3', '<') || !gc_enabled()) && !ini_get('zend.ze1_compatibility_mode'))
+		if (!gc_enabled())
 		{
 			unset($this->feed);
 		}
@@ -148,10 +147,8 @@ class SimplePie_Item
 		{
 			return $this->data['child'][$namespace][$tag];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -203,14 +200,14 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:id>`, `<guid>`, `<dc:identifier>` or the `about` attribute
 	 * for RDF. If none of these are supplied (or `$hash` is true), creates an
-	 * MD5 hash based on the permalink and title. If either of those are not
-	 * supplied, creates a hash based on the full feed data.
+	 * MD5 hash based on the permalink, title and content.
 	 *
 	 * @since SimplePie Beta 2
 	 * @param boolean $hash Should we force using a hash instead of the supplied ID?
-	 * @return string
+	 * @param string|false $fn User-supplied function to generate an hash
+	 * @return string|null
 	 */
-	public function get_id($hash = false)
+	public function get_id($hash = false, $fn = 'md5')
 	{
 		if (!$hash)
 		{
@@ -238,23 +235,18 @@ class SimplePie_Item
 			{
 				return $this->sanitize($this->data['attribs'][SIMPLEPIE_NAMESPACE_RDF]['about'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
-			elseif (($return = $this->get_permalink()) !== null)
-			{
-				return $return;
-			}
-			elseif (($return = $this->get_title()) !== null)
-			{
-				return $return;
-			}
 		}
-		if ($this->get_permalink() !== null || $this->get_title() !== null)
+		if ($fn === false)
 		{
-			return md5($this->get_permalink() . $this->get_title());
+			return null;
 		}
-		else
+		elseif (!is_callable($fn))
 		{
-			return md5(serialize($this->data));
+			trigger_error('User-supplied function $fn must be callable', E_USER_WARNING);
+			$fn = 'md5';
 		}
+		return call_user_func($fn,
+		       $this->get_permalink().$this->get_title().$this->get_content());
 	}
 
 	/**
@@ -322,51 +314,58 @@ class SimplePie_Item
 	 */
 	public function get_description($description_only = false)
 	{
-		if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary'))
+		if (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'summary')) &&
+		    ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($tags[0]['attribs'])), $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'summary')) &&
+		        ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($tags[0]['attribs'])), $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'description')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_MAYBE_HTML, $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'description')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'description')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'description')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'summary')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ITUNES, 'subtitle')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT)))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'description')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_HTML)))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML);
+			return $return;
 		}
 
 		elseif (!$description_only)
 		{
 			return $this->get_content(true);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -385,26 +384,51 @@ class SimplePie_Item
 	 */
 	public function get_content($content_only = false)
 	{
-		if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content'))
+		if (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'content')) &&
+		    ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($tags[0]['attribs'])), $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_10_content_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'content')) &&
+		        ($return = $this->sanitize($tags[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($tags[0]['attribs'])), $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], $this->registry->call('Misc', 'atom_03_construct_type', array($return[0]['attribs'])), $this->get_base($return[0]));
+			return $return;
 		}
-		elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded'))
+		elseif (($tags = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_10_MODULES_CONTENT, 'encoded')) &&
+		        ($return = $this->sanitize($tags[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($tags[0]))))
 		{
-			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
+			return $return;
 		}
 		elseif (!$content_only)
 		{
 			return $this->get_description(true);
 		}
-		else
+
+		return null;
+	}
+
+	/**
+	 * Get the media:thumbnail of the item
+	 *
+	 * Uses `<media:thumbnail>`
+	 *
+	 *
+	 * @return array|null
+	 */
+	public function get_thumbnail()
+	{
+		if (!isset($this->data['thumbnail']))
 		{
-			return null;
+			if ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_MEDIARSS, 'thumbnail'))
+			{
+				$this->data['thumbnail'] = $return[0]['attribs'][''];
+			}
+			else
+			{
+				$this->data['thumbnail'] = null;
+			}
 		}
+		return $this->data['thumbnail'];
 	}
 
 	/**
@@ -421,10 +445,8 @@ class SimplePie_Item
 		{
 			return $categories[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -432,14 +454,20 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:category>`, `<category>` or `<dc:subject>`
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie Beta 3
 	 * @return array|null List of {@see SimplePie_Category} objects
+=======
+	 * @since Beta 3
+	 * @return SimplePie_Category[]|null List of {@see SimplePie_Category} objects
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_categories()
 	{
 		$categories = array();
 
-		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'category') as $category)
+		$type = 'category';
+		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, $type) as $category)
 		{
 			$term = null;
 			$scheme = null;
@@ -456,9 +484,9 @@ class SimplePie_Item
 			{
 				$label = $this->sanitize($category['attribs']['']['label'], SIMPLEPIE_CONSTRUCT_TEXT);
 			}
-			$categories[] = $this->registry->create('Category', array($term, $scheme, $label));
+			$categories[] = $this->registry->create('Category', array($term, $scheme, $label, $type));
 		}
-		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'category') as $category)
+		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, $type) as $category)
 		{
 			// This is really the label, but keep this as the term also for BC.
 			// Label will also work on retrieving because that falls back to term.
@@ -471,25 +499,25 @@ class SimplePie_Item
 			{
 				$scheme = null;
 			}
-			$categories[] = $this->registry->create('Category', array($term, $scheme, null));
+			$categories[] = $this->registry->create('Category', array($term, $scheme, null, $type));
 		}
-		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'subject') as $category)
+
+		$type = 'subject';
+		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, $type) as $category)
 		{
-			$categories[] = $this->registry->create('Category', array($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null));
+			$categories[] = $this->registry->create('Category', array($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null, $type));
 		}
-		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'subject') as $category)
+		foreach ((array) $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, $type) as $category)
 		{
-			$categories[] = $this->registry->create('Category', array($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null));
+			$categories[] = $this->registry->create('Category', array($this->sanitize($category['data'], SIMPLEPIE_CONSTRUCT_TEXT), null, null, $type));
 		}
 
 		if (!empty($categories))
 		{
 			return array_unique($categories);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -506,10 +534,8 @@ class SimplePie_Item
 		{
 			return $authors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -526,10 +552,8 @@ class SimplePie_Item
 		{
 			return $contributors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -537,8 +561,13 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:contributor>`
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie 1.1
 	 * @return array|null List of {@see SimplePie_Author} objects
+=======
+	 * @since 1.1
+	 * @return SimplePie_Author[]|null List of {@see SimplePie_Author} objects
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_contributors()
 	{
@@ -592,10 +621,8 @@ class SimplePie_Item
 		{
 			return array_unique($contributors);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -603,8 +630,13 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:author>`, `<author>`, `<dc:creator>` or `<itunes:author>`
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie Beta 2
 	 * @return array|null List of {@see SimplePie_Author} objects
+=======
+	 * @since Beta 2
+	 * @return SimplePie_Author[]|null List of {@see SimplePie_Author} objects
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_authors()
 	{
@@ -682,10 +714,8 @@ class SimplePie_Item
 		{
 			return $authors;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -710,10 +740,8 @@ class SimplePie_Item
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -738,6 +766,18 @@ class SimplePie_Item
 			{
 				$this->data['date']['raw'] = $return[0]['data'];
 			}
+			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'pubDate'))
+			{
+				$this->data['date']['raw'] = $return[0]['data'];
+			}
+			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'date'))
+			{
+				$this->data['date']['raw'] = $return[0]['data'];
+			}
+			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'date'))
+			{
+				$this->data['date']['raw'] = $return[0]['data'];
+			}
 			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'updated'))
 			{
 				$this->data['date']['raw'] = $return[0]['data'];
@@ -751,18 +791,6 @@ class SimplePie_Item
 				$this->data['date']['raw'] = $return[0]['data'];
 			}
 			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'modified'))
-			{
-				$this->data['date']['raw'] = $return[0]['data'];
-			}
-			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'pubDate'))
-			{
-				$this->data['date']['raw'] = $return[0]['data'];
-			}
-			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_11, 'date'))
-			{
-				$this->data['date']['raw'] = $return[0]['data'];
-			}
-			elseif ($return = $this->get_item_tags(SIMPLEPIE_NAMESPACE_DC_10, 'date'))
 			{
 				$this->data['date']['raw'] = $return[0]['data'];
 			}
@@ -792,10 +820,8 @@ class SimplePie_Item
 					return date($date_format, $this->data['date']['parsed']);
 			}
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -821,7 +847,7 @@ class SimplePie_Item
 			if (!empty($this->data['updated']['raw']))
 			{
 				$parser = $this->registry->call('Parse_Date', 'get');
-				$this->data['updated']['parsed'] = $parser->parse($this->data['date']['raw']);
+				$this->data['updated']['parsed'] = $parser->parse($this->data['updated']['raw']);
 			}
 			else
 			{
@@ -843,10 +869,8 @@ class SimplePie_Item
 					return date($date_format, $this->data['updated']['parsed']);
 			}
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -872,10 +896,8 @@ class SimplePie_Item
 		{
 			return strftime($date_format, $date);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -936,10 +958,8 @@ class SimplePie_Item
 		{
 			return $enclosure->get_link();
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -953,14 +973,12 @@ class SimplePie_Item
 	public function get_link($key = 0, $rel = 'alternate')
 	{
 		$links = $this->get_links($rel);
-		if ($links[$key] !== null)
+		if ($links && $links[$key] !== null)
 		{
 			return $links[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -1040,10 +1058,8 @@ class SimplePie_Item
 		{
 			return $this->data['links'][$rel];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -1063,10 +1079,8 @@ class SimplePie_Item
 		{
 			return $enclosures[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -1080,8 +1094,8 @@ class SimplePie_Item
 	 *
 	 * @since SimplePie Beta 2
 	 * @todo Add support for end-user defined sorting of enclosures by type/handler (so we can prefer the faster-loading FLV over MP4).
-	 * @todo If an element exists at a level, but it's value is empty, we should fall back to the value from the parent (if it exists).
-	 * @return array|null List of SimplePie_Enclosure items
+	 * @todo If an element exists at a level, but its value is empty, we should fall back to the value from the parent (if it exists).
+	 * @return SimplePie_Enclosure[]|null List of SimplePie_Enclosure items
 	 */
 	public function get_enclosures()
 	{
@@ -2658,7 +2672,9 @@ class SimplePie_Item
 						// PLAYER
 						if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player']))
 						{
-							$player = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+							if (isset($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'])) {
+								$player = $this->sanitize($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['player'][0]['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+							}
 						}
 						else
 						{
@@ -2733,7 +2749,9 @@ class SimplePie_Item
 						{
 							foreach ($content['child'][SIMPLEPIE_NAMESPACE_MEDIARSS]['thumbnail'] as $thumbnail)
 							{
-								$thumbnails[] = $this->sanitize($thumbnail['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+								if (isset($thumbnail['attribs']['']['url'])) {
+									$thumbnails[] = $this->sanitize($thumbnail['attribs']['']['url'], SIMPLEPIE_CONSTRUCT_IRI);
+								}
 							}
 							if (is_array($thumbnails))
 							{
@@ -2789,9 +2807,17 @@ class SimplePie_Item
 					{
 						$length = ceil($link['attribs']['']['length']);
 					}
+					if (isset($link['attribs']['']['title']))
+					{
+						$title = $this->sanitize($link['attribs']['']['title'], SIMPLEPIE_CONSTRUCT_TEXT);
+					}
+					else
+					{
+						$title = $title_parent;
+					}
 
 					// Since we don't have group or content for these, we'll just pass the '*_parent' variables directly to the constructor
-					$this->data['enclosures'][] = $this->registry->create('Enclosure', array($url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title_parent, $width));
+					$this->data['enclosures'][] = $this->registry->create('Enclosure', array($url, $type, $length, null, $bitrate, $captions_parent, $categories_parent, $channels, $copyrights_parent, $credits_parent, $description_parent, $duration_parent, $expression, $framerate, $hashes_parent, $height, $keywords_parent, $lang, $medium, $player_parent, $ratings_parent, $restrictions_parent, $samplingrate, $thumbnails_parent, $title, $width));
 				}
 			}
 
@@ -2877,10 +2903,8 @@ class SimplePie_Item
 		{
 			return $this->data['enclosures'];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2905,10 +2929,8 @@ class SimplePie_Item
 		{
 			return (float) $match[1];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2937,10 +2959,8 @@ class SimplePie_Item
 		{
 			return (float) $match[2];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2955,10 +2975,7 @@ class SimplePie_Item
 		{
 			return $this->registry->create('Source', array($this, $return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Item.php
+++ b/src/wp-includes/SimplePie/Item.php
@@ -454,13 +454,8 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:category>`, `<category>` or `<dc:subject>`
 	 *
-<<<<<<< HEAD
 	 * @since SimplePie Beta 3
 	 * @return array|null List of {@see SimplePie_Category} objects
-=======
-	 * @since Beta 3
-	 * @return SimplePie_Category[]|null List of {@see SimplePie_Category} objects
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_categories()
 	{
@@ -561,13 +556,8 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:contributor>`
 	 *
-<<<<<<< HEAD
 	 * @since SimplePie 1.1
 	 * @return array|null List of {@see SimplePie_Author} objects
-=======
-	 * @since 1.1
-	 * @return SimplePie_Author[]|null List of {@see SimplePie_Author} objects
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_contributors()
 	{
@@ -630,13 +620,8 @@ class SimplePie_Item
 	 *
 	 * Uses `<atom:author>`, `<author>`, `<dc:creator>` or `<itunes:author>`
 	 *
-<<<<<<< HEAD
 	 * @since SimplePie Beta 2
 	 * @return array|null List of {@see SimplePie_Author} objects
-=======
-	 * @since Beta 2
-	 * @return SimplePie_Author[]|null List of {@see SimplePie_Author} objects
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 */
 	public function get_authors()
 	{

--- a/src/wp-includes/SimplePie/Locator.php
+++ b/src/wp-includes/SimplePie/Locator.php
@@ -94,7 +94,7 @@ class SimplePie_Locator
 		$this->registry = $registry;
 	}
 
-	public function find($type = SIMPLEPIE_LOCATOR_ALL, &$working)
+	public function find($type = SIMPLEPIE_LOCATOR_ALL, &$working = null)
 	{
 		if ($this->is_feed($this->file))
 		{

--- a/src/wp-includes/SimplePie/Misc.php
+++ b/src/wp-includes/SimplePie/Misc.php
@@ -364,11 +364,12 @@ class SimplePie_Misc
 		}
 
 		// Check that the encoding is supported
-		if (@mb_convert_encoding("\x80", 'UTF-16BE', $input) === "\x00\x80")
+		if (!in_array($input, mb_list_encodings()))
 		{
 			return false;
 		}
-		if (!in_array($input, mb_list_encodings()))
+
+		if (@mb_convert_encoding("\x80", 'UTF-16BE', $input) === "\x00\x80")
 		{
 			return false;
 		}

--- a/src/wp-includes/SimplePie/Misc.php
+++ b/src/wp-includes/SimplePie/Misc.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -138,7 +137,7 @@ class SimplePie_Misc
 		foreach ($element['attribs'] as $key => $value)
 		{
 			$key = strtolower($key);
-			$full .= " $key=\"" . htmlspecialchars($value['data']) . '"';
+			$full .= " $key=\"" . htmlspecialchars($value['data'], ENT_COMPAT, 'UTF-8') . '"';
 		}
 		if ($element['self_closing'])
 		{
@@ -218,10 +217,25 @@ class SimplePie_Misc
 		{
 			return substr_replace($url, 'itpc', 0, 4);
 		}
-		else
+
+		return $url;
+	}
+
+	public static function array_merge_recursive($array1, $array2)
+	{
+		foreach ($array2 as $key => $value)
 		{
-			return $url;
+			if (is_array($value))
+			{
+				$array1[$key] = SimplePie_Misc::array_merge_recursive($array1[$key], $value);
+			}
+			else
+			{
+				$array1[$key] = $value;
+			}
 		}
+
+		return $array1;
 	}
 
 	public static function parse_url($url)
@@ -260,10 +274,8 @@ class SimplePie_Misc
 		{
 			return chr($integer);
 		}
-		else
-		{
-			return strtoupper($match[0]);
-		}
+
+		return strtoupper($match[0]);
 	}
 
 	/**
@@ -317,16 +329,19 @@ class SimplePie_Misc
 		{
 			return $return;
  		}
-		// This is last, as behaviour of this varies with OS userland and PHP version
+		// This is third, as behaviour of this varies with OS userland and PHP version
 		elseif (function_exists('iconv') && ($return = SimplePie_Misc::change_encoding_iconv($data, $input, $output)))
 		{
 			return $return;
 		}
-		// If we can't do anything, just fail
-		else
+		// This is last, as behaviour of this varies with OS userland and PHP version
+		elseif (class_exists('\UConverter') && ($return = SimplePie_Misc::change_encoding_uconverter($data, $input, $output)))
 		{
-			return false;
+			return $return;
 		}
+
+		// If we can't do anything, just fail
+		return false;
 	}
 
 	protected static function change_encoding_mbstring($data, $input, $output)
@@ -370,6 +385,17 @@ class SimplePie_Misc
 	protected static function change_encoding_iconv($data, $input, $output)
 	{
 		return @iconv($input, $output, $data);
+	}
+
+	/**
+	 * @param string $data
+	 * @param string $input
+	 * @param string $output
+	 * @return string|false
+	 */
+	protected static function change_encoding_uconverter($data, $input, $output)
+	{
+		return @\UConverter::transcode($data, $output, $input);
 	}
 
 	/**
@@ -1826,10 +1852,8 @@ class SimplePie_Misc
 		{
 			return trim($mime);
 		}
-		else
-		{
-			return trim(substr($mime, 0, $pos));
-		}
+
+		return trim(substr($mime, 0, $pos));
 	}
 
 	public static function atom_03_construct_type($attribs)
@@ -1862,10 +1886,8 @@ class SimplePie_Misc
 					return SIMPLEPIE_CONSTRUCT_NONE | $mode;
 			}
 		}
-		else
-		{
-			return SIMPLEPIE_CONSTRUCT_TEXT | $mode;
-		}
+
+		return SIMPLEPIE_CONSTRUCT_TEXT | $mode;
 	}
 
 	public static function atom_10_construct_type($attribs)
@@ -1915,10 +1937,8 @@ class SimplePie_Misc
 				return SIMPLEPIE_CONSTRUCT_BASE64;
 			}
 		}
-		else
-		{
-			return SIMPLEPIE_CONSTRUCT_TEXT;
-		}
+
+		return SIMPLEPIE_CONSTRUCT_TEXT;
 	}
 
 	public static function is_isegment_nz_nc($string)
@@ -1926,7 +1946,7 @@ class SimplePie_Misc
 		return (bool) preg_match('/^([A-Za-z0-9\-._~\x{A0}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFEF}\x{10000}-\x{1FFFD}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}\x{40000}-\x{4FFFD}\x{50000}-\x{5FFFD}\x{60000}-\x{6FFFD}\x{70000}-\x{7FFFD}\x{80000}-\x{8FFFD}\x{90000}-\x{9FFFD}\x{A0000}-\x{AFFFD}\x{B0000}-\x{BFFFD}\x{C0000}-\x{CFFFD}\x{D0000}-\x{DFFFD}\x{E1000}-\x{EFFFD}!$&\'()*+,;=@]|(%[0-9ABCDEF]{2}))+$/u', $string);
 	}
 
-	public static function space_seperated_tokens($string)
+	public static function space_separated_tokens($string)
 	{
 		$space_characters = "\x20\x09\x0A\x0B\x0C\x0D";
 		$string_length = strlen($string);
@@ -1975,11 +1995,9 @@ class SimplePie_Misc
 		{
 			return chr(0xf0 | ($codepoint >> 18)) . chr(0x80 | (($codepoint >> 12) & 0x3f)) . chr(0x80 | (($codepoint >> 6) & 0x3f)) . chr(0x80 | ($codepoint & 0x3f));
 		}
-		else
-		{
-			// U+FFFD REPLACEMENT CHARACTER
-			return "\xEF\xBF\xBD";
-		}
+
+		// U+FFFD REPLACEMENT CHARACTER
+		return "\xEF\xBF\xBD";
 	}
 
 	/**
@@ -2183,10 +2201,8 @@ function embed_wmedia(width, height, link) {
 		{
 			return filemtime(dirname(__FILE__) . '/Core.php');
 		}
-		else
-		{
-			return filemtime(__FILE__);
-		}
+
+		return filemtime(__FILE__);
 	}
 
 	/**
@@ -2244,4 +2260,3 @@ function embed_wmedia(width, height, link) {
 		// No-op
 	}
 }
-

--- a/src/wp-includes/SimplePie/Net/IPv6.php
+++ b/src/wp-includes/SimplePie/Net/IPv6.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -54,7 +53,7 @@
  * @author Alexander Merz <alexander.merz@web.de>
  * @author elfrink at introweb dot nl
  * @author Josh Peck <jmp at joshpeck dot org>
- * @author Geoffrey Sneddon <geoffers@gmail.com>
+ * @author Sam Sneddon <geoffers@gmail.com>
  */
 class SimplePie_Net_IPv6
 {
@@ -174,10 +173,8 @@ class SimplePie_Net_IPv6
 		{
 			return implode(':', $ip_parts);
 		}
-		else
-		{
-			return $ip_parts[0];
-		}
+
+		return $ip_parts[0];
 	}
 
 	/**
@@ -201,10 +198,8 @@ class SimplePie_Net_IPv6
 			$ipv4_part = substr($ip, $pos + 1);
 			return array($ipv6_part, $ipv4_part);
 		}
-		else
-		{
-			return array($ip, '');
-		}
+
+		return array($ip, '');
 	}
 
 	/**
@@ -254,10 +249,8 @@ class SimplePie_Net_IPv6
 			}
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/SimplePie/Parse/Date.php
+++ b/src/wp-includes/SimplePie/Parse/Date.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -99,12 +98,20 @@ class SimplePie_Parse_Date
 		'dimanche' => 7,
 		// German
 		'montag' => 1,
+		'mo' => 1,
 		'dienstag' => 2,
+		'di' => 2,
 		'mittwoch' => 3,
+		'mi' => 3,
 		'donnerstag' => 4,
+		'do' => 4,
 		'freitag' => 5,
+		'fr' => 5,
 		'samstag' => 6,
+		'sa' => 6,
 		'sonnabend' => 6,
+		// AFAIK no short form for sonnabend
+		'so' => 7,
 		'sonntag' => 7,
 		// Italian
 		'lunedì' => 1,
@@ -146,6 +153,14 @@ class SimplePie_Parse_Date
 		'Παρ' => 5,
 		'Σαβ' => 6,
 		'Κυρ' => 7,
+		// Russian
+		'Пн.' => 1,
+		'Вт.' => 2,
+		'Ср.' => 3,
+		'Чт.' => 4,
+		'Пт.' => 5,
+		'Сб.' => 6,
+		'Вс.' => 7,
 	);
 
 	/**
@@ -173,7 +188,7 @@ class SimplePie_Parse_Date
 		'aug' => 8,
 		'august' => 8,
 		'sep' => 9,
-		'september' => 8,
+		'september' => 9,
 		'oct' => 10,
 		'october' => 10,
 		'nov' => 11,
@@ -208,17 +223,28 @@ class SimplePie_Parse_Date
 		'décembre' => 12,
 		// German
 		'januar' => 1,
+		'jan' => 1,
 		'februar' => 2,
+		'feb' => 2,
 		'märz' => 3,
+		'mär' => 3,
 		'april' => 4,
-		'mai' => 5,
+		'apr' => 4,
+		'mai' => 5, // no short form for may
 		'juni' => 6,
+		'jun' => 6,
 		'juli' => 7,
+		'jul' => 7,
 		'august' => 8,
+		'aug' => 8,
 		'september' => 9,
+		'sep' => 9,
 		'oktober' => 10,
+		'okt' => 10,
 		'november' => 11,
+		'nov' => 11,
 		'dezember' => 12,
+		'dez' => 12,
 		// Italian
 		'gennaio' => 1,
 		'febbraio' => 2,
@@ -290,7 +316,33 @@ class SimplePie_Parse_Date
 		'Σεπ' => 9,
 		'Οκτ' => 10,
 		'Νοέ' => 11,
-		'Δεκ' => 12,
+		'Δεκ' => 12,		
+		// Russian
+		'Янв' => 1,
+		'января' => 1,
+		'Фев' => 2,
+		'февраля' => 2,
+		'Мар' => 3,
+		'марта' => 3,
+		'Апр' => 4,
+		'апреля' => 4,
+		'Май' => 5,
+		'мая' => 5,
+		'Июн' => 6,
+		'июня' => 6,
+		'Июл' => 7,
+		'июля' => 7,
+		'Авг' => 8,
+		'августа' => 8,
+		'Сен' => 9,
+		'сентября' => 9,
+		'Окт' => 10,
+		'октября' => 10,
+		'Ноя' => 11,
+		'ноября' => 11,
+		'Дек' => 12,
+		'декабря' => 12,
+
 	);
 
 	/**
@@ -614,7 +666,7 @@ class SimplePie_Parse_Date
 	 *
 	 * @final
 	 * @access public
-	 * @param callable $callback
+	 * @param callback $callback
 	 */
 	public function add_callback($callback)
 	{
@@ -631,7 +683,7 @@ class SimplePie_Parse_Date
 	/**
 	 * Parse a superset of W3C-DTF (allows hyphens and colons to be omitted, as
 	 * well as allowing any of upper or lower case "T", horizontal tabs, or
-	 * spaces to be used as the time seperator (including more than one))
+	 * spaces to be used as the time separator (including more than one))
 	 *
 	 * @access protected
 	 * @return int Timestamp
@@ -691,14 +743,12 @@ class SimplePie_Parse_Date
 			}
 
 			// Convert the number of seconds to an integer, taking decimals into account
-			$second = round($match[6] + $match[7] / pow(10, strlen($match[7])));
+			$second = round((int)$match[6] + (int)$match[7] / (10 ** strlen($match[7])));
 
 			return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -721,7 +771,7 @@ class SimplePie_Parse_Date
 		{
 			$output .= substr($string, $position, $pos - $position);
 			$position = $pos + 1;
-			if ($string[$pos - 1] !== '\\')
+			if ($pos === 0 || $string[$pos - 1] !== '\\')
 			{
 				$depth++;
 				while ($depth && $position < $length)
@@ -849,10 +899,8 @@ class SimplePie_Parse_Date
 
 			return gmmktime($match[5], $match[6], $second, $month, $match[2], $match[4]) - $timezone;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -914,10 +962,8 @@ class SimplePie_Parse_Date
 
 			return gmmktime($match[5], $match[6], $match[7], $month, $match[2], $match[4]) - $timezone;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -956,10 +1002,8 @@ class SimplePie_Parse_Date
 			$month = $this->month[strtolower($match[2])];
 			return gmmktime($match[4], $match[5], $match[6], $month, $match[3], $match[7]);
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 
 	/**
@@ -975,10 +1019,7 @@ class SimplePie_Parse_Date
 		{
 			return false;
 		}
-		else
-		{
-			return $strtotime;
-		}
+
+		return $strtotime;
 	}
 }
-

--- a/src/wp-includes/SimplePie/Parser.php
+++ b/src/wp-includes/SimplePie/Parser.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -75,8 +74,22 @@ class SimplePie_Parser
 		$this->registry = $registry;
 	}
 
-	public function parse(&$data, $encoding)
+	public function parse(&$data, $encoding, $url = '')
 	{
+		if (class_exists('DOMXpath') && function_exists('Mf2\parse')) {
+			$doc = new DOMDocument();
+			@$doc->loadHTML($data);
+			$xpath = new DOMXpath($doc);
+			// Check for both h-feed and h-entry, as both a feed with no entries
+			// and a list of entries without an h-feed wrapper are both valid.
+			$query = '//*[contains(concat(" ", @class, " "), " h-feed ") or '.
+				'contains(concat(" ", @class, " "), " h-entry ")]';
+			$result = $xpath->query($query);
+			if ($result->length !== 0) {
+				return $this->parse_microformats($data, $url);
+			}
+		}
+
 		// Use UTF-8 if we get passed US-ASCII, as every US-ASCII character is a UTF-8 character
 		if (strtoupper($encoding) === 'US-ASCII')
 		{
@@ -120,7 +133,7 @@ class SimplePie_Parser
 			if ($declaration->parse())
 			{
 				$data = substr($data, $pos + 2);
-				$data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' . $data;
+				$data = '<?xml version="' . $declaration->version . '" encoding="' . $encoding . '" standalone="' . (($declaration->standalone) ? 'yes' : 'no') . '"?>' ."\n". $this->declare_html_entities() . $data;
 			}
 			else
 			{
@@ -163,76 +176,72 @@ class SimplePie_Parser
 			xml_parser_free($xml);
 			return $return;
 		}
-		else
+
+		libxml_clear_errors();
+		$xml = new XMLReader();
+		$xml->xml($data);
+		while (@$xml->read())
 		{
-			libxml_clear_errors();
-			$xml = new XMLReader();
-			$xml->xml($data);
-			while (@$xml->read())
+			switch ($xml->nodeType)
 			{
-				switch ($xml->nodeType)
-				{
 
-					case constant('XMLReader::END_ELEMENT'):
+				case constant('XMLReader::END_ELEMENT'):
+					if ($xml->namespaceURI !== '')
+					{
+						$tagName = $xml->namespaceURI . $this->separator . $xml->localName;
+					}
+					else
+					{
+						$tagName = $xml->localName;
+					}
+					$this->tag_close(null, $tagName);
+					break;
+				case constant('XMLReader::ELEMENT'):
+					$empty = $xml->isEmptyElement;
+					if ($xml->namespaceURI !== '')
+					{
+						$tagName = $xml->namespaceURI . $this->separator . $xml->localName;
+					}
+					else
+					{
+						$tagName = $xml->localName;
+					}
+					$attributes = array();
+					while ($xml->moveToNextAttribute())
+					{
 						if ($xml->namespaceURI !== '')
 						{
-							$tagName = $xml->namespaceURI . $this->separator . $xml->localName;
+							$attrName = $xml->namespaceURI . $this->separator . $xml->localName;
 						}
 						else
 						{
-							$tagName = $xml->localName;
+							$attrName = $xml->localName;
 						}
+						$attributes[$attrName] = $xml->value;
+					}
+					$this->tag_open(null, $tagName, $attributes);
+					if ($empty)
+					{
 						$this->tag_close(null, $tagName);
-						break;
-					case constant('XMLReader::ELEMENT'):
-						$empty = $xml->isEmptyElement;
-						if ($xml->namespaceURI !== '')
-						{
-							$tagName = $xml->namespaceURI . $this->separator . $xml->localName;
-						}
-						else
-						{
-							$tagName = $xml->localName;
-						}
-						$attributes = array();
-						while ($xml->moveToNextAttribute())
-						{
-							if ($xml->namespaceURI !== '')
-							{
-								$attrName = $xml->namespaceURI . $this->separator . $xml->localName;
-							}
-							else
-							{
-								$attrName = $xml->localName;
-							}
-							$attributes[$attrName] = $xml->value;
-						}
-						$this->tag_open(null, $tagName, $attributes);
-						if ($empty)
-						{
-							$this->tag_close(null, $tagName);
-						}
-						break;
-					case constant('XMLReader::TEXT'):
+					}
+					break;
+				case constant('XMLReader::TEXT'):
 
-					case constant('XMLReader::CDATA'):
-						$this->cdata(null, $xml->value);
-						break;
-				}
-			}
-			if ($error = libxml_get_last_error())
-			{
-				$this->error_code = $error->code;
-				$this->error_string = $error->message;
-				$this->current_line = $error->line;
-				$this->current_column = $error->column;
-				return false;
-			}
-			else
-			{
-				return true;
+				case constant('XMLReader::CDATA'):
+					$this->cdata(null, $xml->value);
+					break;
 			}
 		}
+		if ($error = libxml_get_last_error())
+		{
+			$this->error_code = $error->code;
+			$this->error_string = $error->message;
+			$this->current_line = $error->line;
+			$this->current_column = $error->column;
+			return false;
+		}
+
+		return true;
 	}
 
 	public function get_error_code()
@@ -403,5 +412,250 @@ class SimplePie_Parser
 			}
 		}
 		return $cache[$string];
+	}
+
+	private function parse_hcard($data, $category = false) {
+		$name = '';
+		$link = '';
+		// Check if h-card is set and pass that information on in the link.
+		if (isset($data['type']) && in_array('h-card', $data['type'])) {
+			if (isset($data['properties']['name'][0])) {
+				$name = $data['properties']['name'][0];
+			}
+			if (isset($data['properties']['url'][0])) {
+				$link = $data['properties']['url'][0];
+				if ($name === '') {
+					$name = $link;
+				}
+				else {
+					// can't have commas in categories.
+					$name = str_replace(',', '', $name);
+				}
+				$person_tag = $category ? '<span class="person-tag"></span>' : '';
+				return '<a class="h-card" href="'.$link.'">'.$person_tag.$name.'</a>';
+			}
+		}
+		return isset($data['value']) ? $data['value'] : '';
+	}
+
+	private function parse_microformats(&$data, $url) {
+		$feed_title = '';
+		$feed_author = NULL;
+		$author_cache = array();
+		$items = array();
+		$entries = array();
+		$mf = Mf2\parse($data, $url);
+		// First look for an h-feed.
+		$h_feed = array();
+		foreach ($mf['items'] as $mf_item) {
+			if (in_array('h-feed', $mf_item['type'])) {
+				$h_feed = $mf_item;
+				break;
+			}
+			// Also look for h-feed or h-entry in the children of each top level item.
+			if (!isset($mf_item['children'][0]['type'])) continue;
+			if (in_array('h-feed', $mf_item['children'][0]['type'])) {
+				$h_feed = $mf_item['children'][0];
+				// In this case the parent of the h-feed may be an h-card, so use it as
+				// the feed_author.
+				if (in_array('h-card', $mf_item['type'])) $feed_author = $mf_item;
+				break;
+			}
+			else if (in_array('h-entry', $mf_item['children'][0]['type'])) {
+				$entries = $mf_item['children'];
+				// In this case the parent of the h-entry list may be an h-card, so use
+				// it as the feed_author.
+				if (in_array('h-card', $mf_item['type'])) $feed_author = $mf_item;
+				break;
+			}
+		}
+		if (isset($h_feed['children'])) {
+			$entries = $h_feed['children'];
+			// Also set the feed title and store author from the h-feed if available.
+			if (isset($mf['items'][0]['properties']['name'][0])) {
+				$feed_title = $mf['items'][0]['properties']['name'][0];
+			}
+			if (isset($mf['items'][0]['properties']['author'][0])) {
+				$feed_author = $mf['items'][0]['properties']['author'][0];
+			}
+		}
+		else if (count($entries) === 0) {
+			$entries = $mf['items'];
+		}
+		for ($i = 0; $i < count($entries); $i++) {
+			$entry = $entries[$i];
+			if (in_array('h-entry', $entry['type'])) {
+				$item = array();
+				$title = '';
+				$description = '';
+				if (isset($entry['properties']['url'][0])) {
+					$link = $entry['properties']['url'][0];
+					if (isset($link['value'])) $link = $link['value'];
+					$item['link'] = array(array('data' => $link));
+				}
+				if (isset($entry['properties']['uid'][0])) {
+					$guid = $entry['properties']['uid'][0];
+					if (isset($guid['value'])) $guid = $guid['value'];
+					$item['guid'] = array(array('data' => $guid));
+				}
+				if (isset($entry['properties']['name'][0])) {
+					$title = $entry['properties']['name'][0];
+					if (isset($title['value'])) $title = $title['value'];
+					$item['title'] = array(array('data' => $title));
+				}
+				if (isset($entry['properties']['author'][0]) || isset($feed_author)) {
+					// author is a special case, it can be plain text or an h-card array.
+					// If it's plain text it can also be a url that should be followed to
+					// get the actual h-card.
+					$author = isset($entry['properties']['author'][0]) ?
+						$entry['properties']['author'][0] : $feed_author;
+					if (!is_string($author)) {
+						$author = $this->parse_hcard($author);
+					}
+					else if (strpos($author, 'http') === 0) {
+						if (isset($author_cache[$author])) {
+							$author = $author_cache[$author];
+						}
+						else {
+							$mf = Mf2\fetch($author);
+							foreach ($mf['items'] as $hcard) {
+								// Only interested in an h-card by itself in this case.
+								if (!in_array('h-card', $hcard['type'])) {
+									continue;
+								}
+								// It must have a url property matching what we fetched.
+								if (!isset($hcard['properties']['url']) ||
+										!(in_array($author, $hcard['properties']['url']))) {
+									continue;
+								}
+								// Save parse_hcard the trouble of finding the correct url.
+								$hcard['properties']['url'][0] = $author;
+								// Cache this h-card for the next h-entry to check.
+								$author_cache[$author] = $this->parse_hcard($hcard);
+								$author = $author_cache[$author];
+								break;
+							}
+						}
+					}
+					$item['author'] = array(array('data' => $author));
+				}
+				if (isset($entry['properties']['photo'][0])) {
+					// If a photo is also in content, don't need to add it again here.
+					$content = '';
+					if (isset($entry['properties']['content'][0]['html'])) {
+						$content = $entry['properties']['content'][0]['html'];
+					}
+					$photo_list = array();
+					for ($j = 0; $j < count($entry['properties']['photo']); $j++) {
+						$photo = $entry['properties']['photo'][$j];
+						if (!empty($photo) && strpos($content, $photo) === false) {
+							$photo_list[] = $photo;
+						}
+					}
+					// When there's more than one photo show the first and use a lightbox.
+					// Need a permanent, unique name for the image set, but don't have
+					// anything unique except for the content itself, so use that.
+					$count = count($photo_list);
+					if ($count > 1) {
+						$image_set_id = preg_replace('/[[:^alnum:]]/', '', $photo_list[0]);
+						$description = '<p>';
+						for ($j = 0; $j < $count; $j++) {
+							$hidden = $j === 0 ? '' : 'class="hidden" ';
+							$description .= '<a href="'.$photo_list[$j].'" '.$hidden.
+								'data-lightbox="image-set-'.$image_set_id.'">'.
+								'<img src="'.$photo_list[$j].'"></a>';
+						}
+						$description .= '<br><b>'.$count.' photos</b></p>';
+					}
+					else if ($count == 1) {
+						$description = '<p><img src="'.$photo_list[0].'"></p>';
+					}
+				}
+				if (isset($entry['properties']['content'][0]['html'])) {
+					// e-content['value'] is the same as p-name when they are on the same
+					// element. Use this to replace title with a strip_tags version so
+					// that alt text from images is not included in the title.
+					if ($entry['properties']['content'][0]['value'] === $title) {
+						$title = strip_tags($entry['properties']['content'][0]['html']);
+						$item['title'] = array(array('data' => $title));
+					}
+					$description .= $entry['properties']['content'][0]['html'];
+					if (isset($entry['properties']['in-reply-to'][0])) {
+						$in_reply_to = '';
+						if (is_string($entry['properties']['in-reply-to'][0])) {
+							$in_reply_to = $entry['properties']['in-reply-to'][0];
+						}
+						else if (isset($entry['properties']['in-reply-to'][0]['value'])) {
+							$in_reply_to = $entry['properties']['in-reply-to'][0]['value'];
+						}
+						if ($in_reply_to !== '') {
+							$description .= '<p><span class="in-reply-to"></span> '.
+								'<a href="'.$in_reply_to.'">'.$in_reply_to.'</a><p>';
+						}
+					}
+					$item['description'] = array(array('data' => $description));
+				}
+				if (isset($entry['properties']['category'])) {
+					$category_csv = '';
+					// Categories can also contain h-cards.
+					foreach ($entry['properties']['category'] as $category) {
+						if ($category_csv !== '') $category_csv .= ', ';
+						if (is_string($category)) {
+							// Can't have commas in categories.
+							$category_csv .= str_replace(',', '', $category);
+						}
+						else {
+							$category_csv .= $this->parse_hcard($category, true);
+						}
+					}
+					$item['category'] = array(array('data' => $category_csv));
+				}
+				if (isset($entry['properties']['published'][0])) {
+					$timestamp = strtotime($entry['properties']['published'][0]);
+					$pub_date = date('F j Y g:ia', $timestamp).' GMT';
+					$item['pubDate'] = array(array('data' => $pub_date));
+				}
+				// The title and description are set to the empty string to represent
+				// a deleted item (which also makes it an invalid rss item).
+				if (isset($entry['properties']['deleted'][0])) {
+					$item['title'] = array(array('data' => ''));
+					$item['description'] = array(array('data' => ''));
+				}
+				$items[] = array('child' => array('' => $item));
+			}
+		}
+		// Mimic RSS data format when storing microformats.
+		$link = array(array('data' => $url));
+		$image = '';
+		if (!is_string($feed_author) &&
+				isset($feed_author['properties']['photo'][0])) {
+			$image = array(array('child' => array('' => array('url' =>
+				array(array('data' => $feed_author['properties']['photo'][0]))))));
+		}
+		// Use the name given for the h-feed, or get the title from the html.
+		if ($feed_title !== '') {
+			$feed_title = array(array('data' => htmlspecialchars($feed_title)));
+		}
+		else if ($position = strpos($data, '<title>')) {
+			$start = $position < 200 ? 0 : $position - 200;
+			$check = substr($data, $start, 400);
+			$matches = array();
+			if (preg_match('/<title>(.+)<\/title>/', $check, $matches)) {
+				$feed_title = array(array('data' => htmlspecialchars($matches[1])));
+			}
+		}
+		$channel = array('channel' => array(array('child' => array('' =>
+			array('link' => $link, 'image' => $image, 'title' => $feed_title,
+			      'item' => $items)))));
+		$rss = array(array('attribs' => array('' => array('version' => '2.0')),
+		                   'child' => array('' => $channel)));
+		$this->data = array('child' => array('' => array('rss' => $rss)));
+		return true;
+	}
+
+	private function declare_html_entities() {
+		// This is required because the RSS specification says that entity-encoded
+		// html is allowed, but the xml specification says they must be declared.
+		return '<!DOCTYPE html [ <!ENTITY nbsp "&#x00A0;"> <!ENTITY iexcl "&#x00A1;"> <!ENTITY cent "&#x00A2;"> <!ENTITY pound "&#x00A3;"> <!ENTITY curren "&#x00A4;"> <!ENTITY yen "&#x00A5;"> <!ENTITY brvbar "&#x00A6;"> <!ENTITY sect "&#x00A7;"> <!ENTITY uml "&#x00A8;"> <!ENTITY copy "&#x00A9;"> <!ENTITY ordf "&#x00AA;"> <!ENTITY laquo "&#x00AB;"> <!ENTITY not "&#x00AC;"> <!ENTITY shy "&#x00AD;"> <!ENTITY reg "&#x00AE;"> <!ENTITY macr "&#x00AF;"> <!ENTITY deg "&#x00B0;"> <!ENTITY plusmn "&#x00B1;"> <!ENTITY sup2 "&#x00B2;"> <!ENTITY sup3 "&#x00B3;"> <!ENTITY acute "&#x00B4;"> <!ENTITY micro "&#x00B5;"> <!ENTITY para "&#x00B6;"> <!ENTITY middot "&#x00B7;"> <!ENTITY cedil "&#x00B8;"> <!ENTITY sup1 "&#x00B9;"> <!ENTITY ordm "&#x00BA;"> <!ENTITY raquo "&#x00BB;"> <!ENTITY frac14 "&#x00BC;"> <!ENTITY frac12 "&#x00BD;"> <!ENTITY frac34 "&#x00BE;"> <!ENTITY iquest "&#x00BF;"> <!ENTITY Agrave "&#x00C0;"> <!ENTITY Aacute "&#x00C1;"> <!ENTITY Acirc "&#x00C2;"> <!ENTITY Atilde "&#x00C3;"> <!ENTITY Auml "&#x00C4;"> <!ENTITY Aring "&#x00C5;"> <!ENTITY AElig "&#x00C6;"> <!ENTITY Ccedil "&#x00C7;"> <!ENTITY Egrave "&#x00C8;"> <!ENTITY Eacute "&#x00C9;"> <!ENTITY Ecirc "&#x00CA;"> <!ENTITY Euml "&#x00CB;"> <!ENTITY Igrave "&#x00CC;"> <!ENTITY Iacute "&#x00CD;"> <!ENTITY Icirc "&#x00CE;"> <!ENTITY Iuml "&#x00CF;"> <!ENTITY ETH "&#x00D0;"> <!ENTITY Ntilde "&#x00D1;"> <!ENTITY Ograve "&#x00D2;"> <!ENTITY Oacute "&#x00D3;"> <!ENTITY Ocirc "&#x00D4;"> <!ENTITY Otilde "&#x00D5;"> <!ENTITY Ouml "&#x00D6;"> <!ENTITY times "&#x00D7;"> <!ENTITY Oslash "&#x00D8;"> <!ENTITY Ugrave "&#x00D9;"> <!ENTITY Uacute "&#x00DA;"> <!ENTITY Ucirc "&#x00DB;"> <!ENTITY Uuml "&#x00DC;"> <!ENTITY Yacute "&#x00DD;"> <!ENTITY THORN "&#x00DE;"> <!ENTITY szlig "&#x00DF;"> <!ENTITY agrave "&#x00E0;"> <!ENTITY aacute "&#x00E1;"> <!ENTITY acirc "&#x00E2;"> <!ENTITY atilde "&#x00E3;"> <!ENTITY auml "&#x00E4;"> <!ENTITY aring "&#x00E5;"> <!ENTITY aelig "&#x00E6;"> <!ENTITY ccedil "&#x00E7;"> <!ENTITY egrave "&#x00E8;"> <!ENTITY eacute "&#x00E9;"> <!ENTITY ecirc "&#x00EA;"> <!ENTITY euml "&#x00EB;"> <!ENTITY igrave "&#x00EC;"> <!ENTITY iacute "&#x00ED;"> <!ENTITY icirc "&#x00EE;"> <!ENTITY iuml "&#x00EF;"> <!ENTITY eth "&#x00F0;"> <!ENTITY ntilde "&#x00F1;"> <!ENTITY ograve "&#x00F2;"> <!ENTITY oacute "&#x00F3;"> <!ENTITY ocirc "&#x00F4;"> <!ENTITY otilde "&#x00F5;"> <!ENTITY ouml "&#x00F6;"> <!ENTITY divide "&#x00F7;"> <!ENTITY oslash "&#x00F8;"> <!ENTITY ugrave "&#x00F9;"> <!ENTITY uacute "&#x00FA;"> <!ENTITY ucirc "&#x00FB;"> <!ENTITY uuml "&#x00FC;"> <!ENTITY yacute "&#x00FD;"> <!ENTITY thorn "&#x00FE;"> <!ENTITY yuml "&#x00FF;"> <!ENTITY OElig "&#x0152;"> <!ENTITY oelig "&#x0153;"> <!ENTITY Scaron "&#x0160;"> <!ENTITY scaron "&#x0161;"> <!ENTITY Yuml "&#x0178;"> <!ENTITY fnof "&#x0192;"> <!ENTITY circ "&#x02C6;"> <!ENTITY tilde "&#x02DC;"> <!ENTITY Alpha "&#x0391;"> <!ENTITY Beta "&#x0392;"> <!ENTITY Gamma "&#x0393;"> <!ENTITY Epsilon "&#x0395;"> <!ENTITY Zeta "&#x0396;"> <!ENTITY Eta "&#x0397;"> <!ENTITY Theta "&#x0398;"> <!ENTITY Iota "&#x0399;"> <!ENTITY Kappa "&#x039A;"> <!ENTITY Lambda "&#x039B;"> <!ENTITY Mu "&#x039C;"> <!ENTITY Nu "&#x039D;"> <!ENTITY Xi "&#x039E;"> <!ENTITY Omicron "&#x039F;"> <!ENTITY Pi "&#x03A0;"> <!ENTITY Rho "&#x03A1;"> <!ENTITY Sigma "&#x03A3;"> <!ENTITY Tau "&#x03A4;"> <!ENTITY Upsilon "&#x03A5;"> <!ENTITY Phi "&#x03A6;"> <!ENTITY Chi "&#x03A7;"> <!ENTITY Psi "&#x03A8;"> <!ENTITY Omega "&#x03A9;"> <!ENTITY alpha "&#x03B1;"> <!ENTITY beta "&#x03B2;"> <!ENTITY gamma "&#x03B3;"> <!ENTITY delta "&#x03B4;"> <!ENTITY epsilon "&#x03B5;"> <!ENTITY zeta "&#x03B6;"> <!ENTITY eta "&#x03B7;"> <!ENTITY theta "&#x03B8;"> <!ENTITY iota "&#x03B9;"> <!ENTITY kappa "&#x03BA;"> <!ENTITY lambda "&#x03BB;"> <!ENTITY mu "&#x03BC;"> <!ENTITY nu "&#x03BD;"> <!ENTITY xi "&#x03BE;"> <!ENTITY omicron "&#x03BF;"> <!ENTITY pi "&#x03C0;"> <!ENTITY rho "&#x03C1;"> <!ENTITY sigmaf "&#x03C2;"> <!ENTITY sigma "&#x03C3;"> <!ENTITY tau "&#x03C4;"> <!ENTITY upsilon "&#x03C5;"> <!ENTITY phi "&#x03C6;"> <!ENTITY chi "&#x03C7;"> <!ENTITY psi "&#x03C8;"> <!ENTITY omega "&#x03C9;"> <!ENTITY thetasym "&#x03D1;"> <!ENTITY upsih "&#x03D2;"> <!ENTITY piv "&#x03D6;"> <!ENTITY ensp "&#x2002;"> <!ENTITY emsp "&#x2003;"> <!ENTITY thinsp "&#x2009;"> <!ENTITY zwnj "&#x200C;"> <!ENTITY zwj "&#x200D;"> <!ENTITY lrm "&#x200E;"> <!ENTITY rlm "&#x200F;"> <!ENTITY ndash "&#x2013;"> <!ENTITY mdash "&#x2014;"> <!ENTITY lsquo "&#x2018;"> <!ENTITY rsquo "&#x2019;"> <!ENTITY sbquo "&#x201A;"> <!ENTITY ldquo "&#x201C;"> <!ENTITY rdquo "&#x201D;"> <!ENTITY bdquo "&#x201E;"> <!ENTITY dagger "&#x2020;"> <!ENTITY Dagger "&#x2021;"> <!ENTITY bull "&#x2022;"> <!ENTITY hellip "&#x2026;"> <!ENTITY permil "&#x2030;"> <!ENTITY prime "&#x2032;"> <!ENTITY Prime "&#x2033;"> <!ENTITY lsaquo "&#x2039;"> <!ENTITY rsaquo "&#x203A;"> <!ENTITY oline "&#x203E;"> <!ENTITY frasl "&#x2044;"> <!ENTITY euro "&#x20AC;"> <!ENTITY image "&#x2111;"> <!ENTITY weierp "&#x2118;"> <!ENTITY real "&#x211C;"> <!ENTITY trade "&#x2122;"> <!ENTITY alefsym "&#x2135;"> <!ENTITY larr "&#x2190;"> <!ENTITY uarr "&#x2191;"> <!ENTITY rarr "&#x2192;"> <!ENTITY darr "&#x2193;"> <!ENTITY harr "&#x2194;"> <!ENTITY crarr "&#x21B5;"> <!ENTITY lArr "&#x21D0;"> <!ENTITY uArr "&#x21D1;"> <!ENTITY rArr "&#x21D2;"> <!ENTITY dArr "&#x21D3;"> <!ENTITY hArr "&#x21D4;"> <!ENTITY forall "&#x2200;"> <!ENTITY part "&#x2202;"> <!ENTITY exist "&#x2203;"> <!ENTITY empty "&#x2205;"> <!ENTITY nabla "&#x2207;"> <!ENTITY isin "&#x2208;"> <!ENTITY notin "&#x2209;"> <!ENTITY ni "&#x220B;"> <!ENTITY prod "&#x220F;"> <!ENTITY sum "&#x2211;"> <!ENTITY minus "&#x2212;"> <!ENTITY lowast "&#x2217;"> <!ENTITY radic "&#x221A;"> <!ENTITY prop "&#x221D;"> <!ENTITY infin "&#x221E;"> <!ENTITY ang "&#x2220;"> <!ENTITY and "&#x2227;"> <!ENTITY or "&#x2228;"> <!ENTITY cap "&#x2229;"> <!ENTITY cup "&#x222A;"> <!ENTITY int "&#x222B;"> <!ENTITY there4 "&#x2234;"> <!ENTITY sim "&#x223C;"> <!ENTITY cong "&#x2245;"> <!ENTITY asymp "&#x2248;"> <!ENTITY ne "&#x2260;"> <!ENTITY equiv "&#x2261;"> <!ENTITY le "&#x2264;"> <!ENTITY ge "&#x2265;"> <!ENTITY sub "&#x2282;"> <!ENTITY sup "&#x2283;"> <!ENTITY nsub "&#x2284;"> <!ENTITY sube "&#x2286;"> <!ENTITY supe "&#x2287;"> <!ENTITY oplus "&#x2295;"> <!ENTITY otimes "&#x2297;"> <!ENTITY perp "&#x22A5;"> <!ENTITY sdot "&#x22C5;"> <!ENTITY lceil "&#x2308;"> <!ENTITY rceil "&#x2309;"> <!ENTITY lfloor "&#x230A;"> <!ENTITY rfloor "&#x230B;"> <!ENTITY lang "&#x2329;"> <!ENTITY rang "&#x232A;"> <!ENTITY loz "&#x25CA;"> <!ENTITY spades "&#x2660;"> <!ENTITY clubs "&#x2663;"> <!ENTITY hearts "&#x2665;"> <!ENTITY diams "&#x2666;"> ]>';
 	}
 }

--- a/src/wp-includes/SimplePie/Rating.php
+++ b/src/wp-includes/SimplePie/Rating.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -104,10 +103,8 @@ class SimplePie_Rating
 		{
 			return $this->scheme;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -121,9 +118,7 @@ class SimplePie_Rating
 		{
 			return $this->value;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }

--- a/src/wp-includes/SimplePie/Registry.php
+++ b/src/wp-includes/SimplePie/Registry.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -113,7 +112,7 @@ class SimplePie_Registry
 	 */
 	public function register($type, $class, $legacy = false)
 	{
-		if (!is_subclass_of($class, $this->default[$type]))
+		if (!@is_subclass_of($class, $this->default[$type]))
 		{
 			return false;
 		}

--- a/src/wp-includes/SimplePie/Restriction.php
+++ b/src/wp-includes/SimplePie/Restriction.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -113,10 +112,8 @@ class SimplePie_Restriction
 		{
 			return $this->relationship;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -130,10 +127,8 @@ class SimplePie_Restriction
 		{
 			return $this->type;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -147,9 +142,7 @@ class SimplePie_Restriction
 		{
 			return $this->value;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }

--- a/src/wp-includes/SimplePie/Source.php
+++ b/src/wp-includes/SimplePie/Source.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -80,10 +79,8 @@ class SimplePie_Source
 		{
 			return $this->data['child'][$namespace][$tag];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_base($element = array())
@@ -131,10 +128,8 @@ class SimplePie_Source
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_category($key = 0)
@@ -144,10 +139,8 @@ class SimplePie_Source
 		{
 			return $categories[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_categories()
@@ -201,10 +194,8 @@ class SimplePie_Source
 		{
 			return array_unique($categories);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_author($key = 0)
@@ -214,10 +205,8 @@ class SimplePie_Source
 		{
 			return $authors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_authors()
@@ -284,10 +273,8 @@ class SimplePie_Source
 		{
 			return array_unique($authors);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_contributor($key = 0)
@@ -297,10 +284,8 @@ class SimplePie_Source
 		{
 			return $contributors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_contributors()
@@ -355,10 +340,8 @@ class SimplePie_Source
 		{
 			return array_unique($contributors);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_link($key = 0, $rel = 'alternate')
@@ -368,10 +351,8 @@ class SimplePie_Source
 		{
 			return $links[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -450,10 +431,8 @@ class SimplePie_Source
 		{
 			return $this->data['links'][$rel];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_description()
@@ -494,10 +473,8 @@ class SimplePie_Source
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_copyright()
@@ -522,10 +499,8 @@ class SimplePie_Source
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_language()
@@ -546,10 +521,8 @@ class SimplePie_Source
 		{
 			return $this->sanitize($this->data['xml_lang'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_latitude()
@@ -562,10 +535,8 @@ class SimplePie_Source
 		{
 			return (float) $match[1];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_longitude()
@@ -582,10 +553,8 @@ class SimplePie_Source
 		{
 			return (float) $match[2];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_image_url()
@@ -602,10 +571,7 @@ class SimplePie_Source
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 }
-

--- a/src/wp-includes/SimplePie/XML/Declaration/Parser.php
+++ b/src/wp-includes/SimplePie/XML/Declaration/Parser.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -137,13 +136,11 @@ class SimplePie_XML_Declaration_Parser
 		{
 			return true;
 		}
-		else
-		{
-			$this->version = '';
-			$this->encoding = '';
-			$this->standalone = '';
-			return false;
-		}
+
+		$this->version = '';
+		$this->encoding = '';
+		$this->standalone = '';
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/SimplePie/gzdecode.php
+++ b/src/wp-includes/SimplePie/gzdecode.php
@@ -5,7 +5,7 @@
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2016, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -33,10 +33,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @copyright 2004-2016 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -339,10 +338,8 @@ class SimplePie_gzdecode
 			{
 				return false;
 			}
-			else
-			{
-				$this->position = $this->compressed_size - 8;
-			}
+
+			$this->position = $this->compressed_size - 8;
 
 			// Check CRC of data
 			$crc = current(unpack('V', substr($this->compressed_data, $this->position, 4)));
@@ -363,9 +360,7 @@ class SimplePie_gzdecode
 			// Wow, against all odds, we've actually got a valid gzip string
 			return true;
 		}
-		else
-		{
-			return false;
-		}
+
+		return false;
 	}
 }

--- a/src/wp-includes/class-simplepie.php
+++ b/src/wp-includes/class-simplepie.php
@@ -68,7 +68,7 @@ spl_autoload_register( 'wp_simplepie_autoload' );
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.5.5
+ * @version 1.5.6
  * @copyright 2004-2017 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
  * @author Sam Sneddon
@@ -85,7 +85,7 @@ define('SIMPLEPIE_NAME', 'SimplePie');
 /**
  * SimplePie Version
  */
-define('SIMPLEPIE_VERSION', '1.5.5');
+define('SIMPLEPIE_VERSION', '1.5.6');
 
 /**
  * SimplePie Build

--- a/src/wp-includes/class-simplepie.php
+++ b/src/wp-includes/class-simplepie.php
@@ -40,7 +40,7 @@ spl_autoload_register( 'wp_simplepie_autoload' );
  * A PHP-Based RSS and Atom Feed Framework.
  * Takes the hard work out of managing a complete RSS/Atom solution.
  *
- * Copyright (c) 2004-2012, Ryan Parman, Geoffrey Sneddon, Ryan McCue, and contributors
+ * Copyright (c) 2004-2017, Ryan Parman, Sam Sneddon, Ryan McCue, and contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are
@@ -68,10 +68,10 @@ spl_autoload_register( 'wp_simplepie_autoload' );
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @package SimplePie
- * @version 1.3.1
- * @copyright 2004-2012 Ryan Parman, Geoffrey Sneddon, Ryan McCue
+ * @version 1.5.5
+ * @copyright 2004-2017 Ryan Parman, Sam Sneddon, Ryan McCue
  * @author Ryan Parman
- * @author Geoffrey Sneddon
+ * @author Sam Sneddon
  * @author Ryan McCue
  * @link http://simplepie.org/ SimplePie
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -85,7 +85,7 @@ define('SIMPLEPIE_NAME', 'SimplePie');
 /**
  * SimplePie Version
  */
-define('SIMPLEPIE_VERSION', '1.3.1');
+define('SIMPLEPIE_VERSION', '1.5.5');
 
 /**
  * SimplePie Build
@@ -481,6 +481,13 @@ class SimplePie
 	public $feed_url;
 
 	/**
+	 * @var string Original feed URL, or new feed URL iff HTTP 301 Moved Permanently
+	 * @see SimplePie::subscribe_url()
+	 * @access private
+	 */
+	public $permanent_url = null;
+
+	/**
 	 * @var object Instance of SimplePie_File to use as a feed
 	 * @see SimplePie::set_file()
 	 * @access private
@@ -500,6 +507,13 @@ class SimplePie
 	 * @access private
 	 */
 	public $timeout = 10;
+
+	/**
+	 * @var array Custom curl options
+	 * @see SimplePie::set_curl_options()
+	 * @access private
+	 */
+	public $curl_options = array();
 
 	/**
 	 * @var bool Forces fsockopen() to be used for remote files instead
@@ -523,6 +537,14 @@ class SimplePie
 	 * @access private
 	 */
 	public $cache = true;
+
+	/**
+	 * @var bool Force SimplePie to fallback to expired cache, if enabled,
+	 * when feed is unavailable.
+	 * @see SimplePie::force_cache_fallback()
+	 * @access private
+	 */
+	public $force_cache_fallback = false;
 
 	/**
 	 * @var int Cache duration (in seconds)
@@ -630,6 +652,12 @@ class SimplePie
 	public $item_limit = 0;
 
 	/**
+	 * @var bool Stores if last-modified and/or etag headers were sent with the
+	 * request when checking a feed.
+	 */
+	public $check_modified = false;
+
+	/**
 	 * @var array Stores the default attributes to be stripped by strip_attributes().
 	 * @see SimplePie::strip_attributes()
 	 * @access private
@@ -637,11 +665,24 @@ class SimplePie
 	public $strip_attributes = array('bgsound', 'class', 'expr', 'id', 'style', 'onclick', 'onerror', 'onfinish', 'onmouseover', 'onmouseout', 'onfocus', 'onblur', 'lowsrc', 'dynsrc');
 
 	/**
+	 * @var array Stores the default attributes to add to different tags by add_attributes().
+	 * @see SimplePie::add_attributes()
+	 * @access private
+	 */
+	public $add_attributes = array('audio' => array('preload' => 'none'), 'iframe' => array('sandbox' => 'allow-scripts allow-same-origin'), 'video' => array('preload' => 'none'));
+
+	/**
 	 * @var array Stores the default tags to be stripped by strip_htmltags().
 	 * @see SimplePie::strip_htmltags()
 	 * @access private
 	 */
 	public $strip_htmltags = array('base', 'blink', 'body', 'doctype', 'embed', 'font', 'form', 'frame', 'frameset', 'html', 'iframe', 'input', 'marquee', 'meta', 'noscript', 'object', 'param', 'script', 'style');
+
+	/**
+	 * @var bool Should we throw exceptions, or use the old-style error property?
+	 * @access private
+	 */
+	public $enable_exceptions = false;
 
 	/**
 	 * The SimplePie class contains feed level data and options
@@ -659,9 +700,9 @@ class SimplePie
 	 */
 	public function __construct()
 	{
-		if (version_compare(PHP_VERSION, '5.2', '<'))
+		if (version_compare(PHP_VERSION, '5.6', '<'))
 		{
-			trigger_error('PHP 4.x, 5.0 and 5.1 are no longer supported. Please upgrade to PHP 5.2 or newer.');
+			trigger_error('Please upgrade to PHP 5.6 or newer.');
 			die();
 		}
 
@@ -672,7 +713,7 @@ class SimplePie
 		if (func_num_args() > 0)
 		{
 			$level = defined('E_USER_DEPRECATED') ? E_USER_DEPRECATED : E_USER_WARNING;
-			trigger_error('Passing parameters to the constructor is no longer supported. Please use set_feed_url(), set_cache_location(), and set_cache_location() directly.', $level);
+			trigger_error('Passing parameters to the constructor is no longer supported. Please use set_feed_url(), set_cache_location(), and set_cache_duration() directly.', $level);
 
 			$args = func_get_args();
 			switch (count($args)) {
@@ -700,7 +741,7 @@ class SimplePie
 	 */
 	public function __destruct()
 	{
-		if ((version_compare(PHP_VERSION, '5.3', '<') || !gc_enabled()) && !ini_get('zend.ze1_compatibility_mode'))
+		if (!gc_enabled())
 		{
 			if (!empty($this->data['items']))
 			{
@@ -763,6 +804,7 @@ class SimplePie
 		else
 		{
 			$this->feed_url = $this->registry->call('Misc', 'fix_protocol', array($url, 1));
+			$this->permanent_url = $this->feed_url;
 		}
 	}
 
@@ -777,6 +819,7 @@ class SimplePie
 		if ($file instanceof SimplePie_File)
 		{
 			$this->feed_url = $file->url;
+			$this->permanent_url = $this->feed_url;
 			$this->file =& $file;
 			return true;
 		}
@@ -802,7 +845,7 @@ class SimplePie
 	}
 
 	/**
-	 * Set the the default timeout for fetching remote feeds
+	 * Set the default timeout for fetching remote feeds
 	 *
 	 * This allows you to change the maximum time the feed's server to respond
 	 * and send the feed back.
@@ -813,6 +856,19 @@ class SimplePie
 	public function set_timeout($timeout = 10)
 	{
 		$this->timeout = (int) $timeout;
+	}
+
+	/**
+	 * Set custom curl options
+	 *
+	 * This allows you to change default curl options
+	 *
+	 * @since 1.0 Beta 3
+	 * @param array $curl_options Curl options to add to default settings
+	 */
+	public function set_curl_options(array $curl_options = array())
+	{
+		$this->curl_options = $curl_options;
 	}
 
 	/**
@@ -838,6 +894,21 @@ class SimplePie
 	public function enable_cache($enable = true)
 	{
 		$this->cache = (bool) $enable;
+	}
+
+	/**
+	 * SimplePie to continue to fall back to expired cache, if enabled, when
+	 * feed is unavailable.
+	 *
+	 * This tells SimplePie to ignore any file errors and fall back to cache
+	 * instead. This only works if caching is enabled and cached content
+	 * still exists.
+
+	 * @param bool $enable Force use of cache on fail.
+	 */
+	public function force_cache_fallback($enable = false)
+	{
+		$this->force_cache_fallback= (bool) $enable;
 	}
 
 	/**
@@ -1108,6 +1179,7 @@ class SimplePie
 			$this->strip_comments(false);
 			$this->strip_htmltags(false);
 			$this->strip_attributes(false);
+			$this->add_attributes(false);
 			$this->set_image_handler(false);
 		}
 	}
@@ -1154,16 +1226,25 @@ class SimplePie
 		$this->sanitize->strip_attributes($attribs);
 	}
 
+	public function add_attributes($attribs = '')
+	{
+		if ($attribs === '')
+		{
+			$attribs = $this->add_attributes;
+		}
+		$this->sanitize->add_attributes($attribs);
+	}
+
 	/**
 	 * Set the output encoding
 	 *
 	 * Allows you to override SimplePie's output to match that of your webpage.
 	 * This is useful for times when your webpages are not being served as
-	 * UTF-8.  This setting will be obeyed by {@see handle_content_type()}, and
+	 * UTF-8. This setting will be obeyed by {@see handle_content_type()}, and
 	 * is similar to {@see set_input_encoding()}.
 	 *
 	 * It should be noted, however, that not all character encodings can support
-	 * all characters.  If your page is being served as ISO-8859-1 and you try
+	 * all characters. If your page is being served as ISO-8859-1 and you try
 	 * to display a Japanese feed, you'll likely see garbled characters.
 	 * Because of this, it is highly recommended to ensure that your webpages
 	 * are served as UTF-8.
@@ -1205,8 +1286,8 @@ class SimplePie
 	/**
 	 * Set the handler to enable the display of cached images.
 	 *
-	 * @param str $page Web-accessible path to the handler_image.php file.
-	 * @param str $qs The query string that the value should be passed to.
+	 * @param string $page Web-accessible path to the handler_image.php file.
+	 * @param string $qs The query string that the value should be passed to.
 	 */
 	public function set_image_handler($page = false, $qs = 'i')
 	{
@@ -1231,9 +1312,19 @@ class SimplePie
 	}
 
 	/**
+	 * Enable throwing exceptions
+	 *
+	 * @param boolean $enable Should we throw exceptions, or use the old-style error property?
+	 */
+	public function enable_exceptions($enable = true)
+	{
+		$this->enable_exceptions = $enable;
+	}
+
+	/**
 	 * Initialize the feed object
 	 *
-	 * This is what makes everything happen.  Period.  This is where all of the
+	 * This is what makes everything happen. Period. This is where all of the
 	 * configuration options get processed, feeds are fetched, cached, and
 	 * parsed, and all of that other good stuff.
 	 *
@@ -1244,6 +1335,7 @@ class SimplePie
 		// Check absolute bare minimum requirements.
 		if (!extension_loaded('xml') || !extension_loaded('pcre'))
 		{
+			$this->error = 'XML or PCRE extensions not loaded!';
 			return false;
 		}
 		// Then check the xml extension is sane (i.e., libxml 2.7.x issue on PHP < 5.2.9 and libxml 2.7.0 to 2.7.2 on any version) if we don't have xmlreader.
@@ -1263,6 +1355,11 @@ class SimplePie
 			}
 		}
 
+		// The default sanitize class gets set in the constructor, check if it has
+		// changed.
+		if ($this->registry->get_class('Sanitize') !== 'SimplePie_Sanitize') {
+			$this->sanitize = $this->registry->create('Sanitize');
+		}
 		if (method_exists($this->sanitize, 'set_registry'))
 		{
 			$this->sanitize->set_registry($this->registry);
@@ -1271,7 +1368,7 @@ class SimplePie
 		// Pass whatever was set with config options over to the sanitizer.
 		// Pass the classes in for legacy support; new classes should use the registry instead
 		$this->sanitize->pass_cache_data($this->cache, $this->cache_location, $this->cache_name_function, $this->registry->get_class('Cache'));
-		$this->sanitize->pass_file_data($this->registry->get_class('File'), $this->timeout, $this->useragent, $this->force_fsockopen);
+		$this->sanitize->pass_file_data($this->registry->get_class('File'), $this->timeout, $this->useragent, $this->force_fsockopen, $this->curl_options);
 
 		if (!empty($this->multifeed_url))
 		{
@@ -1300,6 +1397,7 @@ class SimplePie
 
 		$this->error = null;
 		$this->data = array();
+		$this->check_modified = false;
 		$this->multifeed_objects = array();
 		$cache = false;
 
@@ -1310,7 +1408,8 @@ class SimplePie
 			// Decide whether to enable caching
 			if ($this->cache && $parsed_feed_url['scheme'] !== '')
 			{
-				$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $this->feed_url), 'spc'));
+				$url = $this->feed_url . ($this->force_feed ? '#force_feed' : '');
+				$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $url), 'spc'));
 			}
 
 			// Fetch the data via SimplePie_File into $this->raw_data
@@ -1325,13 +1424,20 @@ class SimplePie
 			list($headers, $sniffed) = $fetched;
 		}
 
+		// Empty response check
+		if(empty($this->raw_data)){
+			$this->error = "A feed could not be found at `$this->feed_url`. Empty body.";
+			$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
+			return false;
+		}
+
 		// Set up array of possible encodings
 		$encodings = array();
 
 		// First check to see if input has been overridden.
 		if ($this->input_encoding !== false)
 		{
-			$encodings[] = $this->input_encoding;
+			$encodings[] = strtoupper($this->input_encoding);
 		}
 
 		$application_types = array('application/xml', 'application/xml-dtd', 'application/xml-external-parsed-entity');
@@ -1353,14 +1459,14 @@ class SimplePie
 			{
 				if (isset($headers['content-type']) && preg_match('/;\x20?charset=([^;]*)/i', $headers['content-type'], $charset))
 				{
-					$encodings[] = $charset[1];
+					$encodings[] = strtoupper($charset[1]);
 				}
 				$encodings[] = 'US-ASCII';
 			}
 			// Text MIME-type default
 			elseif (substr($sniffed, 0, 5) === 'text/')
 			{
-				$encodings[] = 'US-ASCII';
+				$encodings[] = 'UTF-8';
 			}
 		}
 
@@ -1382,12 +1488,12 @@ class SimplePie
 				$parser = $this->registry->create('Parser');
 
 				// If it's parsed fine
-				if ($parser->parse($utf8_data, 'UTF-8'))
+				if ($parser->parse($utf8_data, 'UTF-8', $this->permanent_url))
 				{
 					$this->data = $parser->get_data();
 					if (!($this->get_type() & ~SIMPLEPIE_TYPE_NONE))
 					{
-						$this->error = "A feed could not be found at $this->feed_url. This does not appear to be a valid RSS or Atom feed.";
+						$this->error = "A feed could not be found at `$this->feed_url`. This does not appear to be a valid RSS or Atom feed.";
 						$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
 						return false;
 					}
@@ -1401,7 +1507,7 @@ class SimplePie
 					// Cache the file if caching is enabled
 					if ($cache && !$cache->save($this))
 					{
-						trigger_error("$this->cache_location is not writeable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
+						trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
 					}
 					return true;
 				}
@@ -1411,11 +1517,27 @@ class SimplePie
 		if (isset($parser))
 		{
 			// We have an error, just set SimplePie_Misc::error to it and quit
-			$this->error = sprintf('This XML document is invalid, likely due to invalid characters. XML error: %s at line %d, column %d', $parser->get_error_string(), $parser->get_current_line(), $parser->get_current_column());
+			$this->error = $this->feed_url;
+			$this->error .= sprintf(' is invalid XML, likely due to invalid characters. XML error: %s at line %d, column %d', $parser->get_error_string(), $parser->get_current_line(), $parser->get_current_column());
 		}
 		else
 		{
-			$this->error = 'The data could not be converted to UTF-8. You MUST have either the iconv or mbstring extension installed. Upgrading to PHP 5.x (which includes iconv) is highly recommended.';
+			$this->error = 'The data could not be converted to UTF-8.';
+			if (!extension_loaded('mbstring') && !extension_loaded('iconv') && !class_exists('\UConverter')) {
+				$this->error .= ' You MUST have either the iconv, mbstring or intl (PHP 5.5+) extension installed and enabled.';
+			} else {
+				$missingExtensions = array();
+				if (!extension_loaded('iconv')) {
+					$missingExtensions[] = 'iconv';
+				}
+				if (!extension_loaded('mbstring')) {
+					$missingExtensions[] = 'mbstring';
+				}
+				if (!class_exists('\UConverter')) {
+					$missingExtensions[] = 'intl (PHP 5.5+)';
+				}
+				$this->error .= ' Try installing/enabling the ' . implode(' or ', $missingExtensions) . ' extension.';
+			}
 		}
 
 		$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
@@ -1471,7 +1593,10 @@ class SimplePie
 				// Check if the cache has been updated
 				elseif ($cache->mtime() + $this->cache_duration < time())
 				{
-					// If we have last-modified and/or etag set
+					// Want to know if we tried to send last-modified and/or etag headers
+					// when requesting this file. (Note that it's up to the file to
+					// support this, but we don't always send the headers either.)
+					$this->check_modified = true;
 					if (isset($this->data['headers']['last-modified']) || isset($this->data['headers']['etag']))
 					{
 						$headers = array(
@@ -1486,18 +1611,28 @@ class SimplePie
 							$headers['if-none-match'] = $this->data['headers']['etag'];
 						}
 
-						$file = $this->registry->create('File', array($this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen));
+						$file = $this->registry->create('File', array($this->feed_url, $this->timeout/10, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 
 						if ($file->success)
 						{
 							if ($file->status_code === 304)
 							{
+								// Set raw_data to false here too, to signify that the cache
+								// is still valid.
+								$this->raw_data = false;
 								$cache->touch();
 								return true;
 							}
 						}
 						else
 						{
+							$this->check_modified = false;
+							if($this->force_cache_fallback)
+							{
+								$cache->touch();
+								return true;
+							}
+
 							unset($file);
 						}
 					}
@@ -1528,7 +1663,7 @@ class SimplePie
 				$headers = array(
 					'Accept' => 'application/atom+xml, application/rss+xml, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1',
 				);
-				$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen));
+				$file = $this->registry->create('File', array($this->feed_url, $this->timeout, 5, $headers, $this->useragent, $this->force_fsockopen, $this->curl_options));
 			}
 		}
 		// If the file connection has an error, set SimplePie::error to that and quit
@@ -1541,23 +1676,64 @@ class SimplePie
 		if (!$this->force_feed)
 		{
 			// Check if the supplied URL is a feed, if it isn't, look for it.
-			$locate = $this->registry->create('Locator', array(&$file, $this->timeout, $this->useragent, $this->max_checked_feeds));
+			$locate = $this->registry->create('Locator', array(&$file, $this->timeout, $this->useragent, $this->max_checked_feeds, $this->force_fsockopen, $this->curl_options));
 
 			if (!$locate->is_feed($file))
 			{
-				// We need to unset this so that if SimplePie::set_file() has been called that object is untouched
-				unset($file);
+				$copyStatusCode = $file->status_code;
+				$copyContentType = $file->headers['content-type'];
 				try
 				{
-					if (!($file = $locate->find($this->autodiscovery, $this->all_discovered_feeds)))
+					$microformats = false;
+					if (class_exists('DOMXpath') && function_exists('Mf2\parse')) {
+						$doc = new DOMDocument();
+						@$doc->loadHTML($file->body);
+						$xpath = new DOMXpath($doc);
+						// Check for both h-feed and h-entry, as both a feed with no entries
+						// and a list of entries without an h-feed wrapper are both valid.
+						$query = '//*[contains(concat(" ", @class, " "), " h-feed ") or '.
+							'contains(concat(" ", @class, " "), " h-entry ")]';
+						$result = $xpath->query($query);
+						$microformats = $result->length !== 0;
+					}
+					// Now also do feed discovery, but if microformats were found don't
+					// overwrite the current value of file.
+					$discovered = $locate->find($this->autodiscovery,
+					                            $this->all_discovered_feeds);
+					if ($microformats)
 					{
-						$this->error = "A feed could not be found at $this->feed_url. A feed with an invalid mime type may fall victim to this error, or " . SIMPLEPIE_NAME . " was unable to auto-discover it.. Use force_feed() if you are certain this URL is a real feed.";
-						$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
-						return false;
+						if ($hub = $locate->get_rel_link('hub'))
+						{
+							$self = $locate->get_rel_link('self');
+							$this->store_links($file, $hub, $self);
+						}
+						// Push the current file onto all_discovered feeds so the user can
+						// be shown this as one of the options.
+						if (isset($this->all_discovered_feeds)) {
+							$this->all_discovered_feeds[] = $file;
+						}
+					}
+					else
+					{
+						if ($discovered)
+						{
+							$file = $discovered;
+						}
+						else
+						{
+							// We need to unset this so that if SimplePie::set_file() has
+							// been called that object is untouched
+							unset($file);
+							$this->error = "A feed could not be found at `$this->feed_url`; the status code is `$copyStatusCode` and content-type is `$copyContentType`";
+							$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, __FILE__, __LINE__));
+							return false;
+						}
 					}
 				}
 				catch (SimplePie_Exception $e)
 				{
+					// We need to unset this so that if SimplePie::set_file() has been called that object is untouched
+					unset($file);
 					// This is usually because DOMDocument doesn't exist
 					$this->error = $e->getMessage();
 					$this->registry->call('Misc', 'error', array($this->error, E_USER_NOTICE, $e->getFile(), $e->getLine()));
@@ -1568,17 +1744,17 @@ class SimplePie
 					$this->data = array('url' => $this->feed_url, 'feed_url' => $file->url, 'build' => SIMPLEPIE_BUILD);
 					if (!$cache->save($this))
 					{
-						trigger_error("$this->cache_location is not writeable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
+						trigger_error("$this->cache_location is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.", E_USER_WARNING);
 					}
 					$cache = $this->registry->call('Cache', 'get_handler', array($this->cache_location, call_user_func($this->cache_name_function, $file->url), 'spc'));
 				}
-				$this->feed_url = $file->url;
 			}
+			$this->feed_url = $file->url;
 			$locate = null;
 		}
 
 		$this->raw_data = $file->body;
-
+		$this->permanent_url = $file->permanent_url;
 		$headers = $file->headers;
 		$sniffer = $this->registry->create('Content_Type_Sniffer', array(&$file));
 		$sniffed = $sniffer->get_type();
@@ -1587,7 +1763,7 @@ class SimplePie
 	}
 
 	/**
-	 * Get the error message for the occurred error.
+	 * Get the error message for the occured error
 	 *
 	 * @return string|array Error message, or array of messages for multifeeds
 	 */
@@ -1765,25 +1941,50 @@ class SimplePie
 	/**
 	 * Get the URL for the feed
 	 *
-	 * May or may not be different from the URL passed to {@see set_feed_url()},
-	 * depending on whether auto-discovery was used.
+	 * When the 'permanent' mode is enabled, returns the original feed URL,
+	 * except in the case of an `HTTP 301 Moved Permanently` status response,
+	 * in which case the location of the first redirection is returned.
 	 *
+	 * When the 'permanent' mode is disabled (default),
+	 * may or may not be different from the URL passed to {@see set_feed_url()},
+	 * depending on whether auto-discovery was used, and whether there were
+	 * any redirects along the way.
+	 *
+<<<<<<< HEAD
 	 * @since SimplePie Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
 	 * @todo If we have a perm redirect we should return the new URL
 	 * @todo When we make the above change, let's support <itunes:new-feed-url> as well
+=======
+	 * @since Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
+	 * @todo Support <itunes:new-feed-url>
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @todo Also, |atom:link|@rel=self
+	 * @param bool $permanent Permanent mode to return only the original URL or the first redirection
+	 * iff it is a 301 redirection
 	 * @return string|null
 	 */
-	public function subscribe_url()
+	public function subscribe_url($permanent = false)
 	{
-		if ($this->feed_url !== null)
+		if ($permanent)
 		{
-			return $this->sanitize($this->feed_url, SIMPLEPIE_CONSTRUCT_IRI);
+			if ($this->permanent_url !== null)
+			{
+				// sanitize encodes ampersands which are required when used in a url.
+				return str_replace('&amp;', '&',
+				                   $this->sanitize($this->permanent_url,
+				                                   SIMPLEPIE_CONSTRUCT_IRI));
+			}
 		}
 		else
 		{
-			return null;
+			if ($this->feed_url !== null)
+			{
+				return str_replace('&amp;', '&',
+				                   $this->sanitize($this->feed_url,
+				                                   SIMPLEPIE_CONSTRUCT_IRI));
+			}
 		}
+		return null;
 	}
 
 	/**
@@ -1980,10 +2181,8 @@ class SimplePie
 		{
 			return $this->get_link();
 		}
-		else
-		{
-			return $this->subscribe_url();
-		}
+
+		return $this->subscribe_url();
 	}
 
 	/**
@@ -1998,7 +2197,21 @@ class SimplePie
 	 */
 	public function sanitize($data, $type, $base = '')
 	{
-		return $this->sanitize->sanitize($data, $type, $base);
+		try
+		{
+			return $this->sanitize->sanitize($data, $type, $base);
+		}
+		catch (SimplePie_Exception $e)
+		{
+			if (!$this->enable_exceptions)
+			{
+				$this->error = $e->getMessage();
+				$this->registry->call('Misc', 'error', array($this->error, E_USER_WARNING, $e->getFile(), $e->getLine()));
+				return '';
+			}
+
+			throw $e;
+		}
 	}
 
 	/**
@@ -2039,17 +2252,20 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
 	 * Get a category for the feed
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie Unknown Version
 	 * @param int $key The category that you want to return.  Remember that arrays begin with 0, not 1
+=======
+	 * @since Unknown
+	 * @param int $key The category that you want to return. Remember that arrays begin with 0, not 1
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Category|null
 	 */
 	public function get_category($key = 0)
@@ -2059,10 +2275,8 @@ class SimplePie
 		{
 			return $categories[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2124,17 +2338,20 @@ class SimplePie
 		{
 			return array_unique($categories);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
 	 * Get an author for the feed
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie 1.1
 	 * @param int $key The author that you want to return.  Remember that arrays begin with 0, not 1
+=======
+	 * @since 1.1
+	 * @param int $key The author that you want to return. Remember that arrays begin with 0, not 1
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Author|null
 	 */
 	public function get_author($key = 0)
@@ -2144,10 +2361,8 @@ class SimplePie
 		{
 			return $authors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2222,17 +2437,20 @@ class SimplePie
 		{
 			return array_unique($authors);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
 	 * Get a contributor for the feed
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie 1.1
 	 * @param int $key The contrbutor that you want to return.  Remember that arrays begin with 0, not 1
+=======
+	 * @since 1.1
+	 * @param int $key The contrbutor that you want to return. Remember that arrays begin with 0, not 1
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Author|null
 	 */
 	public function get_contributor($key = 0)
@@ -2242,10 +2460,8 @@ class SimplePie
 		{
 			return $contributors[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2308,17 +2524,20 @@ class SimplePie
 		{
 			return array_unique($contributors);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
 	 * Get a single link for the feed
 	 *
+<<<<<<< HEAD
 	 * @since SimplePie 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
 	 * @param int $key The link that you want to return.  Remember that arrays begin with 0, not 1
+=======
+	 * @since 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
+	 * @param int $key The link that you want to return. Remember that arrays begin with 0, not 1
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @param string $rel The relationship of the link to return
 	 * @return string|null Link URL
 	 */
@@ -2329,10 +2548,8 @@ class SimplePie
 		{
 			return $links[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2424,14 +2641,18 @@ class SimplePie
 			}
 		}
 
-		if (isset($this->data['links'][$rel]))
+		if (isset($this->data['headers']['link']) &&
+		    preg_match('/<([^>]+)>; rel='.preg_quote($rel).'/',
+		               $this->data['headers']['link'], $match))
+		{
+			return array($match[1]);
+		}
+		else if (isset($this->data['links'][$rel]))
 		{
 			return $this->data['links'][$rel];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	public function get_all_discovered_feeds()
@@ -2486,10 +2707,8 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_HTML, $this->get_base($return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2522,10 +2741,8 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2566,10 +2783,8 @@ class SimplePie
 		{
 			return $this->sanitize($this->data['headers']['content-language'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2595,10 +2810,8 @@ class SimplePie
 		{
 			return (float) $match[1];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2627,10 +2840,8 @@ class SimplePie
 		{
 			return (float) $match[2];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2664,10 +2875,8 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_TEXT);
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2707,10 +2916,8 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 
@@ -2739,10 +2946,8 @@ class SimplePie
 		{
 			return $this->sanitize($return[0]['data'], SIMPLEPIE_CONSTRUCT_IRI, $this->get_base($return[0]));
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2765,10 +2970,8 @@ class SimplePie
 		{
 			return 88.0;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2791,10 +2994,8 @@ class SimplePie
 		{
 			return 31.0;
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2814,10 +3015,8 @@ class SimplePie
 		{
 			return $qty;
 		}
-		else
-		{
-			return ($qty > $max) ? $max : $qty;
-		}
+
+		return ($qty > $max) ? $max : $qty;
 	}
 
 	/**
@@ -2828,8 +3027,13 @@ class SimplePie
 	 * {@link http://php.net/foreach foreach()} loops.
 	 *
 	 * @see get_item_quantity()
+<<<<<<< HEAD
 	 * @since SimplePie Beta 2
 	 * @param int $key The item that you want to return.  Remember that arrays begin with 0, not 1
+=======
+	 * @since Beta 2
+	 * @param int $key The item that you want to return. Remember that arrays begin with 0, not 1
+>>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Item|null
 	 */
 	public function get_item($key = 0)
@@ -2839,10 +3043,8 @@ class SimplePie
 		{
 			return $items[$key];
 		}
-		else
-		{
-			return null;
-		}
+
+		return null;
 	}
 
 	/**
@@ -2856,7 +3058,7 @@ class SimplePie
 	 * @since SimplePie Beta 2
 	 * @param int $start Index to start at
 	 * @param int $end Number of items to return. 0 for all items after `$start`
-	 * @return array|null List of {@see SimplePie_Item} objects
+	 * @return SimplePie_Item[]|null List of {@see SimplePie_Item} objects
 	 */
 	public function get_items($start = 0, $end = 0)
 	{
@@ -2865,97 +3067,80 @@ class SimplePie
 			if (!empty($this->multifeed_objects))
 			{
 				$this->data['items'] = SimplePie::merge_items($this->multifeed_objects, $start, $end, $this->item_limit);
+				if (empty($this->data['items']))
+				{
+					return array();
+				}
+				return $this->data['items'];
 			}
-			else
+			$this->data['items'] = array();
+			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'entry'))
 			{
-				$this->data['items'] = array();
-				if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_ATOM_10, 'entry'))
+				$keys = array_keys($items);
+				foreach ($keys as $key)
 				{
-					$keys = array_keys($items);
-					foreach ($keys as $key)
-					{
-						$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
-					}
+					$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
 				}
-				if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'entry'))
+			}
+			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_ATOM_03, 'entry'))
+			{
+				$keys = array_keys($items);
+				foreach ($keys as $key)
 				{
-					$keys = array_keys($items);
-					foreach ($keys as $key)
-					{
-						$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
-					}
+					$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
 				}
-				if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'item'))
+			}
+			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_10, 'item'))
+			{
+				$keys = array_keys($items);
+				foreach ($keys as $key)
 				{
-					$keys = array_keys($items);
-					foreach ($keys as $key)
-					{
-						$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
-					}
+					$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
 				}
-				if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'item'))
+			}
+			if ($items = $this->get_feed_tags(SIMPLEPIE_NAMESPACE_RSS_090, 'item'))
+			{
+				$keys = array_keys($items);
+				foreach ($keys as $key)
 				{
-					$keys = array_keys($items);
-					foreach ($keys as $key)
-					{
-						$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
-					}
+					$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
 				}
-				if ($items = $this->get_channel_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'item'))
+			}
+			if ($items = $this->get_channel_tags(SIMPLEPIE_NAMESPACE_RSS_20, 'item'))
+			{
+				$keys = array_keys($items);
+				foreach ($keys as $key)
 				{
-					$keys = array_keys($items);
-					foreach ($keys as $key)
-					{
-						$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
-					}
+					$this->data['items'][] = $this->registry->create('Item', array($this, $items[$key]));
 				}
 			}
 		}
 
-		if (!empty($this->data['items']))
-		{
-			// If we want to order it by date, check if all items have a date, and then sort it
-			if ($this->order_by_date && empty($this->multifeed_objects))
-			{
-				if (!isset($this->data['ordered_items']))
-				{
-					$do_sort = true;
-					foreach ($this->data['items'] as $item)
-					{
-						if (!$item->get_date('U'))
-						{
-							$do_sort = false;
-							break;
-						}
-					}
-					$item = null;
-					$this->data['ordered_items'] = $this->data['items'];
-					if ($do_sort)
-					{
-						usort($this->data['ordered_items'], array(get_class($this), 'sort_items'));
-					}
-				}
-				$items = $this->data['ordered_items'];
-			}
-			else
-			{
-				$items = $this->data['items'];
-			}
-
-			// Slice the data as desired
-			if ($end === 0)
-			{
-				return array_slice($items, $start);
-			}
-			else
-			{
-				return array_slice($items, $start, $end);
-			}
-		}
-		else
+		if (empty($this->data['items']))
 		{
 			return array();
 		}
+
+		if ($this->order_by_date)
+		{
+			if (!isset($this->data['ordered_items']))
+			{
+				$this->data['ordered_items'] = $this->data['items'];
+				usort($this->data['ordered_items'], array(get_class($this), 'sort_items'));
+		 	}
+			$items = $this->data['ordered_items'];
+		}
+		else
+		{
+			$items = $this->data['items'];
+		}
+		// Slice the data as desired
+		if ($end === 0)
+		{
+			return array_slice($items, $start);
+		}
+
+		return array_slice($items, $start, $end);
 	}
 
 	/**
@@ -2982,7 +3167,7 @@ class SimplePie
 
 		if (($url = $this->get_link()) !== null)
 		{
-			return 'http://g.etfv.co/' . urlencode($url);
+			return 'https://www.google.com/s2/favicons?domain=' . urlencode($url);
 		}
 
 		return false;
@@ -3027,7 +3212,19 @@ class SimplePie
 	 */
 	public static function sort_items($a, $b)
 	{
-		return $a->get_date('U') <= $b->get_date('U');
+		$a_date = $a->get_date('U');
+		$b_date = $b->get_date('U');
+		if ($a_date && $b_date) {
+			return $a_date > $b_date ? -1 : 1;
+		}
+		// Sort items without dates to the top.
+		if ($a_date) {
+			return 1;
+		}
+		if ($b_date) {
+			return -1;
+		}
+		return 0;
 	}
 
 	/**
@@ -3060,34 +3257,55 @@ class SimplePie
 				}
 			}
 
-			$do_sort = true;
-			foreach ($items as $item)
-			{
-				if (!$item->get_date('U'))
-				{
-					$do_sort = false;
-					break;
-				}
-			}
-			$item = null;
-			if ($do_sort)
-			{
-				usort($items, array(get_class($urls[0]), 'sort_items'));
-			}
+			usort($items, array(get_class($urls[0]), 'sort_items'));
 
 			if ($end === 0)
 			{
 				return array_slice($items, $start);
 			}
+
+			return array_slice($items, $start, $end);
+		}
+
+		trigger_error('Cannot merge zero SimplePie objects', E_USER_WARNING);
+		return array();
+	}
+
+	/**
+	 * Store PubSubHubbub links as headers
+	 *
+	 * There is no way to find PuSH links in the body of a microformats feed,
+	 * so they are added to the headers when found, to be used later by get_links.
+	 * @param SimplePie_File $file
+	 * @param string $hub
+	 * @param string $self
+	 */
+	private function store_links(&$file, $hub, $self) {
+		if (isset($file->headers['link']['hub']) ||
+			  (isset($file->headers['link']) &&
+			   preg_match('/rel=hub/', $file->headers['link'])))
+		{
+			return;
+		}
+
+		if ($hub)
+		{
+			if (isset($file->headers['link']))
+			{
+				if ($file->headers['link'] !== '')
+				{
+					$file->headers['link'] = ', ';
+				}
+			}
 			else
 			{
-				return array_slice($items, $start, $end);
+				$file->headers['link'] = '';
 			}
-		}
-		else
-		{
-			trigger_error('Cannot merge zero SimplePie objects', E_USER_WARNING);
-			return array();
+			$file->headers['link'] .= '<'.$hub.'>; rel=hub';
+			if ($self)
+			{
+				$file->headers['link'] .= ', <'.$self.'>; rel=self';
+			}
 		}
 	}
 }

--- a/src/wp-includes/class-simplepie.php
+++ b/src/wp-includes/class-simplepie.php
@@ -1950,14 +1950,8 @@ class SimplePie
 	 * depending on whether auto-discovery was used, and whether there were
 	 * any redirects along the way.
 	 *
-<<<<<<< HEAD
-	 * @since SimplePie Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
-	 * @todo If we have a perm redirect we should return the new URL
-	 * @todo When we make the above change, let's support <itunes:new-feed-url> as well
-=======
 	 * @since Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
 	 * @todo Support <itunes:new-feed-url>
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @todo Also, |atom:link|@rel=self
 	 * @param bool $permanent Permanent mode to return only the original URL or the first redirection
 	 * iff it is a 301 redirection
@@ -2259,13 +2253,8 @@ class SimplePie
 	/**
 	 * Get a category for the feed
 	 *
-<<<<<<< HEAD
-	 * @since SimplePie Unknown Version
-	 * @param int $key The category that you want to return.  Remember that arrays begin with 0, not 1
-=======
 	 * @since Unknown
 	 * @param int $key The category that you want to return. Remember that arrays begin with 0, not 1
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Category|null
 	 */
 	public function get_category($key = 0)
@@ -2345,13 +2334,8 @@ class SimplePie
 	/**
 	 * Get an author for the feed
 	 *
-<<<<<<< HEAD
-	 * @since SimplePie 1.1
-	 * @param int $key The author that you want to return.  Remember that arrays begin with 0, not 1
-=======
 	 * @since 1.1
 	 * @param int $key The author that you want to return. Remember that arrays begin with 0, not 1
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Author|null
 	 */
 	public function get_author($key = 0)
@@ -2444,13 +2428,8 @@ class SimplePie
 	/**
 	 * Get a contributor for the feed
 	 *
-<<<<<<< HEAD
-	 * @since SimplePie 1.1
-	 * @param int $key The contrbutor that you want to return.  Remember that arrays begin with 0, not 1
-=======
 	 * @since 1.1
 	 * @param int $key The contrbutor that you want to return. Remember that arrays begin with 0, not 1
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Author|null
 	 */
 	public function get_contributor($key = 0)
@@ -2531,13 +2510,8 @@ class SimplePie
 	/**
 	 * Get a single link for the feed
 	 *
-<<<<<<< HEAD
-	 * @since SimplePie 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
-	 * @param int $key The link that you want to return.  Remember that arrays begin with 0, not 1
-=======
 	 * @since 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
 	 * @param int $key The link that you want to return. Remember that arrays begin with 0, not 1
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @param string $rel The relationship of the link to return
 	 * @return string|null Link URL
 	 */
@@ -3027,13 +3001,8 @@ class SimplePie
 	 * {@link http://php.net/foreach foreach()} loops.
 	 *
 	 * @see get_item_quantity()
-<<<<<<< HEAD
-	 * @since SimplePie Beta 2
-	 * @param int $key The item that you want to return.  Remember that arrays begin with 0, not 1
-=======
 	 * @since Beta 2
 	 * @param int $key The item that you want to return. Remember that arrays begin with 0, not 1
->>>>>>> d12ad5050b (External Libraries: Update the SimplePie library to the latest version (1.5.5).)
 	 * @return SimplePie_Item|null
 	 */
 	public function get_item($key = 0)


### PR DESCRIPTION
## Description
This PR backports 2 upstream change sets (47733 and 49176)
These upgrade SimplePie to 1.5.5  and then 1.5.6
This is a fix for #240  

## Motivation and context
Upgrade of external libraries
Fix for open Issue #204

## How has this been tested?
Upstream backport

## Screenshots
N/A

## Types of changes
- Enhancement
- Bug fix - this will also tackle PHP8 errors
