### PR TITLE
WP-r47190: Menus: Introduce new Hooks

### DIFF
--- a/src/wp-admin/includes/class-walker-nav-menu-edit.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-edit.php
@@ -197,6 +197,21 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 					</label>
 				</p>
 
+				<?php
+				/**
+				 * Fires just before the move buttons of a nav menu item in the menu editor.
+				 *
+				 * @since 5.4.0
+				 *
+				 * @param int      $item_id Menu item ID.
+				 * @param WP_Post  $item    Menu item data object.
+				 * @param int      $depth   Depth of menu item. Used for padding.
+				 * @param stdClass $args    An object of menu item arguments.
+				 * @param int      $id      Nav menu ID.
+				 */
+				do_action( 'wp_nav_menu_item_custom_fields', $item_id, $item, $depth, $args, $id );
+				?>
+
 				<fieldset class="field-move hide-if-no-js description description-wide">
 					<span class="field-move-visual-label" aria-hidden="true"><?php _e( 'Move' ); ?></span>
 					<button type="button" class="button-link menus-move menus-move-up" data-dir="up"><?php _e( 'Up one' ); ?></button>

--- a/src/wp-admin/includes/class-walker-nav-menu-edit.php
+++ b/src/wp-admin/includes/class-walker-nav-menu-edit.php
@@ -201,7 +201,7 @@ class Walker_Nav_Menu_Edit extends Walker_Nav_Menu {
 				/**
 				 * Fires just before the move buttons of a nav menu item in the menu editor.
 				 *
-				 * @since 5.4.0
+				 * @since WP-5.4.0
 				 *
 				 * @param int      $item_id Menu item ID.
 				 * @param WP_Post  $item    Menu item data object.

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
@@ -132,7 +132,7 @@ class WP_Customize_Nav_Menu_Item_Control extends WP_Customize_Control {
 			 *
 			 * Additional fields can be rendered here and managed in JavaScript.
 			 *
-			 * @since 5.4.0
+			 * @since WP-5.4.0
 			 */
 			do_action( 'wp_nav_menu_item_custom_fields_customize_template' );
 			?>

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-control.php
@@ -126,6 +126,17 @@ class WP_Customize_Nav_Menu_Item_Control extends WP_Customize_Control {
 				</label>
 			</p>
 
+			<?php
+			/**
+			 * Fires at the end of the form field template for nav menu items in the customizer.
+			 *
+			 * Additional fields can be rendered here and managed in JavaScript.
+			 *
+			 * @since 5.4.0
+			 */
+			do_action( 'wp_nav_menu_item_custom_fields_customize_template' );
+			?>
+
 			<div class="menu-item-actions description-thin submitbox">
 				<# if ( ( 'post_type' === data.item_type || 'taxonomy' === data.item_type ) && '' !== data.original_title ) { #>
 				<p class="link-to-original">


### PR DESCRIPTION
## Description
This is a backport of 2 upstream changes and a fix for issue #565 

## Motivation and context
These hooks were long requested upstream and allow plugins and themes to extend the Nav Menus

## How has this been tested?
These hooks have been available in WP for about a year and a half but we need to ensure this doesn't break some plugin functionality.
One such example is ACF with around 1 million WP installs, however it does look like ACF is simply triggering that action now and collecting the outplay for later processing.

## Screenshots
N/A

## Types of changes
- New feature
- Breaking change

