### PR TITLE
Fix WP and other version specifiers in inline docs

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -728,7 +728,7 @@ function set_screen_options() {
 					 *
 					 * Returning false to the filter will skip saving the current option.
 					 *
-					 * @since 2.8.0
+					 * @since WP-2.8.0
 					 * @since WP-4.9.15 Only applied to options ending with '_page',
 					 *              or the 'layout_columns' option.
 					 *

--- a/src/wp-includes/class-simplepie.php
+++ b/src/wp-includes/class-simplepie.php
@@ -863,7 +863,7 @@ class SimplePie
 	 *
 	 * This allows you to change default curl options
 	 *
-	 * @since 1.0 Beta 3
+	 * @since SimplePie 1.0 Beta 3
 	 * @param array $curl_options Curl options to add to default settings
 	 */
 	public function set_curl_options(array $curl_options = array())
@@ -1950,7 +1950,7 @@ class SimplePie
 	 * depending on whether auto-discovery was used, and whether there were
 	 * any redirects along the way.
 	 *
-	 * @since Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
+	 * @since SimplePie Preview Release (previously called `get_feed_url()` since SimplePie 0.8.)
 	 * @todo Support <itunes:new-feed-url>
 	 * @todo Also, |atom:link|@rel=self
 	 * @param bool $permanent Permanent mode to return only the original URL or the first redirection
@@ -2253,7 +2253,7 @@ class SimplePie
 	/**
 	 * Get a category for the feed
 	 *
-	 * @since Unknown
+	 * @since SimplePie Unknown Version
 	 * @param int $key The category that you want to return. Remember that arrays begin with 0, not 1
 	 * @return SimplePie_Category|null
 	 */
@@ -2334,7 +2334,7 @@ class SimplePie
 	/**
 	 * Get an author for the feed
 	 *
-	 * @since 1.1
+	 * @since SimplePie 1.1
 	 * @param int $key The author that you want to return. Remember that arrays begin with 0, not 1
 	 * @return SimplePie_Author|null
 	 */
@@ -2428,7 +2428,7 @@ class SimplePie
 	/**
 	 * Get a contributor for the feed
 	 *
-	 * @since 1.1
+	 * @since SimplePie 1.1
 	 * @param int $key The contrbutor that you want to return. Remember that arrays begin with 0, not 1
 	 * @return SimplePie_Author|null
 	 */
@@ -2510,7 +2510,7 @@ class SimplePie
 	/**
 	 * Get a single link for the feed
 	 *
-	 * @since 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
+	 * @since SimplePie 1.0 (previously called `get_feed_link` since Preview Release, `get_feed_permalink()` since 0.8)
 	 * @param int $key The link that you want to return. Remember that arrays begin with 0, not 1
 	 * @param string $rel The relationship of the link to return
 	 * @return string|null Link URL
@@ -3001,7 +3001,7 @@ class SimplePie
 	 * {@link http://php.net/foreach foreach()} loops.
 	 *
 	 * @see get_item_quantity()
-	 * @since Beta 2
+	 * @since SimplePie Beta 2
 	 * @param int $key The item that you want to return. Remember that arrays begin with 0, not 1
 	 * @return SimplePie_Item|null
 	 */

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2635,13 +2635,13 @@ function wp_footer() {
  *
  * * See {@see 'wp_body_open'}.
  *
- * @since 5.2.0
+ * @since WP-5.2.0
  */
 function wp_body_open() {
 	/**
 	 * Triggered after the opening <body> tag.
 	 *
-	 * @since 5.2.0
+	 * @since WP-5.2.0
 	 */
 	do_action( 'wp_body_open' );
 }


### PR DESCRIPTION
For example: The wp_body_open function and hook backported from WP 5.2.0 in #647 both say `@since 5.2.0` - this should be `@since WP-5.2.0` instead.

Once this change is merged and included in a new release, it will flow through to https://docs.classicpress.net/reference/functions/wp_body_open/.