### PR TITLE
Add 'allow-plugins' to composer.json

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -64,9 +64,6 @@ jobs:
       - name: Log PHPCS debug information
         run: phpcs -i
 
-      - name: Run PHP compatibility tests for Errors
-        run: phpcs --standard=phpcompat.xml.dist -q -n --report=checkstyle | cs2pr
-
-      - name: Run PHP compatibility tests for Warnings
+      - name: Run PHP compatibility tests
         continue-on-error: true
         run: phpcs --standard=phpcompat.xml.dist -q --report=checkstyle | cs2pr

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Log PHPCS debug information
         run: phpcs -i
 
-      - name: Run PHP compatibility tests
+      - name: Run PHP compatibility tests for Errors
+        run: phpcs --standard=phpcompat.xml.dist -q -n --report=checkstyle | cs2pr
+
+      - name: Run PHP compatibility tests for Warnings
         continue-on-error: true
         run: phpcs --standard=phpcompat.xml.dist -q --report=checkstyle | cs2pr

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.3"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }


### PR DESCRIPTION
## Description
Currently in any GitHub Action that utilises a `composer` installation step we are seeing the following warning:

"For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See 
https://getcomposer.org/allow-plugins

You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins."

This PR aims to fix this warning and ensure continued functionality past the quoted date above.

## Motivation and context
This PR should remove that warning and ensure continues GitHub Action functionality past July 2022.

## How has this been tested?
PR tests will hopefully not contain this message.

## Screenshots
### Before

<img width="1266" alt="Screenshot 2022-03-19 at 09 33 44" src="https://user-images.githubusercontent.com/1280733/159115874-b5ea2eed-09b4-40b6-97ec-84243e228c73.png">

### After

<img width="1282" alt="Screenshot 2022-03-19 at 09 34 00" src="https://user-images.githubusercontent.com/1280733/159115877-4103cddd-e06e-4323-b93d-29cf5410e735.png">


## Types of changes
- Bug fix
