### PR TITLE
WP-r47224: Introduce selective link embedding via REST API

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3912,6 +3912,23 @@ function wp_parse_args( $args, $defaults = '' ) {
 }
 
 /**
+ * Converts a comma- or space-separated list of scalar values to an array.
+ *
+ * @since WP-5.1.0
+ * @param array|string $list List of values.
+ * @return array Array of values.
+ */
+function wp_parse_list( $list ) {
+	if ( ! is_array( $list ) ) {
+		return preg_split( '/[\s,]+/', $list, -1, PREG_SPLIT_NO_EMPTY );
+	}
+	// Validate all entries of the list are scalar.
+	$list = array_filter( $list, 'is_scalar' );
+
+	return $list;
+}
+
+/**
  * Clean up an array, comma- or space-separated list of IDs.
  *
  * @since WP-3.0.0

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1309,14 +1309,12 @@ function rest_sanitize_value_from_schema( $value, $args ) {
 
 	return $value;
 }
-<<<<<<< HEAD
-=======
 
 /**
  * Append result of internal request to REST API for purpose of preloading data to be attached to a page.
  * Expected to be called in the context of `array_reduce`.
  *
- * @since 5.0.0
+ * @since WP-5.0.0
  *
  * @param  array  $memo Reduce accumulator.
  * @param  string $path REST API path to preload.
@@ -1384,7 +1382,7 @@ function rest_preload_api_request( $memo, $path ) {
 /**
  * Parses the "_embed" parameter into the list of resources to embed.
  *
- * @since 5.4.0
+ * @since WP-5.4.0
  *
  * @param string|array $embed Raw "_embed" parameter value.
  * @return true|string[] Either true to embed all embeds, or a list of relations to embed.
@@ -1402,4 +1400,3 @@ function rest_parse_embed_param( $embed ) {
 
 	return $rels;
 }
->>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -425,12 +425,8 @@ class WP_REST_Server {
 	/**
 	 * Converts a response to data to send.
 	 *
-<<<<<<< HEAD
 	 * @since WP-4.4.0
-=======
-	 * @since 4.4.0
-	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
->>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
+	 * @since WP-5.4.0 The $embed parameter can now contain a list of link relations to include.
 	 *
 	 * @param WP_REST_Response $response Response object.
 	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
@@ -551,12 +547,8 @@ class WP_REST_Server {
 	/**
 	 * Embeds the links from the data into the request.
 	 *
-<<<<<<< HEAD
 	 * @since WP-4.4.0
-=======
-	 * @since 4.4.0
-	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
->>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
+	 * @since WP-5.4.0 The $embed parameter can now contain a list of link relations to include.
 	 *
 	 * @param array $data Data from the request.
 	 * @param bool|string[] $embed Whether to embed all links or a filtered list of link relations.
@@ -575,13 +567,8 @@ class WP_REST_Server {
 		$embedded = array();
 
 		foreach ( $data['_links'] as $rel => $links ) {
-<<<<<<< HEAD
-			// Ignore links to self, for obvious reasons.
-			if ( 'self' === $rel ) {
-=======
 			// If a list of relations was specified, and the link relation is not in the whitelist, don't process the link.
 			if ( is_array( $embed ) && ! in_array( $rel, $embed, true ) ) {
->>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
 				continue;
 			}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -385,7 +385,8 @@ class WP_REST_Server {
 			}
 
 			// Embed links inside the request.
-			$result = $this->response_to_data( $result, isset( $_GET['_embed'] ) );
+			$embed  = isset( $_GET['_embed'] ) ? rest_parse_embed_param( $_GET['_embed'] ) : false;
+			$result = $this->response_to_data( $result, $embed );
 
 			/**
 			 * Filters the API response.
@@ -424,10 +425,15 @@ class WP_REST_Server {
 	/**
 	 * Converts a response to data to send.
 	 *
+<<<<<<< HEAD
 	 * @since WP-4.4.0
+=======
+	 * @since 4.4.0
+	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
+>>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
 	 *
 	 * @param WP_REST_Response $response Response object.
-	 * @param bool             $embed    Whether links should be embedded.
+	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
 	 * @return array {
 	 *     Data with sub-requests embedded.
 	 *
@@ -446,9 +452,11 @@ class WP_REST_Server {
 		if ( $embed ) {
 			// Determine if this is a numeric array.
 			if ( wp_is_numeric_array( $data ) ) {
-				$data = array_map( array( $this, 'embed_links' ), $data );
+				foreach ( $data as $key => $item ) {
+					$data[ $key ] = $this->embed_links( $item, $embed );
+				}
 			} else {
-				$data = $this->embed_links( $data );
+				$data = $this->embed_links( $data, $embed );
 			}
 		}
 
@@ -543,9 +551,15 @@ class WP_REST_Server {
 	/**
 	 * Embeds the links from the data into the request.
 	 *
+<<<<<<< HEAD
 	 * @since WP-4.4.0
+=======
+	 * @since 4.4.0
+	 * @since 5.4.0 The $embed parameter can now contain a list of link relations to include.
+>>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
 	 *
 	 * @param array $data Data from the request.
+	 * @param bool|string[] $embed Whether to embed all links or a filtered list of link relations.
 	 * @return array {
 	 *     Data with sub-requests embedded.
 	 *
@@ -553,7 +567,7 @@ class WP_REST_Server {
 	 *     @type array [$_embedded] Embeddeds.
 	 * }
 	 */
-	protected function embed_links( $data ) {
+	protected function embed_links( $data, $embed = true ) {
 		if ( empty( $data['_links'] ) ) {
 			return $data;
 		}
@@ -561,8 +575,13 @@ class WP_REST_Server {
 		$embedded = array();
 
 		foreach ( $data['_links'] as $rel => $links ) {
+<<<<<<< HEAD
 			// Ignore links to self, for obvious reasons.
 			if ( 'self' === $rel ) {
+=======
+			// If a list of relations was specified, and the link relation is not in the whitelist, don't process the link.
+			if ( is_array( $embed ) && ! in_array( $rel, $embed, true ) ) {
+>>>>>>> 98e5dd52de (REST API: Introduce selective link embedding.)
 				continue;
 			}
 

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -705,4 +705,31 @@ class Tests_REST_API extends WP_UnitTestCase {
 		$routes = $GLOBALS['wp_rest_server']->get_routes();
 		$this->assertSame( $routes['/test-ns/test'][0]['methods'], array( 'GET' => true ) );
 	}
+
+	/**
+	 * @dataProvider _dp_rest_parse_embed_param
+	 */
+	public function test_rest_parse_embed_param( $expected, $embed ) {
+		$this->assertEquals( $expected, rest_parse_embed_param( $embed ) );
+	}
+
+	public function _dp_rest_parse_embed_param() {
+		return array(
+			array( true, '' ),
+			array( true, null ),
+			array( true, '1' ),
+			array( true, 'true' ),
+			array( true, array() ),
+			array( array( 'author' ), 'author' ),
+			array( array( 'author', 'replies' ), 'author,replies' ),
+			array( array( 'author', 'replies' ), 'author,replies ' ),
+			array( array( 'wp:term' ), 'wp:term' ),
+			array( array( 'wp:term', 'wp:attachment' ), 'wp:term,wp:attachment' ),
+			array( array( 'author' ), array( 'author' ) ),
+			array( array( 'author', 'replies' ), array( 'author', 'replies' ) ),
+			array( array( 'https://api.w.org/term' ), 'https://api.w.org/term' ),
+			array( array( 'https://api.w.org/term', 'https://api.w.org/attachment' ), 'https://api.w.org/term,https://api.w.org/attachment' ),
+			array( array( 'https://api.w.org/term', 'https://api.w.org/attachment' ), array( 'https://api.w.org/term', 'https://api.w.org/attachment' ) ),
+		);
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -730,6 +730,66 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertSame( $self_not_filtered, $data['_links']['self'][0] );
 	}
 
+	/**
+	 * @dataProvider _dp_response_to_data_embedding
+	 */
+	public function test_response_to_data_embedding( $expected, $embed ) {
+		$response = new WP_REST_Response();
+		$response->add_link( 'author', rest_url( '404' ), array( 'embeddable' => true ) );
+		$response->add_link( 'https://api.w.org/term', rest_url( '404' ), array( 'embeddable' => true ) );
+		$response->add_link( 'https://wordpress.org', rest_url( '404' ), array( 'embeddable' => true ) );
+		$response->add_link( 'no-embed', rest_url( '404' ) );
+
+		$data = rest_get_server()->response_to_data( $response, $embed );
+
+		if ( false === $expected ) {
+			$this->assertArrayNotHasKey( '_embedded', $data );
+		} else {
+			$this->assertEqualSets( $expected, array_keys( $data['_embedded'] ) );
+		}
+	}
+
+	public function _dp_response_to_data_embedding() {
+		return array(
+			array(
+				array( 'author', 'wp:term', 'https://wordpress.org' ),
+				true,
+			),
+			array(
+				array( 'author', 'wp:term', 'https://wordpress.org' ),
+				array( 'author', 'wp:term', 'https://wordpress.org' ),
+			),
+			array(
+				array( 'author' ),
+				array( 'author' ),
+			),
+			array(
+				array( 'wp:term' ),
+				array( 'wp:term' ),
+			),
+			array(
+				array( 'https://wordpress.org' ),
+				array( 'https://wordpress.org' ),
+			),
+			array(
+				array( 'author', 'wp:term' ),
+				array( 'author', 'wp:term' ),
+			),
+			array(
+				false,
+				false,
+			),
+			array(
+				false,
+				array( 'no-embed' ),
+			),
+			array(
+				array( 'author' ),
+				array( 'author', 'no-embed' ),
+			),
+		);
+	}
+
 	public function test_get_index() {
 		$server = new WP_REST_Server();
 		$server->register_route(


### PR DESCRIPTION
Previously the _embed flag would embed all embeddable links in a response even if only a subset of the links were necessary. Now, a list of link relations can be passed in the _embed parameter to restrict the list of embedded objects.

Props rheinardkorf, adamsilverstein, jnylen0, cklosows, chrisvanpatten, TimothyBlynJacobs.