### PR TITLE
Enhance backport script

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -255,15 +255,11 @@ else
 	echo "${color_bold_red}WARNING: Conflict detected!${color_reset}"
 	echo "Fix and commit the files that contain <<""<< or >>"">> conflict markers:"
 	git log -n 1 \
-		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif ( /^.*(_enqueues).*$/ ) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
+		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
 	echo "${color_bold_red}=======${color_reset}"
 	echo
 	echo "If you're not sure how to do this, just push your changes to GitHub"
 	echo "and we can take care of it!"
-	echo
-	echo "There were also changes made from the following upstream locations"
-	git log -n 1 \
-		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif ( /^.*(_enqueues).*$/ ) { print; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { $p = 0; } }'
 	echo
 	if [ $current_branch = no ]; then
 		echo "git push origin $branch"

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -255,7 +255,25 @@ else
 	echo "${color_bold_red}WARNING: Conflict detected!${color_reset}"
 	echo "Fix and commit the files that contain <<""<< or >>"">> conflict markers:"
 	git log -n 1 \
-		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
+		| perl -we '
+			my $p = 0;
+			while (<>) {
+				if (/^\s+Conflicts:$/) {
+					$p = 1;
+				} elsif (/^\s+$/) {
+					$p = 0;
+				} elsif ($p) {
+					# Look for known renames in WP history after fork
+					chomp;
+					s/^[\s-]+//;
+					my $cp_filename = $_;
+					$cp_filename =~ s#^src/js/_enqueues/#src/wp-includes/js/#;
+					print "    - $_\n";
+					if ($cp_filename ne $_) {
+						print "      (probable CP path: $cp_filename)\n";
+					}
+				}
+			}'
 	echo "${color_bold_red}=======${color_reset}"
 	echo
 	echo "If you're not sure how to do this, just push your changes to GitHub"

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -171,7 +171,7 @@ fi
 
 echo "Backporting commit using git cherry-pick"
 set +e
-cmd __failure_allowed git cherry-pick --no-commit "$commit_short"
+cmd __failure_allowed git cherry-pick --no-commit --find-renames "$commit_short"
 conflict_status=$?
 set -e
 
@@ -255,11 +255,15 @@ else
 	echo "${color_bold_red}WARNING: Conflict detected!${color_reset}"
 	echo "Fix and commit the files that contain <<""<< or >>"">> conflict markers:"
 	git log -n 1 \
-		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
+		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif ( /^.*(_enqueues).*$/ ) { $p = 1; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { print; } }'
 	echo "${color_bold_red}=======${color_reset}"
 	echo
 	echo "If you're not sure how to do this, just push your changes to GitHub"
 	echo "and we can take care of it!"
+	echo
+	echo "There were also changes made from the following upstream locations"
+	git log -n 1 \
+		| perl -we 'my $p = 0; while (<>) { if (/^\s+Conflicts:$/) { $p = 1; } elsif ( /^.*(_enqueues).*$/ ) { print; } elsif (/^\s+$/) { $p = 0; } elsif ($p) { $p = 0; } }'
 	echo
 	if [ $current_branch = no ]; then
 		echo "git push origin $branch"


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
The current backport script works very well in the majority of cases however upstream some javascript files are located in a folder called `_enqueues` and they are built and moved into the correct location from there. This causes issue in back porting and currently any changes in these file are conflicts and must be manually back ported.

## Motivation and context
We can try to enhance the script to automatically located renames files and do the backporting for us and then report that this files were conflicting still bu perhaps a little differently than major code conflicts.

This PR aims to:
- Add --find-renames to cherry-pick command to enable backporting of file changes in different locations
- Update `perl` conflict reporting to show issues with these backports a little differently


## How has this been tested?
I have veen testing by back porting an example change set from upstream - the change set is `48288`.

## Screenshots
N/A

## Types of changes
- New feature / Enhancement
