### PR TITLE
Revise login page link layout

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -218,6 +218,21 @@ p {
 	margin: 5em 0 2em;
 }
 
+.login .visit-site-link {
+	text-align:center;
+	font-size:110% !important;
+	margin-bottom:25px;
+}
+
+.login .meta-site-link {
+	  text-align:center;
+	  }
+
+.visit-site-link a,
+.login .meta-site-link a {
+	text-decoration:none;
+	}
+
 .login form .input,
 .login input[type="text"] {
 	font-size: 24px;

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -214,11 +214,14 @@ function login_footer($input_id = '') {
 
 	// Don't allow interim logins to navigate away from the page.
 	if ( ! $interim_login ): ?>
-	<p id="backtoblog"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php
-		/* translators: %s: site title */
-		printf( _x( '&larr; Back to %s', 'site' ), get_bloginfo( 'title', 'display' ) );
-	?></a></p>
-	<?php the_privacy_policy_link( '<div class="privacy-policy-page-link">', '</div>' ); ?>
+	<p id="backtoblog" class="visit-site-link"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php
+			/* translators: %s: site title */
+			printf( _x( 'Visit <strong>%s</strong>', 'site' ), get_bloginfo( 'title', 'display' ) );
+			?></a></p>
+	<p class="meta-site-link">
+		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php _e( 'Reset Password' ); ?></a> &nbsp;
+		<?php the_privacy_policy_link(); ?>
+	</p>
 	<?php endif; ?>
 
 	</div>
@@ -1031,7 +1034,6 @@ default:
 		echo esc_html( $login_link_separator );
 	endif;
 	?>
-	<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php _e( 'Lost your password?' ); ?></a>
 <?php endif; ?>
 </p>
 <?php } ?>


### PR DESCRIPTION
## Description
This PR restyles the links on the login page, per the following forum discussion.

https://forums.classicpress.net/t/center-lost-password-back-links-on-login-page/3563/34

## Motivation and context
A lot of man-hours went into the forum discussion, so, it must be pretty important. :)

## How has this been tested?
Manually tested on localhost.

### Before
![image](https://user-images.githubusercontent.com/12477319/133015052-fba6b607-ba69-49ef-bfaa-9c4760630342.png)

### After - when site has Privacy Policy
![image](https://user-images.githubusercontent.com/12477319/133015086-f3f07197-7dec-48f3-aecf-3c2bc7d8e05e.png)

### After - when site has no Privacy Policy
![image](https://user-images.githubusercontent.com/12477319/133019199-cdf2da9e-7c4d-4ccb-aad0-47c5d63e9fda.png)


## Types of changes
Moves links and adds a few new CSS rules. This is a non-breaking change.
