### PR TITLE
WP-r46148: Avoid a PHP warning in wp_xmlrpc_server::minimum_args() if $args is not an array.

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -726,12 +726,12 @@ class wp_xmlrpc_server extends IXR_Server {
 	 *
 	 * @since WP-3.4.0
 	 *
-	 * @param string|array $args Sanitize single string or array of strings.
+	 * @param array $args  An array of arguments to check.
 	 * @param int $count         Minimum number of arguments.
 	 * @return bool if `$args` contains at least $count arguments.
 	 */
 	protected function minimum_args( $args, $count ) {
-		if ( count( $args ) < $count ) {
+		if ( ! is_array( $args ) || count( $args ) < $count ) {
 			$this->error = new IXR_Error( 400, __( 'Insufficient arguments passed to this XML-RPC method.' ) );
 			return false;
 		}


### PR DESCRIPTION
XML-RPC: Avoid a PHP warning in wp_xmlrpc_server::minimum_args() if $args is not an array.

Correct the documentation to clarify that array is the only acceptable type for $args.

Props bitcomplex, dkarfa.
Fixes [#48046](https://core.trac.wordpress.org/ticket/48046).

Fixes #1079 