### PR TITLE
Whitespace added to comments when using Quick Edit

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -687,15 +687,13 @@ class WP_Comments_List_Table extends WP_List_Table {
 		}
 
 		comment_text( $comment );
+
 		if ( $this->user_can ) {
+			/** This filter is documented in wp-admin/includes/comment.php */
+			$comment_content = apply_filters( 'comment_edit_pre', $comment->comment_content );
 			?>
 		<div id="inline-<?php echo $comment->comment_ID; ?>" class="hidden">
-		<textarea class="comment" rows="1" cols="1">
-			<?php
-			/** This filter is documented in wp-admin/includes/comment.php */
-			echo esc_textarea( apply_filters( 'comment_edit_pre', $comment->comment_content ) );
-			?>
-		</textarea>
+			<textarea class="comment" rows="1" cols="1"><?php echo esc_textarea( $comment_content ); ?></textarea>
 		<div class="author-email"><?php echo esc_attr( $comment->comment_author_email ); ?></div>
 		<div class="author"><?php echo esc_attr( $comment->comment_author ); ?></div>
 		<div class="author-url"><?php echo esc_attr( $comment->comment_author_url ); ?></div>

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -929,9 +929,15 @@ function page_attributes_meta_box( $post ) {
 	if ( count( get_page_templates( $post ) ) > 0 && get_option( 'page_for_posts' ) != $post->ID ) :
 		$template = ! empty( $post->page_template ) ? $post->page_template : false;
 		?>
+<<<<<<< HEAD
 		<p class="post-attributes-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
 		<?php
 			/**
+=======
+<p class="post-attributes-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
+<?php
+/**
+>>>>>>> 31816ccec2 (Posts, Post Types: Remove extra tabs around `page_attributes_meta_box_template` action in `page_attributes_meta_box()`.)
 			 * Fires immediately after the label inside the 'Template' section
 			 * of the 'Page Attributes' meta box.
 			 *
@@ -940,12 +946,21 @@ function page_attributes_meta_box( $post ) {
 			 * @param string  $template The template used for the current post.
 			 * @param WP_Post $post     The current post.
 			 */
+<<<<<<< HEAD
 			do_action( 'page_attributes_meta_box_template', $template, $post );
 		?>
 		</p>
 		<select name="page_template" id="page_template">
 		<?php
 		/**
+=======
+do_action( 'page_attributes_meta_box_template', $template, $post );
+?>
+</p>
+<select name="page_template" id="page_template">
+<?php
+/**
+>>>>>>> 31816ccec2 (Posts, Post Types: Remove extra tabs around `page_attributes_meta_box_template` action in `page_attributes_meta_box()`.)
 		 * Filters the title of the default page template displayed in the drop-down.
 		 *
 		 * @since WP-4.1.0

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -929,38 +929,23 @@ function page_attributes_meta_box( $post ) {
 	if ( count( get_page_templates( $post ) ) > 0 && get_option( 'page_for_posts' ) != $post->ID ) :
 		$template = ! empty( $post->page_template ) ? $post->page_template : false;
 		?>
-<<<<<<< HEAD
 		<p class="post-attributes-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
 		<?php
-			/**
-=======
-<p class="post-attributes-label-wrapper"><label class="post-attributes-label" for="page_template"><?php _e( 'Template' ); ?></label>
-<?php
-/**
->>>>>>> 31816ccec2 (Posts, Post Types: Remove extra tabs around `page_attributes_meta_box_template` action in `page_attributes_meta_box()`.)
-			 * Fires immediately after the label inside the 'Template' section
-			 * of the 'Page Attributes' meta box.
-			 *
-			 * @since WP-4.4.0
-			 *
-			 * @param string  $template The template used for the current post.
-			 * @param WP_Post $post     The current post.
-			 */
-<<<<<<< HEAD
-			do_action( 'page_attributes_meta_box_template', $template, $post );
+		/**
+		 * Fires immediately after the label inside the 'Template' section
+		 * of the 'Page Attributes' meta box.
+		 *
+		 * @since WP-4.4.0
+		 *
+		 * @param string  $template The template used for the current post.
+		 * @param WP_Post $post     The current post.
+		 */
+		do_action( 'page_attributes_meta_box_template', $template, $post );
 		?>
 		</p>
 		<select name="page_template" id="page_template">
 		<?php
 		/**
-=======
-do_action( 'page_attributes_meta_box_template', $template, $post );
-?>
-</p>
-<select name="page_template" id="page_template">
-<?php
-/**
->>>>>>> 31816ccec2 (Posts, Post Types: Remove extra tabs around `page_attributes_meta_box_template` action in `page_attributes_meta_box()`.)
 		 * Filters the title of the default page template displayed in the drop-down.
 		 *
 		 * @since WP-4.1.0

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -353,15 +353,7 @@ foreach ( (array) $options as $option ) :
 	<th scope="row"><label for="<?php echo $name; ?>"><?php echo esc_html( $option->option_name ); ?></label></th>
 <td>
 	<?php if ( strpos( $value, "\n" ) !== false ) : ?>
-<<<<<<< HEAD
-	<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5">
-								<?php
-								echo esc_textarea( $value );
-								?>
-	</textarea>
-=======
 		<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5"><?php echo esc_textarea( $value ); ?></textarea>
->>>>>>> 0859c8c968 (Options: Avoid extra tabs in a textarea in `wp-admin/options.php`.)
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?> />
 	<?php endif ?></td>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -353,11 +353,15 @@ foreach ( (array) $options as $option ) :
 	<th scope="row"><label for="<?php echo $name; ?>"><?php echo esc_html( $option->option_name ); ?></label></th>
 <td>
 	<?php if ( strpos( $value, "\n" ) !== false ) : ?>
+<<<<<<< HEAD
 	<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5">
 								<?php
 								echo esc_textarea( $value );
 								?>
 	</textarea>
+=======
+		<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5"><?php echo esc_textarea( $value ); ?></textarea>
+>>>>>>> 0859c8c968 (Options: Avoid extra tabs in a textarea in `wp-admin/options.php`.)
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?> />
 	<?php endif ?></td>

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -568,9 +568,8 @@ class WP_Customize_Control {
 					rows="5"
 					<?php echo $describedby_attr; ?>
 					<?php $this->input_attrs(); ?>
-					<?php $this->link(); ?>>
-					<?php echo esc_textarea( $this->value() ); ?>
-				</textarea>
+					<?php $this->link(); ?>
+				><?php echo esc_textarea( $this->value() ); ?></textarea>
 				<?php
 				break;
 			case 'dropdown-pages':


### PR DESCRIPTION
## Description
There is an upstream [ticket](https://core.trac.wordpress.org/ticket/43252) noting this same issue.

I recently noticed that whitespace, more specifically tabs were being added before and after comment content when using Quick Edit. I tracked this back to a previously known and fixed issue upstream.

## Motivation and context
The whitespace is unexpected and should not be there. Backporting the fixes from upstream fixes this issue.

## How has this been tested?
See screenshots below.

## Screenshots
### Before
<img width="1566" alt="Screenshot 2022-09-06 at 15 48 48" src="https://user-images.githubusercontent.com/1280733/188666239-a646db4e-c4e7-4d8f-acd0-510b6da09638.png">

### After
<img width="1562" alt="Screenshot 2022-09-06 at 15 48 28" src="https://user-images.githubusercontent.com/1280733/188666297-a16c0fd2-d473-4251-81e4-3e8391990035.png">


## Types of changes
- Bug fix
