### PR TITLE
WP-r52141: Update `_edit_last` meta when posts are bulk edited

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -589,7 +589,9 @@ function bulk_edit_posts( $post_data = null ) {
 			unset( $post_data['tax_input']['post_format'] );
 		}
 
-		$updated[] = wp_update_post( $post_data );
+		$post_id = wp_update_post( $post_data );
+		update_post_meta( $post_id, '_edit_last', get_current_user_id() );
+		$updated[] = $post_id;
 
 		if ( isset( $post_data['sticky'] ) && current_user_can( $ptype->cap->edit_others_posts ) ) {
 			if ( 'sticky' == $post_data['sticky'] )


### PR DESCRIPTION
WP-r52141: Posts, Post Types: Update `_edit_last` meta when posts are edited in bulk.

When posts are edited in bulk, the `_edit_last` meta was not updated for each post.  This change adds a call to update the `_edit_last` meta to the current user ID for each post the is updated.

WP:Props calebwoodbridge, peterwilsoncc, guillaumeturpin, audrasjb.
Fixes https://core.trac.wordpress.org/ticket/42446.

---

Merges https://core.trac.wordpress.org/changeset/52141 / WordPress/wordpress-develop@04f62997d3 to ClassicPress.


## Description
Backport of know issue reported upstream at:
https://core.trac.wordpress.org/ticket/42446

Currently, bulk editing a post does not amend the last editing user information, while it does update the last edited date and time.

## Motivation and context
This seems like a simple and good bug fix for bulk editing

## How has this been tested?
Upstream PR 4 years in the making

## Screenshots
N/A

## Types of changes
- Bug fix