### PR TITLE
Pass EXIF Data to the wp_read_image_metadata filter #904

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -425,7 +425,7 @@ function wp_read_image_metadata( $file ) {
 		 }
 	}
 
-	$exif = array(); 
+	$exif = array();
 
 	/**
 	 * Filters the image types to check for exif data.

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -512,9 +512,9 @@ function wp_read_image_metadata( $file ) {
 	/**
 	 * Filters the array of meta data read from an image's exif data.
 	 *
-	 * @since 2.5.0
-	 * @since 4.4.0 The `$iptc` parameter was added.
-	 * @since 5.0.0 The `$exif` parameter was added.
+	 * @since WP-2.5.0
+	 * @since WP-4.4.0 The `$iptc` parameter was added.
+	 * @since WP-5.0.0 The `$exif` parameter was added.
 	 *
 	 * @param array  $meta            Image meta data.
 	 * @param string $file            Path to image file.

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -348,7 +348,7 @@ function wp_read_image_metadata( $file ) {
 	if ( ! file_exists( $file ) )
 		return false;
 
-	list( , , $sourceImageType ) = @getimagesize( $file );
+	list( , , $image_type ) = @getimagesize( $file );
 
 	/*
 	 * EXIF contains a bunch of data we'll probably never need formatted in ways
@@ -432,7 +432,9 @@ function wp_read_image_metadata( $file ) {
 	 *
 	 * @param array $image_types Image types to check for exif data.
 	 */
-	if ( is_callable( 'exif_read_data' ) && in_array( $sourceImageType, apply_filters( 'wp_read_image_metadata_types', array( IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM ) ) ) ) {
+	$exif_image_types = apply_filters( 'wp_read_image_metadata_types', array( IMAGETYPE_JPEG, IMAGETYPE_TIFF_II, IMAGETYPE_TIFF_MM ) );
+
+	if ( is_callable( 'exif_read_data' ) && in_array( $image_type, $exif_image_types ) ) {
 		$exif = @exif_read_data( $file );
 
 		if ( ! empty( $exif['ImageDescription'] ) ) {
@@ -513,10 +515,10 @@ function wp_read_image_metadata( $file ) {
 	 *
 	 * @param array  $meta            Image meta data.
 	 * @param string $file            Path to image file.
-	 * @param int    $sourceImageType Type of image.
+	 * @param int    $image_type Type of image, one of the `IMAGETYPE_XXX` constants.
 	 * @param array  $iptc            IPTC data.
 	 */
-	return apply_filters( 'wp_read_image_metadata', $meta, $file, $sourceImageType, $iptc );
+	return apply_filters( 'wp_read_image_metadata', $meta, $file, $image_type, $iptc );
 
 }
 

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -512,14 +512,9 @@ function wp_read_image_metadata( $file ) {
 	/**
 	 * Filters the array of meta data read from an image's exif data.
 	 *
-<<<<<<< HEAD
-	 * @since WP-2.5.0
-	 * @since WP-4.4.0 The `$iptc` parameter was added.
-=======
 	 * @since 2.5.0
 	 * @since 4.4.0 The `$iptc` parameter was added.
 	 * @since 5.0.0 The `$exif` parameter was added.
->>>>>>> 56b7476d7a (Media: Pass EXIF data to the `wp_read_image_metadata` filter.)
 	 *
 	 * @param array  $meta            Image meta data.
 	 * @param string $file            Path to image file.

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -425,6 +425,8 @@ function wp_read_image_metadata( $file ) {
 		 }
 	}
 
+	$exif = array(); 
+
 	/**
 	 * Filters the image types to check for exif data.
 	 *
@@ -510,15 +512,22 @@ function wp_read_image_metadata( $file ) {
 	/**
 	 * Filters the array of meta data read from an image's exif data.
 	 *
+<<<<<<< HEAD
 	 * @since WP-2.5.0
 	 * @since WP-4.4.0 The `$iptc` parameter was added.
+=======
+	 * @since 2.5.0
+	 * @since 4.4.0 The `$iptc` parameter was added.
+	 * @since 5.0.0 The `$exif` parameter was added.
+>>>>>>> 56b7476d7a (Media: Pass EXIF data to the `wp_read_image_metadata` filter.)
 	 *
 	 * @param array  $meta            Image meta data.
 	 * @param string $file            Path to image file.
 	 * @param int    $image_type Type of image, one of the `IMAGETYPE_XXX` constants.
 	 * @param array  $iptc            IPTC data.
+	 * @param array  $exif       EXIF data.
 	 */
-	return apply_filters( 'wp_read_image_metadata', $meta, $file, $image_type, $iptc );
+	return apply_filters( 'wp_read_image_metadata', $meta, $file, $image_type, $iptc, $exif );
 
 }
 


### PR DESCRIPTION
## Description
Changeset [43750](https://core.trac.wordpress.org/changeset/43750) passes EXIF Data to the wp_read_image_metadata filter and changeset [43749](https://core.trac.wordpress.org/changeset/43749) fixes a merge conflict by replacing sourceImageType with image_type.

## Motivation and context
Fixes #904. See ticket ticket [43624](https://core.trac.wordpress.org/ticket/43624) for details.

## How has this been tested?
A quick way to test it is to add the following code to your functions.php. Make sure to upload a photo with exif data and replace the file path in the code. Load the website, it should show you exif data and the word "Yes!". See screenshot below.

```
add_action( 'wp_read_image_metadata', 'exif_data', 10, 5 );
function exif_data( $meta, $file, $image_type, $iptc = null, $exif = null ) {
		// If there is no Exif Version set return.
		if ( $exif['ExifVersion'] ) {
			$meta['test_filter'] = 'Yes!';
		}else{
			$meta['test_filter'] = 'No!';
		}
               return $meta;
}

require_once ABSPATH . '/wp-admin/includes/image.php';
$path = ABSPATH . '/wp-content/uploads/2022/06/PXL_20220611_200452520-Small.jpg';
wp_die(var_dump(wp_read_image_metadata( $path )));
```

## Screenshots
![image](https://user-images.githubusercontent.com/1692600/175763394-d233ecca-2cd1-4fa1-bae7-9528a813ea84.png)

## Types of changes
Backport
