### PR TITLE
Set default show_avatars option to off

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -465,7 +465,7 @@ function populate_options() {
 		'tag_base'                        => '',
 
 		// 2.5
-		'show_avatars'                    => '1',
+		'show_avatars'                    => '0',
 		'avatar_rating'                   => 'G',
 		'upload_url_path'                 => '',
 		'thumbnail_size_w'                => 150,

--- a/tests/phpunit/tests/avatar.php
+++ b/tests/phpunit/tests/avatar.php
@@ -6,6 +6,11 @@
  * @group avatar
  */
 class Tests_Avatar extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+		update_option( 'show_avatars', '1' );
+	}
+
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/21195
 	 */

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -116,6 +116,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WP_REST_Comments_Controller;
+		update_option( 'show_avatars', '1' );
 		if ( is_multisite() ) {
 			update_site_option( 'site_admins', array( 'superadmin' ) );
 		}

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -129,6 +129,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WP_REST_Users_Controller();
+		update_option( 'show_avatars', '1' );
 	}
 
 	public function test_register_routes() {

--- a/tests/phpunit/tests/schema.php
+++ b/tests/phpunit/tests/schema.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Test database schema defaults
+ *
+ * @group option
+ */
+class Tests_Schema extends WP_UnitTestCase {
+	public function test_default_avatar_option() {
+		$setting = get_option( 'show_avatars' );
+
+		$this->assertEquals( '0', $setting );
+		$this->assertNotEquals( '1', $setting );
+	}
+}

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -4417,11 +4417,6 @@ mockedApiResponse.UsersCollection = [
         "description": "",
         "link": "http://example.org/?author=1",
         "slug": "admin",
-        "avatar_urls": {
-            "24": "http://0.gravatar.com/avatar/96614ec98aa0c0d2ee75796dced6df54?s=24&d=mm&r=g",
-            "48": "http://0.gravatar.com/avatar/96614ec98aa0c0d2ee75796dced6df54?s=48&d=mm&r=g",
-            "96": "http://0.gravatar.com/avatar/96614ec98aa0c0d2ee75796dced6df54?s=96&d=mm&r=g"
-        },
         "meta": {
             "meta_key": "meta_value"
         },
@@ -4445,11 +4440,6 @@ mockedApiResponse.UsersCollection = [
         "description": "",
         "link": "http://example.org/?author=2",
         "slug": "restapiclientfixtureuser",
-        "avatar_urls": {
-            "24": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=24&d=mm&r=g",
-            "48": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=48&d=mm&r=g",
-            "96": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=96&d=mm&r=g"
-        },
         "meta": {
             "meta_key": ""
         },
@@ -4475,11 +4465,6 @@ mockedApiResponse.UserModel = {
     "description": "",
     "link": "http://example.org/?author=2",
     "slug": "restapiclientfixtureuser",
-    "avatar_urls": {
-        "24": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=24&d=mm&r=g",
-        "48": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=48&d=mm&r=g",
-        "96": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=96&d=mm&r=g"
-    },
     "meta": {
         "meta_key": ""
     }
@@ -4492,11 +4477,6 @@ mockedApiResponse.me = {
     "description": "",
     "link": "http://example.org/?author=2",
     "slug": "restapiclientfixtureuser",
-    "avatar_urls": {
-        "24": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=24&d=mm&r=g",
-        "48": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=48&d=mm&r=g",
-        "96": "http://2.gravatar.com/avatar/57cbd982c963c7eb2294e2eee1b4448e?s=96&d=mm&r=g"
-    },
     "meta": {
         "meta_key": ""
     }
@@ -4518,11 +4498,6 @@ mockedApiResponse.CommentsCollection = [
         "link": "http://example.org/?p=4#comment-2",
         "status": "approved",
         "type": "comment",
-        "author_avatar_urls": {
-            "24": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=24&d=mm&r=g",
-            "48": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=48&d=mm&r=g",
-            "96": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=96&d=mm&r=g"
-        },
         "meta": {
             "meta_key": "meta_value"
         },
@@ -4563,11 +4538,6 @@ mockedApiResponse.CommentModel = {
     "link": "http://example.org/?p=4#comment-2",
     "status": "approved",
     "type": "comment",
-    "author_avatar_urls": {
-        "24": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=24&d=mm&r=g",
-        "48": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=48&d=mm&r=g",
-        "96": "http://2.gravatar.com/avatar/bd7c2b505bcf39cc71cfee564c614956?s=96&d=mm&r=g"
-    },
     "meta": {
         "meta_key": "meta_value"
     }


### PR DESCRIPTION
***Originally Pull Request 803***
[Original Pull Request](https://github.com/ClassicPress/ClassicPress/pull/803) repository has been deleted.

Change a setting so that avatars are set to "off" by default.


## Description

This PR changes the default setting of the show avatars checkbox to be unchecked on any new CP installation.

## Motivation and context

All of the avatar options (including the default mystery option) involve a call out to Gravatar, which is run by Automattic. This is a privacy concern for CP.

The petition has a lot of popular support. More discussion here: https://forums.classicpress.net/t/disable-gr-avatar-by-default/2801

## How has this been tested?

On a new install change this line in schema.php from 1 to 0.
```
	// 2.5
	'show_avatars' => '0',
```
Set up the new site and check in the settings.

**NOTE:** As with the other previous change to schema.php there will probably be other related changes required. This is a preliminary PR to get us started.

## Screenshots

### Before
![before](https://user-images.githubusercontent.com/46998578/134118483-273f63e5-e256-438c-98a8-03f265e35bd5.jpg)

### After
![after](https://user-images.githubusercontent.com/46998578/134118602-3a97ba3d-50f3-46e0-b598-1316ac11d6ff.jpg)

## Type
- New feature

