### PR TITLE
Improve conflict detection/merging in backport script

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -171,7 +171,9 @@ fi
 
 echo "Backporting commit using git cherry-pick"
 set +e
-cmd __failure_allowed git cherry-pick --no-commit --find-renames "$commit_short"
+cmd __failure_allowed git cherry-pick --no-commit --find-renames \
+	--strategy=recursive --strategy-option=patience --strategy-option=ignore-space-change \
+	"$commit_short"
 conflict_status=$?
 set -e
 


### PR DESCRIPTION
These options from @mattyrob are reported to make for fewer and less severe conflicts generated during the backport process.

There was still a proposed improvement that hasn't been implemented yet:

> One improvement that would be helpful to me at least, is to list the conflicting files in 2 blocks, separating out those files that don't exist in out file structure. Block tests are a good example of conflict files that require no further review.

@mattyrob do you have an example of a WP changeset or two that modifies files that don't exist in ClassicPress so that we can implement & test this?