### PR TITLE
Change default_comment_status to closed

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -413,7 +413,7 @@ function populate_options() {
 	'mailserver_pass' => 'password',
 	'mailserver_port' => 110,
 	'default_category' => 1,
-	'default_comment_status' => 'open',
+	'default_comment_status' => 'closed',
 	'default_ping_status' => 'open',
 	'default_pingback_flag' => 1,
 	'posts_per_page' => 10,


### PR DESCRIPTION
## Description

This changes a setting that gets loaded into the database when CP initially installs, so that comments are turned **off** by default, not **on**.

## Motivation and context

The comment system is something that users should _choose_ to use, rather than have it forced on them and have to remember to disable it.

We no longer have Akismet as an included plugin, so we are currently enabling comments by default but not providing any way to deal with the mountains of spam this will generate. 

There is also the issue that comments can be enabled on media items by accident, even though the user is not even using posts or a blog. A user can therefore end up with thousands of images that are unintentionally made open to comments (and spam).

Full discussion is here: https://forums.classicpress.net/t/change-basic-settings-of-comment-options/2744

This has a lot of votes from the previous petition system (note there is also a duplicate petition).

## How has this been tested?

The change shown was made to one line in schema.php. A new CP instance was installed and it was noted that the box was now unticked.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/46998578/132933632-232ca8e9-b8c9-432f-a0d8-18f8e4ea0103.jpg)

### After

![after](https://user-images.githubusercontent.com/46998578/132933646-a4687152-964d-4740-8967-24affb5f41b7.jpg)

## Types of changes

New feature I guess (although I'd consider it more of a bug fix).

