### PR TITLE
Potential fix for failing external-http tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -169,6 +169,15 @@ jobs:
         if: ${{ matrix.memcached }}
         uses: niden/actions-memcached@v7
 
+      - name: Clone PHP.net and create local supported versions for PHPUnit tests
+        if: ${{ matrix.memcached }}
+        run: |
+          mkdir php.net
+          git clone https://github.com/php/web-php php.net
+          cd php.net
+          php -d error_reporting=E_ERROR -f ./supported-versions.php > ../supported-versions.html
+          cd ..
+
       - name: Run PHPUnit default
         env:
           WP_DB_HOST: 127.0.0.1:${{ job.services.mysql.ports['3306'] }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -174,9 +174,7 @@ jobs:
         run: |
           mkdir php.net
           git clone https://github.com/php/web-php php.net
-          cd php.net
-          php -d error_reporting=E_ERROR -f ./supported-versions.php > ../supported-versions.html
-          cd ..
+          php -d error_reporting=E_ERROR -f php.net/supported-versions.php > supported-versions.html
 
       - name: Run PHPUnit default
         env:

--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018-2021 ClassicPress and contributors
+Copyright © 2018-2022 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2021 by the WordPress contributors
+  Copyright 2003-2022 by the WordPress contributors
 
   WordPress is released under the GPL
 

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -15,7 +15,6 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		$this->assertNotEmpty( $matches );
 
 		$version_info = __DIR__ . '/../../../../supported-versions.html';
-		var_dump( $version_info );
 		if ( file_exists( $version_info ) ) {
 			$php = file_get_contents( $version_info );
 		} else {

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -14,13 +14,12 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		);
 		$this->assertNotEmpty( $matches );
 
-		$response = wp_remote_get(
-			'https://secure.php.net/supported-versions.php'
-		);
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$this->fail( 'Could not contact PHP.net to check versions.' );
+		$version_info = getcwd() . '/supported-versions.html';
+		if ( file_exists( $version_info ) ) {
+			$php = file_get_contents( $version_info );
+		} else {
+			$this->markTestSkipped( 'Could not locate PHP.net clone.' );
 		}
-		$php = wp_remote_retrieve_body( $response );
 
 		preg_match_all(
 			'#<tr class="stable">\s*<td>\s*<a [^>]*>\s*([0-9.]*)#s',
@@ -33,7 +32,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		// TODO: Enable this check once PHP 8.0 compatibility is achieved.
 		/*$this->assertContains(
 			$matches[1],
-			$phpmatches[2],
+			$phpmatches[1],
 			"readme.html's Recommended PHP version is too old."
 		);*/
 	}

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -14,7 +14,8 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		);
 		$this->assertNotEmpty( $matches );
 
-		$version_info = getcwd() . '/supported-versions.html';
+		$version_info = __DIR__ . '/../../../../supported-versions.html';
+		var_dump( $version_info );
 		if ( file_exists( $version_info ) ) {
 			$php = file_get_contents( $version_info );
 		} else {


### PR DESCRIPTION
## Description
As described in Issue #891 the external-http group of unit tests are currently failing for us as PHP.net is detecting our parsing of `supported-versions.php` as being non-human in origin.

It would be ideal to maintain the unit test, but running it on every supported branch of PHP is probably unnecessary.

## Motivation and context
This PR provides a possible solution by cloning the PHP.net GitHub repository and locally re-creating the `supported-versions.php` file for comparison.

## How has this been tested?
Local development has included lost of repeated testing in finding a solution.

## Screenshots
N/A

## Types of changes
- Bug fix
