### PR TITLE
Add action within comment form tag

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2309,10 +2309,19 @@ function comment_form( $args = array(), $post_id = null ) {
 			 */
 			do_action( 'comment_form_must_log_in_after' );
 		else : ?>
-			<form action="<?php echo esc_url( $args['action'] ); ?>" method="post" id="<?php echo esc_attr( $args['id_form'] ); ?>" class="<?php echo esc_attr( $args['class_form'] ); ?>"<?php echo $html5 ? ' novalidate' : ''; ?>>
+			<form action="<?php echo esc_url( $args['action'] ); ?>" method="post" id="<?php echo esc_attr( $args['id_form'] ); ?>" class="<?php echo esc_attr( $args['class_form'] ); ?>"<?php echo $html5 ? ' novalidate' : ''; ?>
+			<?php
+			/**
+			 * Fires inside the comment form tag.
+			 *
+			 * @since CP-1.x.x
+			 */
+			do_action( 'comment_form_tag', $args );
+			?>
+			>
 				<?php
 				/**
-				 * Fires at the top of the comment form, inside the form tag.
+				 * Fires at the top of the comment form, just after the form tag.
 				 *
 				 * @since WP-3.0.0
 				 */


### PR DESCRIPTION
New feature.

This PR adds an action within the comment form tag. This makes it possible to change the form to have the attribute `enctype="multipart/form-data"`, which enables the uploading of files together with the comment using code like this:
```
function kts_enable_uploads_with_comment( ) {
	echo ' enctype="multipart/form-data"';
}
add_action( 'comment_form_tag' , 'kts_enable_uploads_with_comment' );
```

The method used here mirrors that already used for posts and categories.

Without this PR, the only way to achieve this is with JavaScript.

The PR also corrects a misleading statement about the `do_action( 'comment_form_top' )` that follows . This currently states that it fires inside the form tag but, in fact, it fires just after the form tag and so is useless for changing the form's `enctype`.