### PR TITLE
WP-r47582: Pass the post object to the before_delete_post, delete_post, deleted_post, and after_delete_post actions.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2581,12 +2581,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires before a post is deleted, at the start of wp_delete_post().
 	 *
-<<<<<<< HEAD
-	 * @since WP-3.2.0
-=======
 	 * @since 3.2.0
 	 * @since 5.5.0 Added the `$post` parameter.
->>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @see wp_delete_post()
 	 *
@@ -2637,12 +2633,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately before a post is deleted from the database.
 	 *
-<<<<<<< HEAD
-	 * @since WP-1.2.0
-=======
 	 * @since 1.2.0
 	 * @since 5.5.0 Added the `$post` parameter.
->>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.
@@ -2656,12 +2648,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately after a post is deleted from the database.
 	 *
-<<<<<<< HEAD
-	 * @since WP-2.2.0
-=======
 	 * @since 2.2.0
 	 * @since 5.5.0 Added the `$post` parameter.
->>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.
@@ -2680,12 +2668,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires after a post is deleted, at the conclusion of wp_delete_post().
 	 *
-<<<<<<< HEAD
-	 * @since WP-3.2.0
-=======
 	 * @since 3.2.0
 	 * @since 5.5.0 Added the `$post` parameter.
->>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @see wp_delete_post()
 	 *

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2581,13 +2581,19 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires before a post is deleted, at the start of wp_delete_post().
 	 *
+<<<<<<< HEAD
 	 * @since WP-3.2.0
+=======
+	 * @since 3.2.0
+	 * @since 5.5.0 Added the `$post` parameter.
+>>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @see wp_delete_post()
 	 *
-	 * @param int $postid Post ID.
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
 	 */
-	do_action( 'before_delete_post', $postid );
+	do_action( 'before_delete_post', $postid, $post );
 
 	delete_post_meta($postid,'_wp_trash_meta_status');
 	delete_post_meta($postid,'_wp_trash_meta_time');
@@ -2631,11 +2637,17 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately before a post is deleted from the database.
 	 *
+<<<<<<< HEAD
 	 * @since WP-1.2.0
+=======
+	 * @since 1.2.0
+	 * @since 5.5.0 Added the `$post` parameter.
+>>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
-	 * @param int $postid Post ID.
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
 	 */
-	do_action( 'delete_post', $postid );
+	do_action( 'delete_post', $postid, $post );
 	$result = $wpdb->delete( $wpdb->posts, array( 'ID' => $postid ) );
 	if ( ! $result ) {
 		return false;
@@ -2644,11 +2656,17 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately after a post is deleted from the database.
 	 *
+<<<<<<< HEAD
 	 * @since WP-2.2.0
+=======
+	 * @since 2.2.0
+	 * @since 5.5.0 Added the `$post` parameter.
+>>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
-	 * @param int $postid Post ID.
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
 	 */
-	do_action( 'deleted_post', $postid );
+	do_action( 'deleted_post', $postid, $post );
 
 	clean_post_cache( $post );
 
@@ -2662,13 +2680,19 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires after a post is deleted, at the conclusion of wp_delete_post().
 	 *
+<<<<<<< HEAD
 	 * @since WP-3.2.0
+=======
+	 * @since 3.2.0
+	 * @since 5.5.0 Added the `$post` parameter.
+>>>>>>> 165bcc506d... Posts, Post Types: Pass the post object to the `before_delete_post`, `delete_post`, `deleted_post`, and `after_delete_post` actions.
 	 *
 	 * @see wp_delete_post()
 	 *
-	 * @param int $postid Post ID.
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
 	 */
-	do_action( 'after_delete_post', $postid );
+	do_action( 'after_delete_post', $postid, $post );
 
 	return $post;
 }

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2581,8 +2581,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires before a post is deleted, at the start of wp_delete_post().
 	 *
-	 * @since 3.2.0
-	 * @since 5.5.0 Added the `$post` parameter.
+	 * @since WP-3.2.0
+	 * @since WP-5.5.0 Added the `$post` parameter.
 	 *
 	 * @see wp_delete_post()
 	 *
@@ -2633,8 +2633,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately before a post is deleted from the database.
 	 *
-	 * @since 1.2.0
-	 * @since 5.5.0 Added the `$post` parameter.
+	 * @since WP-1.2.0
+	 * @since WP-5.5.0 Added the `$post` parameter.
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.
@@ -2648,8 +2648,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately after a post is deleted from the database.
 	 *
-	 * @since 2.2.0
-	 * @since 5.5.0 Added the `$post` parameter.
+	 * @since WP-2.2.0
+	 * @since WP-5.5.0 Added the `$post` parameter.
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.
@@ -2668,8 +2668,8 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires after a post is deleted, at the conclusion of wp_delete_post().
 	 *
-	 * @since 3.2.0
-	 * @since 5.5.0 Added the `$post` parameter.
+	 * @since WP-3.2.0
+	 * @since WP-5.5.0 Added the `$post` parameter.
 	 *
 	 * @see wp_delete_post()
 	 *


### PR DESCRIPTION
## Description
Backports changeset [47582](https://core.trac.wordpress.org/changeset/47582): Posts, Post Types: Pass the post object to the before_delete_post, delete_post, deleted_post, and after_delete_post actions.

## Motivation and context
From [Trac](https://core.trac.wordpress.org/ticket/30940):  When using `wp_delete_post()`, four actions are fired: `before_delete_post`, `delete_post`, `deleted_post` and `after_delete_post`. All of them get the `$postid` argument.

In some situations, it might be useful to have some extra information about the post being deleted, to perform different actions depending on things like the post date or the post type. With extensive usage of custom post types, this becomes more evident.

We can always get that data from the post ID being passed as an argument on those four actions, but that will add extra database calls that we can easily avoid. Early in `wp_delete_post()`, we do get the post row object from the database to check for things like post type and post parent. It seems a waste to recreate that data again if needed, plus it is not there anymore on the last two actions due to, well, post deletion. This limits what can be done on those last two actions in a granular way (no different deleted_post action callback workflow on a per post type basis, for example).

## How has this been tested?
Tested on local install and upstream.

## Types of changes
Exposes the `$post` object when deleting a post, which avoids having to make an extra call to the database using `get_post( $postid )`
