### PR TITLE
Update main branch name for upstream searching

### DIFF
--- a/bin/backport-wp-commit.sh
+++ b/bin/backport-wp-commit.sh
@@ -118,12 +118,12 @@ for range in \
 	'dc512708:5.2' \
 	'c67b47c66:5.3' \
 	'66f510bda:5.4' \
-	'ff6114f8:master'
+	'ff6114f8:trunk'
 do
 	start_commit=$(echo "$range" | cut -d: -f1)
 	search_branch=$(echo "$range" | cut -d: -f2)
 	log_range="$start_commit..$wp_remote/$search_branch"
-	if [ "$search_branch" = master ]; then
+	if [ "$search_branch" = trunk ]; then
 		svn_branch=trunk
 	else
 		svn_branch="branches/$search_branch"


### PR DESCRIPTION
## Description
Upstream main development branch name has been changed from `master` to `trunk`, this updates our backporting script.

## Motivation and context
Unchanged the backport script cannot find changeset to backport
We need to search in `trunk` for changes, ability to search `branches` already exists and is unchanged, if we `leaf` this unfixed our backport script is useless.

## How has this been tested?
Update applied locally and several backports have been successfully created in the last half hour with this change locally in place.

## Screenshots
<!--
N/A

## Types of changes
- Bug fix
