### PR TITLE
Update PHPMailer to 6.5.3

### DIFF
--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -35,7 +35,7 @@ class SMTP
      *
      * @var string
      */
-    const VERSION = '6.5.1';
+    const VERSION = '6.5.3';
 
     /**
      * SMTP line break constant.
@@ -392,7 +392,6 @@ class SMTP
                 STREAM_CLIENT_CONNECT,
                 $socket_context
             );
-            restore_error_handler();
         } else {
             //Fall back to fsockopen which should work in more places, but is missing some features
             $this->edebug(
@@ -407,8 +406,8 @@ class SMTP
                 $errstr,
                 $timeout
             );
-            restore_error_handler();
         }
+        restore_error_handler();
 
         //Verify we connected properly
         if (!is_resource($connection)) {
@@ -696,7 +695,7 @@ class SMTP
     /**
      * Send an SMTP DATA command.
      * Issues a data command and sends the msg_data to the server,
-     * finializing the mail transaction. $msg_data is the message
+     * finalizing the mail transaction. $msg_data is the message
      * that is to be send with the headers. Each header needs to be
      * on a single line followed by a <CRLF> with the message headers
      * and the message body being separated by an additional <CRLF>.
@@ -1170,7 +1169,7 @@ class SMTP
         if (!$this->server_caps) {
             $this->setError('No HELO/EHLO was sent');
 
-            return;
+            return null;
         }
 
         if (!array_key_exists($name, $this->server_caps)) {
@@ -1182,7 +1181,7 @@ class SMTP
             }
             $this->setError('HELO handshake was used; No information about server extensions available');
 
-            return;
+            return null;
         }
 
         return $this->server_caps[$name];


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
This PR updates the PMPMailer external library to the 6.5.3 version.

Currently we are using version 6.5.1

[6.5.2](https://github.com/PHPMailer/PHPMailer/releases/tag/v6.5.2) was a maintenance release with the following fixes / enhancements noted in the release post.

- Enable official support for PHP 8.1
- Enable experimental support for PHP 8.2
- Fix for PHP 5.6
- Fix for incorrect options for punyencoding IDNs

[6.5.3](https://github.com/PHPMailer/PHPMailer/releases/tag/v6.5.3) followed rapidly with the following release post:

- Wrong commit tagged for the 6.5.2 release!
- Version file updated

## Motivation and context
External libraries should be maintained with current versions to ensure security and PHP compatibility are maintained.

## How has this been tested?
PHPUnit tests are passing locally.
I have also updated on two of my own sites and emails for database backups, comments in moderation and registrations etc. are arr still working the same as before.

## Screenshots
N/A

## Types of changes
- Enhancement / update
