### PR TITLE
Duplicated sections in media modal

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -443,7 +443,10 @@
 }
 
 .attachment-details .setting + .description {
+<<<<<<< HEAD
 	clear: both;
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 	font-size: 12px;
 	font-style: normal;
 	margin-bottom: 0.5em;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -443,10 +443,6 @@
 }
 
 .attachment-details .setting + .description {
-<<<<<<< HEAD
-	clear: both;
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 	font-size: 12px;
 	font-style: normal;
 	margin-bottom: 0.5em;

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -141,31 +141,17 @@ function wp_print_media_templates() {
 	$class = 'media-modal wp-core-ui';
 	if ( $is_IE && strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 7') !== false )
 		$class .= ' ie7';
-<<<<<<< HEAD
 
 	$alt_text_description = sprintf(
 		/* translators: 1: link to tutorial, 2: additional link attributes, 3: accessibility text */
 		__( '<a href="%1$s" %2$s>Describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative.' ),
 		esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ),
 		'target="_blank" rel="noopener noreferrer"',
-=======
-	}
-
-	$alt_text_description = sprintf(
-		/* translators: 1: link start tag, 2: accessibility text, 3: link end tag */
-		__( 'Describe %1$sthe purpose of the image%2$s%3$s. Leave empty if the image is purely decorative.' ),
-		'<a href="' . esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ) . '" target="_blank" rel="noopener noreferrer">',
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		sprintf(
 			'<span class="screen-reader-text"> %s</span>',
 			/* translators: accessibility text */
 			__( '(opens in a new tab)' )
-<<<<<<< HEAD
 		)
-=======
-		),
-		'</a>'
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 	);
 	?>
 	<!--[if lte IE 8]>
@@ -406,13 +392,6 @@ function wp_print_media_templates() {
 			</div>
 
 			<div class="settings">
-<<<<<<< HEAD
-				<label class="setting" data-setting="url">
-					<span class="name"><?php _e('URL'); ?></span>
-					<input type="text" value="{{ data.url }}" readonly />
-				</label>
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 				<# var maybeReadOnly = data.can.save || data.allowLocalEdits ? '' : 'readonly'; #>
 				<# if ( 'image' === data.type ) { #>
 					<label class="setting" data-setting="alt">
@@ -603,14 +582,6 @@ function wp_print_media_templates() {
 			</div>
 		</div>
 
-<<<<<<< HEAD
-		<label class="setting" data-setting="url">
-			<span class="name"><?php _e('URL'); ?></span>
-			<input type="text" value="{{ data.url }}" readonly />
-		</label>
-
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<# var maybeReadOnly = data.can.save || data.allowLocalEdits ? '' : 'readonly'; #>
 		<# if ( 'image' === data.type ) { #>
 			<label class="setting" data-setting="alt">
@@ -640,16 +611,6 @@ function wp_print_media_templates() {
 			<span class="name"><?php _e('Caption'); ?></span>
 			<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>
 		</label>
-<<<<<<< HEAD
-		<# if ( 'image' === data.type ) { #>
-			<label class="setting" data-setting="alt">
-				<span class="name"><?php _e('Alt Text'); ?></span>
-				<input type="text" value="{{ data.alt }}" {{ maybeReadOnly }} />
-			</label>
-		<# } #>
-
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<label class="setting" data-setting="description">
 			<span class="name"><?php _e('Description'); ?></span>
 			<textarea {{ maybeReadOnly }}>{{ data.description }}</textarea>
@@ -914,14 +875,6 @@ function wp_print_media_templates() {
 			</label>
 		<?php endif; ?>
 
-<<<<<<< HEAD
-		<label class="setting alt-text">
-			<span><?php _e('Alt Text'); ?></span>
-			<input type="text" data-setting="alt" />
-		</label>
-
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<div class="setting align">
 			<span><?php _e('Align'); ?></span>
 			<div class="button-group button-large" data-setting="align">
@@ -988,14 +941,6 @@ function wp_print_media_templates() {
 						</label>
 					<?php endif; ?>
 
-<<<<<<< HEAD
-					<label class="setting alt-text">
-						<span><?php _e('Alternative Text'); ?></span>
-						<input type="text" data-setting="alt" value="{{ data.model.alt }}" />
-					</label>
-
-=======
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 					<h2><?php _e( 'Display Settings' ); ?></h2>
 					<div class="setting align">
 						<span><?php _e('Align'); ?></span>

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -141,17 +141,31 @@ function wp_print_media_templates() {
 	$class = 'media-modal wp-core-ui';
 	if ( $is_IE && strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 7') !== false )
 		$class .= ' ie7';
+<<<<<<< HEAD
 
 	$alt_text_description = sprintf(
 		/* translators: 1: link to tutorial, 2: additional link attributes, 3: accessibility text */
 		__( '<a href="%1$s" %2$s>Describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative.' ),
 		esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ),
 		'target="_blank" rel="noopener noreferrer"',
+=======
+	}
+
+	$alt_text_description = sprintf(
+		/* translators: 1: link start tag, 2: accessibility text, 3: link end tag */
+		__( 'Describe %1$sthe purpose of the image%2$s%3$s. Leave empty if the image is purely decorative.' ),
+		'<a href="' . esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ) . '" target="_blank" rel="noopener noreferrer">',
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		sprintf(
 			'<span class="screen-reader-text"> %s</span>',
 			/* translators: accessibility text */
 			__( '(opens in a new tab)' )
+<<<<<<< HEAD
 		)
+=======
+		),
+		'</a>'
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 	);
 	?>
 	<!--[if lte IE 8]>
@@ -392,10 +406,13 @@ function wp_print_media_templates() {
 			</div>
 
 			<div class="settings">
+<<<<<<< HEAD
 				<label class="setting" data-setting="url">
 					<span class="name"><?php _e('URL'); ?></span>
 					<input type="text" value="{{ data.url }}" readonly />
 				</label>
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 				<# var maybeReadOnly = data.can.save || data.allowLocalEdits ? '' : 'readonly'; #>
 				<# if ( 'image' === data.type ) { #>
 					<label class="setting" data-setting="alt">
@@ -586,11 +603,14 @@ function wp_print_media_templates() {
 			</div>
 		</div>
 
+<<<<<<< HEAD
 		<label class="setting" data-setting="url">
 			<span class="name"><?php _e('URL'); ?></span>
 			<input type="text" value="{{ data.url }}" readonly />
 		</label>
 
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<# var maybeReadOnly = data.can.save || data.allowLocalEdits ? '' : 'readonly'; #>
 		<# if ( 'image' === data.type ) { #>
 			<label class="setting" data-setting="alt">
@@ -620,6 +640,7 @@ function wp_print_media_templates() {
 			<span class="name"><?php _e('Caption'); ?></span>
 			<textarea {{ maybeReadOnly }}>{{ data.caption }}</textarea>
 		</label>
+<<<<<<< HEAD
 		<# if ( 'image' === data.type ) { #>
 			<label class="setting" data-setting="alt">
 				<span class="name"><?php _e('Alt Text'); ?></span>
@@ -627,6 +648,8 @@ function wp_print_media_templates() {
 			</label>
 		<# } #>
 
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<label class="setting" data-setting="description">
 			<span class="name"><?php _e('Description'); ?></span>
 			<textarea {{ maybeReadOnly }}>{{ data.description }}</textarea>
@@ -891,11 +914,14 @@ function wp_print_media_templates() {
 			</label>
 		<?php endif; ?>
 
+<<<<<<< HEAD
 		<label class="setting alt-text">
 			<span><?php _e('Alt Text'); ?></span>
 			<input type="text" data-setting="alt" />
 		</label>
 
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<div class="setting align">
 			<span><?php _e('Align'); ?></span>
 			<div class="button-group button-large" data-setting="align">
@@ -962,11 +988,14 @@ function wp_print_media_templates() {
 						</label>
 					<?php endif; ?>
 
+<<<<<<< HEAD
 					<label class="setting alt-text">
 						<span><?php _e('Alternative Text'); ?></span>
 						<input type="text" data-setting="alt" value="{{ data.model.alt }}" />
 					</label>
 
+=======
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 					<h2><?php _e( 'Display Settings' ); ?></h2>
 					<div class="setting align">
 						<span><?php _e('Align'); ?></span>

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -1137,11 +1137,7 @@
 						<span class="name">Alternative Text</span>
 						<input type="text" value="{{ data.alt }}" aria-describedby="alt-text-description" {{ maybeReadOnly }} />
 					</label>
-<<<<<<< HEAD
 					<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
-=======
-					<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 				<# } #>
 								<label class="setting" data-setting="title">
 					<span class="name">Title</span>
@@ -1306,11 +1302,7 @@
 				<span class="name">Alt Text</span>
 				<input type="text" value="{{ data.alt }}" aria-describedby="alt-text-description" {{ maybeReadOnly }} />
 			</label>
-<<<<<<< HEAD
 			<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
-=======
-			<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<# } #>
 				<label class="setting" data-setting="title">
 			<span class="name">Title</span>
@@ -1602,12 +1594,7 @@
 			<span>Alternative Text</span>
 			<input type="text" data-setting="alt" aria-describedby="alt-text-description" />
 		</label>
-<<<<<<< HEAD
 		<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
-=======
-		<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
-
 					<label class="setting caption">
 				<span>Caption</span>
 				<textarea data-setting="caption" />
@@ -1661,12 +1648,7 @@
 						<span>Alternative Text</span>
 						<input type="text" data-setting="alt" value="{{ data.model.alt }}" aria-describedby="alt-text-description" />
 					</label>
-<<<<<<< HEAD
 					<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
-=======
-					<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
->>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
-
 											<label class="setting caption">
 							<span>Caption</span>
 							<textarea data-setting="caption">{{ data.model.caption }}</textarea>

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -1137,7 +1137,11 @@
 						<span class="name">Alternative Text</span>
 						<input type="text" value="{{ data.alt }}" aria-describedby="alt-text-description" {{ maybeReadOnly }} />
 					</label>
+<<<<<<< HEAD
 					<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+=======
+					<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 				<# } #>
 								<label class="setting" data-setting="title">
 					<span class="name">Title</span>
@@ -1302,7 +1306,11 @@
 				<span class="name">Alt Text</span>
 				<input type="text" value="{{ data.alt }}" aria-describedby="alt-text-description" {{ maybeReadOnly }} />
 			</label>
+<<<<<<< HEAD
 			<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+=======
+			<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 		<# } #>
 				<label class="setting" data-setting="title">
 			<span class="name">Title</span>
@@ -1594,7 +1602,11 @@
 			<span>Alternative Text</span>
 			<input type="text" data-setting="alt" aria-describedby="alt-text-description" />
 		</label>
+<<<<<<< HEAD
 		<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+=======
+		<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 
 					<label class="setting caption">
 				<span>Caption</span>
@@ -1649,7 +1661,11 @@
 						<span>Alternative Text</span>
 						<input type="text" data-setting="alt" value="{{ data.model.alt }}" aria-describedby="alt-text-description" />
 					</label>
+<<<<<<< HEAD
 					<p class="description" id="alt-text-description"><a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">Describe the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+=======
+					<p class="description" id="alt-text-description">Describe <a href="https://www.w3.org/WAI/tutorials/images/decision-tree" target="_blank" rel="noopener noreferrer">the purpose of the image<span class="screen-reader-text"> (opens in a new tab)</span></a>. Leave empty if the image is purely decorative.</p>
+>>>>>>> 026abd4bc6 (Accessibility: improve the "URL" and "Alt text" fields in the media modals.)
 
 											<label class="setting caption">
 							<span>Caption</span>


### PR DESCRIPTION
## Description
In an earlier backlit (https://github.com/ClassicPress/ClassicPress/pull/562) for A11Y we have created some duplicated content in the Media Modal popup when inserting media. The 'Alt' text box is duplicates and the URL field is also duplicated under different descriptions.

## Motivation and context
This PR back ports and earlier and previously missed changes from upstream (44900) that corrects this behaviour.

## How has this been tested?
Unit tests for PHP and QUnit are passing.
Locahost screenshots are included below
Note that in the current development code we have:
URL, Alt, Title, Caption, **Alt**, Description, **URL** (Duplicated files in bold)
In the updated code we now have
Alt, Title, Caption, Description, URL

## Screenshots
### Before

<img width="300" alt="Screenshot 2021-09-20 at 09 04 19" src="https://user-images.githubusercontent.com/1280733/133972693-1ee5695f-d871-45d2-9112-5b75b2176775.png">

### After

<img width="299" alt="Screenshot 2021-09-20 at 08 52 16" src="https://user-images.githubusercontent.com/1280733/133972711-e74425b9-532a-43b9-9e18-216924dc684b.png">


## Types of changes
- Bug fix
