### PR TITLE
WP-r50677: Login and Registration: Check if `$_GET['login']` is set before using it in `wp-login.php`

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -580,8 +580,14 @@ endif;
 ?>
 </p>
 
+<<<<<<< HEAD
 <?php
 login_footer('user_login');
+=======
+		if ( isset( $_GET['key'] ) && isset( $_GET['login'] ) ) {
+			$value = sprintf( '%s:%s', wp_unslash( $_GET['login'] ), wp_unslash( $_GET['key'] ) );
+			setcookie( $rp_cookie, $value, 0, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
+>>>>>>> 924343c8fc... Login and Registration: Check if `$_GET['login']` is set before using it in `wp-login.php`.
 
 if ( $switched_locale ) {
     restore_previous_locale();

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -580,14 +580,8 @@ endif;
 ?>
 </p>
 
-<<<<<<< HEAD
 <?php
 login_footer('user_login');
-=======
-		if ( isset( $_GET['key'] ) && isset( $_GET['login'] ) ) {
-			$value = sprintf( '%s:%s', wp_unslash( $_GET['login'] ), wp_unslash( $_GET['key'] ) );
-			setcookie( $rp_cookie, $value, 0, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
->>>>>>> 924343c8fc... Login and Registration: Check if `$_GET['login']` is set before using it in `wp-login.php`.
 
 if ( $switched_locale ) {
     restore_previous_locale();

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -593,7 +593,7 @@ case 'resetpass' :
 case 'rp' :
 	list( $rp_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	$rp_cookie = 'wp-resetpass-' . COOKIEHASH;
-	if ( isset( $_GET['key'] ) ) {
+	if ( isset( $_GET['key'] ) && isset( $_GET['login'] ) ) {
 		$value = sprintf( '%s:%s', wp_unslash( $_GET['login'] ), wp_unslash( $_GET['key'] ) );
 		setcookie( $rp_cookie, $value, 0, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
 		wp_safe_redirect( remove_query_arg( array( 'key', 'login' ) ) );


### PR DESCRIPTION
Login and Registration: Check if `$_GET['login']` is set before using it in `wp-login.php`.

This avoids an "Undefined index" PHP notice displayed as part of password reset process if `$_GET['key']` is set, but `$_GET['login']` is not.

WP:Props satrancali.
Fixes https://core.trac.wordpress.org/ticket/52980.

Conflicts:
- src/wp-login.php

---

Merges https://core.trac.wordpress.org/changeset/50677 / WordPress/wordpress-develop@924343c8fc to ClassicPress.