### PR TITLE
Update about.php

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -152,7 +152,7 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				<?php
 				printf(
 					/* translators: %s: WordPress version number */
-					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					__( '<strong>WordPress version %s</strong> addressed some security issues.' ),
 					'4.9.19'
 				);
 				?>


### PR DESCRIPTION
## Description
Text string update on about.php for consistency

## Motivation and context
All security releases except one start "WordPress version..."
This PR updates a singular occurrence of "Version..." to be consistent.

## How has this been tested?
N/A - simple change

## Screenshots
### Before
<img width="695" alt="Screenshot 2022-04-02 at 18 46 21" src="https://user-images.githubusercontent.com/1280733/161394985-39c8412e-bef9-4224-81c9-d049fe32223d.png">

### After
<img width="690" alt="Screenshot 2022-04-02 at 18 46 01" src="https://user-images.githubusercontent.com/1280733/161395000-5a302e5a-e5d0-4399-b7aa-b617e60a8756.png">


## Types of changes
- Bug fix
