### PR TITLE
remove_meta_box triggers warning in PHP 7.4

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -955,20 +955,12 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 			if ( !isset($wp_meta_boxes[$page][$a_context][$a_priority][$id]) )
 				continue;
 
-<<<<<<< HEAD
-			// If a core box was previously added or removed by a plugin, don't add.
-			if ( 'core' == $priority ) {
-				// If core box previously deleted, don't add
-				if ( false === $wp_meta_boxes[$page][$a_context][$a_priority][$id] )
-					return;
-=======
 			// If a core box was previously removed, don't add.
 			if ( ( 'core' === $priority || 'sorted' === $priority )
 				&& false === $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]
 			) {
 				return;
 			}
->>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)
 
 			// If a core box was previously added by a plugin, don't add.
 			if ( 'core' === $priority ) {
@@ -982,19 +974,6 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 				}
 				return;
 			}
-<<<<<<< HEAD
-			// If no priority given and id already present, use existing priority.
-			if ( empty($priority) ) {
-				$priority = $a_priority;
-			/*
-			 * Else, if we're adding to the sorted priority, we don't know the title
-			 * or callback. Grab them from the previously added context/priority.
-			 */
-			} elseif ( 'sorted' == $priority ) {
-				$title = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['title'];
-				$callback = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['callback'];
-				$callback_args = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['args'];
-=======
 
 			// If no priority given and ID already present, use existing priority.
 			if ( empty( $priority ) ) {
@@ -1004,19 +983,15 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 				 * or callback. Grab them from the previously added context/priority.
 				 */
 			} elseif ( 'sorted' === $priority ) {
-				$title         = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['title'];
-				$callback      = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['callback'];
+				$title = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['title'];
+				$callback = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['callback'];
 				$callback_args = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['args'];
 			}
 
 			// An ID can be in only one priority and one context.
 			if ( $priority !== $a_priority || $context !== $a_context ) {
 				unset( $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ] );
->>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)
 			}
-			// An id can be in only one priority and one context.
-			if ( $priority != $a_priority || $context != $a_context )
-				unset($wp_meta_boxes[$page][$a_context][$a_priority][$id]);
 		}
 	}
 

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -956,8 +956,9 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 				continue;
 
 			// If a core box was previously removed, don't add.
-			if ( ( 'core' === $priority || 'sorted' === $priority )
-				&& false === $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]
+			if (
+				( 'core' === $priority || 'sorted' === $priority ) &&
+				false === $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]
 			) {
 				return;
 			}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -955,15 +955,26 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 			if ( !isset($wp_meta_boxes[$page][$a_context][$a_priority][$id]) )
 				continue;
 
+<<<<<<< HEAD
 			// If a core box was previously added or removed by a plugin, don't add.
 			if ( 'core' == $priority ) {
 				// If core box previously deleted, don't add
 				if ( false === $wp_meta_boxes[$page][$a_context][$a_priority][$id] )
 					return;
+=======
+			// If a core box was previously removed, don't add.
+			if ( ( 'core' === $priority || 'sorted' === $priority )
+				&& false === $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]
+			) {
+				return;
+			}
+>>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)
 
+			// If a core box was previously added by a plugin, don't add.
+			if ( 'core' === $priority ) {
 				/*
-				 * If box was added with default priority, give it core priority to
-				 * maintain sort order.
+				 * If the box was added with default priority, give it core priority
+				 * to maintain sort order.
 				 */
 				if ( 'default' == $a_priority ) {
 					$wp_meta_boxes[$page][$a_context]['core'][$id] = $wp_meta_boxes[$page][$a_context]['default'][$id];
@@ -971,6 +982,7 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 				}
 				return;
 			}
+<<<<<<< HEAD
 			// If no priority given and id already present, use existing priority.
 			if ( empty($priority) ) {
 				$priority = $a_priority;
@@ -982,6 +994,25 @@ function add_meta_box( $id, $title, $callback, $screen = null, $context = 'advan
 				$title = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['title'];
 				$callback = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['callback'];
 				$callback_args = $wp_meta_boxes[$page][$a_context][$a_priority][$id]['args'];
+=======
+
+			// If no priority given and ID already present, use existing priority.
+			if ( empty( $priority ) ) {
+				$priority = $a_priority;
+				/*
+				 * Else, if we're adding to the sorted priority, we don't know the title
+				 * or callback. Grab them from the previously added context/priority.
+				 */
+			} elseif ( 'sorted' === $priority ) {
+				$title         = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['title'];
+				$callback      = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['callback'];
+				$callback_args = $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ]['args'];
+			}
+
+			// An ID can be in only one priority and one context.
+			if ( $priority !== $a_priority || $context !== $a_context ) {
+				unset( $wp_meta_boxes[ $page ][ $a_context ][ $a_priority ][ $id ] );
+>>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)
 			}
 			// An id can be in only one priority and one context.
 			if ( $priority != $a_priority || $context != $a_context )

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -109,7 +109,7 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 50019
+	 * @see https://core.trac.wordpress.org/ticket/50019
 	 */
 	public function test_add_meta_box_with_previously_removed_box_and_sorted_priority() {
 		global $wp_meta_boxes;

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -50,7 +50,7 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 		global $wp_meta_boxes;
 
 		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', 'post' );
-		
+
 		$this->assertArrayHasKey( 'testbox1', $wp_meta_boxes['post']['advanced']['default'] );
 	}
 
@@ -79,7 +79,7 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 		// Add a meta box to three different post types
 		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', array( 'post', 'comment', 'attachment' ) );
 
-		$this->assertArrayHasKey( 'testbox1', $wp_meta_boxes['post']['advanced']['default'] ); 
+		$this->assertArrayHasKey( 'testbox1', $wp_meta_boxes['post']['advanced']['default'] );
 		$this->assertArrayHasKey( 'testbox1', $wp_meta_boxes['comment']['advanced']['default'] );
 		$this->assertArrayHasKey( 'testbox1', $wp_meta_boxes['attachment']['advanced']['default'] );
 	}
@@ -108,9 +108,6 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 		$this->assertFalse( $wp_meta_boxes['attachment']['advanced']['default']['testbox1'] );
 	}
 
-<<<<<<< HEAD
-}
-=======
 	/**
 	 * @ticket 50019
 	 */
@@ -129,83 +126,4 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 		// Check that the meta box was not re-added.
 		$this->assertFalse( $wp_meta_boxes[ $current_screen ]['advanced']['default']['testbox1'] );
 	}
-
-	/**
-	 * Test calling get_settings_errors() with variations on where it gets errors from.
-	 *
-	 * @ticket 42498
-	 * @covers ::get_settings_errors()
-	 * @global array $wp_settings_errors
-	 */
-	public function test_get_settings_errors_sources() {
-		global $wp_settings_errors;
-
-		$blogname_error        = array(
-			'setting' => 'blogname',
-			'code'    => 'blogname',
-			'message' => 'Capital P dangit!',
-			'type'    => 'error',
-		);
-		$blogdescription_error = array(
-			'setting' => 'blogdescription',
-			'code'    => 'blogdescription',
-			'message' => 'Too short',
-			'type'    => 'error',
-		);
-
-		$wp_settings_errors = null;
-		$this->assertSame( array(), get_settings_errors( 'blogname' ) );
-
-		// Test getting errors from transient.
-		$_GET['settings-updated'] = '1';
-		set_transient( 'settings_errors', array( $blogname_error ) );
-		$wp_settings_errors = null;
-		$this->assertSame( array( $blogname_error ), get_settings_errors( 'blogname' ) );
-
-		// Test getting errors from transient and from global.
-		$_GET['settings-updated'] = '1';
-		set_transient( 'settings_errors', array( $blogname_error ) );
-		$wp_settings_errors = null;
-		add_settings_error( $blogdescription_error['setting'], $blogdescription_error['code'], $blogdescription_error['message'], $blogdescription_error['type'] );
-		$this->assertEqualSets( array( $blogname_error, $blogdescription_error ), get_settings_errors() );
-
-		$wp_settings_errors = null;
-	}
-
-	/**
-	 * @ticket 44941
-	 * @covers ::settings_errors()
-	 * @global array $wp_settings_errors
-	 * @dataProvider settings_errors_css_classes_provider
-	 */
-	public function test_settings_errors_css_classes( $type, $expected ) {
-		global $wp_settings_errors;
-
-		add_settings_error( 'foo', 'bar', 'Capital P dangit!', $type );
-
-		ob_start();
-		settings_errors();
-		$output = ob_get_clean();
-
-		$wp_settings_errors = null;
-
-		$expected = sprintf( 'notice %s settings-error is-dismissible', $expected );
-
-		$this->assertContains( $expected, $output );
-		$this->assertNotContains( 'notice-notice-', $output );
-	}
-
-	public function settings_errors_css_classes_provider() {
-		return array(
-			array( 'error', 'notice-error' ),
-			array( 'success', 'notice-success' ),
-			array( 'warning', 'notice-warning' ),
-			array( 'info', 'notice-info' ),
-			array( 'updated', 'notice-success' ),
-			array( 'notice-error', 'notice-error' ),
-			array( 'error my-own-css-class hello world', 'error my-own-css-class hello world' ),
-		);
-	}
-
 }
->>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -57,7 +57,7 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 	public function test_remove_meta_box() {
 		global $wp_meta_boxes;
 
-		// Add a meta boxes to remove.
+		// Add a meta box to remove.
 		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', $current_screen = 'post' );
 
 		// Confirm it's there.
@@ -108,4 +108,104 @@ class Tests_Admin_includesTemplate extends WP_UnitTestCase {
 		$this->assertFalse( $wp_meta_boxes['attachment']['advanced']['default']['testbox1'] );
 	}
 
+<<<<<<< HEAD
 }
+=======
+	/**
+	 * @ticket 50019
+	 */
+	public function test_add_meta_box_with_previously_removed_box_and_sorted_priority() {
+		global $wp_meta_boxes;
+
+		// Add a meta box to remove.
+		add_meta_box( 'testbox1', 'Test Metabox', '__return_false', $current_screen = 'post' );
+
+		// Remove the meta box.
+		remove_meta_box( 'testbox1', $current_screen, 'advanced' );
+
+		// Attempt to re-add the meta box with the 'sorted' priority.
+		add_meta_box( 'testbox1', null, null, $current_screen, 'advanced', 'sorted' );
+
+		// Check that the meta box was not re-added.
+		$this->assertFalse( $wp_meta_boxes[ $current_screen ]['advanced']['default']['testbox1'] );
+	}
+
+	/**
+	 * Test calling get_settings_errors() with variations on where it gets errors from.
+	 *
+	 * @ticket 42498
+	 * @covers ::get_settings_errors()
+	 * @global array $wp_settings_errors
+	 */
+	public function test_get_settings_errors_sources() {
+		global $wp_settings_errors;
+
+		$blogname_error        = array(
+			'setting' => 'blogname',
+			'code'    => 'blogname',
+			'message' => 'Capital P dangit!',
+			'type'    => 'error',
+		);
+		$blogdescription_error = array(
+			'setting' => 'blogdescription',
+			'code'    => 'blogdescription',
+			'message' => 'Too short',
+			'type'    => 'error',
+		);
+
+		$wp_settings_errors = null;
+		$this->assertSame( array(), get_settings_errors( 'blogname' ) );
+
+		// Test getting errors from transient.
+		$_GET['settings-updated'] = '1';
+		set_transient( 'settings_errors', array( $blogname_error ) );
+		$wp_settings_errors = null;
+		$this->assertSame( array( $blogname_error ), get_settings_errors( 'blogname' ) );
+
+		// Test getting errors from transient and from global.
+		$_GET['settings-updated'] = '1';
+		set_transient( 'settings_errors', array( $blogname_error ) );
+		$wp_settings_errors = null;
+		add_settings_error( $blogdescription_error['setting'], $blogdescription_error['code'], $blogdescription_error['message'], $blogdescription_error['type'] );
+		$this->assertEqualSets( array( $blogname_error, $blogdescription_error ), get_settings_errors() );
+
+		$wp_settings_errors = null;
+	}
+
+	/**
+	 * @ticket 44941
+	 * @covers ::settings_errors()
+	 * @global array $wp_settings_errors
+	 * @dataProvider settings_errors_css_classes_provider
+	 */
+	public function test_settings_errors_css_classes( $type, $expected ) {
+		global $wp_settings_errors;
+
+		add_settings_error( 'foo', 'bar', 'Capital P dangit!', $type );
+
+		ob_start();
+		settings_errors();
+		$output = ob_get_clean();
+
+		$wp_settings_errors = null;
+
+		$expected = sprintf( 'notice %s settings-error is-dismissible', $expected );
+
+		$this->assertContains( $expected, $output );
+		$this->assertNotContains( 'notice-notice-', $output );
+	}
+
+	public function settings_errors_css_classes_provider() {
+		return array(
+			array( 'error', 'notice-error' ),
+			array( 'success', 'notice-success' ),
+			array( 'warning', 'notice-warning' ),
+			array( 'info', 'notice-info' ),
+			array( 'updated', 'notice-success' ),
+			array( 'notice-error', 'notice-error' ),
+			array( 'error my-own-css-class hello world', 'error my-own-css-class hello world' ),
+		);
+	}
+
+}
+>>>>>>> efb6e805da (Administration: Avoid a PHP 7.4 notice in `add_meta_box()` when attempting to re-add a previously removed box.)


### PR DESCRIPTION
## Description
See Issue #777 and upstream ticket https://core.trac.wordpress.org/ticket/50019

Since PHP 7.4 the `remove_meta_box()` function can trigger PHP warnings 

## Motivation and context
This is a bug fix correcting an issue facing some plugins that are in-use on ClassicPress.

## How has this been tested?
This is an upstream backport and also contains an additional unit test with the PR

## Screenshots
N/A

## Types of changes
- Bug fix
