### PR TITLE
Reverting ClassicPress back to WordPress for required version

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -624,7 +624,7 @@ function install_plugin_information() {
 				</li>
 			<?php } if ( ! empty( $api->requires ) ) { ?>
 				<li>
-					<strong><?php _e( 'Requires ClassicPress Version:' ); ?></strong>
+					<strong><?php _e( 'Requires WordPress Version:' ); ?></strong>
 					<?php
 					/* translators: %s: version number */
 					printf( __( '%s or higher' ), $api->requires );


### PR DESCRIPTION
As Joy pointed out on Slack, when viewing plugin information in the modal it shows "Requires ClassicPress Version: 5.8.0". It should still be WordPress.

## Description
ClassicPress text string changed to WordPress.

## Motivation and context
Provides wrong information to the user, needs to be fixed.

## How has this been tested?
Tested ClassicPress 1.3.0.

## Screenshots
<img width="1145" alt="d587d603-d380-41fd-9627-61d5bff9abcd" src="https://user-images.githubusercontent.com/1692600/138312713-1b6bdaff-c9ff-4380-9012-0a57220e7007.png">

## Types of changes
Bug fix
