### PR TITLE
WP-r50921: Add support for `Update URI` plugin header

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -48,16 +48,20 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		$plugin_info = get_site_transient( 'update_plugins' );
 		if ( isset( $plugin_info->no_update ) ) {
 			foreach ( $plugin_info->no_update as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
 				$plugin->upgrade          = false;
 				$plugins[ $plugin->slug ] = $plugin;
 			}
 		}
+		}
 
 		if ( isset( $plugin_info->response ) ) {
 			foreach ( $plugin_info->response as $plugin ) {
+				if ( isset( $plugin->slug ) ) {
 				$plugin->upgrade          = true;
 				$plugins[ $plugin->slug ] = $plugin;
 			}
+		}
 		}
 
 		return $plugins;

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -49,19 +49,19 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		if ( isset( $plugin_info->no_update ) ) {
 			foreach ( $plugin_info->no_update as $plugin ) {
 				if ( isset( $plugin->slug ) ) {
-				$plugin->upgrade          = false;
-				$plugins[ $plugin->slug ] = $plugin;
+					$plugin->upgrade          = false;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
 			}
-		}
 		}
 
 		if ( isset( $plugin_info->response ) ) {
 			foreach ( $plugin_info->response as $plugin ) {
 				if ( isset( $plugin->slug ) ) {
-				$plugin->upgrade          = true;
-				$plugins[ $plugin->slug ] = $plugin;
+					$plugin->upgrade          = true;
+					$plugins[ $plugin->slug ] = $plugin;
+				}
 			}
-		}
 		}
 
 		return $plugins;

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -47,8 +47,14 @@
  * the file. This is not checked however and the file is only opened for
  * reading.
  *
+<<<<<<< HEAD
  * @since WP-1.5.0
  * @since WP-5.3.0 Added support for `Requires at least` and `Requires PHP`.
+=======
+ * @since 1.5.0
+ * @since 5.3.0 Added support for `Requires at least` and `Requires PHP` headers.
+ * @since 5.8.0 Added support for `Update URI` header.
+>>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
  *
  * @param string $plugin_file Path to the main plugin file.
  * @param bool   $markup      Optional. If the returned data should have HTML markup applied.
@@ -68,6 +74,7 @@
  *     @type bool   $Network     Whether the plugin can only be activated network-wide.
  *     @type string $RequiresWP  Minimum required version of WordPress.
  *     @type string $RequiresPHP Minimum required version of PHP.
+ *     @type string $UpdateURI   ID of the plugin for update purposes, should be a URI.
  * }
  */
 function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
@@ -84,6 +91,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		'Network'     => 'Network',
 		'RequiresWP'  => 'Requires at least',
 		'RequiresPHP' => 'Requires PHP',
+		'UpdateURI'   => 'Update URI',
 		// Site Wide Only is deprecated in favor of Network.
 		'_sitewide'   => 'Site Wide Only',
 	);

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -47,14 +47,9 @@
  * the file. This is not checked however and the file is only opened for
  * reading.
  *
-<<<<<<< HEAD
  * @since WP-1.5.0
- * @since WP-5.3.0 Added support for `Requires at least` and `Requires PHP`.
-=======
- * @since 1.5.0
- * @since 5.3.0 Added support for `Requires at least` and `Requires PHP` headers.
- * @since 5.8.0 Added support for `Update URI` header.
->>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
+ * @since WP-5.3.0 Added support for `Requires at least` and `Requires PHP` headers.
+ * @since WP-5.8.0 Added support for `Update URI` header.
  *
  * @param string $plugin_file Path to the main plugin file.
  * @param bool   $markup      Optional. If the returned data should have HTML markup applied.

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -429,9 +429,6 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 		$compatible_php = is_php_version_compatible( $requires_php );
 		$notice_type    = $compatible_php ? 'notice-warning' : 'notice-error';
 
-<<<<<<< HEAD
-		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr( $response->slug . '-update' ) . '" data-slug="' . esc_attr( $response->slug ) . '" data-plugin="' . esc_attr( $file ) . '"><td colspan="' . esc_attr( $wp_list_table->get_column_count() ) . '" class="plugin-update colspanchange"><div class="update-message notice inline ' . $notice_type . ' notice-alt"><p>';
-=======
 		printf(
 			'<tr class="plugin-update-tr%s" id="%s" data-slug="%s" data-plugin="%s">' .
 			'<td colspan="%s" class="plugin-update colspanchange">' .
@@ -443,7 +440,6 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 			esc_attr( $wp_list_table->get_column_count() ),
 			$notice_type
 		);
->>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			/* translators: 1: plugin name, 2: details URL, 3: additional link attributes, 4: version number */

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -396,7 +396,24 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 	);
 
 	$plugin_name = wp_kses( $plugin_data['Name'], $plugins_allowedtags );
-	$details_url = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $response->slug . '&section=changelog&TB_iframe=true&width=600&height=800' );
+	$plugin_slug = isset( $response->slug ) ? $response->slug : $response->id;
+
+	if ( isset( $response->slug ) ) {
+		$details_url = self_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_slug . '&section=changelog' );
+	} elseif ( isset( $response->url ) ) {
+		$details_url = $response->url;
+	} else {
+		$details_url = $plugin_data['PluginURI'];
+	}
+
+	$details_url = add_query_arg(
+		array(
+			'TB_iframe' => 'true',
+			'width'     => 600,
+			'height'    => 800,
+		),
+		$details_url
+	);
 
 	/** @var WP_Plugins_List_Table $wp_list_table */
 	$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
@@ -412,7 +429,21 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 		$compatible_php = is_php_version_compatible( $requires_php );
 		$notice_type    = $compatible_php ? 'notice-warning' : 'notice-error';
 
+<<<<<<< HEAD
 		echo '<tr class="plugin-update-tr' . $active_class . '" id="' . esc_attr( $response->slug . '-update' ) . '" data-slug="' . esc_attr( $response->slug ) . '" data-plugin="' . esc_attr( $file ) . '"><td colspan="' . esc_attr( $wp_list_table->get_column_count() ) . '" class="plugin-update colspanchange"><div class="update-message notice inline ' . $notice_type . ' notice-alt"><p>';
+=======
+		printf(
+			'<tr class="plugin-update-tr%s" id="%s" data-slug="%s" data-plugin="%s">' .
+			'<td colspan="%s" class="plugin-update colspanchange">' .
+			'<div class="update-message notice inline %s notice-alt"><p>',
+			$active_class,
+			esc_attr( $plugin_slug . '-update' ),
+			esc_attr( $plugin_slug ),
+			esc_attr( $file ),
+			esc_attr( $wp_list_table->get_column_count() ),
+			$notice_type
+		);
+>>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
 
 		if ( ! current_user_can( 'update_plugins' ) ) {
 			/* translators: 1: plugin name, 2: details URL, 3: additional link attributes, 4: version number */

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -265,8 +265,11 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$current = new stdClass;
 	}
 
-	$new_option               = new stdClass;
-	$new_option->last_checked = time();
+	$updates               = new stdClass;
+	$updates->last_checked = time();
+	$updates->response     = array();
+	$updates->translations = array();
+	$updates->no_update    = array();
 
 	$doing_cron = wp_doing_cron();
 
@@ -295,7 +298,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 	if ( $time_not_changed && ! $extra_stats ) {
 		$plugin_changed = false;
 		foreach ( $plugins as $file => $p ) {
-			$new_option->checked[ $file ] = $p['Version'];
+			$updates->checked[ $file ] = $p['Version'];
 
 			if ( ! isset( $current->checked[ $file ] ) || strval( $current->checked[ $file ] ) !== strval( $p['Version'] ) ) {
 				$plugin_changed = true;
@@ -380,33 +383,132 @@ function wp_update_plugins( $extra_stats = array() ) {
 	}
 
 	$response = json_decode( wp_remote_retrieve_body( $raw_response ), true );
+<<<<<<< HEAD
 	foreach ( $response['plugins'] as &$plugin ) {
 		$plugin = (object) $plugin;
 		if ( isset( $plugin->compatibility ) ) {
 			$plugin->compatibility = (object) $plugin->compatibility;
 			foreach ( $plugin->compatibility as &$data ) {
 				$data = (object) $data;
-			}
-		}
+=======
+
+	if ( $response && is_array( $response ) ) {
+		$updates->response     = $response['plugins'];
+		$updates->translations = $response['translations'];
+		$updates->no_update    = $response['no_update'];
 	}
+
+	// Support updates for any plugins using the `Update URI` header field.
+	foreach ( $plugins as $plugin_file => $plugin_data ) {
+		if ( ! $plugin_data['UpdateURI'] || isset( $updates->response[ $plugin_file ] ) ) {
+			continue;
+		}
+
+		$hostname = wp_parse_url( esc_url_raw( $plugin_data['UpdateURI'] ), PHP_URL_HOST );
+
+		/**
+		 * Filters the update response for a given plugin hostname.
+		 *
+		 * The dynamic portion of the hook name, `$hostname`, refers to the hostname
+		 * of the URI specified in the `Update URI` header field.
+		 *
+		 * @since 5.8.0
+		 *
+		 * @param array|false $update {
+		 *     The plugin update data with the latest details. Default false.
+		 *
+		 *     @type string $id           Optional. ID of the plugin for update purposes, should be a URI
+		 *                                specified in the `Update URI` header field.
+		 *     @type string $slug         Slug of the plugin.
+		 *     @type string $version      The version of the plugin.
+		 *     @type string $url          The URL for details of the plugin.
+		 *     @type string $package      Optional. The update ZIP for the plugin.
+		 *     @type string $tested       Optional. The version of WordPress the plugin is tested against.
+		 *     @type string $requires_php Optional. The version of PHP which the plugin requires.
+		 *     @type bool   $autoupdate   Optional. Whether the plugin should automatically update.
+		 *     @type array  $icons        Optional. Array of plugin icons.
+		 *     @type array  $banners      Optional. Array of plugin banners.
+		 *     @type array  $banners_rtl  Optional. Array of plugin RTL banners.
+		 *     @type array  $translations {
+		 *         Optional. List of translation updates for the plugin.
+		 *
+		 *         @type string $language   The language the translation update is for.
+		 *         @type string $version    The version of the plugin this translation is for.
+		 *                                  This is not the version of the language file.
+		 *         @type string $updated    The update timestamp of the translation file.
+		 *                                  Should be a date in the `YYYY-MM-DD HH:MM:SS` format.
+		 *         @type string $package    The ZIP location containing the translation update.
+		 *         @type string $autoupdate Whether the translation should be automatically installed.
+		 *     }
+		 * }
+		 * @param array       $plugin_data      Plugin headers.
+		 * @param string      $plugin_file      Plugin filename.
+		 * @param array       $locales          Installed locales to look translations for.
+		 */
+		$update = apply_filters( "update_plugins_{$hostname}", false, $plugin_data, $plugin_file, $locales );
+
+		if ( ! $update ) {
+			continue;
+>>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
+			}
+
+		$update = (object) $update;
+
+		// Is it valid? We require at least a version.
+		if ( ! isset( $update->version ) ) {
+			continue;
+		}
+
+		// These should remain constant.
+		$update->id     = $plugin_data['UpdateURI'];
+		$update->plugin = $plugin_file;
+
+		// WordPress needs the version field specified as 'new_version'.
+		if ( ! isset( $update->new_version ) ) {
+			$update->new_version = $update->version;
+	}
+<<<<<<< HEAD
 	unset( $plugin, $data );
 	foreach ( $response['no_update'] as &$plugin ) {
 		$plugin = (object) $plugin;
 	}
 	unset( $plugin );
+=======
 
-	if ( is_array( $response ) ) {
-		$new_option->response     = $response['plugins'];
-		$new_option->translations = $response['translations'];
-		// TODO: Perhaps better to store no_update in a separate transient with an expiry?
-		$new_option->no_update = $response['no_update'];
+		// Handle any translation updates.
+		if ( ! empty( $update->translations ) ) {
+			foreach ( $update->translations as $translation ) {
+				if ( isset( $translation['language'], $translation['package'] ) ) {
+					$translation['type'] = 'plugin';
+					$translation['slug'] = isset( $update->slug ) ? $update->slug : $update->id;
+
+					$updates->translations[] = $translation;
+				}
+			}
+		}
+
+		unset( $updates->no_update[ $plugin_file ], $updates->response[ $plugin_file ] );
+>>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
+
+		if ( version_compare( $update->new_version, $plugin_data['Version'], '>' ) ) {
+			$updates->response[ $plugin_file ] = $update;
 	} else {
-		$new_option->response     = array();
-		$new_option->translations = array();
-		$new_option->no_update    = array();
+			$updates->no_update[ $plugin_file ] = $update;
+	}
 	}
 
-	set_site_transient( 'update_plugins', $new_option );
+	$sanitize_plugin_update_payload = function( &$item ) {
+		$item = (object) $item;
+
+		unset( $item->translations, $item->compatibility );
+
+		return $item;
+	};
+
+	array_walk( $updates->response, $sanitize_plugin_update_payload );
+	array_walk( $updates->no_update, $sanitize_plugin_update_payload );
+
+	set_site_transient( 'update_plugins', $updates );
 }
 
 /**

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -457,7 +457,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		// WordPress needs the version field specified as 'new_version'.
 		if ( ! isset( $update->new_version ) ) {
 			$update->new_version = $update->version;
-	}
+		}
 
 		// Handle any translation updates.
 		if ( ! empty( $update->translations ) ) {
@@ -475,9 +475,9 @@ function wp_update_plugins( $extra_stats = array() ) {
 
 		if ( version_compare( $update->new_version, $plugin_data['Version'], '>' ) ) {
 			$updates->response[ $plugin_file ] = $update;
-	} else {
+		} else {
 			$updates->no_update[ $plugin_file ] = $update;
-	}
+		}
 	}
 
 	$sanitize_plugin_update_payload = function( &$item ) {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -383,14 +383,6 @@ function wp_update_plugins( $extra_stats = array() ) {
 	}
 
 	$response = json_decode( wp_remote_retrieve_body( $raw_response ), true );
-<<<<<<< HEAD
-	foreach ( $response['plugins'] as &$plugin ) {
-		$plugin = (object) $plugin;
-		if ( isset( $plugin->compatibility ) ) {
-			$plugin->compatibility = (object) $plugin->compatibility;
-			foreach ( $plugin->compatibility as &$data ) {
-				$data = (object) $data;
-=======
 
 	if ( $response && is_array( $response ) ) {
 		$updates->response     = $response['plugins'];
@@ -412,7 +404,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		 * The dynamic portion of the hook name, `$hostname`, refers to the hostname
 		 * of the URI specified in the `Update URI` header field.
 		 *
-		 * @since 5.8.0
+		 * @since WP-5.8.0
 		 *
 		 * @param array|false $update {
 		 *     The plugin update data with the latest details. Default false.
@@ -449,8 +441,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 
 		if ( ! $update ) {
 			continue;
->>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
-			}
+		}
 
 		$update = (object) $update;
 
@@ -467,13 +458,6 @@ function wp_update_plugins( $extra_stats = array() ) {
 		if ( ! isset( $update->new_version ) ) {
 			$update->new_version = $update->version;
 	}
-<<<<<<< HEAD
-	unset( $plugin, $data );
-	foreach ( $response['no_update'] as &$plugin ) {
-		$plugin = (object) $plugin;
-	}
-	unset( $plugin );
-=======
 
 		// Handle any translation updates.
 		if ( ! empty( $update->translations ) ) {
@@ -488,7 +472,6 @@ function wp_update_plugins( $extra_stats = array() ) {
 		}
 
 		unset( $updates->no_update[ $plugin_file ], $updates->response[ $plugin_file ] );
->>>>>>> 0f45b89ffd (Plugins: Add support for `Update URI` header.)
 
 		if ( version_compare( $update->new_version, $plugin_data['Version'], '>' ) ) {
 			$updates->response[ $plugin_file ] = $update;


### PR DESCRIPTION
## Description
This allows third-party plugins to avoid accidentally being overwritten with an update of a plugin of a similar name from the WordPress.org Plugin Directory.
Additionally, introduce the `update_plugins_{$hostname}` filter, which third-party plugins can use to offer updates for a given hostname.

## Motivation and context
1. Give plugin developers to specify that the updates are not handled by the WP repo.
2. Add a filter that can be useful in the integration of the new ClassicPress directory.

## How has this been tested?
With this code I've successfully update a plugin trom a fork of the new directory.
**Note: the 'View Details' link with this code don't work.**

```
add_filter('update_plugins_dir.educatorecinofilo.dog', 'xsx_test', 10, 4);

function xsx_test($update, $plugin_data, $plugin_file, $locales) {

	$slug = dirname($plugin_file);
	$endpoint = 'https://dir.educatorecinofilo.dog/wp-json/wp/v2/plugins?byslug='.sanitize_key($slug);
	$endpoint = 'https://dir.educatorecinofilo.dog/wp-json/wp/v2/plugins?byslug=vars';
	$response = wp_remote_get($endpoint, ['user-agent' => 'WordPress/4.9.20; https://www.classicpress.net/?wp_compatible=true;'.get_bloginfo('url')]);
	if (is_wp_error($response) || empty($response['response']) || $response['response']['code'] != '200') {
		return false;
	}
	$update_info = json_decode(wp_remote_retrieve_body($response), true);

	$update = [
		'slug'    => $plugin_file,
		'version' => $update_info[0]['meta']['current_version'],
		'package' => $update_info[0]['meta']['download_link'],
		'requires_php' => $update_info[0]['meta']['requires_php'],
		'sections' => ['description' => $update_info[0]['content']['rendered'] ]
	];

	return $update;
}
```

## Types of changes
- New feature

Closes #889 
Closes #908 