### PR TITLE
Change default_comment_status to closed

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -412,7 +412,7 @@ function populate_options() {
 		'mailserver_pass'                 => 'password',
 		'mailserver_port'                 => 110,
 		'default_category'                => 1,
-		'default_comment_status'          => 'open',
+		'default_comment_status'          => 'closed',
 		'default_ping_status'             => 'open',
 		'default_pingback_flag'           => 1,
 		'posts_per_page'                  => 10,

--- a/tests/phpunit/tests/comment-submission.php
+++ b/tests/phpunit/tests/comment-submission.php
@@ -10,6 +10,7 @@ class Tests_Comment_Submission extends WP_UnitTestCase {
 	function setUp() {
 		parent::setUp();
 		require_once ABSPATH . WPINC . '/class-phpass.php';
+		update_option( 'default_comment_status', 'open' );
 	}
 
 	public function test_submitting_comment_to_invalid_post_returns_error() {

--- a/tests/phpunit/tests/comment-submission.php
+++ b/tests/phpunit/tests/comment-submission.php
@@ -7,10 +7,15 @@ class Tests_Comment_Submission extends WP_UnitTestCase {
 
 	protected $preprocess_comment_data = array();
 
-	function setUp() {
+	public function setUp() {
 		parent::setUp();
 		require_once ABSPATH . WPINC . '/class-phpass.php';
 		update_option( 'default_comment_status', 'open' );
+	}
+
+	public function tearDown() {
+		update_option( 'default_comment_status', 'closed' );
+		parent::tearDown();
 	}
 
 	public function test_submitting_comment_to_invalid_post_returns_error() {

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -13,6 +13,11 @@ class Tests_Comment extends WP_UnitTestCase {
 		update_option( 'default_comment_status', 'open' );
 	}
 
+	public function tearDown() {
+		update_option( 'default_comment_status', 'closed' );
+		parent::tearDown();
+	}
+
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(
 			array(

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -10,6 +10,7 @@ class Tests_Comment extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		reset_phpmailer_instance();
+		update_option( 'default_comment_status', 'open' );
 	}
 
 	public static function wpSetUpBeforeClass( $factory ) {

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -9,6 +9,11 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		update_option( 'default_comment_status', 'open' );
 	}
 
+	public function tearDown() {
+		update_option( 'default_comment_status', 'closed' );
+		parent::tearDown();
+	}
+
 	public function test_default_markup_for_submit_button_and_wrapper() {
 		$p = self::factory()->post->create();
 

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -4,6 +4,11 @@
  * @group comment
  */
 class Tests_Comment_CommentForm extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+		update_option( 'default_comment_status', 'open' );
+	}
+
 	public function test_default_markup_for_submit_button_and_wrapper() {
 		$p = self::factory()->post->create();
 

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -18,6 +18,8 @@ class Tests_Feeds_RSS2 extends WP_UnitTestCase {
 	 * Setup a new user and attribute some posts.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
+		update_option( 'default_comment_status', 'open' );
+
 		// Create a user
 		self::$user_id = $factory->user->create(
 			array(

--- a/tests/phpunit/tests/feed/rss2.php
+++ b/tests/phpunit/tests/feed/rss2.php
@@ -59,6 +59,10 @@ class Tests_Feeds_RSS2 extends WP_UnitTestCase {
 		}
 	}
 
+	public static function wpTearDownAfterClass() {
+		update_option( 'default_comment_status', 'closed' );
+	}
+
 	/**
 	 * Setup.
 	 */

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1070,7 +1070,7 @@ class Tests_Post extends WP_UnitTestCase {
 	 * @see https://core.trac.wordpress.org/ticket/31168
 	 */
 	function test_wp_insert_post_cpt_default_comment_ping_status() {
-		$post_type = rand_str(20);
+		$post_type = rand_str( 20 );
 		register_post_type( $post_type, array( 'supports' => array( 'comments', 'trackbacks' ) ) );
 		$post_id = self::factory()->post->create(
 			array(

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -1043,7 +1043,7 @@ class Tests_Post extends WP_UnitTestCase {
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertEquals( 'open', $post->comment_status );
+		$this->assertEquals( 'closed', $post->comment_status );
 		$this->assertEquals( 'open', $post->ping_status );
 	}
 
@@ -1069,8 +1069,8 @@ class Tests_Post extends WP_UnitTestCase {
 	/**
 	 * @see https://core.trac.wordpress.org/ticket/31168
 	 */
-	function test_wp_insert_post_cpt_default_comment_ping_status_open() {
-		$post_type = rand_str( 20 );
+	function test_wp_insert_post_cpt_default_comment_ping_status() {
+		$post_type = rand_str(20);
 		register_post_type( $post_type, array( 'supports' => array( 'comments', 'trackbacks' ) ) );
 		$post_id = self::factory()->post->create(
 			array(
@@ -1083,7 +1083,7 @@ class Tests_Post extends WP_UnitTestCase {
 		);
 		$post    = get_post( $post_id );
 
-		$this->assertEquals( 'open', $post->comment_status );
+		$this->assertEquals( 'closed', $post->comment_status );
 		$this->assertEquals( 'open', $post->ping_status );
 		_unregister_post_type( $post_type );
 	}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -16,6 +16,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	public function setUp() {
 		// Override the normal server with our spying server.
 		$GLOBALS['wp_rest_server'] = new Spy_REST_Server();
+		update_option( 'default_comment_status', 'open' );
 		parent::setUp();
 	}
 

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -22,6 +22,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 
 	public function tearDown() {
 		remove_filter( 'wp_rest_server_class', array( $this, 'filter_wp_rest_server_class' ) );
+		update_option( 'default_comment_status', 'closed' );
 		parent::tearDown();
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -27,6 +27,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	protected $endpoint;
 
 	public static function wpSetUpBeforeClass( $factory ) {
+		update_option( 'default_comment_status', 'open' );
 		self::$superadmin_id = $factory->user->create(
 			array(
 				'role'       => 'administrator',
@@ -111,6 +112,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		wp_delete_post( self::$trash_id, true );
 		wp_delete_post( self::$approved_id, true );
 		wp_delete_post( self::$hold_id, true );
+
+		update_option( 'default_comment_status', 'closed' );
 	}
 
 	public function setUp() {

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -18,6 +18,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		update_option( 'default_comment_status', 'open' );
+
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new Spy_REST_Server;
@@ -28,6 +30,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 
 	public function tearDown() {
 		parent::tearDown();
+
+		update_option( 'default_comment_status', 'closed' );
 
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -18,12 +18,11 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		update_option( 'default_comment_status', 'open' );
-
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$this->server = $wp_rest_server = new Spy_REST_Server;
 		do_action( 'rest_api_init' );
+		update_option( 'default_comment_status', 'open' );
 
 		add_filter( 'pre_http_request', array( $this, 'mock_embed_request' ), 10, 3 );
 	}
@@ -31,11 +30,11 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		update_option( 'default_comment_status', 'closed' );
-
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = null;
+
+		update_option( 'default_comment_status', 'closed' );
 
 		remove_filter( 'pre_http_request', array( $this, 'mock_embed_request' ), 10, 3 );
 	}

--- a/tests/phpunit/tests/schema.php
+++ b/tests/phpunit/tests/schema.php
@@ -8,7 +8,14 @@ class Tests_Schema extends WP_UnitTestCase {
 	public function test_default_avatar_option() {
 		$setting = get_option( 'show_avatars' );
 
-		$this->assertEquals( '0', $setting );
-		$this->assertNotEquals( '1', $setting );
+		$this->assertSame( '0', $setting );
+		$this->assertNotSame( '1', $setting );
+	}
+
+	public function test_comments_off_by_default() {
+		$setting = get_option( 'default_comment_status' );
+
+		$this->assertSame( 'closed', $setting );
+		$this->assertNotSame( 'open', $setting );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/newComment.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newComment.php
@@ -4,6 +4,15 @@
  * @group xmlrpc
  */
 class Tests_XMLRPC_wp_newComment extends WP_XMLRPC_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+		update_option( 'default_comment_status', 'open' );
+	}
+
+	public function tearDown() {
+		update_option( 'default_comment_status', 'closed' );
+		parent::tearDown();
+	}
 
 	function test_valid_comment() {
 		$this->make_user_by_role( 'administrator' );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3571,7 +3571,7 @@ mockedApiResponse.PostsCollection = [
         },
         "author": 0,
         "featured_media": 0,
-        "comment_status": "closed",
+        "comment_status": "open",
         "ping_status": "open",
         "sticky": false,
         "template": "",
@@ -3671,7 +3671,7 @@ mockedApiResponse.PostModel = {
     },
     "author": 0,
     "featured_media": 0,
-    "comment_status": "closed",
+    "comment_status": "open",
     "ping_status": "open",
     "sticky": false,
     "template": "",
@@ -3934,7 +3934,7 @@ mockedApiResponse.MediaCollection = [
             "rendered": "REST API Client Fixture: Attachment"
         },
         "author": 0,
-        "comment_status": "closed",
+        "comment_status": "open",
         "ping_status": "closed",
         "template": "",
         "meta": {
@@ -4000,7 +4000,7 @@ mockedApiResponse.MediaModel = {
         "rendered": "REST API Client Fixture: Attachment"
     },
     "author": 0,
-    "comment_status": "closed",
+    "comment_status": "open",
     "ping_status": "closed",
     "template": "",
     "meta": {
@@ -4560,5 +4560,5 @@ mockedApiResponse.settings = {
     "default_post_format": "0",
     "posts_per_page": 10,
     "default_ping_status": "open",
-    "default_comment_status": "closed"
+    "default_comment_status": "open"
 };

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3571,7 +3571,7 @@ mockedApiResponse.PostsCollection = [
         },
         "author": 0,
         "featured_media": 0,
-        "comment_status": "open",
+        "comment_status": "closed",
         "ping_status": "open",
         "sticky": false,
         "template": "",
@@ -3671,7 +3671,7 @@ mockedApiResponse.PostModel = {
     },
     "author": 0,
     "featured_media": 0,
-    "comment_status": "open",
+    "comment_status": "closed",
     "ping_status": "open",
     "sticky": false,
     "template": "",
@@ -3934,7 +3934,7 @@ mockedApiResponse.MediaCollection = [
             "rendered": "REST API Client Fixture: Attachment"
         },
         "author": 0,
-        "comment_status": "open",
+        "comment_status": "closed",
         "ping_status": "closed",
         "template": "",
         "meta": {
@@ -4000,7 +4000,7 @@ mockedApiResponse.MediaModel = {
         "rendered": "REST API Client Fixture: Attachment"
     },
     "author": 0,
-    "comment_status": "open",
+    "comment_status": "closed",
     "ping_status": "closed",
     "template": "",
     "meta": {
@@ -4590,5 +4590,5 @@ mockedApiResponse.settings = {
     "default_post_format": "0",
     "posts_per_page": 10,
     "default_ping_status": "open",
-    "default_comment_status": "open"
+    "default_comment_status": "closed"
 };


### PR DESCRIPTION
***Originally Pull Request 793***
[Original Pull Request](https://github.com/ClassicPress/ClassicPress/pull/793) repository has been deleted.
Will need addition of a test for default setting once #1109 is merged.

## Description

This changes a setting that gets loaded into the database when CP initially installs, so that comments are turned **off** by default, not **on**.

## Motivation and context

The comment system is something that users should _choose_ to use, rather than have it forced on them and have to remember to disable it.

We no longer have Akismet as an included plugin, so we are currently enabling comments by default but not providing any way to deal with the mountains of spam this will generate. 

There is also the issue that comments can be enabled on media items by accident, even though the user is not even using posts or a blog. A user can therefore end up with thousands of images that are unintentionally made open to comments (and spam).

Full discussion is here: https://forums.classicpress.net/t/change-basic-settings-of-comment-options/2744

This has a lot of votes from the previous petition system (note there is also a duplicate petition).

## How has this been tested?

The change shown was made to one line in schema.php. A new CP instance was installed and it was noted that the box was now unticked.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/46998578/132933632-232ca8e9-b8c9-432f-a0d8-18f8e4ea0103.jpg)

### After

![after](https://user-images.githubusercontent.com/46998578/132933646-a4687152-964d-4740-8967-24affb5f41b7.jpg)

## Types of changes

New feature I guess (although I'd consider it more of a bug fix).

