### PR TITLE
Deprecate single_month_title()

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -108,7 +108,7 @@ foreach ( array( 'the_content', 'the_title', 'wp_title' ) as $filter )
 add_filter( 'comment_text', 'capital_P_dangit', 31 );
 
 // Format titles
-foreach ( array( 'single_post_title', 'single_cat_title', 'single_tag_title', 'single_month_title', 'nav_menu_attr_title', 'nav_menu_description' ) as $filter ) {
+foreach ( array( 'single_post_title', 'single_cat_title', 'single_tag_title', 'nav_menu_attr_title', 'nav_menu_description' ) as $filter ) {
 	add_filter( $filter, 'wptexturize' );
 	add_filter( $filter, 'strip_tags'  );
 }

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -3944,3 +3944,47 @@ function wp_ajax_press_this_add_category() {
 		wp_send_json_error( array( 'errorMessage' => __( 'The Press This plugin is required.' ) ) );
 	}
 }
+
+
+/**
+ * Display or retrieve page title for post archive based on date.
+ *
+ * Useful for when the template only needs to display the month and year,
+ * if either are available. The prefix does not automatically place a space
+ * between the prefix, so if there should be a space, the parameter value
+ * will need to have it at the end.
+ *
+ * @since WP-0.71
+ * @deprecated 1.4.0
+ *
+ * @global WP_Locale $wp_locale
+ *
+ * @param string $prefix  Optional. What to display before the title.
+ * @param bool   $display Optional, default is true. Whether to display or retrieve title.
+ * @return string|void Title when retrieving.
+ */
+function single_month_title($prefix = '', $display = true ) {
+	_deprecated_function( __FUNCTION__, '1.4.0', 'get_the_date()' );
+	global $wp_locale;
+
+	$m = get_query_var('m');
+	$year = get_query_var('year');
+	$monthnum = get_query_var('monthnum');
+
+	if ( !empty($monthnum) && !empty($year) ) {
+		$my_year = $year;
+		$my_month = $wp_locale->get_month($monthnum);
+	} elseif ( !empty($m) ) {
+		$my_year = substr($m, 0, 4);
+		$my_month = $wp_locale->get_month(substr($m, 4, 2));
+	}
+
+	if ( empty($my_month) )
+		return false;
+
+	$result = $prefix . $my_month . $prefix . $my_year;
+
+	if ( !$display )
+		return $result;
+	echo $result;
+}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1397,47 +1397,6 @@ function single_term_title( $prefix = '', $display = true ) {
 }
 
 /**
- * Display or retrieve page title for post archive based on date.
- *
- * Useful for when the template only needs to display the month and year,
- * if either are available. The prefix does not automatically place a space
- * between the prefix, so if there should be a space, the parameter value
- * will need to have it at the end.
- *
- * @since WP-0.71
- *
- * @global WP_Locale $wp_locale
- *
- * @param string $prefix  Optional. What to display before the title.
- * @param bool   $display Optional, default is true. Whether to display or retrieve title.
- * @return string|void Title when retrieving.
- */
-function single_month_title($prefix = '', $display = true ) {
-	global $wp_locale;
-
-	$m = get_query_var('m');
-	$year = get_query_var('year');
-	$monthnum = get_query_var('monthnum');
-
-	if ( !empty($monthnum) && !empty($year) ) {
-		$my_year = $year;
-		$my_month = $wp_locale->get_month($monthnum);
-	} elseif ( !empty($m) ) {
-		$my_year = substr($m, 0, 4);
-		$my_month = $wp_locale->get_month(substr($m, 4, 2));
-	}
-
-	if ( empty($my_month) )
-		return false;
-
-	$result = $prefix . $my_month . $prefix . $my_year;
-
-	if ( !$display )
-		return $result;
-	echo $result;
-}
-
-/**
  * Display the archive title based on the queried object.
  *
  * @since WP-4.1.0


### PR DESCRIPTION
## Description
See discussion in #833, initial proposal to add a new function arrived at decision to deprecate this function for several reasons.

## Motivation and context
We should deprecate poorly designed and coded functions.
This function is poorly replicate with functions of similar names, it is not localized, it is not used in core and the output from this function can be achieved by other means.

## How has this been tested?
This simply moves the function to the `deprecated.php` file.

## Screenshots
N/A

## Types of changes
* Deprecation of core function