### PR TITLE
Add "noreferrer" to comments in dashboard

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -690,7 +690,12 @@ class WP_Comments_List_Table extends WP_List_Table {
 
 		echo "<strong>"; comment_author( $comment ); echo '</strong><br />';
 		if ( ! empty( $author_url_display ) ) {
-			printf( '<a href="%s">%s</a><br />', esc_url( $author_url ), esc_html( $author_url_display ) );
+			// Print link to author URL, and disallow referrer information (without using target="_blank").
+			printf(
+				'<a href="%s" rel="noopener noreferrer">%s</a><br />',
+				esc_url( $author_url ),
+				esc_html( $author_url_display )
+			);
 		}
 
 		if ( $this->user_can ) {


### PR DESCRIPTION
WP-r52007: Comments: Add `noopener noreferrer` to author links in list table.

When viewing the listing of all comments, author links previously passed referrer information to untrusted URLs.  This change adds `noreferrer` to each author link, as well as `noopener` to prevent the passing of information about the parent window.

WP:Props cybr, adam3128, erayalakese, andraganescu, audrasjb, joedolson, sabernhardt. 
Fixes https://core.trac.wordpress.org/ticket/40916.

---

Merges https://core.trac.wordpress.org/changeset/52007 / WordPress/wordpress-develop@d782ee4c3c to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
See upstream ticket:
https://core.trac.wordpress.org/ticket/40916


## Motivation and context
This change prevent browser data leaks if checking website linked to comments.

## How has this been tested?
Upstream change 4 years in the making :)

## Screenshots
N/A

## Types of changes
- Bug fix / Security Enhancement