### PR TITLE
Coding Standards from Ticket 45934

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -236,14 +236,11 @@
 		<exclude-pattern>/src/wp-includes/l10n\.php</exclude-pattern>
 		<exclude-pattern>/tests/phpunit/tests/l10n\.php</exclude-pattern>
 		<exclude-pattern>/tests/phpunit/tests/l10n/loadTextdomainJustInTime\.php</exclude-pattern>
-<<<<<<< HEAD
 	</rule>
 
 	<!-- Translator comments aren't needed in unit tests. -->
 	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
 		<exclude-pattern>/tests/*</exclude-pattern>
-=======
->>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 	</rule>
 
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,17 +2,8 @@
 <ruleset name="ClassicPress Coding Standards">
 	<description>Apply WordPress Coding Standards to all Core files</description>
 
-<<<<<<< HEAD
 	<!-- Only scan PHP files. -->
-=======
-	<rule ref="WordPress-Core"/>
-	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
-
-	<rule ref="PEAR.Functions.FunctionCallSignature">
-		<properties>
-			<property name="allowMultipleArguments" value="false"/>
-		</properties>
-	</rule>
+	<arg name="extensions" value="php"/>
 
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<properties>
@@ -67,9 +58,6 @@
 			</property>
 		</properties>
 	</rule>
-
->>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
-	<arg name="extensions" value="php"/>
 
 	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->
 	<arg name="cache"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,73 @@
 <ruleset name="ClassicPress Coding Standards">
 	<description>Apply WordPress Coding Standards to all Core files</description>
 
+<<<<<<< HEAD
 	<!-- Only scan PHP files. -->
+=======
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress.CodeAnalysis.EmptyStatement"/>
+
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<properties>
+			<property name="allowMultipleArguments" value="false"/>
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<properties>
+			<property name="customPropertiesWhitelist" type="array">
+				<!-- From database structure queries -->
+				<element value="Collation"/>
+				<element value="Column_name"/>
+				<element value="Default"/>
+				<element value="Extra"/>
+				<element value="Field"/>
+				<element value="Index_type"/>
+				<element value="Key"/>
+				<element value="Key_name"/>
+				<element value="Msg_text"/>
+				<element value="Non_unique"/>
+				<element value="Null"/>
+				<element value="Sub_part"/>
+				<element value="Type"/>
+				<!-- From plugin/theme data -->
+				<element value="authorAndUri"/>
+				<element value="Name"/>
+				<element value="Version"/>
+				<!-- From the result of wp_xmlrpc_server::wp_getPageList() -->
+				<element value="dateCreated"/>
+
+				<!-- From DOMDocument -->
+				<element value="childNodes"/>
+				<element value="formatOutput"/>
+				<element value="nodeName"/>
+				<element value="nodeType"/>
+				<element value="parentNode"/>
+				<element value="preserveWhiteSpace"/>
+				<element value="textContent"/>
+				<!-- From PHPMailer -->
+				<element value="AltBody"/>
+				<element value="Body"/>
+				<element value="CharSet"/>
+				<element value="ContentType"/>
+				<element value="Encoding"/>
+				<element value="Hostname"/>
+				<element value="mailHeader"/>
+				<element value="MIMEBody"/>
+				<element value="MIMEHeader"/>
+				<element value="Sender"/>
+				<element value="Subject"/>
+				<!-- From PHPUnit_Util_Getopt -->
+				<element value="longOptions"/>
+				<!-- From POP3 -->
+				<element value="ERROR"/>
+				<!-- From ZipArchive -->
+				<element value="numFiles"/>
+			</property>
+		</properties>
+	</rule>
+
+>>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 	<arg name="extensions" value="php"/>
 
 	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -236,11 +236,14 @@
 		<exclude-pattern>/src/wp-includes/l10n\.php</exclude-pattern>
 		<exclude-pattern>/tests/phpunit/tests/l10n\.php</exclude-pattern>
 		<exclude-pattern>/tests/phpunit/tests/l10n/loadTextdomainJustInTime\.php</exclude-pattern>
+<<<<<<< HEAD
 	</rule>
 
 	<!-- Translator comments aren't needed in unit tests. -->
 	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
 		<exclude-pattern>/tests/*</exclude-pattern>
+=======
+>>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 	</rule>
 
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing">

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -51,11 +51,66 @@ echo '<p class="about-description">' . sprintf(
 	'https://www.classicpress.net/contributors/'
 ) . '</p>';
 
+<<<<<<< HEAD
 echo '<p class="about-description">' . sprintf(
 	/* translators: %s: https://www.classicpress.net/get-involved/ */
 	__( 'Interested in helping out with development? <a href="%s">Get involved in ClassicPress</a>.' ),
 	'https://www.classicpress.net/get-involved/'
 ) . '</p>';
+=======
+foreach ( $credits['groups'] as $group_slug => $group_data ) {
+	if ( $group_data['name'] ) {
+		if ( 'Translators' == $group_data['name'] ) {
+			// Considered a special slug in the API response. (Also, will never be returned for en_US.)
+			$title = _x( 'Translators', 'Translate this to be the equivalent of English Translators in your language for the credits page Translators section' );
+		} elseif ( isset( $group_data['placeholders'] ) ) {
+			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
+			$title = vsprintf( translate( $group_data['name'] ), $group_data['placeholders'] );
+		} else {
+			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
+			$title = translate( $group_data['name'] );
+		}
+
+		echo '<h3 class="wp-people-group">' . esc_html( $title ) . "</h3>\n";
+	}
+
+	if ( ! empty( $group_data['shuffle'] ) ) {
+		shuffle( $group_data['data'] ); // We were going to sort by ability to pronounce "hierarchical," but that wouldn't be fair to Matt.
+	}
+
+	switch ( $group_data['type'] ) {
+		case 'list':
+			array_walk( $group_data['data'], '_wp_credits_add_profile_link', $credits['data']['profiles'] );
+			echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $group_data['data'] ) . "</p>\n\n";
+			break;
+		case 'libraries':
+			array_walk( $group_data['data'], '_wp_credits_build_object_link' );
+			echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $group_data['data'] ) . "</p>\n\n";
+			break;
+		default:
+			$compact = 'compact' == $group_data['type'];
+			$classes = 'wp-people-group ' . ( $compact ? 'compact' : '' );
+			echo '<ul class="' . $classes . '" id="wp-people-group-' . $group_slug . '">' . "\n";
+			foreach ( $group_data['data'] as $person_data ) {
+				echo '<li class="wp-person" id="wp-person-' . esc_attr( $person_data[2] ) . '">' . "\n\t";
+				echo '<a href="' . esc_url( sprintf( $credits['data']['profiles'], $person_data[2] ) ) . '" class="web">';
+				$size   = 'compact' == $group_data['type'] ? 30 : 60;
+				$data   = get_avatar_data( $person_data[1] . '@md5.gravatar.com', array( 'size' => $size ) );
+				$size  *= 2;
+				$data2x = get_avatar_data( $person_data[1] . '@md5.gravatar.com', array( 'size' => $size ) );
+				echo '<img src="' . esc_url( $data['url'] ) . '" srcset="' . esc_url( $data2x['url'] ) . ' 2x" class="gravatar" alt="" />' . "\n";
+				echo esc_html( $person_data[0] ) . "</a>\n\t";
+				if ( ! $compact ) {
+					// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
+					echo '<span class="title">' . translate( $person_data[3] ) . "</span>\n";
+				}
+				echo "</li>\n";
+			}
+			echo "</ul>\n";
+			break;
+	}
+}
+>>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 
 ?>
 </div>

--- a/src/wp-admin/credits.php
+++ b/src/wp-admin/credits.php
@@ -51,66 +51,11 @@ echo '<p class="about-description">' . sprintf(
 	'https://www.classicpress.net/contributors/'
 ) . '</p>';
 
-<<<<<<< HEAD
 echo '<p class="about-description">' . sprintf(
 	/* translators: %s: https://www.classicpress.net/get-involved/ */
 	__( 'Interested in helping out with development? <a href="%s">Get involved in ClassicPress</a>.' ),
 	'https://www.classicpress.net/get-involved/'
 ) . '</p>';
-=======
-foreach ( $credits['groups'] as $group_slug => $group_data ) {
-	if ( $group_data['name'] ) {
-		if ( 'Translators' == $group_data['name'] ) {
-			// Considered a special slug in the API response. (Also, will never be returned for en_US.)
-			$title = _x( 'Translators', 'Translate this to be the equivalent of English Translators in your language for the credits page Translators section' );
-		} elseif ( isset( $group_data['placeholders'] ) ) {
-			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
-			$title = vsprintf( translate( $group_data['name'] ), $group_data['placeholders'] );
-		} else {
-			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
-			$title = translate( $group_data['name'] );
-		}
-
-		echo '<h3 class="wp-people-group">' . esc_html( $title ) . "</h3>\n";
-	}
-
-	if ( ! empty( $group_data['shuffle'] ) ) {
-		shuffle( $group_data['data'] ); // We were going to sort by ability to pronounce "hierarchical," but that wouldn't be fair to Matt.
-	}
-
-	switch ( $group_data['type'] ) {
-		case 'list':
-			array_walk( $group_data['data'], '_wp_credits_add_profile_link', $credits['data']['profiles'] );
-			echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $group_data['data'] ) . "</p>\n\n";
-			break;
-		case 'libraries':
-			array_walk( $group_data['data'], '_wp_credits_build_object_link' );
-			echo '<p class="wp-credits-list">' . wp_sprintf( '%l.', $group_data['data'] ) . "</p>\n\n";
-			break;
-		default:
-			$compact = 'compact' == $group_data['type'];
-			$classes = 'wp-people-group ' . ( $compact ? 'compact' : '' );
-			echo '<ul class="' . $classes . '" id="wp-people-group-' . $group_slug . '">' . "\n";
-			foreach ( $group_data['data'] as $person_data ) {
-				echo '<li class="wp-person" id="wp-person-' . esc_attr( $person_data[2] ) . '">' . "\n\t";
-				echo '<a href="' . esc_url( sprintf( $credits['data']['profiles'], $person_data[2] ) ) . '" class="web">';
-				$size   = 'compact' == $group_data['type'] ? 30 : 60;
-				$data   = get_avatar_data( $person_data[1] . '@md5.gravatar.com', array( 'size' => $size ) );
-				$size  *= 2;
-				$data2x = get_avatar_data( $person_data[1] . '@md5.gravatar.com', array( 'size' => $size ) );
-				echo '<img src="' . esc_url( $data['url'] ) . '" srcset="' . esc_url( $data2x['url'] ) . ' 2x" class="gravatar" alt="" />' . "\n";
-				echo esc_html( $person_data[0] ) . "</a>\n\t";
-				if ( ! $compact ) {
-					// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
-					echo '<span class="title">' . translate( $person_data[3] ) . "</span>\n";
-				}
-				echo "</li>\n";
-			}
-			echo "</ul>\n";
-			break;
-	}
-}
->>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 
 ?>
 </div>

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -203,12 +203,17 @@ function export_wp( $args = array() ) {
 	 * @return string Site URL.
 	 */
 	function wxr_site_url() {
-		// Multisite: the base URL.
 		if ( is_multisite() ) {
+			// Multisite: the base URL.
 			return network_home_url();
+<<<<<<< HEAD
 		}
 		// ClassicPress (single site): the blog URL.
 		else {
+=======
+		} else {
+			// WordPress (single site): the blog URL.
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			return get_bloginfo_rss( 'url' );
 		}
 	}

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -206,14 +206,8 @@ function export_wp( $args = array() ) {
 		if ( is_multisite() ) {
 			// Multisite: the base URL.
 			return network_home_url();
-<<<<<<< HEAD
-		}
-		// ClassicPress (single site): the blog URL.
-		else {
-=======
 		} else {
-			// WordPress (single site): the blog URL.
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
+			// ClassicPress (single site): the blog URL.
 			return get_bloginfo_rss( 'url' );
 		}
 	}

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -213,9 +213,15 @@ function wp_generate_attachment_metadata( $attachment_id, $file ) {
 				update_post_meta( $attachment_id, '_thumbnail_id', $sub_attachment_id );
 			}
 		}
+<<<<<<< HEAD
 	}
 	// Try to create image thumbnails for PDFs
 	elseif ( 'application/pdf' === $mime_type ) {
+=======
+	} elseif ( 'application/pdf' === $mime_type ) {
+		// Try to create image thumbnails for PDFs.
+
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$fallback_sizes = array(
 			'thumbnail',
 			'medium',

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -213,15 +213,9 @@ function wp_generate_attachment_metadata( $attachment_id, $file ) {
 				update_post_meta( $attachment_id, '_thumbnail_id', $sub_attachment_id );
 			}
 		}
-<<<<<<< HEAD
-	}
-	// Try to create image thumbnails for PDFs
-	elseif ( 'application/pdf' === $mime_type ) {
-=======
 	} elseif ( 'application/pdf' === $mime_type ) {
 		// Try to create image thumbnails for PDFs.
 
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$fallback_sizes = array(
 			'thumbnail',
 			'medium',

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -165,12 +165,8 @@ function wp_get_popular_importers() {
 		foreach ( $popular_importers['importers'] as &$importer ) {
 			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 			$importer['description'] = translate( $importer['description'] );
-<<<<<<< HEAD
 			if ( $importer['name'] != 'ClassicPress' ) {
-=======
-			if ( $importer['name'] != 'WordPress' ) {
 				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
->>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 				$importer['name'] = translate( $importer['name'] );
 			}
 		}

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -163,8 +163,14 @@ function wp_get_popular_importers() {
 		}
 
 		foreach ( $popular_importers['importers'] as &$importer ) {
+			// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 			$importer['description'] = translate( $importer['description'] );
+<<<<<<< HEAD
 			if ( $importer['name'] != 'ClassicPress' ) {
+=======
+			if ( $importer['name'] != 'WordPress' ) {
+				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
+>>>>>>> 8cc49330a4 (Coding Standards: Fix the minor `WordPress.WP.I18n` violations.)
 				$importer['name'] = translate( $importer['name'] );
 			}
 		}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -142,6 +142,7 @@ function _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup 
 		}
 		if ( $textdomain ) {
 			foreach ( array( 'Name', 'PluginURI', 'Description', 'Author', 'AuthorURI', 'Version' ) as $field ) {
+				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 				$plugin_data[ $field ] = translate( $plugin_data[ $field ], $textdomain );
 			}
 		}

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -1730,6 +1730,7 @@ function upgrade_330() {
 			$sidebars_widgets                   = $_sidebars_widgets;
 			unset( $_sidebars_widgets );
 
+			// intentional fall-through to upgrade to the next version.
 		case 2:
 			$sidebars_widgets                  = retrieve_widgets();
 			$sidebars_widgets['array_version'] = 3;

--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -205,6 +205,7 @@ switch ( $action ) {
 
 		wp_update_attachment_metadata( $post_id, $newmeta );
 
+		// Intentional fall-through to trigger the edit_post() call.
 	case 'editpost':
 		check_admin_referer( 'update-post_' . $post_id );
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -40,14 +40,8 @@ function list_core_update( $update ) {
 
 	if ( 'en_US' == $update->locale && 'en_US' == get_locale() ) {
 		$version_string = $update->current;
-<<<<<<< HEAD
-	}
-	// If the only available update is a partial builds, it doesn't need a language-specific version string.
-	elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
-=======
 	} elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
 		// If the only available update is a partial builds, it doesn't need a language-specific version string.
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$version_string = $update->current;
 	} else {
 		$version_string = sprintf( '%s&ndash;<strong>%s</strong>', $update->current, $update->locale );
@@ -121,16 +115,9 @@ function list_core_update( $update ) {
 	echo '</p>';
 	if ( 'en_US' != $update->locale && ( ! isset( $wp_local_package ) || $wp_local_package != $update->locale ) ) {
 		echo '<p class="hint">' . __( 'This localized version contains both the translation and various other localization fixes. You can skip upgrading if you want to keep your current translation.' ) . '</p>';
-<<<<<<< HEAD
-	}
-	// Partial builds don't need language-specific warnings.
-	elseif ( 'en_US' == $update->locale && get_locale() != 'en_US' && ( ! $update->packages->partial && $wp_version == $update->partial_version ) ) {
-		echo '<p class="hint">' . sprintf( __( 'You are about to install ClassicPress %s <strong>in English (US).</strong> There is a chance this update will break your translation. You may prefer to wait for the localized version to be released.' ), $update->response != 'development' ? $update->current : '' ) . '</p>';
-=======
 	} elseif ( 'en_US' == $update->locale && get_locale() != 'en_US' && ( ! $update->packages->partial && $wp_version == $update->partial_version ) ) {
 		// Partial builds don't need language-specific warnings.
 		echo '<p class="hint">' . sprintf( __( 'You are about to install WordPress %s <strong>in English (US).</strong> There is a chance this update will break your translation. You may prefer to wait for the localized version to be released.' ), $update->response != 'development' ? $update->current : '' ) . '</p>';
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 	}
 	echo '</form>';
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -40,9 +40,14 @@ function list_core_update( $update ) {
 
 	if ( 'en_US' == $update->locale && 'en_US' == get_locale() ) {
 		$version_string = $update->current;
+<<<<<<< HEAD
 	}
 	// If the only available update is a partial builds, it doesn't need a language-specific version string.
 	elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
+=======
+	} elseif ( 'en_US' == $update->locale && $update->packages->partial && $wp_version == $update->partial_version && ( $updates = get_core_updates() ) && 1 == count( $updates ) ) {
+		// If the only available update is a partial builds, it doesn't need a language-specific version string.
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$version_string = $update->current;
 	} else {
 		$version_string = sprintf( '%s&ndash;<strong>%s</strong>', $update->current, $update->locale );
@@ -116,10 +121,16 @@ function list_core_update( $update ) {
 	echo '</p>';
 	if ( 'en_US' != $update->locale && ( ! isset( $wp_local_package ) || $wp_local_package != $update->locale ) ) {
 		echo '<p class="hint">' . __( 'This localized version contains both the translation and various other localization fixes. You can skip upgrading if you want to keep your current translation.' ) . '</p>';
+<<<<<<< HEAD
 	}
 	// Partial builds don't need language-specific warnings.
 	elseif ( 'en_US' == $update->locale && get_locale() != 'en_US' && ( ! $update->packages->partial && $wp_version == $update->partial_version ) ) {
 		echo '<p class="hint">' . sprintf( __( 'You are about to install ClassicPress %s <strong>in English (US).</strong> There is a chance this update will break your translation. You may prefer to wait for the localized version to be released.' ), $update->response != 'development' ? $update->current : '' ) . '</p>';
+=======
+	} elseif ( 'en_US' == $update->locale && get_locale() != 'en_US' && ( ! $update->packages->partial && $wp_version == $update->partial_version ) ) {
+		// Partial builds don't need language-specific warnings.
+		echo '<p class="hint">' . sprintf( __( 'You are about to install WordPress %s <strong>in English (US).</strong> There is a chance this update will break your translation. You may prefer to wait for the localized version to be released.' ), $update->response != 'development' ? $update->current : '' ) . '</p>';
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 	}
 	echo '</form>';
 

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -173,6 +173,7 @@ switch ( $action ) {
 			exit;
 		}
 
+		// Intentional fall-through to display $errors.
 	default:
 		$profileuser = get_user_to_edit( $user_id );
 

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -845,12 +845,14 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 	} elseif ( ! empty( $args['topic_count_text_callback'] ) ) {
 		// Look for the alternative callback style. Ignore the previous default.
 		if ( $args['topic_count_text_callback'] === 'default_topic_count_text' ) {
+			// wpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
 			$translate_nooped_plural = _n_noop( '%s item', '%s items' );
 		} else {
 			$translate_nooped_plural = false;
 		}
 	} elseif ( isset( $args['single_text'] ) && isset( $args['multiple_text'] ) ) {
 		// If no callback exists, look for the old-style single_text and multiple_text arguments.
+		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
 		$translate_nooped_plural = _n_noop( $args['single_text'], $args['multiple_text'] );
 	} else {
 		// This is the default for when no callback, plural, or argument is passed in.

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -845,7 +845,7 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 	} elseif ( ! empty( $args['topic_count_text_callback'] ) ) {
 		// Look for the alternative callback style. Ignore the previous default.
 		if ( $args['topic_count_text_callback'] === 'default_topic_count_text' ) {
-			// wpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
+			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
 			$translate_nooped_plural = _n_noop( '%s item', '%s items' );
 		} else {
 			$translate_nooped_plural = false;

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -845,7 +845,6 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
 	} elseif ( ! empty( $args['topic_count_text_callback'] ) ) {
 		// Look for the alternative callback style. Ignore the previous default.
 		if ( $args['topic_count_text_callback'] === 'default_topic_count_text' ) {
-			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
 			$translate_nooped_plural = _n_noop( '%s item', '%s items' );
 		} else {
 			$translate_nooped_plural = false;

--- a/src/wp-includes/class-wp-comment-query.php
+++ b/src/wp-includes/class-wp-comment-query.php
@@ -555,7 +555,7 @@ class WP_Comment_Query {
 				preg_split( '/[,\s]/', $this->query_vars['orderby'] );
 
 			$orderby_array            = array();
-			$found_orderby_comment_ID = false;
+			$found_orderby_comment_id = false;
 			foreach ( $ordersby as $_key => $_value ) {
 				if ( ! $_value ) {
 					continue;
@@ -569,8 +569,8 @@ class WP_Comment_Query {
 					$_order   = $_value;
 				}
 
-				if ( ! $found_orderby_comment_ID && in_array( $_orderby, array( 'comment_ID', 'comment__in' ) ) ) {
-					$found_orderby_comment_ID = true;
+				if ( ! $found_orderby_comment_id && in_array( $_orderby, array( 'comment_ID', 'comment__in' ) ) ) {
+					$found_orderby_comment_id = true;
 				}
 
 				$parsed = $this->parse_orderby( $_orderby );
@@ -593,24 +593,24 @@ class WP_Comment_Query {
 			}
 
 			// To ensure determinate sorting, always include a comment_ID clause.
-			if ( ! $found_orderby_comment_ID ) {
-				$comment_ID_order = '';
+			if ( ! $found_orderby_comment_id ) {
+				$comment_id_order = '';
 
 				// Inherit order from comment_date or comment_date_gmt, if available.
 				foreach ( $orderby_array as $orderby_clause ) {
 					if ( preg_match( '/comment_date(?:_gmt)*\ (ASC|DESC)/', $orderby_clause, $match ) ) {
-						$comment_ID_order = $match[1];
+						$comment_id_order = $match[1];
 						break;
 					}
 				}
 
 				// If no date-related order is available, use the date from the first available clause.
-				if ( ! $comment_ID_order ) {
+				if ( ! $comment_id_order ) {
 					foreach ( $orderby_array as $orderby_clause ) {
 						if ( false !== strpos( 'ASC', $orderby_clause ) ) {
-							$comment_ID_order = 'ASC';
+							$comment_id_order = 'ASC';
 						} else {
-							$comment_ID_order = 'DESC';
+							$comment_id_order = 'DESC';
 						}
 
 						break;
@@ -618,11 +618,11 @@ class WP_Comment_Query {
 				}
 
 				// Default to DESC.
-				if ( ! $comment_ID_order ) {
-					$comment_ID_order = 'DESC';
+				if ( ! $comment_id_order ) {
+					$comment_id_order = 'DESC';
 				}
 
-				$orderby_array[] = "$wpdb->comments.comment_ID $comment_ID_order";
+				$orderby_array[] = "$wpdb->comments.comment_ID $comment_id_order";
 			}
 
 			$orderby = implode( ', ', $orderby_array );

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -219,15 +219,8 @@ class WP_Locale {
 		// Set text direction.
 		if ( isset( $GLOBALS['text_direction'] ) ) {
 			$this->text_direction = $GLOBALS['text_direction'];
-<<<<<<< HEAD
-		}
-		/* translators: 'rtl' or 'ltr'. This sets the text direction for ClassicPress. */
-		elseif ( 'rtl' == _x( 'ltr', 'text direction' ) ) {
-=======
-
 			/* translators: 'rtl' or 'ltr'. This sets the text direction for WordPress. */
 		} elseif ( 'rtl' == _x( 'ltr', 'text direction' ) ) {
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			$this->text_direction = 'rtl';
 		}
 

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -219,9 +219,15 @@ class WP_Locale {
 		// Set text direction.
 		if ( isset( $GLOBALS['text_direction'] ) ) {
 			$this->text_direction = $GLOBALS['text_direction'];
+<<<<<<< HEAD
 		}
 		/* translators: 'rtl' or 'ltr'. This sets the text direction for ClassicPress. */
 		elseif ( 'rtl' == _x( 'ltr', 'text direction' ) ) {
+=======
+
+			/* translators: 'rtl' or 'ltr'. This sets the text direction for WordPress. */
+		} elseif ( 'rtl' == _x( 'ltr', 'text direction' ) ) {
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			$this->text_direction = 'rtl';
 		}
 

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -373,10 +373,15 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			// Best match of this final is already taken?  Must mean this final is a new row.
 			if ( isset( $orig_matches[ $o ] ) ) {
 				$final_matches[ $f ] = 'x';
+<<<<<<< HEAD
 			}
 
 			// Best match of this orig is already taken?  Must mean this orig is a deleted row.
 			elseif ( isset( $final_matches[ $f ] ) ) {
+=======
+			} elseif ( isset( $final_matches[ $f ] ) ) {
+				// Best match of this orig is already taken?  Must mean this orig is a deleted row.
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				$orig_matches[ $o ] = 'x';
 			}
 		}

--- a/src/wp-includes/class-wp-text-diff-renderer-table.php
+++ b/src/wp-includes/class-wp-text-diff-renderer-table.php
@@ -373,15 +373,8 @@ class WP_Text_Diff_Renderer_Table extends Text_Diff_Renderer {
 			// Best match of this final is already taken?  Must mean this final is a new row.
 			if ( isset( $orig_matches[ $o ] ) ) {
 				$final_matches[ $f ] = 'x';
-<<<<<<< HEAD
-			}
-
-			// Best match of this orig is already taken?  Must mean this orig is a deleted row.
-			elseif ( isset( $final_matches[ $f ] ) ) {
-=======
 			} elseif ( isset( $final_matches[ $f ] ) ) {
 				// Best match of this orig is already taken?  Must mean this orig is a deleted row.
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				$orig_matches[ $o ] = 'x';
 			}
 		}

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -874,6 +874,7 @@ final class WP_Theme implements ArrayAccess {
 				if ( isset( $this->name_translated ) ) {
 					return $this->name_translated;
 				}
+				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 				$this->name_translated = translate( $value, $this->get( 'TextDomain' ) );
 				return $this->name_translated;
 			case 'Tags':
@@ -925,6 +926,7 @@ final class WP_Theme implements ArrayAccess {
 				return $value;
 
 			default:
+				// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 				$value = translate( $value, $this->get( 'TextDomain' ) );
 		}
 		return $value;

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2916,14 +2916,8 @@ class wp_xmlrpc_server extends IXR_Server {
 		// If we found the page then format the data.
 		if ( $page->ID && ( $page->post_type == 'page' ) ) {
 			return $this->_prepare_page( $page );
-<<<<<<< HEAD
-		}
-		// If the page doesn't exist indicate that.
-		else {
-=======
 		} else {
 			// If the page doesn't exist indicate that.
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			return new IXR_Error( 404, __( 'Sorry, no such page.' ) );
 		}
 	}

--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -2916,9 +2916,14 @@ class wp_xmlrpc_server extends IXR_Server {
 		// If we found the page then format the data.
 		if ( $page->ID && ( $page->post_type == 'page' ) ) {
 			return $this->_prepare_page( $page );
+<<<<<<< HEAD
 		}
 		// If the page doesn't exist indicate that.
 		else {
+=======
+		} else {
+			// If the page doesn't exist indicate that.
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			return new IXR_Error( 404, __( 'Sorry, no such page.' ) );
 		}
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2493,9 +2493,15 @@ function force_balance_tags( $text ) {
 			if ( $stacksize <= 0 ) {
 				$tag = '';
 				// or close to be safe $tag = '/' . $tag;
+<<<<<<< HEAD
 			}
 			// if stacktop value = tag close value then pop
 			elseif ( $tagstack[ $stacksize - 1 ] == $tag ) { // found closing tag
+=======
+
+				// if stacktop value = tag close value then pop
+			} elseif ( $tagstack[ $stacksize - 1 ] == $tag ) { // found closing tag
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				$tag = '</' . $tag . '>'; // Close Tag
 				// Pop
 				array_pop( $tagstack );
@@ -2521,14 +2527,19 @@ function force_balance_tags( $text ) {
 			// If it's an empty tag "< >", do nothing
 			if ( '' == $tag ) {
 				// do nothing
+<<<<<<< HEAD
 			}
 			// ElseIf it presents itself as a self-closing tag...
 			elseif ( substr( $regex[2], -1 ) == '/' ) {
+=======
+			} elseif ( substr( $regex[2], -1 ) == '/' ) { // ElseIf it presents itself as a self-closing tag...
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				// ...but it isn't a known single-entity self-closing tag, then don't let it be treated as such and
 				// immediately close it with a closing tag (the tag will encapsulate no text as a result)
 				if ( ! in_array( $tag, $single_tags ) ) {
 					$regex[2] = trim( substr( $regex[2], 0, -1 ) ) . "></$tag";
 				}
+<<<<<<< HEAD
 			}
 			// ElseIf it's a known single-entity tag but it doesn't close itself, do so
 			elseif ( in_array( $tag, $single_tags ) ) {
@@ -2536,6 +2547,11 @@ function force_balance_tags( $text ) {
 			}
 			// Else it's not a single-entity tag
 			else {
+=======
+			} elseif ( in_array( $tag, $single_tags ) ) { // ElseIf it's a known single-entity tag but it doesn't close itself, do so
+				$regex[2] .= '/';
+			} else { // Else it's not a single-entity tag
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				// If the top of the stack is the same as the tag we want to push, close previous tag
 				if ( $stacksize > 0 && ! in_array( $tag, $nestable_tags ) && $tagstack[ $stacksize - 1 ] == $tag ) {
 					$tagqueue = '</' . array_pop( $tagstack ) . '>';

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2493,15 +2493,8 @@ function force_balance_tags( $text ) {
 			if ( $stacksize <= 0 ) {
 				$tag = '';
 				// or close to be safe $tag = '/' . $tag;
-<<<<<<< HEAD
-			}
-			// if stacktop value = tag close value then pop
-			elseif ( $tagstack[ $stacksize - 1 ] == $tag ) { // found closing tag
-=======
-
 				// if stacktop value = tag close value then pop
 			} elseif ( $tagstack[ $stacksize - 1 ] == $tag ) { // found closing tag
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				$tag = '</' . $tag . '>'; // Close Tag
 				// Pop
 				array_pop( $tagstack );
@@ -2527,31 +2520,15 @@ function force_balance_tags( $text ) {
 			// If it's an empty tag "< >", do nothing
 			if ( '' == $tag ) {
 				// do nothing
-<<<<<<< HEAD
-			}
-			// ElseIf it presents itself as a self-closing tag...
-			elseif ( substr( $regex[2], -1 ) == '/' ) {
-=======
 			} elseif ( substr( $regex[2], -1 ) == '/' ) { // ElseIf it presents itself as a self-closing tag...
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				// ...but it isn't a known single-entity self-closing tag, then don't let it be treated as such and
 				// immediately close it with a closing tag (the tag will encapsulate no text as a result)
 				if ( ! in_array( $tag, $single_tags ) ) {
 					$regex[2] = trim( substr( $regex[2], 0, -1 ) ) . "></$tag";
 				}
-<<<<<<< HEAD
-			}
-			// ElseIf it's a known single-entity tag but it doesn't close itself, do so
-			elseif ( in_array( $tag, $single_tags ) ) {
-				$regex[2] .= '/';
-			}
-			// Else it's not a single-entity tag
-			else {
-=======
 			} elseif ( in_array( $tag, $single_tags ) ) { // ElseIf it's a known single-entity tag but it doesn't close itself, do so
 				$regex[2] .= '/';
 			} else { // Else it's not a single-entity tag
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 				// If the top of the stack is the same as the tag we want to push, close previous tag
 				if ( $stacksize > 0 && ! in_array( $tag, $nestable_tags ) && $tagstack[ $stacksize - 1 ] == $tag ) {
 					$tagqueue = '</' . array_pop( $tagstack ) . '>';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4987,6 +4987,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 		$exists[4] = ( $exists[1] && $exists[3] );
 		$exists[5] = ( $exists[2] && $exists[3] );
 
+		// phpcs:disable WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
 		$zonen[] = array(
 			'continent'   => ( $exists[0] ? $zone[0] : '' ),
 			'city'        => ( $exists[1] ? $zone[1] : '' ),
@@ -4995,6 +4996,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 			't_city'      => ( $exists[4] ? translate( str_replace( '_', ' ', $zone[1] ), 'continents-cities' ) : '' ),
 			't_subcity'   => ( $exists[5] ? translate( str_replace( '_', ' ', $zone[2] ), 'continents-cities' ) : '' ),
 		);
+		// phpcs:enable
 	}
 	usort( $zonen, '_wp_timezone_choice_usort_callback' );
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -655,6 +655,7 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 					'<code>url</code>'
 				)
 			);
+			// Intentional fall-through to be handled by the 'url' case.
 		case 'url':
 			$output = home_url();
 			break;

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -920,15 +920,8 @@ function get_custom_logo( $blog_id = 0 ) {
 			esc_url( home_url( '/' ) ),
 			wp_get_attachment_image( $custom_logo_id, 'full', false, $custom_logo_attr )
 		);
-<<<<<<< HEAD
-	}
-
-	// If no logo is set but we're in the Customizer, leave a placeholder (needed for the live preview).
-	elseif ( is_customize_preview() ) {
-=======
 	} elseif ( is_customize_preview() ) {
 		// If no logo is set but we're in the Customizer, leave a placeholder (needed for the live preview).
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$html = sprintf(
 			'<a href="%1$s" class="custom-logo-link" style="display:none;"><img class="custom-logo"/></a>',
 			esc_url( home_url( '/' ) )

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -920,10 +920,15 @@ function get_custom_logo( $blog_id = 0 ) {
 			esc_url( home_url( '/' ) ),
 			wp_get_attachment_image( $custom_logo_id, 'full', false, $custom_logo_attr )
 		);
+<<<<<<< HEAD
 	}
 
 	// If no logo is set but we're in the Customizer, leave a placeholder (needed for the live preview).
 	elseif ( is_customize_preview() ) {
+=======
+	} elseif ( is_customize_preview() ) {
+		// If no logo is set but we're in the Customizer, leave a placeholder (needed for the live preview).
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$html = sprintf(
 			'<a href="%1$s" class="custom-logo-link" style="display:none;"><img class="custom-logo"/></a>',
 			esc_url( home_url( '/' ) )

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -42,12 +42,17 @@ function wp_fix_server_vars() {
 	// Fix for IIS when running with PHP ISAPI
 	if ( empty( $_SERVER['REQUEST_URI'] ) || ( PHP_SAPI != 'cgi-fcgi' && preg_match( '/^Microsoft-IIS\//', $_SERVER['SERVER_SOFTWARE'] ) ) ) {
 
-		// IIS Mod-Rewrite
 		if ( isset( $_SERVER['HTTP_X_ORIGINAL_URL'] ) ) {
+			// IIS Mod-Rewrite
 			$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_ORIGINAL_URL'];
+<<<<<<< HEAD
 		}
 		// IIS Isapi_Rewrite
 		elseif ( isset( $_SERVER['HTTP_X_REWRITE_URL'] ) ) {
+=======
+		} elseif ( isset( $_SERVER['HTTP_X_REWRITE_URL'] ) ) {
+			// IIS Isapi_Rewrite
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_REWRITE_URL'];
 		} else {
 			// Use ORIG_PATH_INFO if there is no PATH_INFO

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -45,14 +45,8 @@ function wp_fix_server_vars() {
 		if ( isset( $_SERVER['HTTP_X_ORIGINAL_URL'] ) ) {
 			// IIS Mod-Rewrite
 			$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_ORIGINAL_URL'];
-<<<<<<< HEAD
-		}
-		// IIS Isapi_Rewrite
-		elseif ( isset( $_SERVER['HTTP_X_REWRITE_URL'] ) ) {
-=======
 		} elseif ( isset( $_SERVER['HTTP_X_REWRITE_URL'] ) ) {
 			// IIS Isapi_Rewrite
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 			$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_REWRITE_URL'];
 		} else {
 			// Use ORIG_PATH_INFO if there is no PATH_INFO

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -104,13 +104,7 @@ function image_constrain_size_for_editor( $width, $height, $size = 'medium', $co
 		if ( intval( $content_width ) > 0 && 'edit' === $context ) {
 			$max_width = min( intval( $content_width ), $max_width );
 		}
-<<<<<<< HEAD
-	}
-	// $size == 'full' has no constraint
-	else {
-=======
 	} else { // $size == 'full' has no constraint
->>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$max_width  = $width;
 		$max_height = $height;
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -104,9 +104,13 @@ function image_constrain_size_for_editor( $width, $height, $size = 'medium', $co
 		if ( intval( $content_width ) > 0 && 'edit' === $context ) {
 			$max_width = min( intval( $content_width ), $max_width );
 		}
+<<<<<<< HEAD
 	}
 	// $size == 'full' has no constraint
 	else {
+=======
+	} else { // $size == 'full' has no constraint
+>>>>>>> 33caf61b8b (Coding Standards: Fix the `Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace` violations.)
 		$max_width  = $width;
 		$max_height = $height;
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -984,6 +984,7 @@ function register_post_status( $post_status, $args = array() ) {
 	}
 
 	if ( false === $args->label_count ) {
+		// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle,WordPress.WP.I18n.NonSingularStringLiteralPlural
 		$args->label_count = _n_noop( $args->label, $args->label );
 	}
 

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -684,6 +684,15 @@ function load_template( $_template_file, $require_once = true ) {
 	global $posts, $post, $wp_did_header, $wp_query, $wp_rewrite, $wpdb, $wp_version, $wp, $id, $comment, $user_ID;
 
 	if ( is_array( $wp_query->query_vars ) ) {
+		/*
+		 * This use of extract() cannot be removed. There are many possible ways that
+		 * templates could depend on variables that it creates existing, and no way to
+		 * detect and deprecate it.
+		 *
+		 * Passing the EXTR_SKIP flag is the safest option, ensuring globals and
+		 * function variables cannot be overwritten.
+		 */
+		// phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 		extract( $wp_query->query_vars, EXTR_SKIP );
 	}
 

--- a/src/wp-includes/wp-db.php
+++ b/src/wp-includes/wp-db.php
@@ -18,6 +18,7 @@ define( 'EZSQL_VERSION', 'WP1.25' );
  * @since WP-0.71
  */
 define( 'OBJECT', 'OBJECT' );
+// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase
 define( 'object', 'OBJECT' ); // Back compat.
 
 /**

--- a/tests/phpunit/tests/avatar.php
+++ b/tests/phpunit/tests/avatar.php
@@ -103,21 +103,21 @@ class Tests_Avatar extends WP_UnitTestCase {
 		$this->assertEquals( $url, $url2 );
 	}
 
-	protected $fakeURL;
+	protected $fake_url;
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/21195
 	 */
 	public function test_pre_get_avatar_url_filter() {
-		$this->fakeURL = 'haha wat';
+		$this->fake_url = 'haha wat';
 
 		add_filter( 'pre_get_avatar_data', array( $this, 'pre_get_avatar_url_filter' ), 10, 1 );
 		$url = get_avatar_url( 1 );
 		remove_filter( 'pre_get_avatar_data', array( $this, 'pre_get_avatar_url_filter' ), 10 );
 
-		$this->assertEquals( $url, $this->fakeURL );
+		$this->assertEquals( $url, $this->fake_url );
 	}
 	public function pre_get_avatar_url_filter( $args ) {
-		$args['url'] = $this->fakeURL;
+		$args['url'] = $this->fake_url;
 		return $args;
 	}
 
@@ -125,16 +125,16 @@ class Tests_Avatar extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/21195
 	 */
 	public function test_get_avatar_url_filter() {
-		$this->fakeURL = 'omg lol';
+		$this->fake_url = 'omg lol';
 
 		add_filter( 'get_avatar_url', array( $this, 'get_avatar_url_filter' ), 10, 1 );
 		$url = get_avatar_url( 1 );
 		remove_filter( 'get_avatar_url', array( $this, 'get_avatar_url_filter' ), 10 );
 
-		$this->assertEquals( $url, $this->fakeURL );
+		$this->assertEquals( $url, $this->fake_url );
 	}
 	public function get_avatar_url_filter( $url ) {
-		return $this->fakeURL;
+		return $this->fake_url;
 	}
 
 	/**
@@ -207,37 +207,37 @@ class Tests_Avatar extends WP_UnitTestCase {
 	}
 
 
-	protected $fakeIMG;
+	protected $fake_img;
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/21195
 	 */
 	public function test_pre_get_avatar_filter() {
-		$this->fakeIMG = 'YOU TOO?!';
+		$this->fake_img = 'YOU TOO?!';
 
 		add_filter( 'pre_get_avatar', array( $this, 'pre_get_avatar_filter' ), 10, 1 );
 		$img = get_avatar( 1 );
 		remove_filter( 'pre_get_avatar', array( $this, 'pre_get_avatar_filter' ), 10 );
 
-		$this->assertEquals( $img, $this->fakeIMG );
+		$this->assertEquals( $img, $this->fake_img );
 	}
 	public function pre_get_avatar_filter( $img ) {
-		return $this->fakeIMG;
+		return $this->fake_img;
 	}
 
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/21195
 	 */
 	public function test_get_avatar_filter() {
-		$this->fakeURL = 'YA RLY';
+		$this->fake_url = 'YA RLY';
 
 		add_filter( 'get_avatar', array( $this, 'get_avatar_filter' ), 10, 1 );
 		$img = get_avatar( 1 );
 		remove_filter( 'get_avatar', array( $this, 'get_avatar_filter' ), 10 );
 
-		$this->assertEquals( $img, $this->fakeURL );
+		$this->assertEquals( $img, $this->fake_url );
 	}
 	public function get_avatar_filter( $img ) {
-		return $this->fakeURL;
+		return $this->fake_url;
 	}
 
 }

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -7,7 +7,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	function test_wp_parse_args_object() {
 		$x        = new MockClass;
 		$x->_baba = 5;
-		$x->yZ    = 'baba';
+		$x->yZ    = 'baba'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		$x->a     = array( 5, 111, 'x' );
 		$this->assertEquals(
 			array(
@@ -51,7 +51,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	function test_wp_parse_args_defaults() {
 		$x        = new MockClass;
 		$x->_baba = 5;
-		$x->yZ    = 'baba';
+		$x->yZ    = 'baba'; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		$x->a     = array( 5, 111, 'x' );
 		$d        = array( 'pu' => 'bu' );
 		$this->assertEquals(

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -13,7 +13,11 @@
 abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	// You can use your own version of data/WPHTTP-testcase-redirection-script.php here.
 	var $redirection_script = 'http://api.wordpress.org/core/tests/1.0/redirection.php';
+<<<<<<< HEAD
 	var $fileStreamUrl      = 'https://www.classicpress.net/wp-content/uploads/2019/02/celebrating-six-months-150x150.jpg';
+=======
+	var $file_stream_url    = 'http://s.w.org/screenshots/3.9/dashboard.png';
+>>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 
 	protected $http_request_args;
 
@@ -273,8 +277,13 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	function test_file_stream() {
+<<<<<<< HEAD
 		$url  = $this->fileStreamUrl;
 		$size = 5764;
+=======
+		$url  = $this->file_stream_url;
+		$size = 153204;
+>>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -301,8 +310,13 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/26726
 	 */
 	function test_file_stream_limited_size() {
+<<<<<<< HEAD
 		$url  = $this->fileStreamUrl;
 		$size = 5000;
+=======
+		$url  = $this->file_stream_url;
+		$size = 10000;
+>>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -330,8 +344,13 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/31172
 	 */
 	function test_request_limited_size() {
+<<<<<<< HEAD
 		$url  = $this->fileStreamUrl;
 		$size = 5000;
+=======
+		$url  = $this->file_stream_url;
+		$size = 10000;
+>>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 
 		$res = wp_remote_request(
 			$url,

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -274,7 +274,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 
 	function test_file_stream() {
 		$url  = $this->file_stream_url;
-		$size = 153204;
+		$size = 5764;
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -302,7 +302,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 */
 	function test_file_stream_limited_size() {
 		$url  = $this->file_stream_url;
-		$size = 10000;
+		$size = 5000;
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -331,7 +331,7 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 */
 	function test_request_limited_size() {
 		$url  = $this->file_stream_url;
-		$size = 10000;
+		$size = 5000;
 
 		$res = wp_remote_request(
 			$url,

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -13,11 +13,7 @@
 abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	// You can use your own version of data/WPHTTP-testcase-redirection-script.php here.
 	var $redirection_script = 'http://api.wordpress.org/core/tests/1.0/redirection.php';
-<<<<<<< HEAD
-	var $fileStreamUrl      = 'https://www.classicpress.net/wp-content/uploads/2019/02/celebrating-six-months-150x150.jpg';
-=======
-	var $file_stream_url    = 'http://s.w.org/screenshots/3.9/dashboard.png';
->>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
+	var $file_stream_url      = 'https://www.classicpress.net/wp-content/uploads/2019/02/celebrating-six-months-150x150.jpg';
 
 	protected $http_request_args;
 
@@ -277,13 +273,8 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	}
 
 	function test_file_stream() {
-<<<<<<< HEAD
-		$url  = $this->fileStreamUrl;
-		$size = 5764;
-=======
 		$url  = $this->file_stream_url;
 		$size = 153204;
->>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -310,13 +301,8 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/26726
 	 */
 	function test_file_stream_limited_size() {
-<<<<<<< HEAD
-		$url  = $this->fileStreamUrl;
-		$size = 5000;
-=======
 		$url  = $this->file_stream_url;
 		$size = 10000;
->>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 		$res  = wp_remote_request(
 			$url,
 			array(
@@ -344,13 +330,8 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/31172
 	 */
 	function test_request_limited_size() {
-<<<<<<< HEAD
-		$url  = $this->fileStreamUrl;
-		$size = 5000;
-=======
 		$url  = $this->file_stream_url;
 		$size = 10000;
->>>>>>> a139c8cbf7 (Coding Standards: Fix and whitelist variable names.)
 
 		$res = wp_remote_request(
 			$url,

--- a/tests/phpunit/tests/http/curl.php
+++ b/tests/phpunit/tests/http/curl.php
@@ -15,7 +15,7 @@ class Tests_HTTP_curl extends WP_HTTP_UnitTestCase {
 	public function test_http_api_curl_stream_parameter_is_a_reference() {
 		add_action( 'http_api_curl', array( $this, '_action_test_http_api_curl_stream_parameter_is_a_reference' ), 10, 3 );
 		wp_remote_request(
-			$this->fileStreamUrl,
+			$this->file_stream_url,
 			array(
 				'stream'  => true,
 				'timeout' => 30,

--- a/tests/phpunit/tests/post/output.php
+++ b/tests/phpunit/tests/post/output.php
@@ -29,15 +29,14 @@ class Tests_Post_Output extends WP_UnitTestCase {
 	}
 
 	function _shortcode_paragraph( $atts, $content ) {
-		extract(
-			shortcode_atts(
-				array(
-					'class' => 'graf',
-				),
-				$atts
-			)
+		$processed_atts = shortcode_atts(
+			array(
+				'class' => 'graf',
+			),
+			$atts
 		);
-		return "<p class='$class'>$content</p>\n";
+
+		return "<p class='{$processed_atts['class']}'>$content</p>\n";
 	}
 
 	function test_the_content() {

--- a/tests/phpunit/tests/shortcode.php
+++ b/tests/phpunit/tests/shortcode.php
@@ -43,18 +43,16 @@ class Tests_Shortcode extends WP_UnitTestCase {
 
 	// [bartag foo="bar"]
 	function _shortcode_bartag( $atts ) {
-		extract(
-			shortcode_atts(
+		$processed_atts = shortcode_atts(
 				array(
 					'foo' => 'no foo',
 					'baz' => 'default baz',
 				),
 				$atts,
 				'bartag'
-			)
 		);
 
-		return "foo = {$foo}";
+		return "foo = {$processed_atts['foo']}";
 	}
 
 	// [baztag]content[/baztag]

--- a/tests/phpunit/tests/shortcode.php
+++ b/tests/phpunit/tests/shortcode.php
@@ -44,12 +44,12 @@ class Tests_Shortcode extends WP_UnitTestCase {
 	// [bartag foo="bar"]
 	function _shortcode_bartag( $atts ) {
 		$processed_atts = shortcode_atts(
-				array(
-					'foo' => 'no foo',
-					'baz' => 'default baz',
-				),
-				$atts,
-				'bartag'
+			array(
+				'foo' => 'no foo',
+				'baz' => 'default baz',
+			),
+			$atts,
+			'bartag'
 		);
 
 		return "foo = {$processed_atts['foo']}";

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -199,6 +199,7 @@ class Tests_User extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/20043
 	 */
 	public function test_user_unset() {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 		$user = new WP_User( self::$author_id );
 
 		// Test custom fields
@@ -207,6 +208,7 @@ class Tests_User extends WP_UnitTestCase {
 		unset( $user->customField );
 		$this->assertFalse( isset( $user->customField ) );
 		return $user;
+		// phpcs:enable
 	}
 
 	/**

--- a/tests/phpunit/wp-mail-real-test.php
+++ b/tests/phpunit/wp-mail-real-test.php
@@ -55,6 +55,7 @@ wp_install( WP_BLOG_TITLE, WP_USER_NAME, WP_USER_EMAIL, true );
 // make sure we're installed
 assert( true == is_blog_installed() );
 
+// phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase
 define( 'PHPUnit_MAIN_METHOD', false );
 $original_wpdb = $GLOBALS['wpdb'];
 


### PR DESCRIPTION
## Description
This PR includes all relevant changes included in upstream ticket 45934:
https://core.trac.wordpress.org/ticket/45934
Not all of the 12 commits were necessary or needed.

## Motivation and context
Improve coding standards for readability and to aid move to PHP 8 and 8.1 compatibility.
It also commences work as described in the discussion on #1098 

## How has this been tested?
Coding standards and PHPUnit tests run and pas locally after these changes.

## Screenshots
N/A

## Types of changes
- Bug fix / Enhancement
