### PR TITLE
Add backport script to composer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,16 +153,22 @@ When you're ready to backport a code change:
    bin/backport-wp-commit.sh CHANGESET_NUMBER
    ```
 
+	 or use composer:
+
+	 ```
+	 composer run backport CHANGESET_NUMBER
+	 ```
+
    This will create a new branch and apply the WordPress changeset to it. If you're porting multiple changesets, you can create a new `git` branch first and use the `-c` option to this script to apply each changeset to your current branch instead:
 
    ```
    bin/backport-wp-commit.sh -c CHANGESET_NUMBER
    ```
 
-	 Or if you have composer installed globally, run
+	 or use composer:
 
 	 ```
-	 composer run backport CHANGESET_NUMBER
+	 composer run backport -c CHANGESET_NUMBER
 	 ```
 
    Using this script for all backports saves time for you and for the maintainers. It uses a standardized format for commit messages, which makes it possible for us to track which WordPress changes we've already included.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -159,7 +159,14 @@ When you're ready to backport a code change:
    bin/backport-wp-commit.sh -c CHANGESET_NUMBER
    ```
 
+	 Or if you have composer installed globally, run
+
+	 ```
+	 composer run backport CHANGESET_NUMBER
+	 ```
+
    Using this script for all backports saves time for you and for the maintainers. It uses a standardized format for commit messages, which makes it possible for us to track which WordPress changes we've already included.
+
 
    **Pay close attention to the output of this script** and let us know if you see anything strange or confusing!
 3. Resolve merge conflicts (if any) by editing the conflicting files, running `git add` and then `git commit`. If you cannot resolve the conflicts, ask for help in the [**#core** Slack channel](https://www.classicpress.net/join-slack/) or just push your branch as-is and we'll take care of it!

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
 		}
 	},
 	"scripts": {
-		"backport":  "bin/backport-wp-commit.sh -c"
+		"backport": "bin/backport-wp-commit.sh -c"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
 		}
 	},
 	"scripts": {
-		"backport": "bin/backport-wp-commit.sh -c"
+		"backport": "bin/backport-wp-commit.sh"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
+	},
+	"scripts": {
+		"backport":  "bin/backport-wp-commit.sh -c"
 	}
 }


### PR DESCRIPTION
## Description
Add a script to composer to make it easier to backport changes.

## Motivation and context
I have to check the contributions.md file everytime I have to backport changes. Remembering the bash script is mind taxing yet we have composer usage in the repo. If I have to check and type this for 4 changesets in one task, it is limiting.

In addition to  `bin/backport-wp-commit.sh -c CHANGESET_NUMBER` can we make this easier with `composer run backport CHANGESET_NUMBER`?

This does not break anything but allows us to utilize the tools already available to make the task easier.

## How has this been tested?
See manual tests below in screenshots.

## Screenshots
Using the `composer run backport without changeset`

![Screenshot 2022-06-28 at 10 30 21](https://user-images.githubusercontent.com/7713923/176120122-29c0b414-89a0-4b6d-b18d-9a81147ddb47.png)

Using the `composer run backport with changeset`

![Screenshot 2022-06-28 at 10 31 01](https://user-images.githubusercontent.com/7713923/176120107-0a808894-329c-4694-9342-3bd1af1d6d20.png)

## Types of changes
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Dev Process improvement
- [x] Add documentation
