### PR TITLE
WP-r53886: Formatting: Add support for Enums in `is_serialized()`.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -414,12 +414,8 @@ function maybe_unserialize( $original ) {
  * If $data is not a string, then returned value will always be false.
  * Serialized data is always a string.
  *
-<<<<<<< HEAD
  * @since WP-2.0.5
-=======
- * @since 2.0.5
- * @since 6.1.0 Added Enum support.
->>>>>>> 38037ebb2c (Formatting: Add support for Enums in `is_serialized()`.)
+ * @since WP-6.1.0 Added Enum support.
  *
  * @param string $data   Value to check to see if was serialized.
  * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -411,10 +411,15 @@ function maybe_unserialize( $original ) {
 /**
  * Check value to find if it was serialized.
  *
- * If $data is not an string, then returned value will always be false.
+ * If $data is not a string, then returned value will always be false.
  * Serialized data is always a string.
  *
+<<<<<<< HEAD
  * @since WP-2.0.5
+=======
+ * @since 2.0.5
+ * @since 6.1.0 Added Enum support.
+>>>>>>> 38037ebb2c (Formatting: Add support for Enums in `is_serialized()`.)
  *
  * @param string $data   Value to check to see if was serialized.
  * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
@@ -468,6 +473,7 @@ function is_serialized( $data, $strict = true ) {
 			// or else fall through
 		case 'a':
 		case 'O':
+		case 'E':
 			return (bool) preg_match( "/^{$token}:[0-9]+:/s", $data );
 		case 'b':
 		case 'i':

--- a/tests/phpunit/tests/functions/isSerialized.php
+++ b/tests/phpunit/tests/functions/isSerialized.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Tests for `is_serialized()`.
+ *
+ * @ticket 53299
+ *
+ * @group functions.php
+ * @covers ::is_serialized
+ */
+class Tests_Functions_IsSerialized extends WP_UnitTestCase {
+
+	/**
+	 * Run tests on `is_serialized()`.
+	 *
+	 * @dataProvider data_is_serialized
+	 *
+	 * @param mixed $data     Data value to test.
+	 * @param bool  $expected Expected function result.
+	 */
+	public function test_is_serialized_string( $data, $expected ) {
+		$this->assertSame( $expected, is_serialized( $data ) );
+	}
+
+	/**
+	 * Data provider method for testing `is_serialized()`.
+	 *
+	 * @return array
+	 */
+	public function data_is_serialized() {
+		return array(
+			'an array'                             => array(
+				'data'     => array(),
+				'expected' => false,
+			),
+			'an object'                            => array(
+				'data'     => new stdClass(),
+				'expected' => false,
+			),
+			'a boolean false'                      => array(
+				'data'     => false,
+				'expected' => false,
+			),
+			'a boolean true'                       => array(
+				'data'     => true,
+				'expected' => false,
+			),
+			'an integer 0'                         => array(
+				'data'     => 0,
+				'expected' => false,
+			),
+			'an integer 1'                         => array(
+				'data'     => 1,
+				'expected' => false,
+			),
+			'a float 0.0'                          => array(
+				'data'     => 0.0,
+				'expected' => false,
+			),
+			'a float 1.0'                          => array(
+				'data'     => 1.0,
+				'expected' => false,
+			),
+			'string that is too short'             => array(
+				'data'     => 's:3',
+				'expected' => false,
+			),
+			'not a colon in second position'       => array(
+				'data'     => 's!3:"foo";',
+				'expected' => false,
+			),
+			'no trailing semicolon (strict check)' => array(
+				'data'     => 's:3:"foo"',
+				'expected' => false,
+			),
+			'valid serialized null'                => array(
+				'data'     => 'N;',
+				'expected' => true,
+			),
+			'valid serialized Enum'                => array(
+				'data'     => 'E:7:"Foo:bar";',
+				'expected' => true,
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Description
This changeset adds support for Enums in `is_serialized()`. It also adds new unit tests for this function.

WP:Props ayeshrajans, konradyoast, peterwilsoncc, costdev, dennisatyoast, mukesh27. Fixes https://core.trac.wordpress.org/ticket/53299.

Conflicts:
- src/wp-includes/functions.php

---

Merges https://core.trac.wordpress.org/changeset/53886 / WordPress/wordpress-develop@38037ebb2c to ClassicPress.

## Motivation and context
PHP compatibility and partially addresses #1098

## How has this been tested?
Backport, includes new unit testing.

## Screenshots
N/A

## Types of changes
- Enhancement
