### PR TITLE
Update ssh-rsa hostkey options for  SSH2

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -86,7 +86,11 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			$this->options['public_key'] = $opt['public_key'];
 			$this->options['private_key'] = $opt['private_key'];
 
+<<<<<<< HEAD
 			$this->options['hostkey'] = array('hostkey' => 'ssh-rsa');
+=======
+			$this->options['hostkey'] = array( 'hostkey' => 'ssh-rsa,ssh-ed25519' );
+>>>>>>> 33048b9333 (Filesystem API: Include the `ssh-ed25519` public key signature algorithm as an alternative to `ssh-rsa`.)
 
 			$this->keys = true;
 		} elseif ( empty ($opt['username']) ) {

--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -86,11 +86,7 @@ class WP_Filesystem_SSH2 extends WP_Filesystem_Base {
 			$this->options['public_key'] = $opt['public_key'];
 			$this->options['private_key'] = $opt['private_key'];
 
-<<<<<<< HEAD
-			$this->options['hostkey'] = array('hostkey' => 'ssh-rsa');
-=======
 			$this->options['hostkey'] = array( 'hostkey' => 'ssh-rsa,ssh-ed25519' );
->>>>>>> 33048b9333 (Filesystem API: Include the `ssh-ed25519` public key signature algorithm as an alternative to `ssh-rsa`.)
 
 			$this->keys = true;
 		} elseif ( empty ($opt['username']) ) {


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
As per upstream [ticket](https://core.trac.wordpress.org/ticket/52409) the current WP_Filesystem_SSH2  file needs updating to avoid update errors on more modern servers. This is because support for `ssh-rsa` is being phased out.

## Motivation and context
See above

## How has this been tested?
Upstream ticket and patch, we may need a broader understanding of this but PR is minimal.

## Screenshots
N/A

## Types of changes
- Bug fix
- New feature
