### PR TITLE
Do not ignore existing PHP files in wp-content/plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# gitignore file for WordPress Core
+# gitignore file for ClassicPress Core
 
 # Configuration files with possibly sensitive information
 wp-config.php
@@ -21,6 +21,8 @@ wp-tests-config.php
 /src/wp-content/languages
 /src/wp-content/mu-plugins
 /src/wp-content/plugins
+!/src/wp-content/plugins/hello.php
+!/src/wp-content/plugins/index.php
 /src/wp-content/themes/*
 !/src/wp-content/themes/twentyfifteen
 !/src/wp-content/themes/classicpress-twentyfifteen


### PR DESCRIPTION
@viktorix had an issue where `wp-content/plugins/hello.php` was deleted accidentally. His git client didn't pick up on this change and didn't make it easy to restore the file, because the entire `wp-content/plugins` folder has been incorrectly listed in `.gitignore` as ignored. We should ignore everything in this folder _except for_ the `hello.php` and `index.php` files which really are part of the ClassicPress development code.

This PR also changes the comment at the top of `.gitignore` from WordPress to ClassicPress.