### PR TITLE
Add two direct plugin upload links to admin to bypass loading the WP plugin repo

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -209,6 +209,7 @@ $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'activate_plugins'
 
 	if ( ! is_multisite() ) {
 		/* translators: add new plugin */
+		$submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
 		$submenu['plugins.php'][10] = array( _x('Add New', 'plugin'), 'install_plugins', 'plugin-install.php' );
 		$submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 	}

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -79,7 +79,7 @@ get_current_screen()->add_help_tab( array(
 'id'		=> 'overview',
 'title'		=> __('Overview'),
 'content'	=>
-	'<p>' . sprintf( __('Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the official <a href="%s">ClassicPress Plugin Directory</a> are compatible with the license ClassicPress uses.' ), __( 'https://wordpress.org/plugins/' ) ) . '</p>' .
+	'<p>' . sprintf( __('Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the official <a href="%s">Plugin Directory</a> are compatible with the license ClassicPress uses.' ), __( 'https://wordpress.org/plugins/' ) ) . '</p>' .
 	'<p>' . __( 'You can find new plugins to install by searching or browsing the directory right here in your own Plugins section.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>'
 
 ) );
@@ -87,10 +87,10 @@ get_current_screen()->add_help_tab( array(
 'id'		=> 'adding-plugins',
 'title'		=> __('Adding Plugins'),
 'content'	=>
-	'<p>' . __('If you know what you&#8217;re looking for, Search is your best bet. The Search screen has options to search the ClassicPress Plugin Directory for a particular Term, Author, or Tag. You can also search the directory by selecting popular tags. Tags in larger type mean more plugins have been labeled with that tag.') . '</p>' .
+	'<p>' . __('If you know what you&#8217;re looking for, Search is your best bet. The Search screen has options to search the Plugin Directory for a particular Term, Author, or Tag. You can also search the directory by selecting popular tags. Tags in larger type mean more plugins have been labeled with that tag.') . '</p>' .
 	'<p>' . __( 'If you just want to get an idea of what&#8217;s available, you can browse Featured and Popular plugins by using the links above the plugins list. These sections rotate regularly.' ) . '</p>' .
 	'<p>' . __( 'You can also browse a user&#8217;s favorite plugins, by using the Favorites link above the plugins list and entering their WordPress.org username.' ) . '</p>' .
-	'<p>' . __( 'If you want to install a plugin that you&#8217;ve downloaded elsewhere, click the Upload Plugin button above the plugins list. You will be prompted to upload the .zip package, and once uploaded, you can activate the new plugin.' ) . '</p>'
+	'<p>' . __( 'If you want to install a plugin that you&#8217;ve downloaded elsewhere, click the Upload button in the Plugins menu or at the top of the main Plugins page. You can also use the Upload Plugin button on the Plugin Directory page. You will be prompted to upload the .zip package, and once uploaded, you can activate the new plugin.' ) . '</p>'
 ) );
 
 get_current_screen()->set_help_sidebar(

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -79,7 +79,7 @@ get_current_screen()->add_help_tab( array(
 'id'		=> 'overview',
 'title'		=> __('Overview'),
 'content'	=>
-	'<p>' . sprintf( __('Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the official <a href="%s">Plugin Directory</a> are compatible with the license ClassicPress uses.' ), __( 'https://wordpress.org/plugins/' ) ) . '</p>' .
+	'<p>' . sprintf( __('Plugins hook into ClassicPress to extend its functionality with custom features. Plugins are developed independently from the core ClassicPress application by thousands of developers all over the world. All plugins in the <a href="%s">WordPress Plugin Directory</a> are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!' ), __( 'https://wordpress.org/plugins/' ) ) . '</p>' .
 	'<p>' . __( 'You can find new plugins to install by searching or browsing the directory right here in your own Plugins section.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>'
 
 ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -523,6 +523,10 @@ echo esc_html( $title );
 
 <?php
 if ( ( ! is_multisite() || is_network_admin() ) && current_user_can('install_plugins') ) { ?>
+	<a href="<?php echo self_admin_url( 'plugin-install.php?tab=upload' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Upload', 'plugin' ); ?></a>
+<?php
+}
+if ( ( ! is_multisite() || is_network_admin() ) && current_user_can('install_plugins') ) { ?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add New', 'plugin' ); ?></a>
 <?php
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -414,7 +414,7 @@ get_current_screen()->add_help_tab( array(
 	'<p>' . __( 'The search for installed plugins will search for terms in their name, description, or author.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
 	'<p>' . sprintf(
 		/* translators: %s: ClassicPress Plugin Directory URL */
-		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">ClassicPress Plugin Directory</a>. Plugins in the ClassicPress Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses. Oh, and they&#8217;re free!' ),
+		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">Plugin Directory</a>. Plugins in the Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses. Oh, and they&#8217;re free!' ),
 		__( 'https://wordpress.org/plugins/' )
 	) . '</p>'
 ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -414,7 +414,7 @@ get_current_screen()->add_help_tab( array(
 	'<p>' . __( 'The search for installed plugins will search for terms in their name, description, or author.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
 	'<p>' . sprintf(
 		/* translators: %s: ClassicPress Plugin Directory URL */
-		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">Plugin Directory</a>. Plugins in the Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses. Oh, and they&#8217;re free!' ),
+		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!' ),
 		__( 'https://wordpress.org/plugins/' )
 	) . '</p>'
 ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -522,11 +522,9 @@ echo esc_html( $title );
 ?></h1>
 
 <?php
-if ( ( ! is_multisite() || is_network_admin() ) && current_user_can('install_plugins') ) { ?>
+if ( ( ! is_multisite() || is_network_admin() ) && current_user_can( 'install_plugins' ) ) {
+?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php?tab=upload' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Upload', 'plugin' ); ?></a>
-<?php
-}
-if ( ( ! is_multisite() || is_network_admin() ) && current_user_can('install_plugins') ) { ?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add New', 'plugin' ); ?></a>
 <?php
 }


### PR DESCRIPTION
## Description

This PR gives the option to go straight to a simple upload plugin screen without having to first load the WP plugin repo. There are 2 links - one as a sub menu item in the main menu, and one button at the top of the plugins screen.

![add-new](https://user-images.githubusercontent.com/46998578/132503037-82d4ff22-8857-4cc8-a22d-5be1cdfa6023.png)

These links both open this screen:

![upload-screen](https://user-images.githubusercontent.com/46998578/132503100-7b45ede8-669d-4250-8ff1-c4f2b29d1d69.png)

There are also some edits to the help screen to explain the new feature (and a few minor fixes for some phrases that were incorrectly swapped out when WP was changed to CP).

## Motivation and context

ClassicPress users are increasingly uploading plugins manually. When doing this you have to load the whole WP plugin repo page (which takes 4-5 seconds and shows many plugins as incompatible), then do another step to get to the upload panel. This is slow and pointless when you are just wanting to upload a plugin. 

Further discussion here: https://forums.classicpress.net/t/add-a-dedicated-way-to-upload-plugins-bypassing-wp-repo-loading/3546

## How has this been tested?

I have made the necessary changes on a test site and they work well. Note that the link I am using is a standard CP link that has been designed for developers to use if they want a direct upload facility eg for plugins. So the code changes are minimal - just adding 2 links (one button and one extra menu item).

## Screenshots

See above

## Types of changes

- New feature

