### PR TITLE
Restore removed code to TinyMCE plugin

### DIFF
--- a/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js
+++ b/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js
@@ -113,6 +113,15 @@ tinymce.PluginManager.add( 'wordpress', function( editor ) {
 						'alt="" title="' + title + '" data-mce-resize="false" data-mce-placeholder="1" />' );
 			}
 
+			if ( event.load && event.format !== 'raw' ) {
+				if ( hasWpautop ) {
+					event.content = wp.editor.autop( event.content );
+				} else {
+					// Prevent creation of paragraphs out of multiple HTML comments.
+					event.content = event.content.replace( /-->\s+<!--/g, '--><!--' );
+				}
+			}
+
 			if ( event.content.indexOf( '<script' ) !== -1 || event.content.indexOf( '<style' ) !== -1 ) {
 				event.content = event.content.replace( /<(script|style)[^>]*>[\s\S]*?<\/\1>/g, function( match, tag ) {
 					return '<img ' +
@@ -604,6 +613,9 @@ tinymce.PluginManager.add( 'wordpress', function( editor ) {
 
 		if ( hasWpautop ) {
 			event.content = wp.editor.removep( event.content );
+		} else {
+			// Restore formatting of block boundaries.
+			event.content = event.content.replace( /-->\s*<!-- wp:/g, '-->\n\n<!-- wp:' );
 		}
 	});
 


### PR DESCRIPTION
## Description
Version 1.4.0 contained changes to `src/wp-includes/js/tinymce/plugins/wordpress/plugin.js` that results in a bug in the visual editor whereby paragraph are stripped.

## Motivation and context
This PR revery prior changes and restores expected behaviour and this is a potent hot fix #967

## How has this been tested?
Locally tested and reproduced the issue in `develop`

## Screenshots

### Before
<img width="1265" alt="Screenshot 2022-04-01 at 22 16 50" src="https://user-images.githubusercontent.com/1280733/161342432-04f40dc9-bdf2-49b6-be2a-db4b4544f83b.png">

### After
<img width="1262" alt="Screenshot 2022-04-01 at 22 16 26" src="https://user-images.githubusercontent.com/1280733/161342441-dcd852ec-d761-4861-838c-119e0745cac2.png">

## Types of changes
- Bug fix

