### PR TITLE
Add multiple and value field arguments to wp_dropdown_users

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1098,10 +1098,15 @@ function wp_dropdown_users( $args = '' ) {
 	switch ( $value_field ) {
 		case 'ID':
 		case 'user_login':
+			// These fields are valid, and are already included in `$fields`.
+			break;
+
 		case 'user_nicename':
 		case 'user_email':
-			// These fields are valid.
+			// These fields are valid, and need to be included in `$fields`.
+			$fields[] = $value_field;
 			break;
+
 		default:
 			// Another field was specified - fall back to the default of 'ID'.
 			$value_field = 'ID';

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -989,6 +989,7 @@ function setup_userdata($for_user_id = '') {
  * @since WP-2.3.0
  * @since WP-4.5.0 Added the 'display_name_with_login' value for 'show'.
  * @since WP-4.7.0 Added the `$role`, `$role__in`, and `$role__not_in` parameters.
+ * @since 1.4.0 Added the `$select_multiple` and `$value_field` parameters.
  *
  * @param array|string $args {
  *     Optional. Array or string of arguments to generate a drop-down of users.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1112,7 +1112,7 @@ function wp_dropdown_users( $args = '' ) {
 			break;
 	}
 
-	$query_args['fields'] = $fields;
+	$query_args['fields'] = array_unique( $fields );
 
 	$show_option_all = $r['show_option_all'];
 	$show_option_none = $r['show_option_none'];

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1097,15 +1097,11 @@ function wp_dropdown_users( $args = '' ) {
 	switch ( $value_field ) {
 		case 'ID':
 		case 'user_login':
-			// These fields are valid, and are already included in `$fields`.
-			break;
-
 		case 'user_nicename':
 		case 'user_email':
-			// These fields are valid, and need to be included in `$fields`.
+			// These fields are valid, and may need to be queried.
 			$fields[] = $value_field;
 			break;
-
 		default:
 			// Another field was specified - fall back to the default of 'ID'.
 			$value_field = 'ID';

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1037,11 +1037,10 @@ function setup_userdata($for_user_id = '') {
  *                                                 these roles. Default empty array.
  *     @type array        $role__not_in            An array of role names to exclude. Users matching one or more of
  *                                                 these roles will not be included in results. Default empty array.
- *     @type string       $value_field             The name of the `WP_User` object property to use as the `<select>`
- *                                                 element's `value` attribute which is sent back to the server. Accepts
- *                                                 any `WP_User` object property which uniquely identifies a user (`ID`,
- *                                                 `user_login`, `user_nicename` or `user_email`). Default `ID` to use
- *                                                 the user ID.
+ *     @type string       $value_field             The name of the user property to use as the `<select>` element's
+ *                                                 `value` attribute which is sent back to the server. Accepts only a
+ *                                                 user property which uniquely identifies a user (`ID`, `user_login`,
+ *                                                 `user_nicename` or `user_email`). Default `ID` to use the user ID.
  *     @type bool         $select_multiple         Whether the `<select>` element should allow selecting multiple items.
  *                                                 If true, then the `<select>` will have the HTML5 'multiple' attribute
  *                                                 applied and `[]` will be appended to the `name` attribute. Default
@@ -1139,7 +1138,7 @@ function wp_dropdown_users( $args = '' ) {
 		} else {
 			$id = $r['id'] ? " id='" . esc_attr( $r['id'] ) . "'" : " id='$name'";
 		}
-		if ( $r['select_multiple'] ) {
+		if ( $r['select_multiple'] === true ) {
 			$name .= '[]';
 			$multiple_attr = ' multiple';
 		} else {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1105,6 +1105,7 @@ function wp_dropdown_users( $args = '' ) {
 		default:
 			// Another field was specified - fall back to the default of 'ID'.
 			$value_field = 'ID';
+			break;
 	}
 
 	$query_args['fields'] = $fields;
@@ -1191,7 +1192,7 @@ function wp_dropdown_users( $args = '' ) {
 			}
 
 			$_selected = selected( $user->ID, $r['selected'], false );
-			$select_value = $user->$value_field;
+			$select_value = esc_attr( $user->$value_field );
 			$output .= "\t<option value='$select_value'$_selected>" . esc_html( $display ) . "</option>\n";
 		}
 

--- a/tests/phpunit/tests/user/wpDropdownUsers.php
+++ b/tests/phpunit/tests/user/wpDropdownUsers.php
@@ -165,6 +165,28 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 	/**
 	 * @see https://github.com/ClassicPress/ClassicPress/pull/791
 	 */
+	public function test_value_field_added_to_query() {
+		$users = self::factory()->user->create_many( 2 );
+
+		$found = wp_dropdown_users( array(
+			'echo' => false,
+			'include' => $users,
+			'selected' => $users[0],
+			'show' => 'user_login',
+			// The user_nicename field is not included in the `get_users()`
+			// query by default.
+			'value_field' => 'user_nicename',
+		) );
+
+		$user0 = get_userdata( $users[0] );
+		$user1 = get_userdata( $users[1] );
+		$this->assertContains( "<option value='{$user0->user_nicename}' selected='selected'>$user0->user_login</option>", $found );
+		$this->assertContains( "<option value='{$user1->user_nicename}'>$user1->user_login</option>", $found );
+	}
+
+	/**
+	 * @see https://github.com/ClassicPress/ClassicPress/pull/791
+	 */
 	public function test_invalid_value_field() {
 		$users = self::factory()->user->create_many( 2 );
 

--- a/tests/phpunit/tests/user/wpDropdownUsers.php
+++ b/tests/phpunit/tests/user/wpDropdownUsers.php
@@ -240,8 +240,6 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 		$user1 = get_userdata( $users[1] );
 		$this->assertContains( "<option value='{$user1->ID}' selected='selected'>$user1->user_login</option>", $found );
 	}
-
-
 	/**
 	 * @see https://github.com/ClassicPress/ClassicPress/pull/572
 	 * @see https://github.com/ClassicPress/ClassicPress/pull/791

--- a/tests/phpunit/tests/user/wpDropdownUsers.php
+++ b/tests/phpunit/tests/user/wpDropdownUsers.php
@@ -6,6 +6,12 @@
  * @group user
  */
 class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
+	private $check_user_query_vars_calls = 0;
+
+	public function setUp() {
+		$this->check_user_query_vars_calls = 0;
+	}
+
 	public function tearDown() {
 		remove_action( 'pre_get_users', [ $this, 'check_user_query_vars' ] );
 		parent::tearDown();
@@ -194,6 +200,7 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 			array_unique( $user_query->query_vars['fields'] ),
 			'Each queried user field should be listed only once.'
 		);
+		$this->check_user_query_vars_calls++;
 	}
 
 	/**
@@ -218,6 +225,8 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 		$user1 = get_userdata( $users[1] );
 		$this->assertContains( "<option value='{$user0->user_nicename}' selected='selected'>$user0->user_nicename</option>", $found );
 		$this->assertContains( "<option value='{$user1->user_nicename}'>$user1->user_nicename</option>", $found );
+
+		$this->assertSame( $this->check_user_query_vars_calls, 1 );
 	}
 
 	/**
@@ -240,6 +249,7 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 		$user1 = get_userdata( $users[1] );
 		$this->assertContains( "<option value='{$user1->ID}' selected='selected'>$user1->user_login</option>", $found );
 	}
+
 	/**
 	 * @see https://github.com/ClassicPress/ClassicPress/pull/572
 	 * @see https://github.com/ClassicPress/ClassicPress/pull/791

--- a/tests/phpunit/tests/user/wpDropdownUsers.php
+++ b/tests/phpunit/tests/user/wpDropdownUsers.php
@@ -10,6 +10,7 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 
 	public function setUp() {
 		$this->check_user_query_vars_calls = 0;
+		parent::setUp();
 	}
 
 	public function tearDown() {
@@ -225,7 +226,6 @@ class Tests_User_WpDropdownUsers extends WP_UnitTestCase {
 		$user1 = get_userdata( $users[1] );
 		$this->assertContains( "<option value='{$user0->user_nicename}' selected='selected'>$user0->user_nicename</option>", $found );
 		$this->assertContains( "<option value='{$user1->user_nicename}'>$user1->user_nicename</option>", $found );
-
 		$this->assertSame( $this->check_user_query_vars_calls, 1 );
 	}
 


### PR DESCRIPTION
## Description
Add a `multiple` and a `value_field` argument to the $args array, so to allow the User Dropdown to be a multiple select, and to control the select option `value` attribute.

This change will allow a developer to instantiate the `wp_dropdown_users` function as a Multiple Select Dropdown instead of just as as single select.
It also allows to control the `value` value of the `option` in the select dropdown, which by default is the User ID, and that is not only limited, but most of the times, undesired.

Example usage 
`wp_dropdown_users( array( 'value_field' => 'user_login', 'multiple' => 'multiple' ) );`

See also https://forums.classicpress.net/t/update-wp-dropdown-users-args-to-support-a-proper-select-option-value-html-attribute/

## Motivation and context
Often it is required to create multiple selects for Users - just google  the question to see it pops up quite often.
Controlling the value of a select is just a must, and pendant wp_dropdown_category already has that, so why not also add it to users? I use this a lot and replaced the function in my plugins... it's time to add it to core :)

Additionally - this function is a _mess_, and sometimes also unsafe, so it needs more work. But for starters it should be complete, and useful.
This change makes a first step in that direction. Later on, we need to make sure things are sanitised/escaped adequately, which currently they are only in display values, not in attribute values, which is just bad.

However it has been like that for years, thus first I think we should complete the function with the missing arguments (this commit should do that). Later we can think about escaping and sanitising this better.

## How has this been tested?
In my plugins, as well as local test of current PR.

## Screenshots
### Before
<img width="1193" alt="Screenshot 2021-09-10 at 11 48 24" src="https://user-images.githubusercontent.com/11800236/132801279-fcbc6a69-3bae-421f-941d-4806e2431c95.png">


### After
<img width="1131" alt="Screenshot 2021-09-10 at 11 48 36" src="https://user-images.githubusercontent.com/11800236/132801291-e690b6da-9821-4e9e-832a-66291807e6c6.png">


## Types of changes
- New Feature (non invasive, backwards compatible)
