### PR TITLE
Backport of security release

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -1297,8 +1297,8 @@ function upgrade_280() {
 		$start = 0;
 		while( $rows = $wpdb->get_results( "SELECT option_name, option_value FROM $wpdb->options ORDER BY option_id LIMIT $start, 20" ) ) {
 			foreach ( $rows as $row ) {
-				$value = $row->option_value;
-				if ( !@unserialize( $value ) )
+				$value = maybe_unserialize( $row->option_value );
+				if ( $value === $row->option_value )
 					$value = stripslashes( $value );
 				if ( $value !== $row->option_value ) {
 					update_option( $row->option_name, $value );

--- a/src/wp-includes/class-wp-meta-query.php
+++ b/src/wp-includes/class-wp-meta-query.php
@@ -695,7 +695,7 @@ class WP_Meta_Query {
 			$clause_compare  = strtoupper( $clause['compare'] );
 			$sibling_compare = strtoupper( $sibling['compare'] );
 			if ( in_array( $clause_compare, $compatible_compares ) && in_array( $sibling_compare, $compatible_compares ) ) {
-				$alias = $sibling['alias'];
+				$alias = preg_replace( '/\W/', '_', $sibling['alias'] );
 				break;
 			}
 		}

--- a/src/wp-includes/class-wp-tax-query.php
+++ b/src/wp-includes/class-wp-tax-query.php
@@ -527,7 +527,7 @@ class WP_Tax_Query {
 
 			// The sibling must both have compatible operator to share its alias.
 			if ( in_array( strtoupper( $sibling['operator'] ), $compatible_operators ) ) {
-				$alias = $sibling['alias'];
+				$alias = preg_replace( '/\W/', '_', $sibling['alias'] );
 				break;
 			}
 		}
@@ -556,7 +556,11 @@ class WP_Tax_Query {
 			return;
 		}
 
+		if ( 'slug' === $query['field'] || 'name' === $query['field'] ) {
 		$query['terms'] = array_unique( (array) $query['terms'] );
+		} else {
+			$query['terms'] = wp_parse_id_list( $query['terms'] );
+		}
 
 		if ( is_taxonomy_hierarchical( $query['taxonomy'] ) && $query['include_children'] ) {
 			$this->transform_query( $query, 'term_id' );

--- a/src/wp-includes/class-wp-tax-query.php
+++ b/src/wp-includes/class-wp-tax-query.php
@@ -557,7 +557,7 @@ class WP_Tax_Query {
 		}
 
 		if ( 'slug' === $query['field'] || 'name' === $query['field'] ) {
-		$query['terms'] = array_unique( (array) $query['terms'] );
+			$query['terms'] = array_unique( (array) $query['terms'] );
 		} else {
 			$query['terms'] = wp_parse_id_list( $query['terms'] );
 		}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1083,13 +1083,19 @@ function wp_check_invalid_utf8( $string, $strip = false ) {
 /**
  * Encode the Unicode values to be used in the URI.
  *
+<<<<<<< HEAD
  * @since WP-1.5.0
+=======
+ * @since 1.5.0
+ * @since 5.8.3 Added the `encode_ascii_characters` parameter.
+>>>>>>> 25331bc640 (Grouped backports to the 4.9 branch.)
  *
- * @param string $utf8_string
+ * @param string $utf8_string             String to encode.
  * @param int    $length Max  length of the string
+ * @param bool   $encode_ascii_characters Whether to encode ascii characters such as < " '
  * @return string String with Unicode encoded for URI.
  */
-function utf8_uri_encode( $utf8_string, $length = 0 ) {
+function utf8_uri_encode( $utf8_string, $length = 0, $encode_ascii_characters = false ) {
 	$unicode        = '';
 	$values         = array();
 	$num_octets     = 1;
@@ -1104,11 +1110,14 @@ function utf8_uri_encode( $utf8_string, $length = 0 ) {
 		$value = ord( $utf8_string[ $i ] );
 
 		if ( $value < 128 ) {
-			if ( $length && ( $unicode_length >= $length ) ) {
+			$char                = chr( $value );
+			$encoded_char        = $encode_ascii_characters ? rawurlencode( $char ) : $char;
+			$encoded_char_length = strlen( $encoded_char );
+			if ( $length && ( $unicode_length + $encoded_char_length ) > $length ) {
 				break;
 			}
-			$unicode .= chr( $value );
-			$unicode_length++;
+			$unicode        .= $encoded_char;
+			$unicode_length += $encoded_char_length;
 		} else {
 			if ( count( $values ) == 0 ) {
 				if ( $value < 224 ) {

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -1083,12 +1083,8 @@ function wp_check_invalid_utf8( $string, $strip = false ) {
 /**
  * Encode the Unicode values to be used in the URI.
  *
-<<<<<<< HEAD
  * @since WP-1.5.0
-=======
- * @since 1.5.0
- * @since 5.8.3 Added the `encode_ascii_characters` parameter.
->>>>>>> 25331bc640 (Grouped backports to the 4.9 branch.)
+ * @since WP-5.8.3 Added the `encode_ascii_characters` parameter.
  *
  * @param string $utf8_string             String to encode.
  * @param int    $length Max  length of the string

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3992,7 +3992,7 @@ function _truncate_post_slug( $slug, $length = 200 ) {
 		if ( $decoded_slug === $slug )
 			$slug = substr( $slug, 0, $length );
 		else
-			$slug = utf8_uri_encode( $decoded_slug, $length );
+			$slug = utf8_uri_encode( $decoded_slug, $length, true );
 	}
 
 	return rtrim( $slug, '-' );


### PR DESCRIPTION
## Description
See: https://wordpress.org/news/2022/01/wordpress-5-8-3-security-release/

## Motivation and context
This is a backport of an upstream set of security fixes affecting WP back to version 3.7.
The patch applied to the  4.9 trunk has been backported here.

## How has this been tested?
Upstream backport with visual comparison only.

## Screenshots
N/A

## Types of changes
- Bug fix