### PR TITLE
WP-r51586: Rename the readonly() function to `wp_readonly()`

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,40 +1,40 @@
 <phpunit
 	bootstrap="tests/phpunit/includes/bootstrap.php"
-        backupGlobals="false"
-        colors="true"
-        beStrictAboutTestsThatDoNotTestAnything="true"
-		beStrictAboutOutputDuringTests="true"
-        >
-    <testsuites>
-        <!-- Default test suite to run all tests -->
-        <testsuite>
-            <directory suffix=".php">tests/phpunit/tests</directory>
-            <exclude>tests/phpunit/tests/actions/closures.php</exclude>
-            <exclude>tests/phpunit/tests/image/editor.php</exclude>
-            <exclude>tests/phpunit/tests/image/editorGd.php</exclude>
-            <exclude>tests/phpunit/tests/image/editorImagick.php</exclude>
-            <exclude>tests/phpunit/tests/oembed/headers.php</exclude>
-            <file phpVersion="5.3.0">tests/phpunit/tests/actions/closures.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editor.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editorGd.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editorImagick.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/oembed/headers.php</file>
-        </testsuite>
-    </testsuites>
-    <groups>
-        <exclude>
-            <group>ajax</group>
-            <group>ms-files</group>
-            <group>ms-required</group>
-            <group>external-http</group>
-        </exclude>
-    </groups>
-    <logging>
-        <log type="junit" target="tests/phpunit/build/logs/junit.xml" logIncompleteSkipped="false"/>
-    </logging>
-    <php>
-        <const name="WP_RUN_CORE_TESTS" value="1" />
-    </php>
+	backupGlobals="false"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	beStrictAboutOutputDuringTests="true"
+	>
+	<testsuites>
+		<!-- Default test suite to run all tests -->
+		<testsuite>
+			<directory suffix=".php">tests/phpunit/tests</directory>
+			<exclude>tests/phpunit/tests/actions/closures.php</exclude>
+			<exclude>tests/phpunit/tests/image/editor.php</exclude>
+			<exclude>tests/phpunit/tests/image/editorGd.php</exclude>
+			<exclude>tests/phpunit/tests/image/editorImagick.php</exclude>
+			<exclude>tests/phpunit/tests/oembed/headers.php</exclude>
+			<file phpVersion="5.3.0">tests/phpunit/tests/actions/closures.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editor.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editorGd.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editorImagick.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/oembed/headers.php</file>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>ajax</group>
+			<group>ms-files</group>
+			<group>ms-required</group>
+			<group>external-http</group>
+		</exclude>
+	</groups>
+	<logging>
+		<log type="junit" target="tests/phpunit/build/logs/junit.xml" logIncompleteSkipped="false"/>
+	</logging>
+	<php>
+		<const name="WP_RUN_CORE_TESTS" value="1" />
+	</php>
 	<listeners>
 		<listener class="SpeedTrapListener" file="tests/phpunit/includes/speed-trap-listener.php">
 			<arguments>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
         backupGlobals="false"
         colors="true"
         beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutOutputDuringTests="true"
         >
     <testsuites>
         <!-- Default test suite to run all tests -->

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4252,15 +4252,29 @@ function disabled( $disabled, $current = true, $echo = true ) {
  *
  * Compares the first two arguments and if identical marks as readonly
  *
+<<<<<<< HEAD
  * @since WP-4.9.0
+=======
+ * @since 5.9.0
+>>>>>>> fff4242f1a (Code Modernization: Rename the `readonly()` function to `wp_readonly()`.)
  *
  * @param mixed $readonly One of the values to compare
  * @param mixed $current  (true) The other value to compare if not just true
  * @param bool  $echo     Whether to echo or just return the string
  * @return string html attribute or empty string
  */
-function readonly( $readonly, $current = true, $echo = true ) {
+function wp_readonly( $readonly, $current = true, $echo = true ) {
 	return __checked_selected_helper( $readonly, $current, $echo, 'readonly' );
+}
+
+/*
+ * Include a compat `readonly()` function on PHP < 8.1. Since PHP 8.1,
+ * `readonly` is a reserved keyword and cannot be used as a function name.
+ * In order to avoid PHP parser errors, this function was extracted
+ * to a separate file and is only included conditionally on PHP < 8.1.
+ */
+if ( PHP_VERSION_ID < 80100 ) {
+	require_once __DIR__ . '/php-compat/readonly.php';
 }
 
 /**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4252,11 +4252,7 @@ function disabled( $disabled, $current = true, $echo = true ) {
  *
  * Compares the first two arguments and if identical marks as readonly
  *
-<<<<<<< HEAD
- * @since WP-4.9.0
-=======
- * @since 5.9.0
->>>>>>> fff4242f1a (Code Modernization: Rename the `readonly()` function to `wp_readonly()`.)
+ * @since WP-5.9.0
  *
  * @param mixed $readonly One of the values to compare
  * @param mixed $current  (true) The other value to compare if not just true

--- a/src/wp-includes/php-compat/readonly.php
+++ b/src/wp-includes/php-compat/readonly.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Conditionally declares a `readonly()` function, which was renamed
+ * to `wp_readonly()` in WordPress 5.9.0.
+ *
+ * In order to avoid PHP parser errors, this function was extracted
+ * to this separate file and is only included conditionally on PHP 8.1.
+ *
+ * Including this file on PHP >= 8.1 results in a fatal error.
+ *
+ * @package WordPress
+ * @since 5.9.0
+ */
+
+/**
+ * Outputs the HTML readonly attribute.
+ *
+ * Compares the first two arguments and if identical marks as readonly
+ *
+ * This function is deprecated, and cannot be used on PHP >= 8.1.
+ *
+ * @since 4.9.0
+ * @deprecated 5.9.0 Use `wp_readonly` introduced in 5.9.0.
+ *
+ * @see wp_readonly()
+ *
+ * @param mixed $readonly One of the values to compare
+ * @param mixed $current  (true) The other value to compare if not just true
+ * @param bool  $echo     Whether to echo or just return the string
+ * @return string HTML attribute or empty string
+ */
+function readonly( $readonly, $current = true, $echo = true ) {
+	_deprecated_function( __FUNCTION__, '5.9.0', 'wp_readonly()' );
+	return wp_readonly( $readonly, $current, $echo );
+}

--- a/src/wp-includes/php-compat/readonly.php
+++ b/src/wp-includes/php-compat/readonly.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Conditionally declares a `readonly()` function, which was renamed
- * to `wp_readonly()` in WordPress 5.9.0.
+ * to `wp_readonly()` in WordPress WP-5.9.0.
  *
  * In order to avoid PHP parser errors, this function was extracted
  * to this separate file and is only included conditionally on PHP 8.1.
@@ -9,7 +9,7 @@
  * Including this file on PHP >= 8.1 results in a fatal error.
  *
  * @package WordPress
- * @since 5.9.0
+ * @since WP-5.9.0
  */
 
 /**
@@ -19,8 +19,8 @@
  *
  * This function is deprecated, and cannot be used on PHP >= 8.1.
  *
- * @since 4.9.0
- * @deprecated 5.9.0 Use `wp_readonly` introduced in 5.9.0.
+ * @since WP-4.9.0
+ * @deprecated WP-5.9.0 Use `wp_readonly` introduced in WP-5.9.0.
  *
  * @see wp_readonly()
  *
@@ -30,6 +30,6 @@
  * @return string HTML attribute or empty string
  */
 function readonly( $readonly, $current = true, $echo = true ) {
-	_deprecated_function( __FUNCTION__, '5.9.0', 'wp_readonly()' );
+	_deprecated_function( __FUNCTION__, 'WP-5.9.0', 'wp_readonly()' );
 	return wp_readonly( $readonly, $current, $echo );
 }

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -1,48 +1,48 @@
 <phpunit
 		bootstrap="includes/bootstrap.php"
-        backupGlobals="false"
-        colors="true"
-        beStrictAboutTestsThatDoNotTestAnything="true"
+		backupGlobals="false"
+		colors="true"
+		beStrictAboutTestsThatDoNotTestAnything="true"
 		beStrictAboutOutputDuringTests="true"
-        >
-    <php>
-        <const name="WP_TESTS_MULTISITE" value="1" />
-    </php>
-    <testsuites>
-        <!-- Default test suite to run all tests -->
-        <testsuite>
-            <directory suffix=".php">tests</directory>
-            <exclude>tests/phpunit/tests/actions/closures.php</exclude>
-            <exclude>tests/phpunit/tests/image/editor.php</exclude>
-            <exclude>tests/phpunit/tests/image/editorGd.php</exclude>
-            <exclude>tests/phpunit/tests/image/editorImagick.php</exclude>
-            <file phpVersion="5.3.0">tests/phpunit/tests/actions/closures.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editor.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editorGd.php</file>
-            <file phpVersion="5.3.0">tests/phpunit/tests/image/editorImagick.php</file>
-        </testsuite>
-    </testsuites>
-    <groups>
-        <exclude>
-            <group>ajax</group>
-            <group>ms-files</group>
-            <group>ms-excluded</group>
-            <group>external-http</group>
-            <group>oembed-headers</group>
-        </exclude>
-    </groups>
-    <php>
-        <const name="WP_RUN_CORE_TESTS" value="1" />
-    </php>
-    <listeners>
-        <listener class="SpeedTrapListener" file="tests/phpunit/includes/speed-trap-listener.php">
-            <arguments>
-                <array>
-                    <element key="slowThreshold">
-                        <integer>150</integer>
-                    </element>
-                </array>
-            </arguments>
-        </listener>
-    </listeners>
+		>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1" />
+	</php>
+	<testsuites>
+		<!-- Default test suite to run all tests -->
+		<testsuite>
+			<directory suffix=".php">tests</directory>
+			<exclude>tests/phpunit/tests/actions/closures.php</exclude>
+			<exclude>tests/phpunit/tests/image/editor.php</exclude>
+			<exclude>tests/phpunit/tests/image/editorGd.php</exclude>
+			<exclude>tests/phpunit/tests/image/editorImagick.php</exclude>
+			<file phpVersion="5.3.0">tests/phpunit/tests/actions/closures.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editor.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editorGd.php</file>
+			<file phpVersion="5.3.0">tests/phpunit/tests/image/editorImagick.php</file>
+		</testsuite>
+	</testsuites>
+	<groups>
+		<exclude>
+			<group>ajax</group>
+			<group>ms-files</group>
+			<group>ms-excluded</group>
+			<group>external-http</group>
+			<group>oembed-headers</group>
+		</exclude>
+	</groups>
+	<php>
+		<const name="WP_RUN_CORE_TESTS" value="1" />
+	</php>
+	<listeners>
+		<listener class="SpeedTrapListener" file="tests/phpunit/includes/speed-trap-listener.php">
+			<arguments>
+				<array>
+					<element key="slowThreshold">
+						<integer>150</integer>
+					</element>
+				</array>
+			</arguments>
+		</listener>
+	</listeners>
 </phpunit>

--- a/tests/phpunit/multisite.xml
+++ b/tests/phpunit/multisite.xml
@@ -3,6 +3,7 @@
         backupGlobals="false"
         colors="true"
         beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutOutputDuringTests="true"
         >
     <php>
         <const name="WP_TESTS_MULTISITE" value="1" />

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -747,6 +747,7 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * @group login
 	 */
 	function test_login_html_option_enabled_with_custom_image_banner() {
@@ -825,6 +826,11 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 	/**
 	 * @group login
+=======
+	 * @ticket 44183
+	 *
+	 * @covers ::get_the_archive_title
+>>>>>>> fff4242f1a (Code Modernization: Rename the `readonly()` function to `wp_readonly()`.)
 	 */
 	function test_login_html_option_enabled_with_custom_logo_and_filters() {
 		update_option( 'login_custom_image_state', '1' );

--- a/tests/phpunit/tests/general/template.php
+++ b/tests/phpunit/tests/general/template.php
@@ -747,7 +747,6 @@ class Tests_General_Template extends WP_UnitTestCase {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * @group login
 	 */
 	function test_login_html_option_enabled_with_custom_image_banner() {
@@ -826,11 +825,6 @@ class Tests_General_Template extends WP_UnitTestCase {
 
 	/**
 	 * @group login
-=======
-	 * @ticket 44183
-	 *
-	 * @covers ::get_the_archive_title
->>>>>>> fff4242f1a (Code Modernization: Rename the `readonly()` function to `wp_readonly()`.)
 	 */
 	function test_login_html_option_enabled_with_custom_logo_and_filters() {
 		update_option( 'login_custom_image_state', '1' );

--- a/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
+++ b/tests/phpunit/tests/general/template_CheckedSelectedHelper.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * A set of unit tests for the __checked_selected_helper() and associated functions in wp-includes/general-template.php.
+ *
+ * @group general
+ */
+
+class Tests_General_Template_CheckedSelectedHelper extends WP_UnitTestCase {
+
+	/**
+	 * List of functions using the __checked_selected_helper() function.
+	 *
+	 * Doesn't list the conditionally available `readonly` function on purpose.
+	 *
+	 * @var array
+	 */
+	private $child_functions = array(
+		'selected'    => true,
+		'checked'     => true,
+		'disabled'    => true,
+		'wp_readonly' => true,
+	);
+
+	/**
+	 * Tests that the return value for selected() is as expected with equal values.
+	 *
+	 * @ticket 53858
+	 * @covers ::selected
+	 */
+	public function test_selected_with_equal_values() {
+		$this->assertSame( " selected='selected'", selected( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for checked() is as expected with equal values.
+	 *
+	 * @ticket 53858
+	 * @covers ::checked
+	 */
+	public function test_checked_with_equal_values() {
+		$this->assertSame( " checked='checked'", checked( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for disabled() is as expected with equal values.
+	 *
+	 * @ticket 53858
+	 * @covers ::disabled
+	 */
+	public function test_disabled_with_equal_values() {
+		$this->assertSame( " disabled='disabled'", disabled( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for readonly() is as expected with equal values.
+	 *
+	 * @ticket 53858
+	 * @covers ::readonly
+	 */
+	public function test_readonly_with_equal_values() {
+		if ( ! function_exists( 'readonly' ) ) {
+			$this->markTestSkipped( 'readonly() function is not available on PHP 8.1' );
+		}
+
+		$this->setExpectedDeprecated( 'readonly' );
+
+		// Call the function via a variable to prevent a parse error for this file on PHP 8.1.
+		$fn = 'readonly';
+		$this->assertSame( " readonly='readonly'", $fn( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * Tests that the return value for wp_readonly() is as expected with equal values.
+	 *
+	 * @ticket 53858
+	 * @covers ::wp_readonly
+	 */
+	public function test_wp_readonly_with_equal_values() {
+		$this->assertSame( " readonly='readonly'", wp_readonly( 'foo', 'foo', false ) );
+	}
+
+	/**
+	 * @dataProvider data_equal_values
+	 *
+	 * @ticket 9862
+	 * @ticket 51166
+	 * @ticket 53858
+	 * @covers ::__checked_selected_helper
+	 *
+	 * @param mixed $helper  One of the values to compare.
+	 * @param mixed $current The other value to compare.
+	 */
+	public function test_checked_selected_helper_with_equal_values( $helper, $current ) {
+		$this->assertSame( " test='test'", __checked_selected_helper( $helper, $current, false, 'test' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_equal_values() {
+		return array(
+			'same value, "foo"; 1: string; 2: string'   => array( 'foo', 'foo' ),
+			'same value, 1; 1: string; 2: int'          => array( '1', 1 ),
+			'same value, 1; 1: string; 2: float'        => array( '1', 1.0 ),
+			'same value, 1; 1: string; 2: bool true'    => array( '1', true ),
+			'same value, 1; 1: int; 2: int'             => array( 1, 1 ),
+			'same value, 1; 1: int; 2: float'           => array( 1, 1.0 ),
+			'same value, 1; 1: int; 2: bool true'       => array( 1, true ),
+			'same value, 1; 1: float; 2: bool true'     => array( 1.0, true ),
+			'same value, 1; 1: bool true; 2: bool true' => array( true, true ),
+			'same value, 1; 1: float 1.0; 2: float calculation 1.0' => array( 1.0, 3 / 3 ),
+			'same value, 0; 1: string; 2: int'          => array( '0', 0 ),
+			'same value, 0; 1: string; 2: float'        => array( '0', 0.0 ),
+			'same value, 0; 1: int; 2: int'             => array( 0, 0 ),
+			'same value, 0; 1: int; 2: float'           => array( 0, 0.0 ),
+			'same value, empty string; 1: string; 2: string' => array( '', '' ),
+			'same value, empty string; 1: empty string; 2: bool false' => array( '', false ),
+			'same value, empty string; 1: bool false; 2: bool false' => array( false, false ),
+			'same value, empty string; 1: empty string; 2: null' => array( '', null ),
+			'same value, empty string; 1: bool false; 2: null' => array( false, null ),
+			'same value, null; 1: null; 2: null'        => array( null, null ),
+		);
+	}
+
+	/**
+	 * @dataProvider data_non_equal_values
+	 *
+	 * @ticket 9862
+	 * @ticket 51166
+	 * @ticket 53858
+	 * @covers ::__checked_selected_helper
+	 *
+	 * @param mixed $helper  One of the values to compare.
+	 * @param mixed $current The other value to compare.
+	 */
+	public function test_checked_selected_helper_with_non_equal_values( $helper, $current ) {
+		$this->assertSame( '', __checked_selected_helper( $helper, $current, false, 'test' ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_non_equal_values() {
+		return array(
+			'1: string foo; 2: string bar' => array( 'foo', 'bar' ),
+			'1: string 0; 2: empty string' => array( '0', '' ),
+			'1: string 0; 2: null'         => array( '0', null ),
+			'1: int 0; 2: empty string'    => array( 0, '' ),
+			'1: int 0; 2: bool true'       => array( 0, true ),
+			'1: int 0; 2: bool false'      => array( 0, false ),
+			'1: int 0; 2: null'            => array( 0, null ),
+			'1: float 0; 2: empty string'  => array( 0.0, '' ),
+			'1: float 0; 2: bool true'     => array( 0.0, true ),
+			'1: float 0; 2: bool false'    => array( 0.0, false ),
+			'1: float 0; 2: null'          => array( 0.0, null ),
+			'1: null; 2: bool true'        => array( null, true ),
+			'1: null 0; 2: string "foo"'   => array( null, 'foo' ),
+			'1: int 1; 2: float 1.5'       => array( 1, 1.5 ),
+		);
+	}
+
+	/**
+	 * Tests that the `$echo` parameter is handled correctly and that even when the output is echoed out,
+	 * the text is also returned.
+	 *
+	 * @ticket 53858
+	 * @covers ::__checked_selected_helper
+	 */
+	public function test_checked_selected_helper_echoes_result_by_default() {
+		$expected = " disabled='disabled'";
+		$this->expectOutputString( $expected );
+		$this->assertSame( $expected, disabled( 'foo', 'foo' ) );
+	}
+
+	/**
+	 * Tests that the function compares against `true` when the second parameter is not passed.
+	 *
+	 * @dataProvider data_checked_selected_helper_default_value_for_second_parameter
+	 *
+	 * @ticket 53858
+	 * @covers ::__checked_selected_helper
+	 * @covers ::selected
+	 * @covers ::checked
+	 * @covers ::disabled
+	 * @covers ::wp_readonly
+	 *
+	 * @param mixed $input         Input value
+	 * @param mixed $expect_output Optional. Whether output is expected. Defaults to false.
+	 */
+	public function test_checked_selected_helper_default_value_for_second_parameter( $input, $expect_output = false ) {
+		$fn       = array_rand( $this->child_functions );
+		$expected = '';
+
+		if ( false !== $expect_output ) {
+			$expected = " {$fn}='{$fn}'";
+			if ( 'wp_readonly' === $fn ) {
+				// Account for the function name not matching the expected output string.
+				$expected = " readonly='readonly'";
+			}
+
+			// Only set output expectation when output is expected, so the test will fail on unexpected output.
+			$this->expectOutputString( $expected );
+		}
+
+		// Function will always return the value, even when echoing it out.
+		$this->assertSame( $expected, $fn( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_checked_selected_helper_default_value_for_second_parameter() {
+		return array(
+			'truthy; boolean true'          => array(
+				'input'         => true,
+				'expect_output' => true,
+			),
+			'truthy; int 1'                 => array(
+				'input'         => 1,
+				'expect_output' => true,
+			),
+			'truthy; string 1'              => array(
+				'input'         => '1',
+				'expect_output' => true,
+			),
+			'truthy, but not equal to true' => array(
+				'input' => 'foo',
+			),
+			'falsy; null'                   => array(
+				'input' => null,
+			),
+			'falsy; bool false'             => array(
+				'input' => false,
+			),
+			'falsy; int 0'                  => array(
+				'input' => 0,
+			),
+		);
+	}
+}


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
Backport of upstream fix for PHP8.1 reserved name.

## Motivation and context
This change ensure future compatibility with PHP8.1 and closes #775

## How has this been tested?
Upstream backport
Unit test files included in backport changes

## Screenshots
N/A

## Types of changes
- Bug fix
