### PR TITLE
Backport script improvement

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -258,6 +258,8 @@ else
 	echo "Fix and commit the files that contain <<""<< or >>"">> conflict markers:"
 	git log -n 1 \
 		| perl -we '
+			use if "MSWin32" eq $^O, "Win32::Console::ANSI";
+			use Term::ANSIColor qw(:constants);
 			my $p = 0;
 			while (<>) {
 				if (/^\s+Conflicts:$/) {
@@ -270,7 +272,11 @@ else
 					s/^[\s-]+//;
 					my $cp_filename = $_;
 					$cp_filename =~ s#^src/js/_enqueues/#src/wp-includes/js/#;
-					print "    - $_\n";
+					if ( -e $_ ) {
+						print "    - $_\n";
+					} else {
+						print RED, "    - $_", RESET, "\n";
+					}
 					if ($cp_filename ne $_) {
 						print "      (probable CP path: $cp_filename)\n";
 					}


### PR DESCRIPTION
This is a potential fix for ClassicPress/ClassicPress-v1#53

## Description
Currently conflicting files listed by the backport script do not differentiate between files with conflicts and files that don't exist in ClassicPress but do in WordPress.

## Motivation and context
This enhancement checks if the file exists in the ClassicPress branch and if it does not the file name is highlighted in red. This will make is easer for local review of conflicts from backports - the red coloured files can be briefly reviewed and more rapidly ignored if they don't existing in ClassicPress.

## How has this been tested?
Local testing using the conflicts in backport of changeset 49539 both on MacOS and Windows (thanks to @viktorix

## Screenshots
### Before
<img width="390" alt="Screenshot 2021-10-16 at 22 07 59" src="https://user-images.githubusercontent.com/1280733/137602131-cd34d5f8-b472-4b65-ab3d-382ccf4f9f9d.png">

### After
<img width="401" alt="Screenshot 2021-10-16 at 22 08 07" src="https://user-images.githubusercontent.com/1280733/137602136-0a966939-6466-423d-b842-0cc3929033da.png">

## Types of changes
- New feature / enhancement
