### PR TITLE
WP-r54427: External Libraries: Upgrade PHPMailer to version 6.6.5

### DIFF
--- a/src/wp-includes/PHPMailer/PHPMailer.php
+++ b/src/wp-includes/PHPMailer/PHPMailer.php
@@ -750,7 +750,7 @@ class PHPMailer
      *
      * @var string
      */
-    const VERSION = '6.6.4';
+    const VERSION = '6.6.5';
 
     /**
      * Error severity: message only, continue processing.
@@ -1673,7 +1673,7 @@ class PHPMailer
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
             }
         } catch (Exception $exc) {
-            if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true) {
+            if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true && $this->smtp->connected()) {
                 $this->smtp->reset();
             }
             $this->setError($exc->getMessage());
@@ -1865,7 +1865,7 @@ class PHPMailer
         if (!static::isPermittedPath($path)) {
             return false;
         }
-        $readable = file_exists($path);
+        $readable = is_file($path);
         //If not a UNC path (expected to start with \\), check read permission, see #2069
         if (strpos($path, '\\\\') !== 0) {
             $readable = $readable && is_readable($path);
@@ -2110,6 +2110,9 @@ class PHPMailer
         $this->smtp->setDebugLevel($this->SMTPDebug);
         $this->smtp->setDebugOutput($this->Debugoutput);
         $this->smtp->setVerp($this->do_verp);
+        if ($this->Host === null) {
+            $this->Host = 'localhost';
+        }
         $hosts = explode(';', $this->Host);
         $lastexception = null;
 

--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -35,7 +35,7 @@ class SMTP
      *
      * @var string
      */
-    const VERSION = '6.6.4';
+    const VERSION = '6.6.5';
 
     /**
      * SMTP line break constant.
@@ -682,7 +682,6 @@ class SMTP
      */
     public function close()
     {
-        $this->setError('');
         $this->server_caps = null;
         $this->helo_rply = null;
         if (is_resource($this->smtp_conn)) {


### PR DESCRIPTION
## Description

This is a maintenance release with minor changes:
* Don't try to issue `RSET` if there has been a connection error.
* Reject attempts to add folders as attachments.
* Don't suppress earlier error messages on `close()`.
* Handle `Host === null` better.

Release notes:
https://github.com/PHPMailer/PHPMailer/releases/tag/v6.6.5

For a full list of changes in this update, see the PHPMailer GitHub: https://github.com/PHPMailer/PHPMailer/compare/v6.6.4...v6.6.5

Follow-up to https://core.trac.wordpress.org/changeset/50628, https://core.trac.wordpress.org/changeset/50799, https://core.trac.wordpress.org/changeset/51169, https://core.trac.wordpress.org/changeset/51634, https://core.trac.wordpress.org/changeset/51635, https://core.trac.wordpress.org/changeset/52252, https://core.trac.wordpress.org/changeset/52749, https://core.trac.wordpress.org/changeset/52811, https://core.trac.wordpress.org/changeset/53500, https://core.trac.wordpress.org/changeset/53535, https://core.trac.wordpress.org/changeset/53917.

WP:Props ayeshrajans, Synchro.
Fixes https://core.trac.wordpress.org/ticket/56772.

---

Merges https://core.trac.wordpress.org/changeset/54427 / WordPress/wordpress-develop@f1396626d1 to ClassicPress.


## Motivation and context
Update external libraries for compatibility and security.

## How has this been tested?
Unit tests

## Screenshots
N/A

## Types of changes
- Enhancement