### PR TITLE
Accessibility: Themes: use aria-current for the Walker_Nav_Menu current link (and patch)

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -169,11 +169,11 @@ class Walker_Nav_Menu extends Walker {
 
 		$output .= $indent . '<li' . $id . $class_names . '>';
 
-		$atts           = array();
-		$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
-		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-		$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
-		$atts['href']   = ! empty( $item->url ) ? $item->url : '';
+		$atts                 = array();
+		$atts['title']        = ! empty( $item->attr_title ) ? $item->attr_title : '';
+		$atts['target']       = ! empty( $item->target ) ? $item->target : '';
+		$atts['rel']          = ! empty( $item->xfn ) ? $item->xfn : '';
+		$atts['href']         = ! empty( $item->url ) ? $item->url : '';
 		$atts['aria-current'] = $item->current ? 'page' : '';
 
 		/**

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -174,6 +174,7 @@ class Walker_Nav_Menu extends Walker {
 		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
 		$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
 		$atts['href']   = ! empty( $item->url ) ? $item->url : '';
+		$atts['aria-current'] = $item->current ? 'page' : '';
 
 		/**
 		 * Filters the HTML attributes applied to a menu item's anchor element.
@@ -188,6 +189,7 @@ class Walker_Nav_Menu extends Walker {
 		 *     @type string $target Target attribute.
 		 *     @type string $rel    The rel attribute.
 		 *     @type string $href   The href attribute.
+		 *     @type string $aria_current The aria-current attribute.
 		 * }
 		 * @param WP_Post  $item  The current menu item.
 		 * @param stdClass $args  An object of wp_nav_menu() arguments.


### PR DESCRIPTION
## Description
This is a slightly different PR. The main thing it does is backports [changeset 42808](https://core.trac.wordpress.org/changeset/42808). This changeset introduced a bug that causes PHP errors, reported in [ticket 46382](https://core.trac.wordpress.org/ticket/46382). The ticket has a patch that's 3 years old and WP hasn't fixed it. It simply misses `empty()`.

Changeset does improve accessibility of the nav menu, so it's good to have. While the patch fixes PHP errors. This was originally requested as [a petition](https://forums.classicpress.net/t/add-empty-check-to-class-walker-nav-menu-php/2929/4). 

No merge conflicts.

## Motivation and context
The changeset improves the accessibility of the nav menu, while the patch fixes a bug introduced by that changeset.

## How has this been tested?
When you have an active theme and a menu, click on a menu item to go to the page. Once on the page, inspect the menu item you just clicked. It should have `aria-current="page"` attribute set for `<a>`. 

## Screenshots
See below.

### Before
![image](https://user-images.githubusercontent.com/1692600/175799568-4b2aaefe-994e-4bd3-9b28-1cd338bac6d9.png)

### After
![image](https://user-images.githubusercontent.com/1692600/175799757-48289c9e-95b3-4565-a852-fb970990b4a0.png)

## Types of changes
- Backport
- Bug fix