### PR TITLE
Improve JS template error handling

### DIFF
--- a/src/wp-includes/js/wp-util.js
+++ b/src/wp-includes/js/wp-util.js
@@ -33,7 +33,7 @@ window.wp = window.wp || {};
 
 		return function ( data ) {
 			try {
-				compiled = compiled || _.template( $( '#tmpl-' + id ).html(),  options );
+				compiled = compiled || _.template( $( '#tmpl-' + id ).html(), options );
 				return compiled( data );
 			} catch (originalError) {
 				var err = new Error(

--- a/src/wp-includes/js/wp-util.js
+++ b/src/wp-includes/js/wp-util.js
@@ -35,7 +35,7 @@ window.wp = window.wp || {};
 			try {
 				compiled = compiled || _.template( $( '#tmpl-' + id ).html(), options );
 				return compiled( data );
-			} catch (originalError) {
+			} catch ( originalError ) {
 				var err = new Error(
 					'"' + originalError.message + '" '
 					+ "when compiling wp.template( '" + id + "' ). "

--- a/src/wp-includes/js/wp-util.js
+++ b/src/wp-includes/js/wp-util.js
@@ -37,9 +37,9 @@ window.wp = window.wp || {};
 				return compiled( data );
 			} catch ( originalError ) {
 				var err = new Error(
-					'"' + originalError.message + '" '
-					+ "when compiling wp.template( '" + id + "' ). "
-					+ 'See wp.template.errorData for more information.'
+					'"' + originalError.message + '" ' +
+					'when compiling wp.template( \'' + id + '\' ). ' +
+					'See wp.template.errorData for more information.'
 				);
 				wp.template.errorData.push( {
 					errorMessage: err.message,

--- a/src/wp-includes/js/wp-util.js
+++ b/src/wp-includes/js/wp-util.js
@@ -32,10 +32,27 @@ window.wp = window.wp || {};
 			};
 
 		return function ( data ) {
-			compiled = compiled || _.template( $( '#tmpl-' + id ).html(),  options );
-			return compiled( data );
+			try {
+				compiled = compiled || _.template( $( '#tmpl-' + id ).html(),  options );
+				return compiled( data );
+			} catch (originalError) {
+				var err = new Error(
+					'"' + originalError.message + '" '
+					+ "when compiling wp.template( '" + id + "' ). "
+					+ 'See wp.template.errorData for more information.'
+				);
+				wp.template.errorData.push( {
+					errorMessage: err.message,
+					originalError: originalError,
+					themeId: id,
+					elementId: '#tmpl-' + id,
+					templateHTML: $( '#tmpl-' + id ).html()
+				} );
+				throw err;
+			}
 		};
 	});
+	wp.template.errorData = [];
 
 	// wp.ajax
 	// ------


### PR DESCRIPTION
This PR improves the error that appears in the browser console when one of the JavaScript templates used in various places in the admin screens is malformed and cannot compile. This still results in a broken site, potentially with other JavaScript errors appearing later on, but this change makes it much easier to track down the real problem.

## Before

The previous error message is not very helpful about what is going on:

![2022-04-03T19-22-21Z](https://user-images.githubusercontent.com/227022/161444743-037fd240-4133-4543-b898-8945f5831e53.png)

## After

This PR improves the error message to explain more about what operation was being performed when the error occurred, and also provides a way to see more data using a new variable `wp.template.errorData`:

![2022-04-03T19-21-44Z](https://user-images.githubusercontent.com/227022/161444762-71b92fd7-0592-487d-aa60-2df60f983bde.png)

## How to test

Cause a syntax error in one of the templates, for example by removing these two lines from `wp-admin/themes.php`:

https://github.com/ClassicPress/ClassicPress/blob/b7562b7b4594971a0d1ee522b47246b37bc16247/src/wp-admin/themes.php#L451-L452

For that template, go to the Appearance > Themes page in the admin area, and attempt to click on a theme to load the Theme Details dialog. This will fail after removing the indicated lines and you should see one of the errors mentioned in this PR in your browser console.