### PR TITLE
WP-r52841: Quick/Bulk Edit taxonomy improvement

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -307,7 +307,11 @@ function get_inline_data($post) {
 	foreach ( $taxonomy_names as $taxonomy_name) {
 		$taxonomy = get_taxonomy( $taxonomy_name );
 
-		if ( $taxonomy->hierarchical && $taxonomy->show_ui ) {
+		if ( ! $taxonomy->show_in_quick_edit ) {
+			continue;
+		}
+
+		if ( $taxonomy->hierarchical ) {
 
 			$terms = get_object_term_cache( $post->ID, $taxonomy_name );
 			if ( false === $terms ) {
@@ -318,7 +322,7 @@ function get_inline_data($post) {
 
 			echo '<div class="post_category" id="' . $taxonomy_name . '_' . $post->ID . '">' . implode( ',', $term_ids ) . '</div>';
 
-		} elseif ( $taxonomy->show_ui ) {
+		} else {
 
 			$terms_to_edit = get_terms_to_edit( $post->ID, $taxonomy_name );
 			if ( ! is_string( $terms_to_edit ) ) {


### PR DESCRIPTION
WP-r52841: Quick/Bulk Edit: Check the `show_in_quick_edit` taxonomy property when populating the data for the posts list table.

Previously, setting the `show_in_quick_edit` property to `false` removed the taxonomy from the inline edit form, but the terms were still being populated in the data for each table row via the `get_inline_data()` function, which only checked the `$taxonomy->show_ui` property.

This commit:
* Improves performance by ensuring that taxonomy terms are not unnecessarily populated for each table row when `show_in_quick_edit` is `false`.
* Properly populates the taxonomy terms when `show_in_quick_edit` is `true` and `show_ui` is `false`.

Follow-up to https://core.trac.wordpress.org/changeset/31307.

WP:Props jazbek, figureone, sabernhardt, ovidiul, webcommsat, SergeyBiryukov.
Fixes https://core.trac.wordpress.org/ticket/42916, https://core.trac.wordpress.org/ticket/49701.

---

Merges https://core.trac.wordpress.org/changeset/52841 / WordPress/wordpress-develop@e4955f67c2 to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
This upstream patch contains a performance improvment

## Motivation and context
Performance

## How has this been tested?
Upstream testing and commit, code review indicates simple change, needs further manual testing

## Screenshots
N/A

## Types of changes
- Enhancement for performance
