### PR TITLE
Removes the Security Page Menu

### DIFF
--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -343,3 +343,16 @@ if ( !user_can_access_admin_page() ) {
 }
 
 $menu = add_menu_classes($menu);
+
+/**
+ * Remove the ClassicPress Security Page Menu when it is not used.
+ * The page itself is still accessible if calling the direct URL, or,
+ * if a plugin uses add_security_page()
+ *
+ * @since CP-1.5.0
+ */
+if ( isset( $menu[85] )
+	&& isset( $menu[85][2] )
+	&& 'security.php' === $menu[85][2] ) {
+	unset( $menu[85] );
+}

--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -346,13 +346,16 @@ $menu = add_menu_classes($menu);
 
 /**
  * Remove the ClassicPress Security Page Menu when it is not used.
+ *
  * The page itself is still accessible if calling the direct URL, or,
  * if a plugin uses add_security_page()
  *
+ * The way we unhook the menu is by checking if the $submenu global holds the key `security.php`,
+ * which is only the case if a plugin added another submenu with `add_security_page` on the `admin_menu` hook.
+ * Note that plugins COULD also add said menu on `init`, but that is doing_it_wrong and will actually produce an erroneus menu sequence, even if it "works"
+ *
  * @since CP-1.5.0
  */
-if ( isset( $menu[85] )
-	&& isset( $menu[85][2] )
-	&& 'security.php' === $menu[85][2] ) {
+if ( ! isset( $submenu['security.php'] ) )  {
 	unset( $menu[85] );
 }

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -491,4 +491,29 @@ class Tests_Admin_includesPlugin extends WP_UnitTestCase {
 			rmdir( $di_bu_dir );
 		}
 	}
+
+	/**
+	 * Test securty page is only visible if used by a plugin
+	 */
+	function test_add_security_menu() {
+		global $_parent_pages;
+		$current_user = get_current_user_id();
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		update_option( 'siteurl', 'http://example.com' );
+
+		// add_security_page() requires a menu_slug that matches an active plugin
+		activate_plugin( 'hello.php' );
+		$expected = 'http://example.com/wp-admin/security.php?page=hello.php';
+
+		$this->assertNotContains( 'security.php', $_parent_pages );
+		$this->assertNotEquals( $expected, menu_page_url( 'hello.php', false ) );
+
+		add_security_page( 'Security Page Test', 'Security Page Test', 'hello.php', null );
+
+		$this->assertContains( 'security.php', $_parent_pages );
+		$this->assertEquals( $expected, menu_page_url( 'hello.php', false ) );
+
+		wp_set_current_user( $current_user );
+		deactivate_plugins( 'hello.php' );
+	}
 }


### PR DESCRIPTION
## Description
Removes the CP Security Page MENU.
The page is still accessible by direct URL or when a plugin uses `add_security_page ()`

There is plenty of reasons why this should be removed: https://forums.classicpress.net/t/security-page-feedback-and-improvements/3442
The only reason we cannot ditch it completely is because "backwards" compatibility.

## How has this been tested?
On local install with, and without plugin which adds (and once not) security page item.

## Screenshots
### Before
This is the standard. It is a useless, empty and bad looking menu + page
<img width="161" alt="Screenshot 2022-06-08 at 16 06 10" src="https://user-images.githubusercontent.com/11800236/172577908-59026696-6a97-4eef-860b-ee513dad9c19.png">

### After
No more useless menu, UNLESS some plugin uses it using `add_security_page()` as documented at https://docs.classicpress.net/reference/functions/add_security_page/ and https://docs.classicpress.net/developer-guides/security-page/
<img width="161" alt="Screenshot 2022-06-08 at 16 06 58" src="https://user-images.githubusercontent.com/11800236/172578053-92730b15-0040-4cce-94f4-7e56cef658a4.png">


## Types of changes
- New feature (well, it is a new feature removed...)
- NOT Breaking change