### PR TITLE
Renovate[bot]: Update dependency grunt-contrib-concat to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3262,13 +3262,64 @@
       }
     },
     "grunt-contrib-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-1.0.1.tgz",
-      "integrity": "sha1-YVCYYwhOhx1+ht5IwBUlntl3Rb0=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-2.0.0.tgz",
+      "integrity": "sha512-/cfWwsGiprVTOl7c2bZwMdQ8hIf3e1f4szm1i7qhY9hOnR/X2KL+Xe7dynNweTYHa6aWPZx2B5GPsUpxAXNCaA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
+        "chalk": "^4.1.2",
         "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "grunt-contrib-connect": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grunt-banner": "0.6.0",
     "grunt-contrib-clean": "2.0.0",
     "grunt-contrib-compress": "2.0.0",
-    "grunt-contrib-concat": "1.0.1",
+    "grunt-contrib-concat": "2.0.0",
     "grunt-contrib-connect": "3.0.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-cssmin": "4.0.0",


### PR DESCRIPTION
The PR #813 is not running GitHub Actions checks even after rebasing, adding empty commits, etc. I have seen this happen a couple of times and the only way to make it work has been to open a new PR.

Closing/reopening the PR might also work, but since that action has special meaning for the Renovate bot (it will tell the bot to ignore that specific upgrade), let's not do that.

I propose to do the following instead:

- Make sure the GitHub Actions checks run on this PR
- Trust the automated review from https://github.com/ClassicPress/ClassicPress/pull/813#issuecomment-973107086 which tells us that there are no build changes resulting from this dependency upgrade (the commit hash is the same on this PR and on #813)
- Merge this PR
- Renovate should then automatically close #813 by itself.