### PR TITLE
WP-r47856: Posts, Post Types: Pass the post object to the delete_attachment action.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5071,8 +5071,8 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	/**
 	 * Fires before an attachment is deleted, at the start of wp_delete_attachment().
 	 *
-	 * @since 2.0.0
-	 * @since 5.5.0 Added the `$post` parameter.
+	 * @since WP-2.0.0
+	 * @since WP-5.5.0 Added the `$post` parameter.
 	 *
 	 * @param int     $post_id Attachment ID.
 	 * @param WP_Post $post    Post object.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5071,11 +5071,17 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	/**
 	 * Fires before an attachment is deleted, at the start of wp_delete_attachment().
 	 *
+<<<<<<< HEAD
 	 * @since WP-2.0.0
+=======
+	 * @since 2.0.0
+	 * @since 5.5.0 Added the `$post` parameter.
+>>>>>>> adcf5cf7a3... Posts, Post Types: Pass the post object to the `delete_attachment` action.
 	 *
-	 * @param int $post_id Attachment ID.
+	 * @param int     $post_id Attachment ID.
+	 * @param WP_Post $post    Post object.
 	 */
-	do_action( 'delete_attachment', $post_id );
+	do_action( 'delete_attachment', $post_id, $post );
 
 	wp_delete_object_term_relationships($post_id, array('category', 'post_tag'));
 	wp_delete_object_term_relationships($post_id, get_object_taxonomies($post->post_type));
@@ -5097,13 +5103,13 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 		delete_metadata_by_mid( 'post', $mid );
 
 	/** This action is documented in wp-includes/post.php */
-	do_action( 'delete_post', $post_id );
+	do_action( 'delete_post', $post_id, $post );
 	$result = $wpdb->delete( $wpdb->posts, array( 'ID' => $post_id ) );
 	if ( ! $result ) {
 		return false;
 	}
 	/** This action is documented in wp-includes/post.php */
-	do_action( 'deleted_post', $post_id );
+	do_action( 'deleted_post', $post_id, $post );
 
 	wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file );
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5071,12 +5071,8 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	/**
 	 * Fires before an attachment is deleted, at the start of wp_delete_attachment().
 	 *
-<<<<<<< HEAD
-	 * @since WP-2.0.0
-=======
 	 * @since 2.0.0
 	 * @since 5.5.0 Added the `$post` parameter.
->>>>>>> adcf5cf7a3... Posts, Post Types: Pass the post object to the `delete_attachment` action.
 	 *
 	 * @param int     $post_id Attachment ID.
 	 * @param WP_Post $post    Post object.


### PR DESCRIPTION
## Description
Backport of Changeset [47856](https://core.trac.wordpress.org/changeset/47856): Posts, Post Types: Pass the post object to the delete_attachment action. Follows PR #805

## Motivation and context
Also add the missing `$post` parameter to the `delete_post` and `deleted_post actions` in `wp_delete_attachment()`.

## How has this been tested?
Upstream
