### PR TITLE
Add 'allow-plugins' to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,28 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
+<<<<<<< HEAD
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.3"
+=======
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+		"squizlabs/php_codesniffer": "3.6.0",
+		"wp-coding-standards/wpcs": "~2.3.0",
+		"phpcompatibility/phpcompatibility-wp": "~2.1.2",
+		"yoast/phpunit-polyfills": "^1.0.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
+	},
+	"scripts": {
+		"compat": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist --report=summary,source",
+		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
+		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
+		"lint:errors": "@lint -n",
+		"test": "@php ./vendor/phpunit/phpunit/phpunit"
+>>>>>>> 81f4ca8727 (Build/Test Tools: Allow the PHPCS plugin in Composer configuration.)
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -13,28 +13,13 @@
 		"php": ">=5.6"
 	},
 	"require-dev": {
-<<<<<<< HEAD
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.3"
-=======
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-		"squizlabs/php_codesniffer": "3.6.0",
-		"wp-coding-standards/wpcs": "~2.3.0",
-		"phpcompatibility/phpcompatibility-wp": "~2.1.2",
-		"yoast/phpunit-polyfills": "^1.0.1"
 	},
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
-	},
-	"scripts": {
-		"compat": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist --report=summary,source",
-		"format": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf --report=summary,source",
-		"lint": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --report=summary,source",
-		"lint:errors": "@lint -n",
-		"test": "@php ./vendor/phpunit/phpunit/phpunit"
->>>>>>> 81f4ca8727 (Build/Test Tools: Allow the PHPCS plugin in Composer configuration.)
 	}
 }


### PR DESCRIPTION
## Description
Build/Test Tools: Allow the PHPCS plugin in Composer configuration.

The dealerdirect/phpcodesniffer-composer-installer Composer plugin is used to register external PHPCS standards with PHPCS.

As of Composer 2.2, Composer plugins need to be explicitly allowed to run. This commit adds the necessary configuration for that to prevent Composer asking every single time composer install or composer update is run.

Reference: [Composer 2.2: More secure plugin execution](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution).

Props jrf, johnbillion.
Fixes [#54686](https://core.trac.wordpress.org/ticket/54686).

## Motivation and context
Maintains functionality of some GitHub Actions

## How has this been tested?
Upstrem backport, locally tested on another PR that wasn't a backport:
https://github.com/ClassicPress/ClassicPress/pull/960

## Screenshots
See:
https://github.com/ClassicPress/ClassicPress/pull/960

## Types of changes
- Bug fix
