### PR TITLE
Security page improvements

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1292,11 +1292,6 @@ ul.cat-checklist {
 	white-space: nowrap;
 }
 
-.plugins .dashicon {
-	font: 16px dashicons;
-	vertical-align: text-bottom;
-}
-
 .plugins .plugin-title img,
 .plugins .plugin-title .dashicons {
 	float: left;

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1434,7 +1434,7 @@ function _security_page_action_links( $actions, $plugin_file, $plugin_data, $con
 		array_unshift(
 			$actions,
 			sprintf(
-				'<a href="%s?page=%s" title="%s"><span class="dashicon dashicons-shield"></span></a>',
+				'<a href="%1$s?page=%2$s" title="%3$s">%3$s</a>',
 				$admin_url,
 				$parts[0],
 				__( 'Security' )

--- a/src/wp-admin/security.php
+++ b/src/wp-admin/security.php
@@ -63,7 +63,7 @@ switch ( $active_tab ) :
 		<?php
 		printf(
 			/* translators: canonical link to security forum */
-			__( 'Watch this page and the ClassicPress <a href="%s" rel="noopener" target="_blank">Security forum</a> for more news as development continues.' ),
+			__( 'Watch this page and the ClassicPress <a href="%s" rel="noopener" target="_blank">Core Development forum</a> for more news as development continues.' ),
 			'https://link.classicpress.net/forum/security'
 		);
 		?>


### PR DESCRIPTION
This PR is intended to address the feedback raised here: https://forums.classicpress.net/t/security-page-feedback-and-improvements/3442/28

Specifically:

- [x] When a plugin registers a Security sub-page, there is a link from that plugin's row in the Plugins screen to its page of security settings. Change this link from a shield icon with poor accessibility to a plain text link that says Security.
- [ ] Add a new option that allows ClassicPress site owners to hide the Security page when it is empty. For backwards compatibility, this option is disabled by default. **PLACEHOLDER - NOT IMPLEMENTED YET.**
- [x] Fix the wording of the link from the Security page that links to our "Security forum", which no longer exists. The Core Development forum is now a better fit for this link. The link URL was updated separately: https://github.com/ClassicPress/subdomain-link/commit/90a257204076d76276f036bc672510bb3e41c456

**DRAFT. UNTESTED AND UNFINISHED.**