### PR TITLE
WP-r45310: Remove duplicate `font-face` declaration

### DIFF
--- a/src/wp-includes/css/dashicons.css
+++ b/src/wp-includes/css/dashicons.css
@@ -5,14 +5,6 @@
  */
 
 /* stylelint-disable function-url-quotes, declaration-colon-newline-after */
-
-@font-face {
-	font-family: dashicons;
-	src: url("../fonts/dashicons.eot?50db0456fde2a241f005968eede3f987");
-	font-weight: 400;
-	font-style: normal;
-}
-
 @font-face {
 	font-family: dashicons;
 	src: url("../fonts/dashicons.eot?99ac726223c749443b642ce33df8b800");


### PR DESCRIPTION
## Description

WP-r45310: Administration: Remove duplicate `font-face` declaration n Dashicons CSS.

This was causing console warnings in some browsers.

WP:Props aduth, joen, afercia, timph, ianbelanger.
Fixes https://core.trac.wordpress.org/ticket/47183.

---

Merges https://core.trac.wordpress.org/changeset/45310 / WordPress/wordpress-develop@cc12950d41 to ClassicPress.


## Description
I noticed a console error in my browser when viewing my site, the error related to a missing server resource:
https://www.example.com/wp-includes/fonts/dashicons.eot?50db0456fde2a241f005968eede3f987

## Motivation and context
The upstream ticket and changeset I located was merged 3 years ago as a fix for this issue. After applying the patch the issue is resolved in the browser.

## How has this been tested?
Upstream testing was done and I have applied the patch on my live sites and confirmed this fix.

## Screenshots
### Before
<img width="436" alt="Screenshot 2022-03-12 at 19 29 02" src="https://user-images.githubusercontent.com/1280733/158032256-24d8bd88-e11d-40d1-81f7-923a90eb8dfc.png">

### After
<img width="381" alt="Screenshot 2022-03-12 at 19 29 32" src="https://user-images.githubusercontent.com/1280733/158032261-9c76f2e0-e122-4614-b21a-47bea078859a.png">

## Types of changes
- Bug fix