### PR TITLE
wp-r47251:: Store the original attachment URL in the `_source_url` post meta value 

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -912,14 +912,24 @@ function wp_media_upload_handler() {
 /**
  * Downloads an image from the specified URL and attaches it to a post.
  *
+<<<<<<< HEAD
  * @since WP-2.6.0
  * @since WP-4.2.0 Introduced the `$return` parameter.
  * @since WP-4.8.0 Introduced the 'id' option within the `$return` parameter.
+=======
+ * @since 2.6.0
+ * @since 4.2.0 Introduced the `$return` parameter.
+ * @since 4.8.0 Introduced the 'id' option within the `$return` parameter.
+ * @since 5.3.0 The `$post_id` parameter was made optional.
+ * @since 5.4.0 The original URL of the attachment is stored in the `_source_url`
+ *              post meta value.
+>>>>>>> 45cb25d4f2 (Media: In `media_sideload_image()`, store the original attachment URL in the `_source_url` post meta value.)
  *
  * @param string $file    The URL of the image to download.
  * @param int    $post_id The post ID the media is to be associated with.
  * @param string $desc    Optional. Description of the image.
- * @param string $return  Optional. Accepts 'html' (image tag html) or 'src' (URL), or 'id' (attachment ID). Default 'html'.
+ * @param string $return  Optional. Accepts 'html' (image tag html) or 'src' (URL),
+ *                        or 'id' (attachment ID). Default 'html'.
  * @return string|WP_Error Populated HTML img tag on success, WP_Error object otherwise.
  */
 function media_sideload_image( $file, $post_id, $desc = null, $return = 'html' ) {
@@ -949,8 +959,18 @@ function media_sideload_image( $file, $post_id, $desc = null, $return = 'html' )
 		if ( is_wp_error( $id ) ) {
 			@unlink( $file_array['tmp_name'] );
 			return $id;
+<<<<<<< HEAD
 			// If attachment id was requested, return it early.
 		} elseif ( $return === 'id' ) {
+=======
+		}
+
+		// Store the original attachment source in meta.
+		add_post_meta( $id, '_source_url', $file );
+
+		// If attachment id was requested, return it.
+		if ( 'id' === $return ) {
+>>>>>>> 45cb25d4f2 (Media: In `media_sideload_image()`, store the original attachment URL in the `_source_url` post meta value.)
 			return $id;
 		}
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -912,18 +912,12 @@ function wp_media_upload_handler() {
 /**
  * Downloads an image from the specified URL and attaches it to a post.
  *
-<<<<<<< HEAD
- * @since WP-2.6.0
- * @since WP-4.2.0 Introduced the `$return` parameter.
- * @since WP-4.8.0 Introduced the 'id' option within the `$return` parameter.
-=======
  * @since 2.6.0
  * @since 4.2.0 Introduced the `$return` parameter.
  * @since 4.8.0 Introduced the 'id' option within the `$return` parameter.
  * @since 5.3.0 The `$post_id` parameter was made optional.
  * @since 5.4.0 The original URL of the attachment is stored in the `_source_url`
  *              post meta value.
->>>>>>> 45cb25d4f2 (Media: In `media_sideload_image()`, store the original attachment URL in the `_source_url` post meta value.)
  *
  * @param string $file    The URL of the image to download.
  * @param int    $post_id The post ID the media is to be associated with.
@@ -959,10 +953,6 @@ function media_sideload_image( $file, $post_id, $desc = null, $return = 'html' )
 		if ( is_wp_error( $id ) ) {
 			@unlink( $file_array['tmp_name'] );
 			return $id;
-<<<<<<< HEAD
-			// If attachment id was requested, return it early.
-		} elseif ( $return === 'id' ) {
-=======
 		}
 
 		// Store the original attachment source in meta.
@@ -970,7 +960,6 @@ function media_sideload_image( $file, $post_id, $desc = null, $return = 'html' )
 
 		// If attachment id was requested, return it.
 		if ( 'id' === $return ) {
->>>>>>> 45cb25d4f2 (Media: In `media_sideload_image()`, store the original attachment URL in the `_source_url` post meta value.)
 			return $id;
 		}
 


### PR DESCRIPTION
Backport https://core.trac.wordpress.org/changeset/47251

In `media_sideload_image()`, store the original attachment URL in the `_source_url` post meta value.

Picks https://core.trac.wordpress.org/changeset/47251 as a follow-up of https://github.com/ClassicPress/ClassicPress/pull/950

Thanks to @dshanske via https://github.com/ClassicPress/ClassicPress/issues/1026#issuecomment-1272182273