### PR TITLE
wp-r54420:: Remove instances of _wp_http_referer from GET forms in the admin.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1616,7 +1616,8 @@ function wp_nonce_field( $action = -1, $name = '_wpnonce', $referer = true, $ech
  * @return string Referer field HTML markup.
  */
 function wp_referer_field( $echo = true ) {
-	$referer_field = '<input type="hidden" name="_wp_http_referer" value="' . esc_attr( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . '" />';
+	$request_url   = remove_query_arg( '_wp_http_referer' );
+	$referer_field = '<input type="hidden" name="_wp_http_referer" value="' . esc_url( $request_url ) . '" />';
 
 	if ( $echo ) {
 		echo $referer_field;

--- a/tests/phpunit/tests/functions/wpNonceField.php
+++ b/tests/phpunit/tests/functions/wpNonceField.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * Tests for the wp_nonce_field() function.
+ *
+ * @since 6.1.0
+ *
+ * @group functions.php
+ * @covers ::wp_nonce_field
+ */
+class Tests_Functions_wpNonceField extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_nonce_field() {
+
+		wp_nonce_field();
+		$this->expectOutputRegex( '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#' );
+	}
+
+	/**
+	 * @ticket 55578
+	 *
+	 * @dataProvider data_wp_nonce_field
+	 *
+	 * @param int|string $action Action name.
+	 * @param string     $name Nonce name.
+	 * @param bool       $referer Whether to set the referer field fior validation.
+	 * @param string     $expected_reg_exp The expected regular expression.
+	 */
+	public function test_wp_nonce_field_return( $action, $name, $referer, $expected_reg_exp ) {
+
+		$this->assertMatchesRegularExpression( $expected_reg_exp, wp_nonce_field( $action, $name, $referer, false ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_nonce_field() {
+
+		return array(
+			'default'     => array(
+				'action'           => - 1,
+				'name'             => '_wpnonce',
+				'referer'          => true,
+				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+			),
+			'nonce_name'  => array(
+				'action'           => - 1,
+				'name'             => 'nonce_name',
+				'referer'          => true,
+				'expected_reg_exp' => '#^<input type="hidden" id="nonce_name" name="nonce_name" value=".{10}" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+			),
+			'action_name' => array(
+				'action'           => 'action_name',
+				'name'             => '_wpnonce',
+				'referer'          => true,
+				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value="' . wp_create_nonce( 'action_name' ) . '" /><input type="hidden" name="_wp_http_referer" value="" />$#',
+			),
+			'no_referer'  => array(
+				'action'           => - 1,
+				'name'             => '_wpnonce',
+				'referer'          => false,
+				'expected_reg_exp' => '#^<input type="hidden" id="_wpnonce" name="_wpnonce" value=".{10}" />$#',
+			),
+			'& in name'   => array(
+				'action'           => - 1,
+				'name'             => 'a&b',
+				'referer'          => false,
+				'expected_reg_exp' => '#^<input type="hidden" id="a\&amp;b" name="a\&amp;b" value=".{10}" />$#',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/functions/wpNonceField.php
+++ b/tests/phpunit/tests/functions/wpNonceField.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the wp_nonce_field() function.
  *
- * @since 6.1.0
+ * @since WP-6.1.0
  *
  * @group functions.php
  * @covers ::wp_nonce_field
@@ -11,7 +11,7 @@
 class Tests_Functions_wpNonceField extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 55578
+	 * @see https://core.trac.wordpress.org/ticket/55578
 	 */
 	public function test_wp_nonce_field() {
 
@@ -20,7 +20,7 @@ class Tests_Functions_wpNonceField extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 55578
+	 * @see https://core.trac.wordpress.org/ticket/55578
 	 *
 	 * @dataProvider data_wp_nonce_field
 	 *

--- a/tests/phpunit/tests/functions/wpRefererField.php
+++ b/tests/phpunit/tests/functions/wpRefererField.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Tests for the wp_referer_field() function.
+ *
+ * @since 6.1.0
+ *
+ * @group functions.php
+ * @covers ::wp_referer_field
+ */
+class Tests_Functions_wpRefererField extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_referer_field() {
+
+		$_SERVER['REQUEST_URI'] = '/test/';
+		wp_referer_field();
+		$this->expectOutputString( '<input type="hidden" name="_wp_http_referer" value="/test/" />' );
+	}
+
+	/**
+	 * @ticket 55578
+	 */
+	public function test_wp_referer_field_return() {
+
+		$_SERVER['REQUEST_URI'] = '/test/';
+
+		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="/test/" />', wp_referer_field( false ) );
+	}
+}

--- a/tests/phpunit/tests/functions/wpRefererField.php
+++ b/tests/phpunit/tests/functions/wpRefererField.php
@@ -29,4 +29,50 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 
 		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="/test/" />', wp_referer_field( false ) );
 	}
+
+	/**
+	 * Tests that the echo argument is respected.
+	 *
+	 * @ticket 54106
+	 *
+	 * @dataProvider data_wp_referer_field_should_respect_echo_arg
+	 *
+	 * @param mixed $echo Whether to echo or return the referer field.
+	 */
+	public function test_wp_referer_field_should_respect_echo_arg( $echo ) {
+		$actual = $echo ? get_echo( 'wp_referer_field' ) : wp_referer_field( false );
+
+		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="" />', $actual );
+	}
+
+	/**
+	 * Data provider for test_wp_referer_field_should_respect_echo_arg().
+	 *
+	 * @return array
+	 */
+	public function data_wp_referer_field_should_respect_echo_arg() {
+		return array(
+			'true'         => array( true ),
+			'(int) 1'      => array( 1 ),
+			'(string) "1"' => array( '1' ),
+			'false'        => array( false ),
+			'null'         => array( null ),
+			'(int) 0'      => array( 0 ),
+			'(string) "0"' => array( '0' ),
+		);
+	}
+
+	/**
+	 * @ticket 54106
+	 */
+	public function test_wp_referer_field_with_referer() {
+		$old_request_uri        = $_SERVER['REQUEST_URI'];
+		$_SERVER['REQUEST_URI'] = 'edit.php?_wp_http_referer=edit.php';
+
+		$actual = wp_referer_field( false );
+
+		$_SERVER['REQUEST_URI'] = $old_request_uri;
+
+		$this->assertSame( '<input type="hidden" name="_wp_http_referer" value="edit.php" />', $actual );
+	}
 }

--- a/tests/phpunit/tests/functions/wpRefererField.php
+++ b/tests/phpunit/tests/functions/wpRefererField.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the wp_referer_field() function.
  *
- * @since 6.1.0
+ * @since WP-6.1.0
  *
  * @group functions.php
  * @covers ::wp_referer_field
@@ -11,7 +11,7 @@
 class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 55578
+	 * @see https://core.trac.wordpress.org/ticket/55578
 	 */
 	public function test_wp_referer_field() {
 
@@ -21,7 +21,7 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 55578
+	 * @see https://core.trac.wordpress.org/ticket/55578
 	 */
 	public function test_wp_referer_field_return() {
 
@@ -33,7 +33,7 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 	/**
 	 * Tests that the echo argument is respected.
 	 *
-	 * @ticket 54106
+	 * @see https://core.trac.wordpress.org/ticket/54106
 	 *
 	 * @dataProvider data_wp_referer_field_should_respect_echo_arg
 	 *
@@ -63,7 +63,7 @@ class Tests_Functions_wpRefererField extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 54106
+	 * @see https://core.trac.wordpress.org/ticket/54106
 	 */
 	public function test_wp_referer_field_with_referer() {
 		$old_request_uri        = $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
Remove instances of _wp_http_referer from GET forms in the admin.

This changeset removes all instances of _wp_http_referer variable from the URL when creating a hidden input for _wp_http_referer. It prevents the hidden field from having an additional version of _wp_http_referer each time the form is submitted.

Props msolution, justinahinon, pbearne, mikeschroder, mukesh27, audrasjb, Clorith, chaion07, robinwpdeveloper, hztyfoon, davidbaumwald, costdev, adamsilverstein.

## How has this been tested?
See: https://core.trac.wordpress.org/ticket/54106#comment:21 and https://core.trac.wordpress.org/ticket/54106#comment:22

## Types of changes
- [x] Bug fix