### PR TITLE
CSS amended for Widgets page

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -290,16 +290,6 @@
 	outline: none;
 }
 
-#widgets-left .sidebar-name .toggle-indicator {
-	display: none;
-}
-
-#widgets-left .widgets-holder-wrap.closed .sidebar-name .toggle-indicator,
-#widgets-left .sidebar-name:hover .toggle-indicator,
-#widgets-left .sidebar-name .handlediv:focus .toggle-indicator {
-	display: block;
-}
-
 .sidebar-name .toggle-indicator:before {
 	padding: 1px 2px 1px 0;
 	border-radius: 50%;


### PR DESCRIPTION
## Description
This is a potential fix for #637 

Currently there is a toggle switch that is hidden from users unless hovered, focussed or if the Active Widget section is already collapsed.

## Motivation and context
Addresses an open issue and improves usability of the admin by by revealing a hidden toggle feature.

## How has this been tested?
Manual testing on a local install. Not that on page load a small 'up' arrow is now visible above the word 'widget' above the right hand column of available widgets.

## Screenshots
### Before
<img width="519" alt="Screenshot 2021-09-05 at 19 24 57" src="https://user-images.githubusercontent.com/1280733/132137435-4bf231a6-e8bb-4887-8b50-74b5d2acbf58.png">

### After
<img width="531" alt="Screenshot 2021-09-05 at 19 24 28" src="https://user-images.githubusercontent.com/1280733/132137443-7751c516-470f-4d2b-8099-9496c0558f1a.png">


## Types of changes
- New feature


