### PR TITLE
Filesystem API: Correct variable name

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -454,7 +454,7 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			$limit_file = false;
 		}
 
-		if ( ! $this->is_dir( $path ) || ! $this->is_readable( $dir ) ) {
+		if ( ! $this->is_dir( $path ) || ! $this->is_readable( $path ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Description
Backporting of upstream changes for PHP Compatibility (#958) included a bug that has also been fixed upstream in a further ticket. Unfortunately this was not noted in testing or code review before committing - thanks to @xxsimoxx for raising awareness.

## Motivation and context
Change upstream reference an undeclared variable as an incorrect variable name was used, this was fixed in the change set below.

WP-r45613: Filesystem API: Check correct variable in `WP_Filesystem_Direct::dirlist()` after https://core.trac.wordpress.org/changeset/45611.

WP:Props zinigor.
Fixes https://core.trac.wordpress.org/ticket/47668. See https://core.trac.wordpress.org/ticket/47632.

---

Merges https://core.trac.wordpress.org/changeset/45613 / WordPress/wordpress-develop@40d9fdf1f9 to ClassicPress.

## How has this been tested?
See screenshots below

## Screenshots
### Before
<img width="382" alt="Screenshot 2022-06-08 at 16 52 21" src="https://user-images.githubusercontent.com/1280733/172662524-61b46317-a008-40ec-818f-a50f552bd807.png">

### After
<img width="379" alt="Screenshot 2022-06-08 at 16 52 40" src="https://user-images.githubusercontent.com/1280733/172662580-78c7b43b-d124-47d6-9ba4-abe98bd42f28.png">


## Types of changes
- Bug fix
