### PR TITLE
PR to show posts and pages id

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -535,7 +535,8 @@ class WP_Posts_List_Table extends WP_List_Table {
 		/* translators: manage posts column name */
 		$posts_columns['title'] = _x( 'Title', 'column name' );
 
-		$posts_columns['ID'] = __( 'ID' );
+		/* translators: manage posts column name */
+		$posts_columns['ID'] = _x( 'ID', 'column name' );
 
 		if ( post_type_supports( $post_type, 'author' ) ) {
 			$posts_columns['author'] = __( 'Author' );

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -535,6 +535,8 @@ class WP_Posts_List_Table extends WP_List_Table {
 		/* translators: manage posts column name */
 		$posts_columns['title'] = _x( 'Title', 'column name' );
 
+		$posts_columns['ID'] = __( 'ID' );
+
 		if ( post_type_supports( $post_type, 'author' ) ) {
 			$posts_columns['author'] = __( 'Author' );
 		}
@@ -957,6 +959,17 @@ class WP_Posts_List_Table extends WP_List_Table {
 		}
 
 		get_inline_data( $post );
+	}
+
+	/**
+	 * Handles the ID column output.
+	 *
+	 * @since CP-1.3.0
+	 *
+	 * @param WP_Post $post The current WP_Post object.
+	 */
+	public function column_ID( $post ) {
+		echo $post->ID;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -964,7 +964,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	/**
 	 * Handles the ID column output.
 	 *
-	 * @since 1.3.0
+	 * @since 1.4.0
 	 *
 	 * @param WP_Post $post The current WP_Post object.
 	 */

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -970,7 +970,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 * @param WP_Post $post The current WP_Post object.
 	 */
 	public function column_ID( $post ) {
-		echo $post->ID;
+		echo esc_html( $post->ID );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -964,7 +964,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	/**
 	 * Handles the ID column output.
 	 *
-	 * @since CP-1.3.0
+	 * @since 1.3.0
 	 *
 	 * @param WP_Post $post The current WP_Post object.
 	 */

--- a/src/wp-admin/includes/screen.php
+++ b/src/wp-admin/includes/screen.php
@@ -60,7 +60,7 @@ function get_hidden_columns( $screen ) {
 	$use_defaults = ! is_array( $hidden );
 
 	if ( $use_defaults ) {
-		$hidden = array('ID'); // ID column will be hidden by default
+		$hidden = array( 'ID' );
 
 		/**
 		 * Filters the default list of hidden columns.

--- a/src/wp-admin/includes/screen.php
+++ b/src/wp-admin/includes/screen.php
@@ -60,7 +60,7 @@ function get_hidden_columns( $screen ) {
 	$use_defaults = ! is_array( $hidden );
 
 	if ( $use_defaults ) {
-		$hidden = array();
+		$hidden = array('ID'); // ID column will be hidden by default
 
 		/**
 		 * Filters the default list of hidden columns.


### PR DESCRIPTION
This is a PR for the petition [Show Post/Page ID](https://forums.classicpress.net/t/show-post-page-id/2950/1).

It works fine. By default the ID column is hidden and can be enabled via screen options.