### PR TITLE
Fix fatal error in themes.php admin page

### DIFF
--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -585,9 +585,6 @@ function wp_prepare_themes_for_js( $themes = null ) {
 		$update_requires_wp  = isset( $updates[ $slug ]['requires'] ) ? $updates[ $slug ]['requires'] : null;
 		$update_requires_php = isset( $updates[ $slug ]['requires_php'] ) ? $updates[ $slug ]['requires_php'] : null;
 
-		$auto_update        = in_array( $slug, $auto_updates, true );
-		$auto_update_action = $auto_update ? 'disable-auto-update' : 'enable-auto-update';
-
 		$prepared_themes[ $slug ] = array(
 			'id'             => $slug,
 			'name'           => $theme->display( 'Name' ),
@@ -608,14 +605,10 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			'hasUpdate'      => isset( $updates[ $slug ] ),
 			'hasPackage'     => isset( $updates[ $slug ] ) && ! empty( $updates[ $slug ]['package'] ),
 			'update'         => get_theme_update_available( $theme ),
-			'autoupdate'     => $auto_update,
 			'actions'        => array(
 				'activate'   => current_user_can( 'switch_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=activate&amp;stylesheet=' . $encoded_slug ), 'switch-theme_' . $slug ) : null,
 				'customize'  => $customize_action,
 				'delete'     => current_user_can( 'delete_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=delete&amp;stylesheet=' . $encoded_slug ), 'delete-theme_' . $slug ) : null,
-				'autoupdate' => wp_is_auto_update_enabled_for_type( 'theme' ) && ! is_multisite() && current_user_can( 'update_themes' )
-					? wp_nonce_url( admin_url( 'themes.php?action=' . $auto_update_action . '&amp;stylesheet=' . $encoded_slug ), 'updates' )
-					: null,
 			),
 		);
 	}


### PR DESCRIPTION
## Description
Possible fix for #878

## Motivation and context
Backporting to enable zip uploads for themes and plugins has introduce additional and unnecessary auto-update code. A fragment of this code produces a PHP error on the `wp-admin/themes.php` page.
This PR fixes #878 by removing the unnecessary code fragments.

## How has this been tested?
Local Testing, see screen shots below

## Screenshots
### Before
<img width="1517" alt="Screenshot 2021-12-11 at 11 48 33" src="https://user-images.githubusercontent.com/1280733/145675436-3b6c54cb-88a6-404d-9e9a-5be1b43215d7.png">

### After
![Screenshot 2021-12-11 at 11 48 11](https://user-images.githubusercontent.com/1280733/145675442-3329c828-112d-4f22-8c7d-d5727e31fd8c.png)

## Types of changes
- Bug fix
