### PR TITLE
Separate conflicting and absent files into 2 lists

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -286,7 +286,7 @@ else
 			}
 			print $files_conflicting;
 			if ( "" ne $files_nonexistent ) {
-				print "The following files may not exist in ClassicPress:\n";
+				print "The following files do not exist in the ClassicPress development code:\n";
 				print RED, $files_nonexistent, RESET;
 			}
 			'

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -261,8 +261,8 @@ else
 			use if "MSWin32" eq $^O, "Win32::Console::ANSI";
 			use Term::ANSIColor qw(:constants);
 			my $p = 0;
-			my $c = "";
-			my $e = "";
+			my $files_conflicting = "";
+			my $files_nonexistent = "";
 			while (<>) {
 				if (/^\s+Conflicts:$/) {
 					$p = 1;
@@ -275,18 +275,20 @@ else
 					my $cp_filename = $_;
 					$cp_filename =~ s#^src/js/_enqueues/#src/wp-includes/js/#;
 					if ( -e $_ ) {
-						$c = $c .  "    - $_\n";
+						$files_conflicting = $files_conflicting .  "    - $_\n";
 					} else {
-						$e = $e . "    - $_\n";
+						$files_nonexistent = $files_nonexistent . "    - $_\n";
 					}
 					if ( $cp_filename ne $_ ) {
-						$c = $c . "      (probable CP path: $cp_filename)\n";
+						$files_conflicting = $files_conflicting . "      (probable CP path: $cp_filename)\n";
 					}
 				}
 			}
-			print $c;
-			print "The following files may not exist in ClassicPress:\n";
-			print RED, $e, RESET;
+			print $files_conflicting;
+			if ( "" ne $files_nonexistent ) {
+				print "The following files may not exist in ClassicPress:\n";
+				print RED, $files_nonexistent, RESET;
+			}
 			'
 	echo "${color_bold_red}=======${color_reset}"
 	echo

--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -261,6 +261,8 @@ else
 			use if "MSWin32" eq $^O, "Win32::Console::ANSI";
 			use Term::ANSIColor qw(:constants);
 			my $p = 0;
+			my $c = "";
+			my $e = "";
 			while (<>) {
 				if (/^\s+Conflicts:$/) {
 					$p = 1;
@@ -273,15 +275,19 @@ else
 					my $cp_filename = $_;
 					$cp_filename =~ s#^src/js/_enqueues/#src/wp-includes/js/#;
 					if ( -e $_ ) {
-						print "    - $_\n";
+						$c = $c .  "    - $_\n";
 					} else {
-						print RED, "    - $_", RESET, "\n";
+						$e = $e . "    - $_\n";
 					}
-					if ($cp_filename ne $_) {
-						print "      (probable CP path: $cp_filename)\n";
+					if ( $cp_filename ne $_ ) {
+						$c = $c . "      (probable CP path: $cp_filename)\n";
 					}
 				}
-			}'
+			}
+			print $c;
+			print "The following files may not exist in ClassicPress:\n";
+			print RED, $e, RESET;
+			'
 	echo "${color_bold_red}=======${color_reset}"
 	echo
 	echo "If you're not sure how to do this, just push your changes to GitHub"


### PR DESCRIPTION
 Separate conflicting and absent files into 2 lists in backport script…reporting

## Description
The `backport-wp-commit.sh` has been evolving and improving. This is a further minor improvement.

## Motivation and context
A recent minor improvement was committed that lists non-existent files in red. As per the discussion on [slack](https://classicpress.slack.com/archives/CCCF22HG8/p1634829680014400) it was proposed listing the conflicting files and non-existent files separately would be an enhancement.


## How has this been tested?
Local testing in branch with:
`bin/backport-wp-commit.sh -c -v 49539`

## Screenshots
<img width="467" alt="Screenshot 2021-10-23 at 16 11 33" src="https://user-images.githubusercontent.com/1280733/138561947-38d0a9cf-0ad9-48f7-b82a-3c1dedcadee9.png">

## Types of changes
- New feature / enhancement
