### PR TITLE
Fix/heic

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -15,6 +15,7 @@ add_action( 'activity_box_end', 'wp_dashboard_quota' );
 
 // Media hooks.
 add_action( 'attachment_submitbox_misc_actions', 'attachment_submitbox_metadata' );
+add_filter( 'plupload_init', 'wp_show_heic_upload_error' );
 
 add_action( 'media_upload_image', 'wp_media_upload_handler' );
 add_action( 'media_upload_audio', 'wp_media_upload_handler' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -475,6 +475,11 @@ add_filter( 'the_content', 'do_shortcode', 11 ); // AFTER wpautop()
 // Media
 add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 add_action( 'customize_controls_enqueue_scripts', 'wp_plupload_default_settings' );
+<<<<<<< HEAD
+=======
+add_action( 'plugins_loaded', '_wp_add_additional_image_sizes', 0 );
+add_filter( 'plupload_default_settings', 'wp_show_heic_upload_error' );
+>>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 
 // Nav menu
 add_filter( 'nav_menu_item_id', '_nav_menu_item_id_use_once', 10, 2 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -475,11 +475,7 @@ add_filter( 'the_content', 'do_shortcode', 11 ); // AFTER wpautop()
 // Media
 add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 add_action( 'customize_controls_enqueue_scripts', 'wp_plupload_default_settings' );
-<<<<<<< HEAD
-=======
-add_action( 'plugins_loaded', '_wp_add_additional_image_sizes', 0 );
 add_filter( 'plupload_default_settings', 'wp_show_heic_upload_error' );
->>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 
 // Nav menu
 add_filter( 'nav_menu_item_id', '_nav_menu_item_id_use_once', 10, 2 );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2473,7 +2473,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		} else {
 			if ( $type !== $real_mime ) {
 				/*
-				 * Everything else including image/* and application/*: 
+				 * Everything else including image/* and application/*:
 				 * If the real content type doesn't match the file extension, assume it's dangerous.
 				 */
 				$type = $ext = false;
@@ -2482,7 +2482,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 		}
 	}
 
-	// The mime type must be allowed 
+	// The mime type must be allowed
 	if ( $type ) {
 		$allowed = get_allowed_mime_types();
 
@@ -2561,7 +2561,6 @@ function wp_get_mime_types() {
 	 * @param array $wp_get_mime_types Mime types keyed by the file extension regex
 	 *                                 corresponding to those types.
 	 */
-<<<<<<< HEAD
 	return apply_filters( 'mime_types', array(
 	// Image formats.
 	'jpg|jpeg|jpe' => 'image/jpeg',
@@ -2570,6 +2569,7 @@ function wp_get_mime_types() {
 	'bmp' => 'image/bmp',
 	'tiff|tif' => 'image/tiff',
 	'ico' => 'image/x-icon',
+	'heic' => 'image/heic',
 	// Video formats.
 	'asf|asx' => 'video/x-ms-asf',
 	'wmv' => 'video/x-ms-wmv',
@@ -2665,115 +2665,6 @@ function wp_get_mime_types() {
 	'numbers' => 'application/vnd.apple.numbers',
 	'pages' => 'application/vnd.apple.pages',
 	) );
-=======
-	return apply_filters(
-		'mime_types',
-		array(
-			// Image formats.
-			'jpg|jpeg|jpe'                 => 'image/jpeg',
-			'gif'                          => 'image/gif',
-			'png'                          => 'image/png',
-			'bmp'                          => 'image/bmp',
-			'tiff|tif'                     => 'image/tiff',
-			'ico'                          => 'image/x-icon',
-			'heic'                         => 'image/heic',
-			// Video formats.
-			'asf|asx'                      => 'video/x-ms-asf',
-			'wmv'                          => 'video/x-ms-wmv',
-			'wmx'                          => 'video/x-ms-wmx',
-			'wm'                           => 'video/x-ms-wm',
-			'avi'                          => 'video/avi',
-			'divx'                         => 'video/divx',
-			'flv'                          => 'video/x-flv',
-			'mov|qt'                       => 'video/quicktime',
-			'mpeg|mpg|mpe'                 => 'video/mpeg',
-			'mp4|m4v'                      => 'video/mp4',
-			'ogv'                          => 'video/ogg',
-			'webm'                         => 'video/webm',
-			'mkv'                          => 'video/x-matroska',
-			'3gp|3gpp'                     => 'video/3gpp',  // Can also be audio.
-			'3g2|3gp2'                     => 'video/3gpp2', // Can also be audio.
-			// Text formats.
-			'txt|asc|c|cc|h|srt'           => 'text/plain',
-			'csv'                          => 'text/csv',
-			'tsv'                          => 'text/tab-separated-values',
-			'ics'                          => 'text/calendar',
-			'rtx'                          => 'text/richtext',
-			'css'                          => 'text/css',
-			'htm|html'                     => 'text/html',
-			'vtt'                          => 'text/vtt',
-			'dfxp'                         => 'application/ttaf+xml',
-			// Audio formats.
-			'mp3|m4a|m4b'                  => 'audio/mpeg',
-			'aac'                          => 'audio/aac',
-			'ra|ram'                       => 'audio/x-realaudio',
-			'wav'                          => 'audio/wav',
-			'ogg|oga'                      => 'audio/ogg',
-			'flac'                         => 'audio/flac',
-			'mid|midi'                     => 'audio/midi',
-			'wma'                          => 'audio/x-ms-wma',
-			'wax'                          => 'audio/x-ms-wax',
-			'mka'                          => 'audio/x-matroska',
-			// Misc application formats.
-			'rtf'                          => 'application/rtf',
-			'js'                           => 'application/javascript',
-			'pdf'                          => 'application/pdf',
-			'swf'                          => 'application/x-shockwave-flash',
-			'class'                        => 'application/java',
-			'tar'                          => 'application/x-tar',
-			'zip'                          => 'application/zip',
-			'gz|gzip'                      => 'application/x-gzip',
-			'rar'                          => 'application/rar',
-			'7z'                           => 'application/x-7z-compressed',
-			'exe'                          => 'application/x-msdownload',
-			'psd'                          => 'application/octet-stream',
-			'xcf'                          => 'application/octet-stream',
-			// MS Office formats.
-			'doc'                          => 'application/msword',
-			'pot|pps|ppt'                  => 'application/vnd.ms-powerpoint',
-			'wri'                          => 'application/vnd.ms-write',
-			'xla|xls|xlt|xlw'              => 'application/vnd.ms-excel',
-			'mdb'                          => 'application/vnd.ms-access',
-			'mpp'                          => 'application/vnd.ms-project',
-			'docx'                         => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-			'docm'                         => 'application/vnd.ms-word.document.macroEnabled.12',
-			'dotx'                         => 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
-			'dotm'                         => 'application/vnd.ms-word.template.macroEnabled.12',
-			'xlsx'                         => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-			'xlsm'                         => 'application/vnd.ms-excel.sheet.macroEnabled.12',
-			'xlsb'                         => 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
-			'xltx'                         => 'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
-			'xltm'                         => 'application/vnd.ms-excel.template.macroEnabled.12',
-			'xlam'                         => 'application/vnd.ms-excel.addin.macroEnabled.12',
-			'pptx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-			'pptm'                         => 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
-			'ppsx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
-			'ppsm'                         => 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
-			'potx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.template',
-			'potm'                         => 'application/vnd.ms-powerpoint.template.macroEnabled.12',
-			'ppam'                         => 'application/vnd.ms-powerpoint.addin.macroEnabled.12',
-			'sldx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.slide',
-			'sldm'                         => 'application/vnd.ms-powerpoint.slide.macroEnabled.12',
-			'onetoc|onetoc2|onetmp|onepkg' => 'application/onenote',
-			'oxps'                         => 'application/oxps',
-			'xps'                          => 'application/vnd.ms-xpsdocument',
-			// OpenOffice formats.
-			'odt'                          => 'application/vnd.oasis.opendocument.text',
-			'odp'                          => 'application/vnd.oasis.opendocument.presentation',
-			'ods'                          => 'application/vnd.oasis.opendocument.spreadsheet',
-			'odg'                          => 'application/vnd.oasis.opendocument.graphics',
-			'odc'                          => 'application/vnd.oasis.opendocument.chart',
-			'odb'                          => 'application/vnd.oasis.opendocument.database',
-			'odf'                          => 'application/vnd.oasis.opendocument.formula',
-			// WordPerfect formats.
-			'wp|wpd'                       => 'application/wordperfect',
-			// iWork formats.
-			'key'                          => 'application/vnd.apple.keynote',
-			'numbers'                      => 'application/vnd.apple.numbers',
-			'pages'                        => 'application/vnd.apple.pages',
-		)
-	);
->>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2686,6 +2686,7 @@ function wp_get_ext_types() {
 	 * @param array $ext2type Multi-dimensional array with extensions for a default set
 	 *                        of file types.
 	 */
+<<<<<<< HEAD
 	return apply_filters( 'ext2type', array(
 		'image'       => array( 'jpg', 'jpeg', 'jpe',  'gif',  'png',  'bmp',   'tif',  'tiff', 'ico' ),
 		'audio'       => array( 'aac', 'ac3',  'aif',  'aiff', 'flac', 'm3a',  'm4a',   'm4b',  'mka',  'mp1',  'mp2',  'mp3', 'ogg', 'oga', 'ram', 'wav', 'wma' ),
@@ -2697,6 +2698,22 @@ function wp_get_ext_types() {
 		'archive'     => array( 'bz2', 'cab',  'dmg',  'gz',   'rar',  'sea',   'sit',  'sqx',  'tar',  'tgz',  'zip', '7z' ),
 		'code'        => array( 'css', 'htm',  'html', 'php',  'js' ),
 	) );
+=======
+	return apply_filters(
+		'ext2type',
+		array(
+			'image'       => array( 'jpg', 'jpeg', 'jpe', 'gif', 'png', 'bmp', 'tif', 'tiff', 'ico', 'heic' ),
+			'audio'       => array( 'aac', 'ac3', 'aif', 'aiff', 'flac', 'm3a', 'm4a', 'm4b', 'mka', 'mp1', 'mp2', 'mp3', 'ogg', 'oga', 'ram', 'wav', 'wma' ),
+			'video'       => array( '3g2', '3gp', '3gpp', 'asf', 'avi', 'divx', 'dv', 'flv', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'mpv', 'ogm', 'ogv', 'qt', 'rm', 'vob', 'wmv' ),
+			'document'    => array( 'doc', 'docx', 'docm', 'dotm', 'odt', 'pages', 'pdf', 'xps', 'oxps', 'rtf', 'wp', 'wpd', 'psd', 'xcf' ),
+			'spreadsheet' => array( 'numbers', 'ods', 'xls', 'xlsx', 'xlsm', 'xlsb' ),
+			'interactive' => array( 'swf', 'key', 'ppt', 'pptx', 'pptm', 'pps', 'ppsx', 'ppsm', 'sldx', 'sldm', 'odp' ),
+			'text'        => array( 'asc', 'csv', 'tsv', 'txt' ),
+			'archive'     => array( 'bz2', 'cab', 'dmg', 'gz', 'rar', 'sea', 'sit', 'sqx', 'tar', 'tgz', 'zip', '7z' ),
+			'code'        => array( 'css', 'htm', 'html', 'php', 'js' ),
+		)
+	);
+>>>>>>> 480dbc89c6 (Media: Add `heic` extension to `wp_get_ext_types()`, for consistency with `wp_get_mime_types()`.)
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2561,6 +2561,7 @@ function wp_get_mime_types() {
 	 * @param array $wp_get_mime_types Mime types keyed by the file extension regex
 	 *                                 corresponding to those types.
 	 */
+<<<<<<< HEAD
 	return apply_filters( 'mime_types', array(
 	// Image formats.
 	'jpg|jpeg|jpe' => 'image/jpeg',
@@ -2664,6 +2665,115 @@ function wp_get_mime_types() {
 	'numbers' => 'application/vnd.apple.numbers',
 	'pages' => 'application/vnd.apple.pages',
 	) );
+=======
+	return apply_filters(
+		'mime_types',
+		array(
+			// Image formats.
+			'jpg|jpeg|jpe'                 => 'image/jpeg',
+			'gif'                          => 'image/gif',
+			'png'                          => 'image/png',
+			'bmp'                          => 'image/bmp',
+			'tiff|tif'                     => 'image/tiff',
+			'ico'                          => 'image/x-icon',
+			'heic'                         => 'image/heic',
+			// Video formats.
+			'asf|asx'                      => 'video/x-ms-asf',
+			'wmv'                          => 'video/x-ms-wmv',
+			'wmx'                          => 'video/x-ms-wmx',
+			'wm'                           => 'video/x-ms-wm',
+			'avi'                          => 'video/avi',
+			'divx'                         => 'video/divx',
+			'flv'                          => 'video/x-flv',
+			'mov|qt'                       => 'video/quicktime',
+			'mpeg|mpg|mpe'                 => 'video/mpeg',
+			'mp4|m4v'                      => 'video/mp4',
+			'ogv'                          => 'video/ogg',
+			'webm'                         => 'video/webm',
+			'mkv'                          => 'video/x-matroska',
+			'3gp|3gpp'                     => 'video/3gpp',  // Can also be audio.
+			'3g2|3gp2'                     => 'video/3gpp2', // Can also be audio.
+			// Text formats.
+			'txt|asc|c|cc|h|srt'           => 'text/plain',
+			'csv'                          => 'text/csv',
+			'tsv'                          => 'text/tab-separated-values',
+			'ics'                          => 'text/calendar',
+			'rtx'                          => 'text/richtext',
+			'css'                          => 'text/css',
+			'htm|html'                     => 'text/html',
+			'vtt'                          => 'text/vtt',
+			'dfxp'                         => 'application/ttaf+xml',
+			// Audio formats.
+			'mp3|m4a|m4b'                  => 'audio/mpeg',
+			'aac'                          => 'audio/aac',
+			'ra|ram'                       => 'audio/x-realaudio',
+			'wav'                          => 'audio/wav',
+			'ogg|oga'                      => 'audio/ogg',
+			'flac'                         => 'audio/flac',
+			'mid|midi'                     => 'audio/midi',
+			'wma'                          => 'audio/x-ms-wma',
+			'wax'                          => 'audio/x-ms-wax',
+			'mka'                          => 'audio/x-matroska',
+			// Misc application formats.
+			'rtf'                          => 'application/rtf',
+			'js'                           => 'application/javascript',
+			'pdf'                          => 'application/pdf',
+			'swf'                          => 'application/x-shockwave-flash',
+			'class'                        => 'application/java',
+			'tar'                          => 'application/x-tar',
+			'zip'                          => 'application/zip',
+			'gz|gzip'                      => 'application/x-gzip',
+			'rar'                          => 'application/rar',
+			'7z'                           => 'application/x-7z-compressed',
+			'exe'                          => 'application/x-msdownload',
+			'psd'                          => 'application/octet-stream',
+			'xcf'                          => 'application/octet-stream',
+			// MS Office formats.
+			'doc'                          => 'application/msword',
+			'pot|pps|ppt'                  => 'application/vnd.ms-powerpoint',
+			'wri'                          => 'application/vnd.ms-write',
+			'xla|xls|xlt|xlw'              => 'application/vnd.ms-excel',
+			'mdb'                          => 'application/vnd.ms-access',
+			'mpp'                          => 'application/vnd.ms-project',
+			'docx'                         => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+			'docm'                         => 'application/vnd.ms-word.document.macroEnabled.12',
+			'dotx'                         => 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+			'dotm'                         => 'application/vnd.ms-word.template.macroEnabled.12',
+			'xlsx'                         => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			'xlsm'                         => 'application/vnd.ms-excel.sheet.macroEnabled.12',
+			'xlsb'                         => 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
+			'xltx'                         => 'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+			'xltm'                         => 'application/vnd.ms-excel.template.macroEnabled.12',
+			'xlam'                         => 'application/vnd.ms-excel.addin.macroEnabled.12',
+			'pptx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+			'pptm'                         => 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+			'ppsx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+			'ppsm'                         => 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+			'potx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.template',
+			'potm'                         => 'application/vnd.ms-powerpoint.template.macroEnabled.12',
+			'ppam'                         => 'application/vnd.ms-powerpoint.addin.macroEnabled.12',
+			'sldx'                         => 'application/vnd.openxmlformats-officedocument.presentationml.slide',
+			'sldm'                         => 'application/vnd.ms-powerpoint.slide.macroEnabled.12',
+			'onetoc|onetoc2|onetmp|onepkg' => 'application/onenote',
+			'oxps'                         => 'application/oxps',
+			'xps'                          => 'application/vnd.ms-xpsdocument',
+			// OpenOffice formats.
+			'odt'                          => 'application/vnd.oasis.opendocument.text',
+			'odp'                          => 'application/vnd.oasis.opendocument.presentation',
+			'ods'                          => 'application/vnd.oasis.opendocument.spreadsheet',
+			'odg'                          => 'application/vnd.oasis.opendocument.graphics',
+			'odc'                          => 'application/vnd.oasis.opendocument.chart',
+			'odb'                          => 'application/vnd.oasis.opendocument.database',
+			'odf'                          => 'application/vnd.oasis.opendocument.formula',
+			// WordPerfect formats.
+			'wp|wpd'                       => 'application/wordperfect',
+			// iWork formats.
+			'key'                          => 'application/vnd.apple.keynote',
+			'numbers'                      => 'application/vnd.apple.numbers',
+			'pages'                        => 'application/vnd.apple.pages',
+		)
+	);
+>>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2686,9 +2686,9 @@ function wp_get_ext_types() {
 	 * @param array $ext2type Multi-dimensional array with extensions for a default set
 	 *                        of file types.
 	 */
-<<<<<<< HEAD
+
 	return apply_filters( 'ext2type', array(
-		'image'       => array( 'jpg', 'jpeg', 'jpe',  'gif',  'png',  'bmp',   'tif',  'tiff', 'ico' ),
+		'image'       => array( 'jpg', 'jpeg', 'jpe',  'gif',  'png',  'bmp',   'tif',  'tiff', 'ico', 'heic' ),
 		'audio'       => array( 'aac', 'ac3',  'aif',  'aiff', 'flac', 'm3a',  'm4a',   'm4b',  'mka',  'mp1',  'mp2',  'mp3', 'ogg', 'oga', 'ram', 'wav', 'wma' ),
 		'video'       => array( '3g2',  '3gp', '3gpp', 'asf', 'avi',  'divx', 'dv',   'flv',  'm4v',   'mkv',  'mov',  'mp4',  'mpeg', 'mpg', 'mpv', 'ogm', 'ogv', 'qt',  'rm', 'vob', 'wmv' ),
 		'document'    => array( 'doc', 'docx', 'docm', 'dotm', 'odt',  'pages', 'pdf',  'xps',  'oxps', 'rtf',  'wp', 'wpd', 'psd', 'xcf' ),
@@ -2698,22 +2698,6 @@ function wp_get_ext_types() {
 		'archive'     => array( 'bz2', 'cab',  'dmg',  'gz',   'rar',  'sea',   'sit',  'sqx',  'tar',  'tgz',  'zip', '7z' ),
 		'code'        => array( 'css', 'htm',  'html', 'php',  'js' ),
 	) );
-=======
-	return apply_filters(
-		'ext2type',
-		array(
-			'image'       => array( 'jpg', 'jpeg', 'jpe', 'gif', 'png', 'bmp', 'tif', 'tiff', 'ico', 'heic' ),
-			'audio'       => array( 'aac', 'ac3', 'aif', 'aiff', 'flac', 'm3a', 'm4a', 'm4b', 'mka', 'mp1', 'mp2', 'mp3', 'ogg', 'oga', 'ram', 'wav', 'wma' ),
-			'video'       => array( '3g2', '3gp', '3gpp', 'asf', 'avi', 'divx', 'dv', 'flv', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg', 'mpv', 'ogm', 'ogv', 'qt', 'rm', 'vob', 'wmv' ),
-			'document'    => array( 'doc', 'docx', 'docm', 'dotm', 'odt', 'pages', 'pdf', 'xps', 'oxps', 'rtf', 'wp', 'wpd', 'psd', 'xcf' ),
-			'spreadsheet' => array( 'numbers', 'ods', 'xls', 'xlsx', 'xlsm', 'xlsb' ),
-			'interactive' => array( 'swf', 'key', 'ppt', 'pptx', 'pptm', 'pps', 'ppsx', 'ppsm', 'sldx', 'sldm', 'odp' ),
-			'text'        => array( 'asc', 'csv', 'tsv', 'txt' ),
-			'archive'     => array( 'bz2', 'cab', 'dmg', 'gz', 'rar', 'sea', 'sit', 'sqx', 'tar', 'tgz', 'zip', '7z' ),
-			'code'        => array( 'css', 'htm', 'html', 'php', 'js' ),
-		)
-	);
->>>>>>> 480dbc89c6 (Media: Add `heic` extension to `wp_get_ext_types()`, for consistency with `wp_get_mime_types()`.)
 }
 
 /**

--- a/src/wp-includes/js/plupload/handlers.js
+++ b/src/wp-includes/js/plupload/handlers.js
@@ -470,6 +470,11 @@ jQuery(document).ready(function($){
 			uploadStart();
 
 			plupload.each( files, function( file ) {
+				if ( file.type === 'image/heic' && up.settings.heic_upload_error ) {
+					// Show error but do not block uploading.
+					wpQueueError( pluploadL10n.unsupported_image )
+				}
+
 				fileQueued( file );
 			});
 

--- a/src/wp-includes/js/plupload/wp-plupload.js
+++ b/src/wp-includes/js/plupload/wp-plupload.js
@@ -210,6 +210,15 @@ window.wp = window.wp || {};
 					return;
 				}
 
+				if ( file.type === 'image/heic' && up.settings.heic_upload_error ) {
+					// Show error but do not block uploading.
+					Uploader.errors.unshift({
+						message: pluploadL10n.unsupported_image,
+						data:    {},
+						file:    file
+					});
+				}
+
 				// Generate attributes for a new `Attachment` model.
 				attributes = _.extend({
 					file:      file,

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3044,7 +3044,13 @@ function wp_plupload_default_settings() {
 	 * @param array $params Default Plupload parameters array.
 	 */
 	$params = apply_filters( 'plupload_default_params', $params );
+<<<<<<< HEAD
 	$params['_wpnonce'] = wp_create_nonce( 'media-form' );
+=======
+
+	$params['_wpnonce'] = wp_create_nonce( 'media-form' );
+
+>>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 	$defaults['multipart_params'] = $params;
 
 	$settings = array(
@@ -4035,3 +4041,39 @@ function wp_media_personal_data_exporter( $email_address, $page = 1 ) {
 		'done' => $done,
 	);
 }
+<<<<<<< HEAD
+=======
+
+/**
+ * Add additional default image sub-sizes.
+ *
+ * These sizes are meant to enhance the way WordPress displays images on the front-end on larger,
+ * high-density devices. They make it possible to generate more suitable `srcset` and `sizes` attributes
+ * when the users upload large images.
+ *
+ * The sizes can be changed or removed by themes and plugins but that is not recommended.
+ * The size "names" reflect the image dimensions, so changing the sizes would be quite misleading.
+ *
+ * @since 5.3.0
+ * @access private
+ */
+function _wp_add_additional_image_sizes() {
+	// 2x medium_large size.
+	add_image_size( '1536x1536', 1536, 1536 );
+	// 2x large size.
+	add_image_size( '2048x2048', 2048, 2048 );
+}
+
+/**
+ * Callback to enable showig of the user error when uploading .heic images.
+ *
+ * @since 5.5.0
+ *
+ * @param array[] $plupload_settings The settings for Plupload.js.
+ * @return array[] Modified settings for Plupload.js.
+ */
+function wp_show_heic_upload_error( $plupload_settings ) {
+	$plupload_settings['heic_upload_error'] = true;
+	return $plupload_settings;
+}
+>>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4037,7 +4037,31 @@ function wp_media_personal_data_exporter( $email_address, $page = 1 ) {
 }
 
 /**
+<<<<<<< HEAD
  * Callback to enable showig of the user error when uploading .heic images.
+=======
+ * Add additional default image sub-sizes.
+ *
+ * These sizes are meant to enhance the way WordPress displays images on the front-end on larger,
+ * high-density devices. They make it possible to generate more suitable `srcset` and `sizes` attributes
+ * when the users upload large images.
+ *
+ * The sizes can be changed or removed by themes and plugins but that is not recommended.
+ * The size "names" reflect the image dimensions, so changing the sizes would be quite misleading.
+ *
+ * @since 5.3.0
+ * @access private
+ */
+function _wp_add_additional_image_sizes() {
+	// 2x medium_large size.
+	add_image_size( '1536x1536', 1536, 1536 );
+	// 2x large size.
+	add_image_size( '2048x2048', 2048, 2048 );
+}
+
+/**
+ * Callback to enable showing of the user error when uploading .heic images.
+>>>>>>> b9d9968ae9 (Docs: Correct typo introduced in [48288].)
  *
  * @since WP-5.5.0
  *

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4037,31 +4037,7 @@ function wp_media_personal_data_exporter( $email_address, $page = 1 ) {
 }
 
 /**
-<<<<<<< HEAD
- * Callback to enable showig of the user error when uploading .heic images.
-=======
- * Add additional default image sub-sizes.
- *
- * These sizes are meant to enhance the way WordPress displays images on the front-end on larger,
- * high-density devices. They make it possible to generate more suitable `srcset` and `sizes` attributes
- * when the users upload large images.
- *
- * The sizes can be changed or removed by themes and plugins but that is not recommended.
- * The size "names" reflect the image dimensions, so changing the sizes would be quite misleading.
- *
- * @since 5.3.0
- * @access private
- */
-function _wp_add_additional_image_sizes() {
-	// 2x medium_large size.
-	add_image_size( '1536x1536', 1536, 1536 );
-	// 2x large size.
-	add_image_size( '2048x2048', 2048, 2048 );
-}
-
-/**
  * Callback to enable showing of the user error when uploading .heic images.
->>>>>>> b9d9968ae9 (Docs: Correct typo introduced in [48288].)
  *
  * @since WP-5.5.0
  *

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3044,13 +3044,7 @@ function wp_plupload_default_settings() {
 	 * @param array $params Default Plupload parameters array.
 	 */
 	$params = apply_filters( 'plupload_default_params', $params );
-<<<<<<< HEAD
 	$params['_wpnonce'] = wp_create_nonce( 'media-form' );
-=======
-
-	$params['_wpnonce'] = wp_create_nonce( 'media-form' );
-
->>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 	$defaults['multipart_params'] = $params;
 
 	$settings = array(
@@ -4041,33 +4035,11 @@ function wp_media_personal_data_exporter( $email_address, $page = 1 ) {
 		'done' => $done,
 	);
 }
-<<<<<<< HEAD
-=======
-
-/**
- * Add additional default image sub-sizes.
- *
- * These sizes are meant to enhance the way WordPress displays images on the front-end on larger,
- * high-density devices. They make it possible to generate more suitable `srcset` and `sizes` attributes
- * when the users upload large images.
- *
- * The sizes can be changed or removed by themes and plugins but that is not recommended.
- * The size "names" reflect the image dimensions, so changing the sizes would be quite misleading.
- *
- * @since 5.3.0
- * @access private
- */
-function _wp_add_additional_image_sizes() {
-	// 2x medium_large size.
-	add_image_size( '1536x1536', 1536, 1536 );
-	// 2x large size.
-	add_image_size( '2048x2048', 2048, 2048 );
-}
 
 /**
  * Callback to enable showig of the user error when uploading .heic images.
  *
- * @since 5.5.0
+ * @since WP-5.5.0
  *
  * @param array[] $plupload_settings The settings for Plupload.js.
  * @return array[] Modified settings for Plupload.js.
@@ -4076,4 +4048,3 @@ function wp_show_heic_upload_error( $plupload_settings ) {
 	$plupload_settings['heic_upload_error'] = true;
 	return $plupload_settings;
 }
->>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -320,7 +320,6 @@ function wp_default_scripts( &$scripts ) {
 
 	// Error messages for Plupload.
 	$uploader_l10n = array(
-<<<<<<< HEAD
 		'queue_limit_exceeded' => __('You have attempted to queue too many files.'),
 		'file_exceeds_size_limit' => __('%s exceeds the maximum upload size for this site.'),
 		'zero_byte_file' => __('This file is empty. Please try another.'),
@@ -343,37 +342,8 @@ function wp_default_scripts( &$scripts ) {
 		'dismiss' => __('Dismiss'),
 		'crunching' => __('Crunching&hellip;'),
 		'deleted' => __('moved to the trash.'),
-		'error_uploading' => __('&#8220;%s&#8221; has failed to upload.')
-=======
-		'queue_limit_exceeded'      => __( 'You have attempted to queue too many files.' ),
-		/* translators: %s: File name. */
-		'file_exceeds_size_limit'   => __( '%s exceeds the maximum upload size for this site.' ),
-		'zero_byte_file'            => __( 'This file is empty. Please try another.' ),
-		'invalid_filetype'          => __( 'Sorry, this file type is not permitted for security reasons.' ),
-		'not_an_image'              => __( 'This file is not an image. Please try another.' ),
-		'image_memory_exceeded'     => __( 'Memory exceeded. Please try another smaller file.' ),
-		'image_dimensions_exceeded' => __( 'This is larger than the maximum size. Please try another.' ),
-		'default_error'             => __( 'An error occurred in the upload. Please try again later.' ),
-		'missing_upload_url'        => __( 'There was a configuration error. Please contact the server administrator.' ),
-		'upload_limit_exceeded'     => __( 'You may only upload 1 file.' ),
-		'http_error'                => __( 'Unexpected response from the server. The file may have been uploaded successfully. Check in the Media Library or reload the page.' ),
-		'http_error_image'          => __( 'Post-processing of the image failed likely because the server is busy or does not have enough resources. Uploading a smaller image may help. Suggested maximum size is 2500 pixels.' ),
-		'upload_failed'             => __( 'Upload failed.' ),
-		/* translators: 1: Opening link tag, 2: Closing link tag. */
-		'big_upload_failed'         => __( 'Please try uploading this file with the %1$sbrowser uploader%2$s.' ),
-		/* translators: %s: File name. */
-		'big_upload_queued'         => __( '%s exceeds the maximum upload size for the multi-file uploader when used in your browser.' ),
-		'io_error'                  => __( 'IO error.' ),
-		'security_error'            => __( 'Security error.' ),
-		'file_cancelled'            => __( 'File canceled.' ),
-		'upload_stopped'            => __( 'Upload stopped.' ),
-		'dismiss'                   => __( 'Dismiss' ),
-		'crunching'                 => __( 'Crunching&hellip;' ),
-		'deleted'                   => __( 'moved to the Trash.' ),
-		/* translators: %s: File name. */
-		'error_uploading'           => __( '&#8220;%s&#8221; has failed to upload.' ),
-		'unsupported_image'         => __( 'This image cannot be displayed in a web browser. For best results convert it to JPEG before uploading.' ),
->>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
+		'error_uploading' => __('&#8220;%s&#8221; has failed to upload.'),
+		'unsupported_image' => __( 'This image cannot be displayed in a web browser. For best results convert it to JPEG before uploading.' ),
 	);
 
 	$scripts->add( 'moxiejs', "/wp-includes/js/plupload/moxie$suffix.js", array(), '1.3.5' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -320,6 +320,7 @@ function wp_default_scripts( &$scripts ) {
 
 	// Error messages for Plupload.
 	$uploader_l10n = array(
+<<<<<<< HEAD
 		'queue_limit_exceeded' => __('You have attempted to queue too many files.'),
 		'file_exceeds_size_limit' => __('%s exceeds the maximum upload size for this site.'),
 		'zero_byte_file' => __('This file is empty. Please try another.'),
@@ -343,6 +344,36 @@ function wp_default_scripts( &$scripts ) {
 		'crunching' => __('Crunching&hellip;'),
 		'deleted' => __('moved to the trash.'),
 		'error_uploading' => __('&#8220;%s&#8221; has failed to upload.')
+=======
+		'queue_limit_exceeded'      => __( 'You have attempted to queue too many files.' ),
+		/* translators: %s: File name. */
+		'file_exceeds_size_limit'   => __( '%s exceeds the maximum upload size for this site.' ),
+		'zero_byte_file'            => __( 'This file is empty. Please try another.' ),
+		'invalid_filetype'          => __( 'Sorry, this file type is not permitted for security reasons.' ),
+		'not_an_image'              => __( 'This file is not an image. Please try another.' ),
+		'image_memory_exceeded'     => __( 'Memory exceeded. Please try another smaller file.' ),
+		'image_dimensions_exceeded' => __( 'This is larger than the maximum size. Please try another.' ),
+		'default_error'             => __( 'An error occurred in the upload. Please try again later.' ),
+		'missing_upload_url'        => __( 'There was a configuration error. Please contact the server administrator.' ),
+		'upload_limit_exceeded'     => __( 'You may only upload 1 file.' ),
+		'http_error'                => __( 'Unexpected response from the server. The file may have been uploaded successfully. Check in the Media Library or reload the page.' ),
+		'http_error_image'          => __( 'Post-processing of the image failed likely because the server is busy or does not have enough resources. Uploading a smaller image may help. Suggested maximum size is 2500 pixels.' ),
+		'upload_failed'             => __( 'Upload failed.' ),
+		/* translators: 1: Opening link tag, 2: Closing link tag. */
+		'big_upload_failed'         => __( 'Please try uploading this file with the %1$sbrowser uploader%2$s.' ),
+		/* translators: %s: File name. */
+		'big_upload_queued'         => __( '%s exceeds the maximum upload size for the multi-file uploader when used in your browser.' ),
+		'io_error'                  => __( 'IO error.' ),
+		'security_error'            => __( 'Security error.' ),
+		'file_cancelled'            => __( 'File canceled.' ),
+		'upload_stopped'            => __( 'Upload stopped.' ),
+		'dismiss'                   => __( 'Dismiss' ),
+		'crunching'                 => __( 'Crunching&hellip;' ),
+		'deleted'                   => __( 'moved to the Trash.' ),
+		/* translators: %s: File name. */
+		'error_uploading'           => __( '&#8220;%s&#8221; has failed to upload.' ),
+		'unsupported_image'         => __( 'This image cannot be displayed in a web browser. For best results convert it to JPEG before uploading.' ),
+>>>>>>> 1285255381 (Media: Show an error message when a `.heic` file is uploaded that this type of files cannot be displayed in a web browser and suggesting to convert to JPEG. The message is shown by using filters, plugins that want to handle uploading of `.heic` files can remove it.)
 	);
 
 	$scripts->add( 'moxiejs', "/wp-includes/js/plupload/moxie$suffix.js", array(), '1.3.5' );


### PR DESCRIPTION
## Description
While back porting changes for WebP support (see https://github.com/ClassicPress/ClassicPress/pull/772), additional differences related to the `heir` image format were noted,

## Motivation and context
The heir image format is not supported in modern browsers, this may lead to frustration from users who try to upload images in this format and cannot understand why the CMS won't allow the upload.

This change set detects attempted `heir` image format uploads and reports an error to the user with a recommendation to convert to `jpeg` format and try again - this provides a better user experience.

## How has this been tested?
Unit tests are included in the backport.

## Screenshots
N/A

## Types of changes
- New feature

