### PR TITLE
Remove wp-includes/fonts/dashicons.woff2 from $_old_files

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -56,7 +56,6 @@ $_old_files = array(
 	'wp-includes/class-wp-recovery-mode-link-service.php',
 	'wp-includes/class-wp-recovery-mode.php',
 	'wp-includes/error-protection.php',
-	'wp-includes/fonts/dashicons.woff2',
 	'wp-includes/js/backbone.js',
 	'wp-includes/js/clipboard.js',
 	'wp-includes/js/clipboard.min.js',


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
In #695 we updated Dashicons to the most recent and final iteration from upstream.

In the upgrade code we list a file as an '$_old_file' that we now include in our build.

## Motivation and context
This fix removes the affected file from the '$_old_file' list.

## How has this been tested?
Issue was noted during PHPUnit testing after a build process. The removal of this file listing fixed the reported PHPUnit failure.

## Screenshots
N/A

## Types of changes
- Bug fix
