### PR TITLE
Add HTTP/3 as a valid HTTP protocol

### DIFF
--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -14,6 +14,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WPINC', 'wp-includes' );
 
+<<<<<<< HEAD
+=======
+$protocol = $_SERVER['SERVER_PROTOCOL'];
+if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
+	$protocol = 'HTTP/1.0';
+}
+
+>>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 $load = $_GET['load'];
 if ( is_array( $load ) )
 	$load = implode( '', $load );

--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -14,14 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WPINC', 'wp-includes' );
 
-<<<<<<< HEAD
-=======
-$protocol = $_SERVER['SERVER_PROTOCOL'];
-if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
-	$protocol = 'HTTP/1.0';
-}
-
->>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 $load = $_GET['load'];
 if ( is_array( $load ) )
 	$load = implode( '', $load );
@@ -44,7 +36,7 @@ wp_default_scripts($wp_scripts);
 
 if ( isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) && stripslashes( $_SERVER['HTTP_IF_NONE_MATCH'] ) === $wp_version ) {
 	$protocol = $_SERVER['SERVER_PROTOCOL'];
-	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
+	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
 		$protocol = 'HTTP/1.0';
 	}
 	header( "$protocol 304 Not Modified" );

--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -14,9 +14,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WPINC', 'wp-includes' );
 
+<<<<<<< HEAD
 require( ABSPATH . 'wp-admin/includes/noop.php' );
 require( ABSPATH . WPINC . '/script-loader.php' );
 require( ABSPATH . WPINC . '/version.php' );
+=======
+require ABSPATH . 'wp-admin/includes/noop.php';
+require ABSPATH . WPINC . '/theme.php';
+require ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
+require ABSPATH . WPINC . '/global-styles-and-settings.php';
+require ABSPATH . WPINC . '/script-loader.php';
+require ABSPATH . WPINC . '/version.php';
+
+$protocol = $_SERVER['SERVER_PROTOCOL'];
+if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
+	$protocol = 'HTTP/1.0';
+}
+>>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 
 $load = $_GET['load'];
 if ( is_array( $load ) ) {

--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -14,23 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WPINC', 'wp-includes' );
 
-<<<<<<< HEAD
 require( ABSPATH . 'wp-admin/includes/noop.php' );
 require( ABSPATH . WPINC . '/script-loader.php' );
 require( ABSPATH . WPINC . '/version.php' );
-=======
-require ABSPATH . 'wp-admin/includes/noop.php';
-require ABSPATH . WPINC . '/theme.php';
-require ABSPATH . WPINC . '/class-wp-theme-json-resolver.php';
-require ABSPATH . WPINC . '/global-styles-and-settings.php';
-require ABSPATH . WPINC . '/script-loader.php';
-require ABSPATH . WPINC . '/version.php';
-
-$protocol = $_SERVER['SERVER_PROTOCOL'];
-if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
-	$protocol = 'HTTP/1.0';
-}
->>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 
 $load = $_GET['load'];
 if ( is_array( $load ) ) {
@@ -51,7 +37,7 @@ wp_default_styles($wp_styles);
 
 if ( isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) && stripslashes( $_SERVER['HTTP_IF_NONE_MATCH'] ) === $wp_version ) {
 	$protocol = $_SERVER['SERVER_PROTOCOL'];
-	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
+	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
 		$protocol = 'HTTP/1.0';
 	}
 	header( "$protocol 304 Not Modified" );

--- a/src/wp-comments-post.php
+++ b/src/wp-comments-post.php
@@ -7,7 +7,11 @@
 
 if ( 'POST' != $_SERVER['REQUEST_METHOD'] ) {
 	$protocol = $_SERVER['SERVER_PROTOCOL'];
+<<<<<<< HEAD
 	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
+=======
+	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
+>>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 		$protocol = 'HTTP/1.0';
 	}
 

--- a/src/wp-comments-post.php
+++ b/src/wp-comments-post.php
@@ -7,11 +7,7 @@
 
 if ( 'POST' != $_SERVER['REQUEST_METHOD'] ) {
 	$protocol = $_SERVER['SERVER_PROTOCOL'];
-<<<<<<< HEAD
-	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
-=======
 	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
->>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 		$protocol = 'HTTP/1.0';
 	}
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -13,13 +13,8 @@
  * @return string The HTTP protocol. Default: HTTP/1.0.
  */
 function wp_get_server_protocol() {
-<<<<<<< HEAD
-	$protocol = $_SERVER['SERVER_PROTOCOL'];
-	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
-=======
 	$protocol = isset( $_SERVER['SERVER_PROTOCOL'] ) ? $_SERVER['SERVER_PROTOCOL'] : '';
 	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
->>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 		$protocol = 'HTTP/1.0';
 	}
 	return $protocol;

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -13,8 +13,13 @@
  * @return string The HTTP protocol. Default: HTTP/1.0.
  */
 function wp_get_server_protocol() {
+<<<<<<< HEAD
 	$protocol = $_SERVER['SERVER_PROTOCOL'];
 	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0' ) ) ) {
+=======
+	$protocol = isset( $_SERVER['SERVER_PROTOCOL'] ) ? $_SERVER['SERVER_PROTOCOL'] : '';
+	if ( ! in_array( $protocol, array( 'HTTP/1.1', 'HTTP/2', 'HTTP/2.0', 'HTTP/3' ), true ) ) {
+>>>>>>> d4447c0d76 (Bootstrap/Load: Add `HTTP/3` as a valid HTTP protocol. )
 		$protocol = 'HTTP/1.0';
 	}
 	return $protocol;


### PR DESCRIPTION
WP-r52087: Bootstrap/Load: Add HTTP/3 as a valid HTTP protocol.
As of November 2021, the `HTTP/3` protocol is still officially an Internet Draft, but is already supported by 74% of running web browsers and, according to W3Techs, 23% of the top 10 million websites. It has been supported by Google Chrome (including Chrome for Android, and Microsoft Edge, which is based on it) since April 2020 and by Mozilla Firefox since May 2021. Safari 14 (on macOS Big Sur and iOS 14) has also implemented the protocol but support is hidden behind a feature flag.

Based on the wide support, this change adds `HTTP/3` as a valid HTTP protocol.

WP:Props malthert.
Fixes https://core.trac.wordpress.org/ticket/54404.

## Description
Add HTTP/3 as a valid HTTP protocol

## Motivation and context
Backport of upstream ticker with apparently well research support data.

## How has this been tested?
Upstream backport

## Screenshots
N/A

## Types of changes
- New feature

