### PR TITLE
WP-r48788: Code Modernization: Remove `final` keyword from private me…

### DIFF
--- a/src/wp-includes/class-wp-session-tokens.php
+++ b/src/wp-includes/class-wp-session-tokens.php
@@ -66,7 +66,7 @@ abstract class WP_Session_Tokens {
 	 * @param string $token Session token to hash.
 	 * @return string A hash of the session token (a verifier).
 	 */
-	final private function hash_token( $token ) {
+	private function hash_token( $token ) {
 		// If ext/hash is not present, use sha1() instead.
 		if ( function_exists( 'hash' ) ) {
 			return hash( 'sha256', $token );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -56,7 +56,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		return $meta_value;
 	}
 
-	final private function _getSingleSitePrimitiveCaps() {
+	private function _getSingleSitePrimitiveCaps() {
 		return array(
 
 			'unfiltered_html'        => array( 'administrator', 'editor' ),
@@ -135,7 +135,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 	}
 
-	final private function _getMultiSitePrimitiveCaps() {
+	private function _getMultiSitePrimitiveCaps() {
 		return array(
 
 			'unfiltered_html'        => array(),
@@ -215,7 +215,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 	}
 
-	final private function _getSingleSiteMetaCaps() {
+	private function _getSingleSiteMetaCaps() {
 		return array(
 			'create_sites'           => array(),
 			'delete_sites'           => array(),
@@ -252,7 +252,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		);
 	}
 
-	final private function _getMultiSiteMetaCaps() {
+	private function _getMultiSiteMetaCaps() {
 		return array(
 			'create_sites'           => array(),
 			'delete_sites'           => array(),


### PR DESCRIPTION
Declaring a `private` method as `final` is an oxymoron, as `private` methods cannot be overloaded anyway.

Using `final private function...` will generate a warning in PHP 8.

WP:Props jrf.
Fixes https://core.trac.wordpress.org/ticket/50897.

---

Merges https://core.trac.wordpress.org/changeset/48788 / WordPress/wordpress-develop@1bf0a780b3 to ClassicPress.

## Description
After installing CP on server with PHP 8.0, there are errors.

## How has this been tested?
After backporting the patch from upstream. The error message disappears. See screenshots.

## Screenshots
### Before
![Screenshot 2021-07-20 at 12 34 06](https://user-images.githubusercontent.com/7713923/126300497-2566bd54-fa30-467c-9d62-f703b261b762.png)

### After
![Screenshot 2021-07-20 at 12 38 21](https://user-images.githubusercontent.com/7713923/126300432-1a0411db-117b-417a-ae6d-ba88554b4b3f.png)

## Types of changes
- [x] Bug fix
