### PR TITLE
WP-r52825: General: Improve MS Edge user-agent sniff.

### DIFF
--- a/src/wp-includes/vars.php
+++ b/src/wp-includes/vars.php
@@ -53,7 +53,7 @@ $is_lynx = $is_gecko = $is_winIE = $is_macIE = $is_opera = $is_NS4 = $is_safari 
 if ( isset($_SERVER['HTTP_USER_AGENT']) ) {
 	if ( strpos($_SERVER['HTTP_USER_AGENT'], 'Lynx') !== false ) {
 		$is_lynx = true;
-	} elseif ( strpos( $_SERVER['HTTP_USER_AGENT'], 'Edge' ) !== false ) {
+	} elseif ( strpos( $_SERVER['HTTP_USER_AGENT'], 'Edg' ) !== false ) {
 		$is_edge = true;
 	} elseif ( stripos($_SERVER['HTTP_USER_AGENT'], 'chrome') !== false ) {
 		if ( stripos( $_SERVER['HTTP_USER_AGENT'], 'chromeframe' ) !== false ) {


### PR DESCRIPTION
Update the `$is_edge` global to be `true` if the browser's user-agent contains `Edg` rather than `Edge`. Microsoft have dropped an E from the UA string.

Refer to [https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms Microsoft's documentation on detecting edge].

WP:Props costdev, abdullahramzan, mukesh27, Boniu91.
Fixes https://core.trac.wordpress.org/ticket/55297.

---

Merges https://core.trac.wordpress.org/changeset/52825 / WordPress/wordpress-develop@177c315c12 to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
Upstream ticket backport to improve browser detection.

## Motivation and context
This change improves detection of the Edge browser.

## How has this been tested?
Testing on upstream ticket and references to best practices for browser detection as per Edge development team

## Screenshots
N/A

## Types of changes
- Bug fix / Enhancement