### PR TITLE
Add Previous and Next buttons alongside Add New button on single post screen in admin

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -528,11 +528,11 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
 
 		if ( ! empty( $previous_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-prev" title="Previous post: ' . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">← Previous</a>';
+			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-prev" title="' . _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
 		}
 
 		if ( ! empty( $next_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-next" title="Next post: ' . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">Next →</a>';
+			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-next" title="' . _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
 		}
 
 		echo '</span>';

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -502,25 +502,37 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 	 */
 	if ( apply_filters( 'admin-post-navigation', true, $post_type_object->name ) ) {
 
-		// Setting per user
-		$hidden = '';
-		$metaboxhidden = get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
+		// Setting per user per post type
+		$nav_display = 'inline';
+		$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
 
-		if ( in_array( 'adminpostnav', $metaboxhidden ) ) {
-			$hidden = 'hidden="hidden"';
+		if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
+			$nav_display = 'none';
 		}
 
-		$previous_post = get_previous_post();
 		$next_post = get_next_post();
+		$previous_post = get_previous_post();
 
-		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none;"' . $hidden . '>';
+		echo '<span id="adminpostnavspan" class="postbox" style="background: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
 
 		if ( ! empty( $previous_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-prev" title="' . _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
+
+			$previous_link = esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' );
+
+			$prev_title = _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title );
+
+			echo ' <a href="' . $previous_link . '" id="adminpostnav-prev" title="' . $prev_title . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
+
 		}
 
 		if ( ! empty( $next_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-next" title="' . _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
+
+			$next_link = esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' );
+
+			$next_title = _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title );
+
+			echo ' <a href="' . $next_link . '" id="adminpostnav-next" title="' . $next_title . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
+
 		}
 
 		echo '</span>';

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -528,11 +528,11 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
 
 		if ( ! empty( $previous_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() ) . 'post.php?post=' . $previous_post->ID . '&amp;action=edit" id="adminpostnav-prev" title="Previous post: ' . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">← Previous</a>';
+			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-prev" title="Previous post: ' . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">← Previous</a>';
 		}
 
 		if ( ! empty( $next_post ) ) {
-			echo ' <a href="' . esc_url( admin_url() ) . 'post.php?post=' . $next_post->ID . '&amp;action=edit" id="adminpostnav-next" title="Next post: ' . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">Next →</a>';
+			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-next" title="Next post: ' . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">Next →</a>';
 		}
 
 		echo '</span>';

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -493,11 +493,8 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
 	
 	/**
-	 * Adds Previous and Next buttons alongside Add New button. Setting
+	 * Adds Previous and Next links alongside Add New link. Setting
 	 * works per user per post type.
-	 * 
-	 * @param bool 	Whether to show Previous and Next buttons. Default true.
-	 * @param $post_type
 	 *
 	 * @since CP-1.x.x
 	 */

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -503,29 +503,17 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 	if ( apply_filters( 'admin-post-navigation', true, $post_type_object->name ) ) {
 
 		// Setting per user
-		$nav_display = 'inline';
-		$metaboxhidden_post = get_user_meta( get_current_user_id(), 'metaboxhidden_post', true );
+		$hidden = '';
+		$metaboxhidden = get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
 
-		if ( in_array( 'adminpostnav', $metaboxhidden_post ) ) {
-			$nav_display = 'none';
+		if ( in_array( 'adminpostnav', $metaboxhidden ) ) {
+			$hidden = 'hidden="hidden"';
 		}
-
-		/*
-		 * Enable overriding of default choice (made on post screen) for
-		 * other post types.
-		 * 
-		 * @param $nav_display	Must be either 'inline' or 'none'.
-		 * @param $post_type
-		 *
-		 * @since CP-1.x.x 
-		 */
-		$admin_nav = apply_filters( 'admin-post-navigation-buttons', $nav_display, $post_type_object->name );
-		$nav_display = ( in_array( $admin_nav, ['inline', 'none'] ) ) ? $admin_nav : $nav_display;
 
 		$previous_post = get_previous_post();
 		$next_post = get_next_post();
 
-		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
+		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none;"' . $hidden . '>';
 
 		if ( ! empty( $previous_post ) ) {
 			echo ' <a href="' . esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' ) . '" id="adminpostnav-prev" title="' . _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -491,6 +491,54 @@ echo esc_html( $title );
 <?php
 if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create_posts ) ) {
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
+	
+	/**
+	 * Adds Previous and Next buttons alongside Add New button.
+	 * 
+	 * @param bool 	Whether to show Previous and Next buttons. Default true.
+	 * @param $post_type
+	 *
+	 * @since CP-1.x.x
+	 */
+	if ( apply_filters( 'admin-post-navigation', true, $post_type_object->name ) ) {
+
+		// Setting per user
+		$nav_display = 'inline';
+		$metaboxhidden_post = get_user_meta( get_current_user_id(), 'metaboxhidden_post', true );
+
+		if ( in_array( 'adminpostnav', $metaboxhidden_post ) ) {
+			$nav_display = 'none';
+		}
+
+		/*
+		 * Enable overriding of default choice (made on post screen) for
+		 * other post types.
+		 * 
+		 * @param $nav_display	Must be either 'inline' or 'none'.
+		 * @param $post_type
+		 *
+		 * @since CP-1.x.x 
+		 */
+		$admin_nav = apply_filters( 'admin-post-navigation-buttons', $nav_display, $post_type_object->name );
+		$nav_display = ( in_array( $admin_nav, ['inline', 'none'] ) ) ? $admin_nav : $nav_display;
+
+		$previous_post = get_previous_post();
+		$next_post = get_next_post();
+
+		echo '<span id="adminpostnav" class="postbox" style="background-color: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
+
+		if ( ! empty( $previous_post ) ) {
+			echo ' <a href="' . esc_url( admin_url() ) . 'post.php?post=' . $previous_post->ID . '&amp;action=edit" id="adminpostnav-prev" title="Previous post: ' . esc_attr( $previous_post->post_title ) . ' " class="add-new-h2">← Previous</a>';
+		}
+
+		if ( ! empty( $next_post ) ) {
+			echo ' <a href="' . esc_url( admin_url() ) . 'post.php?post=' . $next_post->ID . '&amp;action=edit" id="adminpostnav-next" title="Next post: ' . esc_attr( $next_post->post_title ) . ' " class="add-new-h2">Next →</a>';
+		}
+
+		echo '</span>';
+
+	}
+
 }
 ?>
 

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -493,51 +493,47 @@ if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
 	
 	/**
-	 * Adds Previous and Next buttons alongside Add New button.
+	 * Adds Previous and Next buttons alongside Add New button. Setting
+	 * works per user per post type.
 	 * 
 	 * @param bool 	Whether to show Previous and Next buttons. Default true.
 	 * @param $post_type
 	 *
 	 * @since CP-1.x.x
 	 */
-	if ( apply_filters( 'admin-post-navigation', true, $post_type_object->name ) ) {
+	$nav_display = 'inline';
+	$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
 
-		// Setting per user per post type
-		$nav_display = 'inline';
-		$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $post_type_object->name, true );
+	if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
+		$nav_display = 'none';
+	}
 
-		if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
-			$nav_display = 'none';
-		}
+	$next_post = get_next_post();
+	$previous_post = get_previous_post();
 
-		$next_post = get_next_post();
-		$previous_post = get_previous_post();
+	echo '<span id="adminpostnavspan" class="postbox" style="background: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
 
-		echo '<span id="adminpostnavspan" class="postbox" style="background: transparent; border: none; box-shadow: none; display: ' . $nav_display . ';">';
+	if ( ! empty( $previous_post ) ) {
 
-		if ( ! empty( $previous_post ) ) {
+		$previous_link = esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' );
 
-			$previous_link = esc_url( admin_url() . 'post.php?post=' . $previous_post->ID . '&amp;action=edit' );
+		$prev_title = _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title );
 
-			$prev_title = _x( 'Previous post: ', 'Admin Post Navigation' ) . esc_attr( $previous_post->post_title );
-
-			echo ' <a href="' . $previous_link . '" id="adminpostnav-prev" title="' . $prev_title . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
-
-		}
-
-		if ( ! empty( $next_post ) ) {
-
-			$next_link = esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' );
-
-			$next_title = _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title );
-
-			echo ' <a href="' . $next_link . '" id="adminpostnav-next" title="' . $next_title . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
-
-		}
-
-		echo '</span>';
+		echo ' <a href="' . $previous_link . '" id="adminpostnav-prev" title="' . $prev_title . ' " class="add-new-h2">' . _x( '&larr; Previous', 'Admin Post Navigation' ) . '</a>';
 
 	}
+
+	if ( ! empty( $next_post ) ) {
+
+		$next_link = esc_url( admin_url() . 'post.php?post=' . $next_post->ID . '&amp;action=edit' );
+
+		$next_title = _x( 'Next post: ', 'Admin Post Navigation' ) . esc_attr( $next_post->post_title );
+
+		echo ' <a href="' . $next_link . '" id="adminpostnav-next" title="' . $next_title . ' " class="add-new-h2">' . _x( 'Next &rarr;', 'Admin Post Navigation' ) . '</a>';
+
+	}
+
+	echo '</span>';
 
 }
 ?>

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -905,10 +905,7 @@ final class WP_Screen {
 			$expand		.= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
 
 			/**
-			 * Filter for Previous and Next buttons alongside Add New button.
-			 * 
-			 * @param bool Whether to show these buttons. Default true.
-			 * @param $post_type
+			 * Adds Previous and Next buttons alongside Add New button.
 			 *
 			 * @since CP-1.x.x
 			 */			

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -911,7 +911,7 @@ final class WP_Screen {
 			 */
 			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ) );
+			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ), true, false );
 
 			$expand	.= '<label for="adminpostnav-hide">';
 			$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . esc_attr( $checked ) . ' />';

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -900,9 +900,70 @@ final class WP_Screen {
 		$this->_screen_settings = '';
 
 		if ( 'post' === $this->base ) {
-			$expand                 = '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
-			$expand                .= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
-			$expand                .= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label></fieldset>';
+			$expand		= '<fieldset class="editor-expand hidden"><legend>' . __( 'Additional settings' ) . '</legend><label for="editor-expand-toggle">';
+			$expand		.= '<input type="checkbox" id="editor-expand-toggle"' . checked( get_user_setting( 'editor_expand', 'on' ), 'on', false ) . ' />';
+			$expand		.= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
+
+			/**
+			 * Filter for Previous and Next buttons alongside Add New button.
+			 * 
+			 * @param bool Whether to show these buttons. Default true.
+			 * @param $post_type
+			 *
+			 * @since CP-1.x.x
+			 */			
+			if ( apply_filters( 'admin-post-navigation', true, $this->post_type ) ) {
+
+				$checked = 'checked="checked"';
+				$nav_display = 'inline';
+				$metaboxhidden_post = get_user_meta( get_current_user_id(), 'metaboxhidden_post', true );
+
+				if ( in_array( 'adminpostnav', $metaboxhidden_post ) ) {
+					$checked = '';
+					$nav_display = 'none';
+				}
+
+				/*
+				 * Enable overriding of default choice (made on post
+				 * screen) for other post types.
+				 * 
+				 * @param $nav_display	Must be either 'inline' or 'none'.
+				 * @param $post_type
+				 *
+				 * @since CP-1.x.x 
+				 */
+				$admin_nav = apply_filters( 'admin-post-navigation-buttons', $nav_display, $this->post_type );
+				if ( $admin_nav === 'inline' ) {
+					$checked = 'checked="checked"';
+				}
+				elseif ( $admin_nav === 'none' ) {
+					$checked = '';
+				}
+
+				$expand	.= '<label for="admin-post-nav-hide">';
+				$expand	.= '<input id="admin-post-nav-hide" class="hide-postbox-tog" name="admin-post-nav-hide" type="checkbox" value="adminpostnav"' . $checked . ' />';
+				$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
+				$expand	.= '</label></fieldset>';
+				?>
+
+				<script>
+				document.addEventListener('DOMContentLoaded', function() {
+					const checkboxNav = document.getElementById('admin-post-nav-hide');
+					const buttonsNav = document.getElementById('adminpostnav');
+
+					checkboxNav.addEventListener('change', function(event) {
+						if (event.currentTarget.checked) {
+							buttonsNav.removeAttribute('hidden');
+						} else {
+							buttonsNav.setAttribute('hidden', 'hidden');
+						}
+					});
+				});
+				</script>
+
+				<?php
+			}		
+
 			$this->_screen_settings = $expand;
 		}
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -915,35 +915,17 @@ final class WP_Screen {
 			if ( apply_filters( 'admin-post-navigation', true, $this->post_type ) ) {
 
 				$checked = 'checked="checked"';
-				$metaboxhidden = get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
+				$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-				if ( in_array( 'adminpostnav', $metaboxhidden ) ) {
+				if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
 					$checked = '';
 				}
 
 				$expand	.= '<label for="adminpostnav-hide">';
-				$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnav"' . $checked . ' />';
+				$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . $checked . ' />';
 				$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
 				$expand	.= '</label></fieldset>';
-				?>
-
-				<script>
-				document.addEventListener('DOMContentLoaded', function() {
-					const checkboxNav = document.getElementById('adminpostnav-hide');
-					const buttonsNav = document.getElementById('adminpostnav');
-
-					checkboxNav.addEventListener('change', function(event) {
-						if (event.currentTarget.checked) {
-							buttonsNav.removeAttribute('hidden');
-						} else {
-							buttonsNav.setAttribute('hidden', 'hidden');
-						}
-					});
-				});
-				</script>
-
-				<?php
-			}		
+			}
 
 			$this->_screen_settings = $expand;
 		}

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -915,33 +915,14 @@ final class WP_Screen {
 			if ( apply_filters( 'admin-post-navigation', true, $this->post_type ) ) {
 
 				$checked = 'checked="checked"';
-				$nav_display = 'inline';
-				$metaboxhidden_post = get_user_meta( get_current_user_id(), 'metaboxhidden_post', true );
+				$metaboxhidden = get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-				if ( in_array( 'adminpostnav', $metaboxhidden_post ) ) {
-					$checked = '';
-					$nav_display = 'none';
-				}
-
-				/*
-				 * Enable overriding of default choice (made on post
-				 * screen) for other post types.
-				 * 
-				 * @param $nav_display	Must be either 'inline' or 'none'.
-				 * @param $post_type
-				 *
-				 * @since CP-1.x.x 
-				 */
-				$admin_nav = apply_filters( 'admin-post-navigation-buttons', $nav_display, $this->post_type );
-				if ( $admin_nav === 'inline' ) {
-					$checked = 'checked="checked"';
-				}
-				elseif ( $admin_nav === 'none' ) {
+				if ( in_array( 'adminpostnav', $metaboxhidden ) ) {
 					$checked = '';
 				}
 
-				$expand	.= '<label for="admin-post-nav-hide">';
-				$expand	.= '<input id="admin-post-nav-hide" class="hide-postbox-tog" name="admin-post-nav-hide" type="checkbox" value="adminpostnav"' . $checked . ' />';
+				$expand	.= '<label for="adminpostnav-hide">';
+				$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnav"' . $checked . ' />';
 				$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
 				$expand	.= '</label></fieldset>';
 				?>

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -929,7 +929,7 @@ final class WP_Screen {
 
 				<script>
 				document.addEventListener('DOMContentLoaded', function() {
-					const checkboxNav = document.getElementById('admin-post-nav-hide');
+					const checkboxNav = document.getElementById('adminpostnav-hide');
 					const buttonsNav = document.getElementById('adminpostnav');
 
 					checkboxNav.addEventListener('change', function(event) {

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -905,19 +905,16 @@ final class WP_Screen {
 			$expand		.= __( 'Enable full-height editor and distraction-free functionality.' ) . '</label>';
 
 			/**
-			 * Adds Previous and Next buttons alongside Add New button.
+			 * Adds Previous and Next links alongside Add New link.
 			 *
 			 * @since CP-1.x.x
-			 */			
-			$checked = 'checked="checked"';
+			 */
 			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-			if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
-				$checked = '';
-			}
+			$checked = checked( ! in_array( 'adminpostnavspan', $metaboxhidden ) );
 
 			$expand	.= '<label for="adminpostnav-hide">';
-			$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . $checked . ' />';
+			$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . esc_attr( $checked ) . ' />';
 			$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
 			$expand	.= '</label></fieldset>';
 

--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -912,20 +912,17 @@ final class WP_Screen {
 			 *
 			 * @since CP-1.x.x
 			 */			
-			if ( apply_filters( 'admin-post-navigation', true, $this->post_type ) ) {
+			$checked = 'checked="checked"';
+			$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
 
-				$checked = 'checked="checked"';
-				$metaboxhidden = (array) get_user_meta( get_current_user_id(), 'metaboxhidden_' . $this->post_type, true );
-
-				if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
-					$checked = '';
-				}
-
-				$expand	.= '<label for="adminpostnav-hide">';
-				$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . $checked . ' />';
-				$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
-				$expand	.= '</label></fieldset>';
+			if ( in_array( 'adminpostnavspan', $metaboxhidden ) ) {
+				$checked = '';
 			}
+
+			$expand	.= '<label for="adminpostnav-hide">';
+			$expand	.= '<input id="adminpostnav-hide" class="hide-postbox-tog" name="adminpostnav-hide" type="checkbox" value="adminpostnavspan" ' . $checked . ' />';
+			$expand	.= _x( 'Enable Previous and Next buttons', 'Admin Post Navigation' );
+			$expand	.= '</label></fieldset>';
 
 			$this->_screen_settings = $expand;
 		}


### PR DESCRIPTION
New feature. Also includes one filter to turn off all the new code, and another filter that enables the default setting (set on the post screen) to be overridden for other post types.

## Motivation and context
See https://forums.classicpress.net/t/ability-to-navigate-to-the-next-previous-post-after-saving-edits-to-the-current-post/2891

## How has this been tested?
Tested on localhost

## Screenshots
![Screenshot from 2021-11-10 19-58-53](https://user-images.githubusercontent.com/4127662/141218187-8b051a8b-c851-4a34-9bab-5e3402ec3f9f.png)