### PR TITLE
WP-r52028: Media: Add filter for post thumbnail id.

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -37,7 +37,7 @@ function get_post_thumbnail_id( $post = null ) {
 		return '';
 	}
 
-	$thumbnail_id = (int) get_post_meta( $post->ID, '_thumbnail_id', true );
+	$thumbnail_id = get_post_meta( $post->ID, '_thumbnail_id', true );
 
 	/**
 	 * Filters post thumbnail ID.
@@ -47,7 +47,7 @@ function get_post_thumbnail_id( $post = null ) {
 	 * @param int|false        $thumbnail_id Post thumbnail ID or false if the post does not exist.
 	 * @param int|WP_Post|null $post         Post ID or WP_Post object. Default is global `$post`.
 	 */
-	return (int) apply_filters( 'post_thumbnail_id', $thumbnail_id, $post );
+	return apply_filters( 'post_thumbnail_id', $thumbnail_id, $post );
 }
 
 /**

--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -36,22 +36,18 @@ function get_post_thumbnail_id( $post = null ) {
 	if ( ! $post ) {
 		return '';
 	}
-<<<<<<< HEAD
-	return get_post_meta( $post->ID, '_thumbnail_id', true );
-=======
 
 	$thumbnail_id = (int) get_post_meta( $post->ID, '_thumbnail_id', true );
 
 	/**
 	 * Filters post thumbnail ID.
 	 *
-	 * @since 5.9.0
+	 * @since WP-5.9.0
 	 *
 	 * @param int|false        $thumbnail_id Post thumbnail ID or false if the post does not exist.
 	 * @param int|WP_Post|null $post         Post ID or WP_Post object. Default is global `$post`.
 	 */
 	return (int) apply_filters( 'post_thumbnail_id', $thumbnail_id, $post );
->>>>>>> cdb15e353a (Media: Add filter for post thumbnail id.)
 }
 
 /**

--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -36,7 +36,22 @@ function get_post_thumbnail_id( $post = null ) {
 	if ( ! $post ) {
 		return '';
 	}
+<<<<<<< HEAD
 	return get_post_meta( $post->ID, '_thumbnail_id', true );
+=======
+
+	$thumbnail_id = (int) get_post_meta( $post->ID, '_thumbnail_id', true );
+
+	/**
+	 * Filters post thumbnail ID.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param int|false        $thumbnail_id Post thumbnail ID or false if the post does not exist.
+	 * @param int|WP_Post|null $post         Post ID or WP_Post object. Default is global `$post`.
+	 */
+	return (int) apply_filters( 'post_thumbnail_id', $thumbnail_id, $post );
+>>>>>>> cdb15e353a (Media: Add filter for post thumbnail id.)
 }
 
 /**


### PR DESCRIPTION
Introduces new filter `post_thumbnail_id` which allows overriding the default id returned from `get_post_thumbnail_id()`.

WP:Props engelen, alexvorn2, gilbitron, sebastianpisula, SergeyBiryukov, leogermani, rzen, joemcgill, audrasjb.
Fixes https://core.trac.wordpress.org/ticket/23983.

Conflicts:
- src/wp-includes/post-thumbnail-template.php

---

Merges https://core.trac.wordpress.org/changeset/52028 / WordPress/wordpress-develop@cdb15e353a to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
ntroduces new filter post_thumbnail_id

## Motivation and context
Backport of upstream filter to maintain cross compatibility between WP and CP

## How has this been tested?
Upstream backport, should already have non-breaking unit tests

## Screenshots
N/A

## Types of changes
- New feature

