### PR TITLE
Fixed "Become a sponsor" URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Would you like to help? [Here is how you can start ›](https://github.com/Class
 
 
 ## Sponsors
-Corporate sponsors that believe in ClassicPress. [Become a sponsor ›](https://opencollective.com/babel#sponsor)   
+Corporate sponsors that believe in ClassicPress. [Become a sponsor ›](https://opencollective.com/classicpress)   
 All donations are tax-deductible in the United States.
 
 [![Brinkhost IT](https://www.classicpress.net/wp-content/uploads/2022/07/brinkhost-webhosting-domeinregistratie-webdesign-logo.png)](https://www.brinkhost.nl)


### PR DESCRIPTION
## Description
"Become a sponsor" URL was wrong.

## Motivation and context
Issue reported in PR #1040 
https://github.com/ClassicPress/ClassicPress/pull/1040#issuecomment-1185764958

## How has this been tested?
Checked README.md in my own fork on Github.
![image](https://user-images.githubusercontent.com/1692600/179339191-402d0f5f-b23d-466e-87e6-87422db8f3d7.png)

## Types of changes
- Bug fix
