### PR TITLE
Fix variable name in REST API

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -73,7 +73,7 @@ function register_rest_route( $namespace, $route, $args = array(), $override = f
 				sprintf(
 					/* translators: 1. The REST API route being registered. 2. The argument name. 3. The suggested function name. */
 					__( 'The REST API route definition for %1$s is missing the required %2$s argument. For REST API routes that are intended to be public, use %3$s as the permission callback.' ),
-					'<code>' . $clean_namespace . '/' . trim( $route, '/' ) . '</code>',
+					'<code>' . $namespace . '/' . trim( $route, '/' ) . '</code>',
 					'<code>permission_callback</code>',
 					'<code>__return_true</code>'
 				),


### PR DESCRIPTION
## Description
During the backport of 48256 that was merge in #732 we have used an incorrect variable name.

## Motivation and context
The upstream code also contains checks to ensure that REST API namespaces do not start or end with a slash, this is part of [47842](https://core.trac.wordpress.org/changeset/47842)

Backporting the above may well be a breaking change for any code using a namespace with a slash included at the tart or end of the namespace, so the easiest fix is a variable name correction in our code.

## How has this been tested?
Will need testing under conditions that identified the issue as reported in issue #974 
As such, this may Fix #974 

## Screenshots
N/A

## Types of changes
- Bug fix
