### PR TITLE
Change "Add New" plugins menu entry to "Add WP Plugin"

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2086,7 +2086,7 @@ div.action-links,
 		line-height: 1.5;
 	}
 
-	/* Add New plugins page */
+	/* Add WP Plugin page */
 	table.plugin-install .column-name,
 	table.plugin-install .column-version,
 	table.plugin-install .column-rating,

--- a/src/wp-admin/includes/class-plugin-installer-skin.php
+++ b/src/wp-admin/includes/class-plugin-installer-skin.php
@@ -110,20 +110,20 @@ class Plugin_Installer_Skin extends WP_Upgrader_Skin {
 		} elseif ( 'web' === $this->type ) {
 			$install_actions['plugins_page'] = sprintf(
 				'<a href="%s" target="_parent">%s</a>',
-				self_admin_url( 'plugin-install.php' ),
-				__( 'Go to Plugin Installer' )
+				self_admin_url( 'plugins.php' ),
+				__( 'Go to Installed Plugins' )
 			);
 		} elseif ( 'upload' === $this->type && 'plugins' === $from ) {
 			$install_actions['plugins_page'] = sprintf(
 				'<a href="%s">%s</a>',
-				self_admin_url( 'plugin-install.php' ),
-				__( 'Go to Plugin Installer' )
+				self_admin_url( 'plugins.php' ),
+				__( 'Go to Installed Plugins' )
 			);
 		} else {
 			$install_actions['plugins_page'] = sprintf(
 				'<a href="%s" target="_parent">%s</a>',
 				self_admin_url( 'plugins.php' ),
-				__( 'Go to Plugins page' )
+				__( 'Go to Installed Plugins' )
 			);
 		}
 

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -208,9 +208,10 @@ $menu[65] = array( sprintf( __('Plugins %s'), $count ), 'activate_plugins', 'plu
 $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'activate_plugins', 'plugins.php' );
 
 	if ( ! is_multisite() ) {
-		/* translators: add new plugin */
+		/* translators: upload new plugin */
 		$submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
-		$submenu['plugins.php'][10] = array( _x('Add New', 'plugin'), 'install_plugins', 'plugin-install.php' );
+		/* translators: add new plugin from WP plugin repository */
+		$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php' );
 		$submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 	}
 

--- a/src/wp-admin/network/menu.php
+++ b/src/wp-admin/network/menu.php
@@ -59,7 +59,8 @@ if ( current_user_can( 'update_plugins' ) && $update_data['counts']['plugins'] )
 	$menu[20] = array( __('Plugins'), 'manage_network_plugins', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' );
 }
 $submenu['plugins.php'][5]  = array( __('Installed Plugins'), 'manage_network_plugins', 'plugins.php' );
-$submenu['plugins.php'][10] = array( _x('Add New', 'plugin'), 'install_plugins', 'plugin-install.php' );
+$submenu['plugins.php'][7] = array( _x('Upload', 'plugin'), 'install_plugins', 'plugin-install.php?tab=upload' );
+$submenu['plugins.php'][10] = array( _x('Add WP Plugin', 'plugin'), 'install_plugins', 'plugin-install.php' );
 $submenu['plugins.php'][15] = array( _x('Editor', 'plugin editor'), 'edit_plugins', 'plugin-editor.php' );
 
 $menu[25] = array(__('Settings'), 'manage_network_options', 'settings.php', '', 'menu-top menu-icon-settings', 'menu-settings', 'dashicons-admin-settings');

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -413,8 +413,8 @@ get_current_screen()->add_help_tab( array(
 	'<p>' . __('Plugins extend and expand the functionality of ClassicPress. Once a plugin is installed, you may activate it or deactivate it here.') . '</p>' .
 	'<p>' . __( 'The search for installed plugins will search for terms in their name, description, or author.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
 	'<p>' . sprintf(
-		/* translators: %s: ClassicPress Plugin Directory URL */
-		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!' ),
+		/* translators: %s: WordPress Plugin Directory URL */
+		__( 'If you would like to see more plugins to choose from, click on the &#8220;Add WP Plugin&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license ClassicPress uses, but they are not necessarily designed for ClassicPress. Be sure to confirm their compatibility prior to install!' ),
 		__( 'https://wordpress.org/plugins/' )
 	) . '</p>'
 ) );
@@ -525,7 +525,7 @@ echo esc_html( $title );
 if ( ( ! is_multisite() || is_network_admin() ) && current_user_can( 'install_plugins' ) ) {
 ?>
 	<a href="<?php echo self_admin_url( 'plugin-install.php?tab=upload' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Upload', 'plugin' ); ?></a>
-	<a href="<?php echo self_admin_url( 'plugin-install.php' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add New', 'plugin' ); ?></a>
+	<a href="<?php echo self_admin_url( 'plugin-install.php' ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add WP Plugin', 'plugin' ); ?></a>
 <?php
 }
 

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -2265,10 +2265,17 @@
 				</span>
 					</li>
 					<li class="wp-first-item">
-						<a href="plugins.php" class="wp-first-item">Installed Plugins</a></li><li><a href="plugin-install.php">Add New</a>
-				</li><li>
-					<a href="plugin-editor.php">Editor</a>
-				</li>
+						<a href="plugins.php" class="wp-first-item">Installed Plugins</a>
+					</li>
+					<li>
+						<a href="plugin-install.php?tab=upload">Upload</a>
+					</li>
+					<li>
+						<a href="plugin-install.php">Add WP Plugin</a>
+					</li>
+					<li>
+						<a href="plugin-editor.php">Editor</a>
+					</li>
 				</ul>
 			</li>
 		</div>


### PR DESCRIPTION
Currently (after #788) there are two links "Upload" and "Add New" right next to each other under the Plugins admin menu and on the Plugins admin page. This is a bit confusing, since "Upload" is also a way to "Add New". I suggest changing "Add New" to "Add WP Plugin", which also makes it a bit clearer that plugins added this way come from the WP plugin repo:

| Before | After |
|--|--|
| ![2021-12-09T19-36-18Z](https://user-images.githubusercontent.com/227022/145464132-0296bf12-2a36-473a-9856-40a6bf457eee.png) | ![2021-12-09T19-43-50Z](https://user-images.githubusercontent.com/227022/145464928-eb98f1e5-4c12-474c-aa54-06a311440fb0.png) |

Finally this PR also updates the "Go to Plugin Installer" message that appears after installing or upgrading a plugin to go to the installed plugins page instead of the WP plugin repository:

| Before | After |
|--|--|
| ![2021-12-09T19-17-29Z](https://user-images.githubusercontent.com/227022/145465036-5012ba55-f624-4e86-809c-e366467892aa.png) | ![2021-12-09T19-45-45Z](https://user-images.githubusercontent.com/227022/145465211-28dd1d17-8177-47cf-a05d-881debbeca15.png) |

We should start to de-emphasize the WP plugin repo a bit, and also it generally makes more sense to me to go look at the plugin I just installed/updated rather than to go back and install more plugins.