### PR TITLE
WP-r51582: Set the MySQLi error reporting off for PHP 8.1

### DIFF
--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -1566,6 +1566,13 @@ class wpdb {
 		$client_flags = defined( 'MYSQL_CLIENT_FLAGS' ) ? MYSQL_CLIENT_FLAGS : 0;
 
 		if ( $this->use_mysqli ) {
+			/*
+			 * Set the MySQLi error reporting off because WordPress handles its own.
+			 * This is due to the default value change from `MYSQLI_REPORT_OFF`
+			 * to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT` in PHP 8.1.
+			 */
+			mysqli_report( MYSQLI_REPORT_OFF );
+
 			$this->dbh = mysqli_init();
 
 			$host    = $this->dbhost;


### PR DESCRIPTION
## Description
WP-r51582: Code Modernization: Set the MySQLi error reporting off for PHP 8.1.

Prior to PHP 8.1, the default error handling mode was `MYSQLI_REPORT_OFF`. An error in the extension, database, query, or the database connection returned `false` and emitted a PHP warning:
{{{
$mysqli = new mysqli("localhost", "non-existing-user", "", "");

Warning: mysqli::__construct(): (HY000/2002): No connection could be made because the target machine actively refused it in ... on line ...
}}}

From PHP 8.1 and later, the default error mode is set to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT`. An error in the extension, database, query, or the database connection throws an exception:
{{{
$mysqli = new mysqli("localhost", "non-existing-user", "", "");

Fatal error: Uncaught mysqli_sql_exception: Connection refused in ...:...
}}}

WordPress has its own error reporting and gracefully handles the database errors by inspecting the error codes. Setting the MySQLi error reporting to off avoids fatal errors due to uncaught exceptions and maintains the current behavior.

References:
* [https://php.watch/versions/8.1/mysqli-error-mode PHP 8.1: MySQLi: Default error mode set to exceptions]
* [https://wiki.php.net/rfc/mysqli_default_errmode PHP RFC: Change Default mysqli Error Mode]

WP:Props ayeshrajans, jrf.
Fixes https://core.trac.wordpress.org/ticket/52825.

---

Merges https://core.trac.wordpress.org/changeset/51582 / WordPress/wordpress-develop@25bc89f44a to ClassicPress.

## Motivation and context
Upstream change that fixes general DB errors in core code with PHP 8.1 - this issue have been noted when added experimental PHP 8.1 unit testing in #815

## How has this been tested?
Upstream backport added 08/08/2021.

## Screenshots
N/A

## Types of changes
- Bug fix / compatibility enhancement
