### PR TITLE
Minimize a race condition when using an object cache

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -177,12 +177,8 @@ function form_option( $option ) {
 /**
  * Loads and caches all autoloaded options, if available or all options.
  *
-<<<<<<< HEAD
  * @since WP-2.2.0
-=======
- * @since 2.2.0
- * @since 5.3.1 The `$force_cache` parameter was added.
->>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
+ * @since WP-5.3.1 The `$force_cache` parameter was added.
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
@@ -384,13 +380,8 @@ function update_option( $option, $value, $autoload = null ) {
 	}
 
 	if ( ! wp_installing() ) {
-<<<<<<< HEAD
-		$alloptions = wp_load_alloptions();
-		if ( isset( $alloptions[$option] ) ) {
-=======
 		$alloptions = wp_load_alloptions( true );
 		if ( isset( $alloptions[ $option ] ) ) {
->>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 			$alloptions[ $option ] = $serialized_value;
 			wp_cache_set( 'alloptions', $alloptions, 'options' );
 		} else {
@@ -491,11 +482,7 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' )
 
 	if ( ! wp_installing() ) {
 		if ( 'yes' == $autoload ) {
-<<<<<<< HEAD
-			$alloptions = wp_load_alloptions();
-=======
 			$alloptions            = wp_load_alloptions( true );
->>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 			$alloptions[ $option ] = $serialized_value;
 			wp_cache_set( 'alloptions', $alloptions, 'options' );
 		} else {
@@ -571,15 +558,9 @@ function delete_option( $option ) {
 	$result = $wpdb->delete( $wpdb->options, array( 'option_name' => $option ) );
 	if ( ! wp_installing() ) {
 		if ( 'yes' == $row->autoload ) {
-<<<<<<< HEAD
-			$alloptions = wp_load_alloptions();
-			if ( is_array( $alloptions ) && isset( $alloptions[$option] ) ) {
-				unset( $alloptions[$option] );
-=======
 			$alloptions = wp_load_alloptions( true );
 			if ( is_array( $alloptions ) && isset( $alloptions[ $option ] ) ) {
 				unset( $alloptions[ $option ] );
->>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 				wp_cache_set( 'alloptions', $alloptions, 'options' );
 			}
 		} else {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -177,17 +177,24 @@ function form_option( $option ) {
 /**
  * Loads and caches all autoloaded options, if available or all options.
  *
+<<<<<<< HEAD
  * @since WP-2.2.0
+=======
+ * @since 2.2.0
+ * @since 5.3.1 The `$force_cache` parameter was added.
+>>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
  *
  * @global wpdb $wpdb ClassicPress database abstraction object.
  *
+ * @param bool $force_cache Optional. Whether to force an update of the local cache
+ *                          from the persistent cache. Default false.
  * @return array List of all options.
  */
-function wp_load_alloptions() {
+function wp_load_alloptions( $force_cache = false ) {
 	global $wpdb;
 
 	if ( ! wp_installing() || ! is_multisite() ) {
-		$alloptions = wp_cache_get( 'alloptions', 'options' );
+		$alloptions = wp_cache_get( 'alloptions', 'options', $force_cache );
 	} else {
 		$alloptions = false;
 	}
@@ -377,8 +384,13 @@ function update_option( $option, $value, $autoload = null ) {
 	}
 
 	if ( ! wp_installing() ) {
+<<<<<<< HEAD
 		$alloptions = wp_load_alloptions();
 		if ( isset( $alloptions[$option] ) ) {
+=======
+		$alloptions = wp_load_alloptions( true );
+		if ( isset( $alloptions[ $option ] ) ) {
+>>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 			$alloptions[ $option ] = $serialized_value;
 			wp_cache_set( 'alloptions', $alloptions, 'options' );
 		} else {
@@ -479,7 +491,11 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = 'yes' )
 
 	if ( ! wp_installing() ) {
 		if ( 'yes' == $autoload ) {
+<<<<<<< HEAD
 			$alloptions = wp_load_alloptions();
+=======
+			$alloptions            = wp_load_alloptions( true );
+>>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 			$alloptions[ $option ] = $serialized_value;
 			wp_cache_set( 'alloptions', $alloptions, 'options' );
 		} else {
@@ -555,9 +571,15 @@ function delete_option( $option ) {
 	$result = $wpdb->delete( $wpdb->options, array( 'option_name' => $option ) );
 	if ( ! wp_installing() ) {
 		if ( 'yes' == $row->autoload ) {
+<<<<<<< HEAD
 			$alloptions = wp_load_alloptions();
 			if ( is_array( $alloptions ) && isset( $alloptions[$option] ) ) {
 				unset( $alloptions[$option] );
+=======
+			$alloptions = wp_load_alloptions( true );
+			if ( is_array( $alloptions ) && isset( $alloptions[ $option ] ) ) {
+				unset( $alloptions[ $option ] );
+>>>>>>> e0584e95ce... Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.
 				wp_cache_set( 'alloptions', $alloptions, 'options' );
 			}
 		} else {


### PR DESCRIPTION
Options, Meta APIs: Avoid a race condition causing the first of two subsequent requests updating different options at the same time to lose changes.

Every time an autoloaded option is updated or deleted, the alloptions cache is similarly updated. Due to the race condition, on any autoloaded option being updated, every other autoloaded option had its value set to the value at load time, causing a mismatch between the data in the persistent cache and the database.

This change introduces a $force_cache parameter for wp_load_alloptions() to force an update of the local alloptions cache from the persistent cache when an option is added, updated, or deleted, to minimize the chance of affecting other options.

Props fabifott, rmccue, tollmanz, johnjamesjacoby, spacedmonkey, dd32, jipmoors, tellyworth, jeremyclarke, joehoyle, boonebgorges, danielbachhuber, flixos90, jeichorn, mihdan, Grzegorz.Janoszka, SergeyBiryukov.
Merges [46753] and [46779] to the 5.3 branch.
Fixes #31245.

I have tested this in a local install with many custom options and have had no problems.