### PR TITLE
Update importer API

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -62,15 +62,22 @@ $parent_file = 'tools.php';
 <?php if ( ! empty( $_GET['invalid'] ) ) : ?>
 	<div class="error">
 		<p><strong><?php _e( 'ERROR:' ); ?></strong>
-							 <?php
-								/* translators: %s: importer slug */
-								printf( __( 'The %s importer is invalid or is not installed.' ), '<strong>' . esc_html( $_GET['invalid'] ) . '</strong>' );
-								?>
+		<?php
+			/* translators: %s: importer slug */
+			printf( __( 'The %s importer is invalid or is not installed.' ), '<strong>' . esc_html( $_GET['invalid'] ) . '</strong>' );
+		?>
 		</p>
 	</div>
 <?php endif; ?>
 <p><?php _e( 'If you have posts or comments in another system, ClassicPress can import those into this site. To get started, choose a system to import from below:' ); ?></p>
-
+<p>
+<?php
+printf(
+	__( 'If you need a WordPress Importer, follow <a href="%s">these instructions</a> to install it manually.' ),
+	esc_url( 'https://docs.classicpress.net/user-guides/using-classicpress/tools-import-screen/' )
+);
+?>
+</p>
 <?php
 // Registered (already installed) importers. They're stored in the global $wp_importers.
 $importers = get_importers();

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -217,11 +217,5 @@ function wp_get_popular_importers() {
 			'plugin-slug' => 'tumblr-importer',
 			'importer-id' => 'tumblr',
 		),
-		'wordpress'   => array(
-			'name'        => 'ClassicPress',
-			'description' => __( 'Import posts, pages, comments, custom fields, categories, and tags from a ClassicPress export file.' ),
-			'plugin-slug' => 'wordpress-importer',
-			'importer-id' => 'wordpress',
-		),
 	);
 }

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -142,7 +142,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => $wp_version,
 			),
-			'https://api.wordpress.org/core/importers/1.1/'
+			'https://api-v1.classicpress.net/core/importers/1.0/'
 		);
 		$options = array( 'user-agent' => classicpress_user_agent() );
 


### PR DESCRIPTION
## Description
Replace the hard-coded API URL used for collecting a list of importer plugins.

## Motivation and context
Fixes #1168 however it should be noted that the Wordpress importer can no be installed due to the plugin declaring it is incompatible.
It also seems that the default list contained in the `` file is in use prior to this PR so maybe the WordPress API is failing.

## How has this been tested?
Local testing and viewing of database transient entry.

## Screenshots
### Before
<img width="751" alt="Screenshot 2022-11-17 at 11 55 01" src="https://user-images.githubusercontent.com/1280733/202442769-85ef845f-280c-42e9-9e6a-46a623eef855.png">

### After
<img width="752" alt="Screenshot 2022-11-17 at 11 55 11" src="https://user-images.githubusercontent.com/1280733/202442778-b83de25c-a3b0-4c3f-b7fe-20a4f4aa34f8.png">

## Types of changes
- New feature
