### PR TITLE
Enhancements to Renovate

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvmrc
 
       - name: Install NodeJS

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvmrc
 
       - name: Install NodeJS

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -64,7 +64,7 @@ jobs:
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvmrc
 
       - name: Install NodeJS

--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -46,7 +46,7 @@ npm install
 grunt build
 
 mv build/ build-branch/
-cp -var build-branch/ build-branch-unminified/
+cp -vaR build-branch/ build-branch-unminified/
 
 unminify_build_dir build-branch-unminified/
 
@@ -59,7 +59,7 @@ rm -rf node_modules/
 npm install
 grunt build
 
-cp -var build/ build-unminified/
+cp -vaR build/ build-unminified/
 
 unminify_build_dir build-unminified/
 

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,12 @@
 		"bot"
 	],
 	"commitMessagePrefix": "Renovate[bot]:",
+	"prBodyNotes": [
+		"---",
+		"### Pre-merge checks",
+		"- [ ] Make sure the GitHub Actions tests are passing.",
+		"- [ ] Run `bin/compare-build-branch.sh` locally against `develop` branch and confirm that this PR is not causing unexpected changes to the build.  Requirements to run this script: `grunt build` and `nvm`."
+	],
 	"ignoreDeps": [
 		"uglify-js"
 	]


### PR DESCRIPTION
## Description
This PR makes the build and compare bash script work on MacOS locally as well as Unix, it adds a section to the Renovate PR message about what tests need to be performed and also updates the Workflow actions to avoid the deprecated `set-output` command

## Motivation and context
Maintain unit testing and ease Renovate creation and testing

## How has this been tested?
- new NVMRC reading has been testing in a private repository and tests should work on this PR
- build script can be tested on unix and MacOS after merge but has been tests on MacOS locally.
- Renovate added section will need to await next Renovate PR creation

## Screenshots
N/A

## Types of changes
- Enhancement
