### PR TITLE
WP-r52083: Mail: Add `wp_mail_succeeded` hook to `wp_mail`.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -513,26 +513,27 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	 */
 	do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
 
-		$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
+	$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
 
 	// Send!
 	try {
-			$send = $phpmailer->send();
+		$send = $phpmailer->send();
 
-			/**
-			 * Fires after PHPMailer has successfully sent a mail.
-			 *
-			 * The firing of this action does not necessarily mean that the recipient received the
-			 * email successfully. It only means that the `send` method above was able to
-			 * process the request without any errors.
-			 *
-			 * @since 5.9.0
-			 *
-			 * @param array $mail_data An array containing the mail recipient, subject, message, headers, and attachments.
-			 */
-			do_action( 'wp_mail_succeeded', $mail_data );
+		/**
+		 * Fires after PHPMailer has successfully sent a mail.
+		 *
+		 * The firing of this action does not necessarily mean that the recipient received the
+		 * email successfully. It only means that the `send` method above was able to
+		 * process the request without any errors.
+		 *
+		 * @since WP-5.9.0
+		 * @since CP-1.5.0
+		 *
+		 * @param array $mail_data An array containing the mail recipient, subject, message, headers, and attachments.
+		 */
+		do_action( 'wp_mail_succeeded', $mail_data );
 
-			return $send;
+		return $send;
 	} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_data['phpmailer_exception_code'] = $e->getCode();
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -513,13 +513,28 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	 */
 	do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
 
+		$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
+
 	// Send!
 	try {
-		return $phpmailer->send();
-	} catch ( PHPMailer\PHPMailer\Exception $e ) {
+			$send = $phpmailer->send();
 
-		$mail_error_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
-		$mail_error_data['phpmailer_exception_code'] = $e->getCode();
+			/**
+			 * Fires after PHPMailer has successfully sent a mail.
+			 *
+			 * The firing of this action does not necessarily mean that the recipient received the
+			 * email successfully. It only means that the `send` method above was able to
+			 * process the request without any errors.
+			 *
+			 * @since 5.9.0
+			 *
+			 * @param array $mail_data An array containing the mail recipient, subject, message, headers, and attachments.
+			 */
+			do_action( 'wp_mail_succeeded', $mail_data );
+
+			return $send;
+	} catch ( PHPMailer\PHPMailer\Exception $e ) {
+			$mail_data['phpmailer_exception_code'] = $e->getCode();
 
 		/**
 		 * Fires after a PHPMailer\PHPMailer\Exception is caught.
@@ -529,7 +544,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		 * @param WP_Error $error A WP_Error object with the phpmailerException message, and an array
 		 *                        containing the mail recipient, subject, message, headers, and attachments.
 		 */
-		do_action( 'wp_mail_failed', new WP_Error( 'wp_mail_failed', $e->getMessage(), $mail_error_data ) );
+			do_action( 'wp_mail_failed', new WP_Error( 'wp_mail_failed', $e->getMessage(), $mail_data ) );
 
 		return false;
 	}


### PR DESCRIPTION
Adds a new `wp_mail_succeeded` action in `wp_mail` after the mail is sent.  Also, adds a disclaimer to the hook's docblock, clarifying that the hook's firing doesn't necessarily mean the recipient received the mail, only that the mail was processed without any errors.

WP:Props birgire, donmhico, johnbillion.
Fixes https://core.trac.wordpress.org/ticket/53826.

---

Merges https://core.trac.wordpress.org/changeset/52083 / WordPress/wordpress-develop@16b7125de0 to ClassicPress.

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
<!--
Describe your changes in detail.
-->

## Motivation and context
<!--
Why is this change required? What problem does it solve?

If it fixes an open issue, please link to the issue here.
-->

## How has this been tested?
<!--
Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to see how
your change affects other areas of the code, etc.

Please include automated tests with new or changed code, if applicable.
-->

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

### Before
<!--
Insert screenshot(s) of the current behavior (before your changes) here.
-->

### After
<!--
Insert screenshot(s) of the new, proposed behavior (after your changes) here.
-->

## Types of changes
<!--
What types of changes does your code introduce?  Most PRs are one of the following:

- Bug fix
- New feature
- Breaking change
-->
