### PR TITLE
Set default show_avatars option to off

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -466,7 +466,7 @@ function populate_options() {
 	'tag_base' => '',
 
 	// 2.5
-	'show_avatars' => '1',
+	'show_avatars' => '0',
 	'avatar_rating' => 'G',
 	'upload_url_path' => '',
 	'thumbnail_size_w' => 150,


### PR DESCRIPTION
<!--
Change a setting so that avatars are set to "off" by default.
-->

## Description
<!--
This PR changes the default setting of the show avatars checkbox to be unchecked on any new CP installation.
-->

## Motivation and context
<!--
All of the avatar options (including the default mystery option) involve a call out to Gravatar, which is run by Automattic. This is a privacy concern for CP.

The petition has a lot of popular support. More discussion here: https://forums.classicpress.net/t/disable-gr-avatar-by-default/2801
-->

## How has this been tested?
<!--
On a new install change this line schema.php from 1 to 0.
```
	// 2.5
	'show_avatars' => '0',
```
Set up the new site and check in the settings.

**NOTE:** As with the other previous change to schema.php there will probably be other related changes required. This is a preliminary PR to get us started.
-->

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/46998578/134118483-273f63e5-e256-438c-98a8-03f265e35bd5.jpg)

### After
![after](https://user-images.githubusercontent.com/46998578/134118602-3a97ba3d-50f3-46e0-b598-1316ac11d6ff.jpg)

## Type
- New feature

