### PR TITLE
Try running tests under PHP 8

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -36,7 +36,7 @@ jobs:
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:
       matrix:
-        php: [ '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
+        php: [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6.20' ]
         os: [ ubuntu-18.04 ]
         memcached: [ false ]
         include:


### PR DESCRIPTION
Getting the automated tests running and passing under PHP 8 is a pre-requisite for doing a release that declares PHP 8 compatibility.

This PR just adds a new job to GitHub Actions - making it actually run and pass is probably going to take a good bit of work. See https://core.trac.wordpress.org/ticket/50902 and https://core.trac.wordpress.org/ticket/46149 for starters.

Once tests are passing then we should be able to set the "PHP 8.0" job as a _required status check_ in the GitHub options for this repository. Note also that WP is using the GitHub Actions `continue-on-error` feature while they prepare for PHP 8.1 compatibility, which we may also need to do even though this feature has some drawbacks (https://github.community/t/continue-on-error-allow-failure-ui-indication/16773, https://github.com/actions/toolkit/issues/399).