### PR TITLE
Add 4 new attributes to paginate_links

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3832,11 +3832,11 @@ function paginate_links( $args = '' ) {
 		 *
 		 * @param string $link The paginated link URL.
 		 */
-		$page_links[] = '<a class="prev page-numbers ' . esc_attr( $args['a_classes'] ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['prev_text'] . '</a>';
+		$page_links[] = '<a class="' . trim( esc_attr( 'prev page-numbers ' . $args['a_classes'] ) ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['prev_text'] . '</a>';
 	endif;
 	for ( $n = 1; $n <= $total; $n++ ) :
 		if ( $n == $current ) :
-			$page_links[] = "<span aria-current='" . esc_attr( $args['aria_current'] ) . "' class='page-numbers current " . esc_attr( $args['current_classes'] ) . "'> " . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</span>';
+			$page_links[] = "<span aria-current='" . esc_attr( $args['aria_current'] ) . "' class='" . trim( esc_attr( 'page-numbers current ' . $args['current_classes'] ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</span>';
 			$dots = true;
 		else :
 			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size ) ) :
@@ -3848,7 +3848,7 @@ function paginate_links( $args = '' ) {
 				$link .= $args['add_fragment'];
 
 				/** This filter is documented in wp-includes/general-template.php */
-				$page_links[] = "<a class='page-numbers " . esc_attr( $args['a_classes'] ) . "' href='" . esc_url( apply_filters( 'paginate_links', $link ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</a>';
+				$page_links[] = "<a class='" . trim( esc_attr( 'page-numbers ' . $args['a_classes'] ) ) . "' href='" . esc_url( apply_filters( 'paginate_links', $link ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</a>';
 				$dots = true;
 			elseif ( $dots && ! $args['show_all'] ) :
 				$page_links[] = '<span class="page-numbers dots">' . __( '&hellip;' ) . '</span>';
@@ -3865,14 +3865,14 @@ function paginate_links( $args = '' ) {
 		$link .= $args['add_fragment'];
 
 		/** This filter is documented in wp-includes/general-template.php */
-		$page_links[] = '<a class="next page-numbers ' . esc_attr( $args['a_classes'] ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['next_text'] . '</a>';
+		$page_links[] = '<a class="' . trim( esc_attr( 'next page-numbers ' . $args['a_classes'] ) ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['next_text'] . '</a>';
 	endif;
 	switch ( $args['type'] ) {
 		case 'array':
 			return $page_links;
 
 		case 'list':
-			$r .= "<ul class='page-numbers " . esc_attr( $args['ul_classes'] ) . "'>\n\t<li class='" . esc_attr( $args['li_classes'] ) . "'>";
+			$r .= "<ul class='page-numbers " . trim( esc_attr( 'page-numbers ' . $args['ul_classes'] ) ) . "'>\n\t<li class='" . esc_attr( $args['li_classes'] ) . "'>";
 			$r .= join( "</li>\n\t<li class='" . esc_attr( $args['li_classes'] ) . "'>", $page_links );
 			$r .= "</li>\n</ul>\n";
 			break;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3724,6 +3724,12 @@ function language_attributes( $doctype = 'html' ) {
  *     @type string $add_fragment       A string to append to each link. Default empty.
  *     @type string $before_page_number A string to appear before the page number. Default empty.
  *     @type string $after_page_number  A string to append after the page number. Default empty.
+ *
+ *     @type string $li_classes         Classes to be added to each LIST element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $ul_classes         Classes to be added to the UL element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $a_classes          Classes to be added to each a href element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $current_classes    Classes to be added to each span (aria current) element. Default: empty. Accepts: valid HTML
+ *                                      classes.
  * }
  * @return array|string|void String of page links or array of page links.
  */
@@ -3746,7 +3752,7 @@ function paginate_links( $args = '' ) {
 	$format .= $wp_rewrite->using_permalinks() ? user_trailingslashit( $wp_rewrite->pagination_base . '/%#%', 'paged' ) : '?paged=%#%';
 
 	$defaults = array(
-		'base'               => $pagenum_link, // http://example.com/all_posts.php%_% : %_% is replaced by format (below)
+		'base'               => $pagenum_link, // http://example.com/all_posts.php%_% : %_% is replaced by format (below).
 		'format'             => $format, // ?page=%#% : %#% is replaced by the page number
 		'total'              => $total,
 		'current'            => $current,
@@ -3758,10 +3764,14 @@ function paginate_links( $args = '' ) {
 		'end_size'           => 1,
 		'mid_size'           => 2,
 		'type'               => 'plain',
-		'add_args'           => array(), // array of query args to add
+		'add_args'           => array(), // array of query args to add.
 		'add_fragment'       => '',
 		'before_page_number' => '',
 		'after_page_number'  => '',
+		'li_classes'         => '',
+		'ul_classes'         => '',
+		'a_classes'          => '',
+		'current_classes'    => '',
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -3788,7 +3798,7 @@ function paginate_links( $args = '' ) {
 		$args['add_args'] = array_merge( $args['add_args'], urlencode_deep( $url_query_args ) );
 	}
 
-	// Who knows what else people pass in $args
+	// Who knows what else people pass in $args.
 	$total = (int) $args['total'];
 	if ( $total < 2 ) {
 		return;
@@ -3810,8 +3820,9 @@ function paginate_links( $args = '' ) {
 	if ( $args['prev_next'] && $current && 1 < $current ) :
 		$link = str_replace( '%_%', 2 == $current ? '' : $args['format'], $args['base'] );
 		$link = str_replace( '%#%', $current - 1, $link );
-		if ( $add_args )
+		if ( $add_args ) {
 			$link = add_query_arg( $add_args, $link );
+		}
 		$link .= $args['add_fragment'];
 
 		/**
@@ -3821,22 +3832,23 @@ function paginate_links( $args = '' ) {
 		 *
 		 * @param string $link The paginated link URL.
 		 */
-		$page_links[] = '<a class="prev page-numbers" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['prev_text'] . '</a>';
+		$page_links[] = '<a class="prev page-numbers ' . esc_attr( $args['a_classes'] ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['prev_text'] . '</a>';
 	endif;
 	for ( $n = 1; $n <= $total; $n++ ) :
 		if ( $n == $current ) :
-			$page_links[] = "<span aria-current='" . esc_attr( $args['aria_current'] ) . "' class='page-numbers current'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . "</span>";
+			$page_links[] = "<span aria-current='" . esc_attr( $args['aria_current'] ) . "' class='page-numbers current " . esc_attr( $args['current_classes'] ) . "'> " . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</span>';
 			$dots = true;
 		else :
 			if ( $args['show_all'] || ( $n <= $end_size || ( $current && $n >= $current - $mid_size && $n <= $current + $mid_size ) || $n > $total - $end_size ) ) :
 				$link = str_replace( '%_%', 1 == $n ? '' : $args['format'], $args['base'] );
 				$link = str_replace( '%#%', $n, $link );
-				if ( $add_args )
+				if ( $add_args ) {
 					$link = add_query_arg( $add_args, $link );
+				}
 				$link .= $args['add_fragment'];
 
 				/** This filter is documented in wp-includes/general-template.php */
-				$page_links[] = "<a class='page-numbers' href='" . esc_url( apply_filters( 'paginate_links', $link ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . "</a>";
+				$page_links[] = "<a class='page-numbers " . esc_attr( $args['a_classes'] ) . "' href='" . esc_url( apply_filters( 'paginate_links', $link ) ) . "'>" . $args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number'] . '</a>';
 				$dots = true;
 			elseif ( $dots && ! $args['show_all'] ) :
 				$page_links[] = '<span class="page-numbers dots">' . __( '&hellip;' ) . '</span>';
@@ -3847,25 +3859,26 @@ function paginate_links( $args = '' ) {
 	if ( $args['prev_next'] && $current && $current < $total ) :
 		$link = str_replace( '%_%', $args['format'], $args['base'] );
 		$link = str_replace( '%#%', $current + 1, $link );
-		if ( $add_args )
+		if ( $add_args ) {
 			$link = add_query_arg( $add_args, $link );
+		}
 		$link .= $args['add_fragment'];
 
 		/** This filter is documented in wp-includes/general-template.php */
-		$page_links[] = '<a class="next page-numbers" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['next_text'] . '</a>';
+		$page_links[] = '<a class="next page-numbers ' . esc_attr( $args['a_classes'] ) . '" href="' . esc_url( apply_filters( 'paginate_links', $link ) ) . '">' . $args['next_text'] . '</a>';
 	endif;
 	switch ( $args['type'] ) {
-		case 'array' :
+		case 'array':
 			return $page_links;
 
-		case 'list' :
-			$r .= "<ul class='page-numbers'>\n\t<li>";
-			$r .= join("</li>\n\t<li>", $page_links);
+		case 'list':
+			$r .= "<ul class='page-numbers " . esc_attr( $args['ul_classes'] ) . "'>\n\t<li class='" . esc_attr( $args['li_classes'] ) . "'>";
+			$r .= join( "</li>\n\t<li class='" . esc_attr( $args['li_classes'] ) . "'>", $page_links );
 			$r .= "</li>\n</ul>\n";
 			break;
 
-		default :
-			$r = join("\n", $page_links);
+		default:
+			$r = join( "\n", $page_links );
 			break;
 	}
 	return $r;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3725,8 +3725,8 @@ function language_attributes( $doctype = 'html' ) {
  *     @type string $before_page_number A string to appear before the page number. Default empty.
  *     @type string $after_page_number  A string to append after the page number. Default empty.
  *
- *     @type string $li_classes         Classes to be added to each LIST element. Default: empty. Accepts: valid HTML classes.
  *     @type string $ul_classes         Classes to be added to the UL element. Default: empty. Accepts: valid HTML classes.
+ *     @type string $li_classes         Classes to be added to each LIST element. Default: empty. Accepts: valid HTML classes.
  *     @type string $a_classes          Classes to be added to each a href element. Default: empty. Accepts: valid HTML classes.
  *     @type string $current_classes    Classes to be added to each span (aria current) element. Default: empty. Accepts: valid HTML
  *                                      classes.
@@ -3768,8 +3768,8 @@ function paginate_links( $args = '' ) {
 		'add_fragment'       => '',
 		'before_page_number' => '',
 		'after_page_number'  => '',
-		'li_classes'         => '',
 		'ul_classes'         => '',
+		'li_classes'         => '',
 		'a_classes'          => '',
 		'current_classes'    => '',
 	);


### PR DESCRIPTION
## Description
Adds 4 new attributes to paginate links:
```
'li_classes'         => '',
'ul_classes'         => '',
'a_classes'          => '',
'current_classes'    => '',
```

This allows to control the produced HTML for paginate_links more granularly, particularly helpful when working with Bootstrap or other frameworks which expect certain classes added to ul, li and link + current item.

See also https://forums.classicpress.net/t/update-paginate-links-with-4-new-arguments/

Example usage:
```
echo paginate_links( array( 
    'type' => 'list',
    'li_classes' => 'li-class another-class',
    'ul_classes' => 'ul-class more-stuff',
    'a_classes' => 'link-class etc-class',
    'current_classes' => 'current-item is-really-current', 
) );
```

## Motivation and context
The paginate_links is another instance in WP that needs a lot of love, this is the minimal required additional features that almost every one needs when producing paginate_links. I have seen tons of plugins replacing said function just to add these arguments.

It should help developers get more control over the pagination items.

## How has this been tested?
In my plugins and this pr as well locally 

## Screenshots
### Before
<img width="1272" alt="before" src="https://user-images.githubusercontent.com/11800236/132804647-2dfc8dfa-95d3-4717-8021-910ca67864d2.png">


### After
<img width="1340" alt="after" src="https://user-images.githubusercontent.com/11800236/132804603-262461fa-602e-40e3-90a0-e5308ce575e9.png">


## Types of changes
- New Feature (non invasive, backwards compatible)
