### PR TITLE
Fix Broken Comments in PHP8

### DIFF
--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -454,8 +454,14 @@ class WP_Comment_Query {
 		 */
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
+<<<<<<< HEAD
 		// Convert to WP_Comment instances
 		$comments = array_map( 'get_comment', $_comments );
+=======
+		// Convert to WP_Comment instances.
+		array_walk( $_comments, 'get_comment' );
+		$comments = $_comments;
+>>>>>>> 29bfc56ca2 (Code Modernization: Fix PHP 8 "argument must be passed by reference, value given" error in `WP_Comment_Query::get_comments()`.)
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -454,14 +454,9 @@ class WP_Comment_Query {
 		 */
 		$_comments = apply_filters_ref_array( 'the_comments', array( $_comments, &$this ) );
 
-<<<<<<< HEAD
-		// Convert to WP_Comment instances
-		$comments = array_map( 'get_comment', $_comments );
-=======
 		// Convert to WP_Comment instances.
 		array_walk( $_comments, 'get_comment' );
 		$comments = $_comments;
->>>>>>> 29bfc56ca2 (Code Modernization: Fix PHP 8 "argument must be passed by reference, value given" error in `WP_Comment_Query::get_comments()`.)
 
 		if ( $this->query_vars['hierarchical'] ) {
 			$comments = $this->fill_descendants( $comments );


### PR DESCRIPTION
Closes https://github.com/ClassicPress/ClassicPress/issues/761

WP-r48838: Code Modernization: Fix PHP 8 "argument must be passed by reference, value given" error in `WP_Comment_Query::get_comments()`.

The WP native `get_comment()` function expects the first argument `$comment` to be passed by reference.

The PHP `array_map()` function, however, passes by value, not by reference, resulting in an "arguments must be passed by reference, value given" error.

The PHP native `array_walk()` function does pass by reference. Using this prevents the error on PHP 8 and maintains the existing behaviour on PHP < 8.

WP:Props jrf.
See https://core.trac.wordpress.org/ticket/50913.

Merges https://core.trac.wordpress.org/changeset/48838 / WordPress/wordpress-develop@29bfc56 to ClassicPress.

## Screenshots
### Before
![Screenshot 2021-07-21 at 08 16 50](https://user-images.githubusercontent.com/7713923/126436267-0c136d93-b7f1-4f8e-a87a-83a514923a4e.png)
![Screenshot 2021-07-21 at 08 16 00](https://user-images.githubusercontent.com/7713923/126436271-907fd4b1-fd34-4427-87bc-860906500864.png)

### After
![Screenshot 2021-07-21 at 08 17 28](https://user-images.githubusercontent.com/7713923/126436294-dd7eb921-5467-47dc-a5db-43e35e3f5a18.png)
![Screenshot 2021-07-21 at 08 15 33](https://user-images.githubusercontent.com/7713923/126436298-6b01e4b3-847f-439a-b033-93b05833c0ae.png)

## Types of changes
- [x] Bug fix