### PR TITLE
Make external tests less flaky

### DIFF
--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -52,7 +52,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 		$this->skipTestOnTimeout( $response );
 
-		$response_code = wp_remote_retrieve_response_code( $response )
+		$response_code = wp_remote_retrieve_response_code( $response );
 		$response_body = wp_remote_retrieve_body( $response );
 
 		if ( 200 !== $response_code ) {

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -52,15 +52,26 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 		$this->skipTestOnTimeout( $response );
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$this->fail( 'Could not contact dev.mysql.com to check versions.' );
-		}
+		$response_code = wp_remote_retrieve_response_code( $response )
+		$response_body = wp_remote_retrieve_body( $response );
 
-		$mysql = wp_remote_retrieve_body( $response );
+		if ( 200 !== $response_code ) {
+			$error_message = sprintf(
+				'Could not contact dev.MySQL.com to check versions. Response code: %s. Response body: %s',
+				$response_code,
+				$response_body
+			);
+
+			if ( 503 === $response_code ) {
+				$this->markTestSkipped( $error_message );
+			}
+
+			$this->fail( $error_message );
+		}
 
 		preg_match(
 			'#(\d{4}-\d{2}-\d{2}), General Availability#',
-			$mysql,
+			$response_body,
 			$mysqlmatches
 		);
 		$this->assertNotEmpty( $mysqlmatches );

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -410,9 +410,23 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * Test HTTP Redirects with multiple Location headers specified
 	 *
+<<<<<<< HEAD
 	 * @see https://core.trac.wordpress.org/ticket/16890
 	 */
 	function test_multiple_location_headers() {
+=======
+	 * This test has been disabled due to api.wordpress.org failing to
+	 * send two Location headers. See #57306.
+	 *
+	 * @ticket 16890
+	 *
+	 * @covers ::wp_remote_head
+	 * @covers ::wp_remote_retrieve_header
+	 * @covers ::wp_remote_get
+	 * @covers ::wp_remote_retrieve_body
+	 */
+	public function disabled_test_multiple_location_headers() {
+>>>>>>> 1b42990b0c (Tests: Temporarily disable a `WP_Http` test for multiple `Location` headers.)
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?multiple-location-headers=1';
 		$res = wp_remote_head( $url, array( 'timeout' => 30 ) );
 

--- a/tests/phpunit/tests/http/base.php
+++ b/tests/phpunit/tests/http/base.php
@@ -410,15 +410,10 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	/**
 	 * Test HTTP Redirects with multiple Location headers specified
 	 *
-<<<<<<< HEAD
-	 * @see https://core.trac.wordpress.org/ticket/16890
-	 */
-	function test_multiple_location_headers() {
-=======
 	 * This test has been disabled due to api.wordpress.org failing to
 	 * send two Location headers. See #57306.
 	 *
-	 * @ticket 16890
+	 * @see https://core.trac.wordpress.org/ticket/16890
 	 *
 	 * @covers ::wp_remote_head
 	 * @covers ::wp_remote_retrieve_header
@@ -426,7 +421,6 @@ abstract class WP_HTTP_UnitTestCase extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_body
 	 */
 	public function disabled_test_multiple_location_headers() {
->>>>>>> 1b42990b0c (Tests: Temporarily disable a `WP_Http` test for multiple `Location` headers.)
 		$url = 'http://api.wordpress.org/core/tests/1.0/redirection.php?multiple-location-headers=1';
 		$res = wp_remote_head( $url, array( 'timeout' => 30 ) );
 


### PR DESCRIPTION
## Description
The PHPUnit tests compare the readme to currently supported versions of PHP and MySQL.

This PR updates the test with improved redundancy when the remote servers fail to respond with the expected content.

## Motivation and context
For the PHP test we already clone the GitHub repository and use that rather than querying the php.net site repeatedly.
There is no option to do this for the MySQL site, but what this PR dose is introduce a skipped test on a 503 response from the server rather than failing the test. (When the server is unavailable).

This will help to reduce failed unit test runs seen when external sites are busy.

## How has this been tested?
It is a manual backport of an upstream fix.
Local testing done and automated tests will run on this PR.

## Screenshots
N/A

## Types of changes
- New feature
