### PR TITLE
Editor switch fix

### DIFF
--- a/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js
+++ b/src/wp-includes/js/tinymce/plugins/wordpress/plugin.js
@@ -113,13 +113,8 @@ tinymce.PluginManager.add( 'wordpress', function( editor ) {
 						'alt="" title="' + title + '" data-mce-resize="false" data-mce-placeholder="1" />' );
 			}
 
-			if ( event.load && event.format !== 'raw' ) {
-				if ( hasWpautop ) {
-					event.content = wp.editor.autop( event.content );
-				} else {
-					// Prevent creation of paragraphs out of multiple HTML comments.
-					event.content = event.content.replace( /-->\s+<!--/g, '--><!--' );
-				}
+			if ( event.load && event.format !== 'raw' && hasWpautop ) {
+				event.content = wp.editor.autop( event.content );
 			}
 
 			if ( event.content.indexOf( '<script' ) !== -1 || event.content.indexOf( '<style' ) !== -1 ) {
@@ -613,9 +608,6 @@ tinymce.PluginManager.add( 'wordpress', function( editor ) {
 
 		if ( hasWpautop ) {
 			event.content = wp.editor.removep( event.content );
-		} else {
-			// Restore formatting of block boundaries.
-			event.content = event.content.replace( /-->\s*<!-- wp:/g, '-->\n\n<!-- wp:' );
 		}
 	});
 


### PR DESCRIPTION

## Description
This is an alternate approach to fixing the problem with the editor losing line breaks when switching modes.
It removes the change (again) from https://core.trac.wordpress.org/changeset/43336 that is specific to WP blocks.
It checks for existence of the selection marker before removing the elements.
It does not remove the marker parent (which is what deletes content).
It enhances `removep` and `autop` to preserve comments, pre, and script tags.
It includes a fix for having the cursor in a comment, from https://core.trac.wordpress.org/ticket/45947

## Motivation and context
The upgrade of the editor to 4.9.11 is desirable, but the change for WP blocks is not. This fixes the problems better than other attempts (which I'm not sure the state of).

## How has this been tested?
I tested locally, using the following data in a post, switching between Text and Visual modes with the cursor in various places. It's important to switch multiple times and to start the editor in both modes because different code paths are taken.
```
<!-- plain comment -->

<!-- wp:paragraph -->
<p>content of paragraph<br> <!-- comment inside paragraph -->
This is a long sentence just for the sake of testing that there is no change and a line break before the paragraph tag.
</p>
<!-- /wp:paragraph -->

More content without block.
<!-- another comment with <p> tag -->

<script>alert('<p>I am a paragraph!</p>');</script>
<!--nextpage-->
<pre>

<!-- plain comment -->

content of paragraph inside pre<br> <!-- comment inside pre line -->
This is a long sentence just for the sake of testing that there is no change and a line break at the end.

<!-- a comment on a line -->

More content without block.
<!-- another comment -->

</pre>
```



## Types of changes
 Bug fix
