### PR TITLE
Multiple select support for wp_dropdown_categories

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -272,7 +272,7 @@ function category_description( $category = 0 ) {
  * @since WP-2.1.0
  * @since WP-4.2.0 Introduced the `value_field` argument.
  * @since WP-4.6.0 Introduced the `required` argument.
- * @since CP-1.4.0 Introduced the `multiple` argument.
+ * @since 1.4.0 Introduced the `multiple` argument.
  *
  * @param string|array $args {
  *     Optional. Array or string of arguments to generate a categories drop-down element. See WP_Term_Query::__construct()
@@ -307,7 +307,7 @@ function category_description( $category = 0 ) {
  *     @type bool         $required          Whether the `<select>` element should have the HTML5 'required' attribute.
  *                                           Default false.
  *     @type string       $multiple          Whether the `<select>` element should have the HTML5 'multiple' attribute
- *                                           and an `[]` in the name. Accepts '' or 'multiple'. Default ''.
+ *                                           and an `[]` in the name. Accepts bool true or false. Default false.
  * }
  * @return string HTML content only if 'echo' argument is 0.
  */
@@ -334,7 +334,7 @@ function wp_dropdown_categories( $args = '' ) {
 		'option_none_value' => -1,
 		'value_field'       => 'term_id',
 		'required'          => false,
-		'multiple'          => '',
+		'multiple'          => false,
 	);
 
 	$defaults['selected'] = ( is_category() ) ? get_query_var( 'cat' ) : 0;
@@ -350,9 +350,16 @@ function wp_dropdown_categories( $args = '' ) {
 		);
 		$args['taxonomy'] = 'link_category';
 	}
-
+	
 	$r = wp_parse_args( $args, $defaults );
 	$option_none_value = $r['option_none_value'];
+	/**
+	 * Validate Boolean Values of $args.
+	 */
+	foreach ( array( 'hide_if_empty', 'required', 'multiple' ) as $bool ) {
+		$r[ $bool ] = wp_validate_boolean( $r[ $bool ] );
+	}
+
 
 	if ( ! isset( $r['pad_counts'] ) && $r['show_count'] && $r['hierarchical'] ) {
 		$r['pad_counts'] = true;
@@ -374,9 +381,9 @@ function wp_dropdown_categories( $args = '' ) {
 	$class = esc_attr( $r['class'] );
 	$id = $r['id'] ? esc_attr( $r['id'] ) : $name;
 	$required = $r['required'] ? 'required' : '';
-	$multiple = esc_attr( $r['multiple'] );
-	if ( 'multiple' === $multiple ) {
+	if ( $r['multiple'] ) {
 		$name = $name . '[]';
+		$multiple = 'multiple';
 	}
 	if ( ! $r['hide_if_empty'] || ! empty( $categories ) ) {
 		$output = "<select $required name='$name' id='$id' class='$class' $tab_index_attribute $multiple>\n";

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -381,6 +381,7 @@ function wp_dropdown_categories( $args = '' ) {
 	$class = esc_attr( $r['class'] );
 	$id = $r['id'] ? esc_attr( $r['id'] ) : $name;
 	$required = $r['required'] ? 'required' : '';
+	$multiple = '';
 	if ( $r['multiple'] ) {
 		$name = $name . '[]';
 		$multiple = 'multiple';

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -14,7 +14,6 @@
  * @see get_term_link()
  *
  * @param int|object $category Category ID or object.
- * @return string Link on success, empty string if category does not exist.
  */
 function get_category_link( $category ) {
 	if ( ! is_object( $category ) )
@@ -273,6 +272,7 @@ function category_description( $category = 0 ) {
  * @since WP-2.1.0
  * @since WP-4.2.0 Introduced the `value_field` argument.
  * @since WP-4.6.0 Introduced the `required` argument.
+ * @since CP-1.4.0 Introduced the `multiple` argument.
  *
  * @param string|array $args {
  *     Optional. Array or string of arguments to generate a categories drop-down element. See WP_Term_Query::__construct()
@@ -306,6 +306,8 @@ function category_description( $category = 0 ) {
  *                                           Default false (create select element even if no categories are found).
  *     @type bool         $required          Whether the `<select>` element should have the HTML5 'required' attribute.
  *                                           Default false.
+ *     @type string       $multiple          Whether the `<select>` element should have the HTML5 'multiple' attribute
+ *                                           and an `[]` in the name. Accepts '' or 'multiple'. Default ''.
  * }
  * @return string HTML content only if 'echo' argument is 0.
  */
@@ -332,6 +334,7 @@ function wp_dropdown_categories( $args = '' ) {
 		'option_none_value' => -1,
 		'value_field'       => 'term_id',
 		'required'          => false,
+		'multiple'          => '',
 	);
 
 	$defaults['selected'] = ( is_category() ) ? get_query_var( 'cat' ) : 0;
@@ -371,9 +374,12 @@ function wp_dropdown_categories( $args = '' ) {
 	$class = esc_attr( $r['class'] );
 	$id = $r['id'] ? esc_attr( $r['id'] ) : $name;
 	$required = $r['required'] ? 'required' : '';
-
+	$multiple = esc_attr( $r['multiple'] );
+	if ( 'multiple' === $multiple ) {
+		$name = $name . '[]';
+	}
 	if ( ! $r['hide_if_empty'] || ! empty( $categories ) ) {
-		$output = "<select $required name='$name' id='$id' class='$class' $tab_index_attribute>\n";
+		$output = "<select $required name='$name' id='$id' class='$class' $tab_index_attribute $multiple>\n";
 	} else {
 		$output = '';
 	}
@@ -404,7 +410,7 @@ function wp_dropdown_categories( $args = '' ) {
 
 			/** This filter is documented in wp-includes/category-template.php */
 			$show_option_all = apply_filters( 'list_cats', $r['show_option_all'], null );
-			$selected = ( '0' === strval($r['selected']) ) ? " selected='selected'" : '';
+			$selected = ( '0' === strval( $r['selected'] ) ) ? " selected='selected'" : '';
 			$output .= "\t<option value='0'$selected>$show_option_all</option>\n";
 		}
 


### PR DESCRIPTION
## Description
Adds a new argument to the $args array for `wp_dropdown_categories`, allowing to pass either empty string or `multiple`. 

If left empty, the select defaults to a single select, if `multiple` is passed the Select will allow for multiple selection and pass an `[]` to the name attribute value as well.

See also https://forums.classicpress.net/t/update-wp-dropdown-categories-to-allow-for-multiple-selection/

## Motivation and context
The requirement to produce a Categories or else Custom taxonomy Dropdown with multiselect support has been around for years (google search will show what I mean).
I use to replace said function in my plugins with this (and other) amendments and thus I think it is time to have this tiny, but powerful change in core.

## How has this been tested?
This was tested on several installs of mine (I use to replace said function with a custom one). Also tested this particular commit on my local install
Example usage:
`wp_dropdown_categories( array('multiple' => 'multiple') );`

## Screenshots


### Before
<img width="599" alt="Screenshot 2021-09-10 at 11 06 25" src="https://user-images.githubusercontent.com/11800236/132798163-de1a91de-1da5-4263-bd8c-1ca6680024e0.png">


### After
<img width="502" alt="Screenshot 2021-09-10 at 11 06 37" src="https://user-images.githubusercontent.com/11800236/132798173-1d14ed7c-1134-491a-8df7-c6181514f785.png">

NOTE:
This now also allows for Select2 MultiSelects, of course (the developer just needs to instantiate S2 on the select input produced...)

## Types of changes
- New Feature (backwards compatible and non-disturbing)