### PR TITLE
Fix for failing Unit Tests

### DIFF
--- a/tests/phpunit/includes/plural-form-function.php
+++ b/tests/phpunit/includes/plural-form-function.php
@@ -10,9 +10,6 @@ function tests_make_plural_form_function( $nplurals, $expression ) {
 	$closure = function ( $n ) use ( $nplurals, $expression ) {
 		$expression = str_replace( 'n', $n, $expression );
 
-<<<<<<< HEAD
-	return create_function( '$n', $func_body );
-=======
 		// phpcs:ignore Squiz.PHP.Eval -- This is test code, not production.
 		$index = (int) eval( 'return ' . $expression . ';' );
 
@@ -20,5 +17,4 @@ function tests_make_plural_form_function( $nplurals, $expression ) {
 	};
 
 	return $closure;
->>>>>>> f0733600c9 (Code Modernization: Change `create_function()` in `phpunit/includes/plural-form-function.php` to closure.)
 }

--- a/tests/phpunit/includes/plural-form-function.php
+++ b/tests/phpunit/includes/plural-form-function.php
@@ -7,10 +7,18 @@
  * @param string $expression
  */
 function tests_make_plural_form_function( $nplurals, $expression ) {
-	$expression = str_replace( 'n', '$n', $expression );
-	$func_body = "
-		\$index = (int)($expression);
-		return (\$index < $nplurals)? \$index : $nplurals - 1;";
+	$closure = function ( $n ) use ( $nplurals, $expression ) {
+		$expression = str_replace( 'n', $n, $expression );
 
+<<<<<<< HEAD
 	return create_function( '$n', $func_body );
+=======
+		// phpcs:ignore Squiz.PHP.Eval -- This is test code, not production.
+		$index = (int) eval( 'return ' . $expression . ';' );
+
+		return ( $index < $nplurals ) ? $index : $nplurals - 1;
+	};
+
+	return $closure;
+>>>>>>> f0733600c9 (Code Modernization: Change `create_function()` in `phpunit/includes/plural-form-function.php` to closure.)
 }

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -22,7 +22,11 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		}
 		$php = wp_remote_retrieve_body( $response );
 
-		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $response_body, $phpmatches );
+		preg_match_all(
+			'#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
+			$php,
+			$phpmatches
+		);
 
 		$this->assertNotEmpty( $phpmatches );
 

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -22,9 +22,9 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		}
 		$php = wp_remote_retrieve_body( $response );
 
-		$this->assertNotEmpty( $phpmatches );
-
 		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $response_body, $phpmatches );
+
+		$this->assertNotEmpty( $phpmatches );
 
 		// TODO: Enable this check once PHP 8.0 compatibility is achieved.
 		/*$this->assertContains(

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -22,12 +22,23 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		}
 		$php = wp_remote_retrieve_body( $response );
 
+<<<<<<< HEAD
 		preg_match_all(
 			'#<tr class="(security|stable)">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
 			$php,
 			$phpmatches
 		);
 		$this->assertNotEmpty( $phpmatches );
+=======
+		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $response_body, $phpmatches );
+
+		// TODO: Enable this check once PHP 8.0 compatibility is achieved.
+		// $this->assertContains( $matches[1], $phpmatches[1], "readme.html's Recommended PHP version is too old. Remember to update the WordPress.org Requirements page, too." );
+
+		preg_match( '#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
+
+		$response = wp_remote_get( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
+>>>>>>> 8de99e840f (Tests: Temporarily disable the check that the current recommended PHP version is actively supported.)
 
 		$this->assertContains(
 			$matches[1],

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -22,29 +22,16 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		}
 		$php = wp_remote_retrieve_body( $response );
 
-<<<<<<< HEAD
-		preg_match_all(
-			'#<tr class="(security|stable)">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
-			$php,
-			$phpmatches
-		);
 		$this->assertNotEmpty( $phpmatches );
-=======
+
 		preg_match_all( '#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s', $response_body, $phpmatches );
 
 		// TODO: Enable this check once PHP 8.0 compatibility is achieved.
-		// $this->assertContains( $matches[1], $phpmatches[1], "readme.html's Recommended PHP version is too old. Remember to update the WordPress.org Requirements page, too." );
-
-		preg_match( '#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
-
-		$response = wp_remote_get( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
->>>>>>> 8de99e840f (Tests: Temporarily disable the check that the current recommended PHP version is actively supported.)
-
-		$this->assertContains(
+		/*$this->assertContains(
 			$matches[1],
 			$phpmatches[2],
 			"readme.html's Recommended PHP version is too old."
-		);
+		);*/
 	}
 
 	function test_readme_recommended_mysql_version() {

--- a/tests/phpunit/tests/pomo/pluralForms.php
+++ b/tests/phpunit/tests/pomo/pluralForms.php
@@ -53,7 +53,7 @@ class PluralFormsTest extends WP_UnitTestCase {
 			if ( is_wp_error( $filename ) ) {
 				return array();
 			}
-			require_once $filename;			
+			require_once $filename;
 		}
 
 		$locales = GP_Locales::locales();
@@ -74,15 +74,7 @@ class PluralFormsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_regression( $lang, $nplurals, $expression ) {
-<<<<<<< HEAD
-		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
-			$this->markTestSkipped( 'Lambda functions are deprecated in PHP 7.2' );
-		}
-
-		require_once dirname( dirname( dirname( __FILE__ ) ) ) . '/includes/plural-form-function.php';
-=======
 		require_once dirname( dirname( __DIR__ ) ) . '/includes/plural-form-function.php';
->>>>>>> f0733600c9 (Code Modernization: Change `create_function()` in `phpunit/includes/plural-form-function.php` to closure.)
 
 		$parenthesized = self::parenthesize_plural_expression( $expression );
 		$old_style = tests_make_plural_form_function( $nplurals, $parenthesized );

--- a/tests/phpunit/tests/pomo/pluralForms.php
+++ b/tests/phpunit/tests/pomo/pluralForms.php
@@ -74,11 +74,15 @@ class PluralFormsTest extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test_regression( $lang, $nplurals, $expression ) {
+<<<<<<< HEAD
 		if ( version_compare( phpversion(), '7.2', '>=' ) ) {
 			$this->markTestSkipped( 'Lambda functions are deprecated in PHP 7.2' );
 		}
 
 		require_once dirname( dirname( dirname( __FILE__ ) ) ) . '/includes/plural-form-function.php';
+=======
+		require_once dirname( dirname( __DIR__ ) ) . '/includes/plural-form-function.php';
+>>>>>>> f0733600c9 (Code Modernization: Change `create_function()` in `phpunit/includes/plural-form-function.php` to closure.)
 
 		$parenthesized = self::parenthesize_plural_expression( $expression );
 		$old_style = tests_make_plural_form_function( $nplurals, $parenthesized );


### PR DESCRIPTION
## Description
Changes on the PHP site about current supported versions are breaking unit testing as reported upstream nd spooned by `joyously`

## Motivation and context
This PR backports an upstream fix for the time being and while there ensures some tests are not skipped in PHP > 7.2 in the `pomo` tests by also backporting changeset 48790
https://core.trac.wordpress.org/changeset/52260
https://core.trac.wordpress.org/changeset/48790

## How has this been tested?
Upstream changes via backport
These are current failing and skipped tests

## Screenshots
N/A

## Types of changes
- Bug fix
