### PR TITLE
Updated bug reporting link

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -891,9 +891,10 @@ class WP_Automatic_Updater {
 
 This debugging email is sent when you are using a development version of ClassicPress.
 
-If you think these failures might be due to a bug in ClassicPress, could you report it?
- * If you need general support: https://docs.classicpress.net/faq-support/
- * Or, if you're comfortable writing a bug report: https://docs.classicpress.net/testing-classicpress/#reporting-bugs
+If you think these failures might be due to a bug in ClassicPress, could you report it please?
+ * General support and questions: https://forums.classicpress.net/c/support/5
+ * Documentation and code reference: https://docs.classicpress.net/
+ * If you're comfortable filing a bug report: https://github.com/ClassicPress/ClassicPress/issues/new/choose
 
 Thanks! -- The ClassicPress Team"
 				)


### PR DESCRIPTION
This is related to [issue 32 in Documentation Tracker](https://github.com/ClassicPress/Documentation-Issue-Tracker/issues/32).

## Description
Changed URL to the correct bug reporting URL and updated wording to be more helpful.

## Motivation and context
An email sent when beta testing contained a broken bug reporting link. 

## How has this been tested?
I haven't tested this yet. I need help understanding how the email is triggered. There are no code changes, only text in the email body sent to the user.

## Types of changes
- Bug fix
