### PR TITLE
Fix #924 Incorrect menu item highlights as current

### DIFF
--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -202,11 +202,25 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 						$class[] = 'current';
 						$aria_attributes .= ' aria-current="page"';
 					}
-				// If plugin_page is set the parent must either match the current page or not physically exist.
-				// This allows plugin pages with the same hook to exist under different parents.
-				} elseif (
-					( ! isset( $plugin_page ) && $self == $sub_item[2] && ( ! isset( $_GET['tab'] ) || true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' !== $_GET['tab'] ) ) ||
-					( 'plugin-install.php' === $self && true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' === $_GET['tab'] && 'plugin-install.php?tab=upload' === $sub_item[2] ) ||
+				} else if (
+					'plugin-install.php' === $self &&
+					'plugin-install.php' === strtok( $sub_item[2], '?' )
+				) {
+					// Special case: plugin-install.php now has 2 sub-pages in
+					// the menu.  Pick out the correct one based on whether the
+					// 'tab' parameter is used to select the Upload page.
+					$menu_item_is_upload = ( 'plugin-install.php?tab=upload' === $sub_item[2] );
+					$page_is_upload = ( isset( $_GET['tab'] ) && 'upload' === $_GET['tab'] );
+					if ( $menu_item_is_upload === $page_is_upload ) {
+						$class[] = 'current';
+						$aria_attributes .= ' aria-current="page"';
+					}
+				} else if (
+					// If plugin_page is set the parent must either match the
+					// current page or not physically exist.  This allows
+					// plugin pages with the same hook to exist under different
+					// parents.
+					( ! isset( $plugin_page ) && $self == $sub_item[2] ) ||
 					( isset( $plugin_page ) && $plugin_page == $sub_item[2] && ( $item[2] == $self_type || $item[2] == $self || file_exists($menu_file) === false ) )
 				) {
 					$class[] = 'current';

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -205,7 +205,8 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 				// If plugin_page is set the parent must either match the current page or not physically exist.
 				// This allows plugin pages with the same hook to exist under different parents.
 				} elseif (
-					( ! isset( $plugin_page ) && $self == $sub_item[2] ) ||
+					( ! isset( $plugin_page ) && $self == $sub_item[2] && ! isset( $_GET['tab'] ) ) ||
+					( true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' === $_GET['tab'] && 'plugin-install.php?tab=upload' === $sub_item[2] ) ||
 					( isset( $plugin_page ) && $plugin_page == $sub_item[2] && ( $item[2] == $self_type || $item[2] == $self || file_exists($menu_file) === false ) )
 				) {
 					$class[] = 'current';

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -205,8 +205,8 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 				// If plugin_page is set the parent must either match the current page or not physically exist.
 				// This allows plugin pages with the same hook to exist under different parents.
 				} elseif (
-					( ! isset( $plugin_page ) && $self == $sub_item[2] && ! isset( $_GET['tab'] ) ) ||
-					( true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' === $_GET['tab'] && 'plugin-install.php?tab=upload' === $sub_item[2] ) ||
+					( ! isset( $plugin_page ) && $self == $sub_item[2] && ( ! isset( $_GET['tab'] ) || true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' !== $_GET['tab'] ) ) ||
+					( 'plugin-install.php' === $self && true === ( $tab = isset( $_GET['tab'] ) ) && 'upload' === $_GET['tab'] && 'plugin-install.php?tab=upload' === $sub_item[2] ) ||
 					( isset( $plugin_page ) && $plugin_page == $sub_item[2] && ( $item[2] == $self_type || $item[2] == $self || file_exists($menu_file) === false ) )
 				) {
 					$class[] = 'current';


### PR DESCRIPTION
## Description
CP choose what to highlight in `src/wp-admin/menu-header.php`.
The PR try to address the very specific bug reported. This is not a good approach for me, but the file changed already have very specific cases that are handled.

## Motivation and context
Fix #924 

## How has this been tested?
Local install.
Can't write unit tests.

### Before
<img width="435" alt="image" src="https://user-images.githubusercontent.com/29772709/154300978-401738ef-de66-4cce-9e81-7d540a85016a.png">

### After
<img width="450" alt="image" src="https://user-images.githubusercontent.com/29772709/154301065-b0a4c4f5-036f-47fa-aca5-188ad4779caa.png">
