### PR TITLE
Bump `$wp_version` to 4.9.22 fixes #1149

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -40,7 +40,7 @@ $cp_version = '1.4.4+dev';
  *
  * @global string $wp_version
  */
-$wp_version = '4.9.20';
+$wp_version = '4.9.22';
 
 /**
  * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.


### PR DESCRIPTION
## Description
In src/wp-includes/version.php should be as in [WP 4.9 branch](https://github.com/WordPress/WordPress/blob/8564a4a082705b9984e3361b78259d840feafe91/wp-includes/version.php#L7):
$wp_version = '4.9.22';

## Types of changes
- Bug fix

