### PR TITLE
Fix for PHP8 error in "ClassicPress News" widget

### DIFF
--- a/src/wp-includes/class-wp-feed-cache.php
+++ b/src/wp-includes/class-wp-feed-cache.php
@@ -4,17 +4,13 @@
  *
  * @package ClassicPress
  * @subpackage Feed
-<<<<<<< HEAD
  * @since WP-4.7.0
-=======
- * @since 4.7.0
- * @deprecated 5.6.0
->>>>>>> e8e031d2dd (Feeds: Register transient feed cache handler using the recommended method for SimplePie 1.3 or later.)
+ * @deprecated WP-5.6.0
  */
 
 _deprecated_file(
 	basename( __FILE__ ),
-	'5.6.0',
+	'WP-5.6.0',
 	'',
 	__( 'This file is only loaded for backward compatibility with SimplePie 1.2.x. Please consider switching to a recent SimplePie version.' )
 );

--- a/src/wp-includes/class-wp-feed-cache.php
+++ b/src/wp-includes/class-wp-feed-cache.php
@@ -4,8 +4,20 @@
  *
  * @package ClassicPress
  * @subpackage Feed
+<<<<<<< HEAD
  * @since WP-4.7.0
+=======
+ * @since 4.7.0
+ * @deprecated 5.6.0
+>>>>>>> e8e031d2dd (Feeds: Register transient feed cache handler using the recommended method for SimplePie 1.3 or later.)
  */
+
+_deprecated_file(
+	basename( __FILE__ ),
+	'5.6.0',
+	'',
+	__( 'This file is only loaded for backward compatibility with SimplePie 1.2.x. Please consider switching to a recent SimplePie version.' )
+);
 
 /**
  * Core class used to implement a feed cache.

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -687,7 +687,6 @@ function fetch_feed( $url ) {
 		require_once ABSPATH . WPINC . '/class-simplepie.php';
 	}
 
-	require_once ABSPATH . WPINC . '/class-wp-feed-cache.php';
 	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';
@@ -699,7 +698,16 @@ function fetch_feed( $url ) {
 	// constructor sets it before we have a chance to set the sanitization class
 	$feed->sanitize = new WP_SimplePie_Sanitize_KSES();
 
+	// Register the cache handler using the recommended method for SimplePie 1.3 or later.
+	if ( method_exists( 'SimplePie_Cache', 'register' ) ) {
+		SimplePie_Cache::register( 'wp_transient', 'WP_Feed_Cache_Transient' );
+		$feed->set_cache_location( 'wp_transient' );
+	} else {
+		// Back-compat for SimplePie 1.2.x.
+		require_once ABSPATH . WPINC . '/class-wp-feed-cache.php';
 	$feed->set_cache_class( 'WP_Feed_Cache' );
+	}
+
 	$feed->set_file_class( 'WP_SimplePie_File' );
 
 	$feed->set_feed_url( $url );

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -705,7 +705,7 @@ function fetch_feed( $url ) {
 	} else {
 		// Back-compat for SimplePie 1.2.x.
 		require_once ABSPATH . WPINC . '/class-wp-feed-cache.php';
-	$feed->set_cache_class( 'WP_Feed_Cache' );
+		$feed->set_cache_class( 'WP_Feed_Cache' );
 	}
 
 	$feed->set_file_class( 'WP_SimplePie_File' );


### PR DESCRIPTION
## Description
Fixes #1164 
This PR backports an upstream fix for instantiation of SimplePie for the dashboard "ClassicPress News" widget that affects PHP8.

## Motivation and context
This PR fixes an issue identified in testing and continues the work towards PHP8 compatibility.

## How has this been tested?
Local testing before and after.

## Screenshots
### Before
<img width="648" alt="Screenshot 2022-11-11 at 18 29 18" src="https://user-images.githubusercontent.com/1280733/201406415-e64d0981-eaea-4341-8577-49c4463e09e6.png">

### After
<img width="644" alt="Screenshot 2022-11-11 at 18 18 38" src="https://user-images.githubusercontent.com/1280733/201406451-f9451ee2-932f-4e37-b711-0b056008b304.png">

## Types of changes
- Bug fix
