### PR TITLE
wp_image_src_get_dimensions() may throw warning or return wrong values

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1337,7 +1337,7 @@ function wp_calculate_image_sizes( $size, $image_src = null, $image_meta = null,
  * attachment post IDs that are in post_content for the exported website may not match
  * the same attachments at the new website.
  *
- * @since 5.5.0
+ * @since WP-5.5.0
  *
  * @param string $image_location  The full path or URI to the image file.
  * @param array  $image_meta      The attachment meta data as returned by 'wp_get_attachment_metadata()'.
@@ -1376,7 +1376,7 @@ function wp_image_file_matches_image_meta( $image_location, $image_meta ) {
 	/**
 	 * Filter whether an image path or URI matches image meta.
 	 *
-	 * @since 5.5.0
+	 * @since WP-5.5.0
 	 *
 	 * @param bool   $match          Whether the image relative path from the image meta
 	 *                               matches the end of the URI or path to the image file.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1412,14 +1412,14 @@ function wp_image_src_get_dimensions( $image_src, $image_meta ) {
 	if ( ! empty( $image_meta['sizes'] ) ) {
 		$src_filename = wp_basename( $image_src );
 
-	foreach ( $image_meta['sizes'] as $image_size_data ) {
+		foreach ( $image_meta['sizes'] as $image_size_data ) {
 			if ( $src_filename === $image_size_data['file'] ) {
-			return array(
-				(int) $image_size_data['width'],
-				(int) $image_size_data['height'],
-			);
+				return array(
+					(int) $image_size_data['width'],
+					(int) $image_size_data['height'],
+				);
+			}
 		}
-	}
 	}
 
 	return false;

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1354,9 +1354,7 @@ function wp_image_file_matches_image_meta( $image_location, $image_meta ) {
 		// Check if the relative image path from the image meta is at the end of $image_location.
 		if ( strrpos( $image_location, $image_meta['file'] ) === strlen( $image_location ) - strlen( $image_meta['file'] ) ) {
 			$match = true;
-		}
-
-		if ( ! empty( $image_meta['sizes'] ) ) {
+		} elseif ( ! empty( $image_meta['sizes'] ) ) {
 			// Retrieve the uploads sub-directory from the full size image.
 			$dirname = _wp_get_attachment_relative_path( $image_meta['file'] );
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1330,6 +1330,65 @@ function wp_calculate_image_sizes( $size, $image_src = null, $image_meta = null,
 }
 
 /**
+ * Determines if the image meta data is for the image source file.
+ *
+ * The image meta data is retrieved by attachment post ID. In some cases the post IDs may change.
+ * For example when the website is exported and imported at another website. Then the
+ * attachment post IDs that are in post_content for the exported website may not match
+ * the same attachments at the new website.
+ *
+ * @since 5.5.0
+ *
+ * @param string $image_location  The full path or URI to the image file.
+ * @param array  $image_meta      The attachment meta data as returned by 'wp_get_attachment_metadata()'.
+ * @return bool Whether the image meta is for this image file.
+ */
+function wp_image_file_matches_image_meta( $image_location, $image_meta ) {
+	$match = false;
+
+	// Ensure the $image_meta is valid.
+	if ( isset( $image_meta['file'] ) && strlen( $image_meta['file'] ) > 4 ) {
+		// Remove quiery args if image URI.
+		list( $image_location ) = explode( '?', $image_location );
+
+		// Check if the relative image path from the image meta is at the end of $image_location.
+		if ( strrpos( $image_location, $image_meta['file'] ) === strlen( $image_location ) - strlen( $image_meta['file'] ) ) {
+			$match = true;
+		}
+
+		if ( ! empty( $image_meta['sizes'] ) ) {
+			// Retrieve the uploads sub-directory from the full size image.
+			$dirname = _wp_get_attachment_relative_path( $image_meta['file'] );
+
+			if ( $dirname ) {
+				$dirname = trailingslashit( $dirname );
+			}
+
+			foreach ( $image_meta['sizes'] as $image_size_data ) {
+				$relative_path = $dirname . $image_size_data['file'];
+
+				if ( strrpos( $image_location, $relative_path ) === strlen( $image_location ) - strlen( $relative_path ) ) {
+					$match = true;
+					break;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Filter whether an image path or URI matches image meta.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param bool   $match          Whether the image relative path from the image meta
+	 *                               matches the end of the URI or path to the image file.
+	 * @param string $image_location Full path or URI to the tested image file.
+	 * @param array  $image_meta     The image meta data being tested.
+	 */
+	return apply_filters( 'wp_image_file_matches_image_meta', $match, $image_location, $image_meta );
+}
+
+/**
  * Determines an image's width and height dimensions based on the source file.
  *
  * @since WP-5.5.0
@@ -1340,22 +1399,29 @@ function wp_calculate_image_sizes( $size, $image_src = null, $image_meta = null,
  *                     or false if dimensions cannot be determined.
  */
 function wp_image_src_get_dimensions( $image_src, $image_meta ) {
-	$image_filename = wp_basename( $image_src );
+	if ( ! wp_image_file_matches_image_meta( $image_src, $image_meta ) ) {
+		return false;
+	}
 
-	if ( wp_basename( $image_meta['file'] ) === $image_filename ) {
+	// Is it a full size image?
+	if ( strpos( $image_src, $image_meta['file'] ) !== false ) {
 		return array(
 			(int) $image_meta['width'],
 			(int) $image_meta['height'],
 		);
 	}
 
+	if ( ! empty( $image_meta['sizes'] ) ) {
+		$src_filename = wp_basename( $image_src );
+
 	foreach ( $image_meta['sizes'] as $image_size_data ) {
-		if ( $image_filename === $image_size_data['file'] ) {
+			if ( $src_filename === $image_size_data['file'] ) {
 			return array(
 				(int) $image_size_data['width'],
 				(int) $image_size_data['height'],
 			);
 		}
+	}
 	}
 
 	return false;

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2702,8 +2702,8 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/44427
-	 * @https://core.trac.wordpress.org/ticket/50367
+	 * @see https://core.trac.wordpress.org/ticket/44427
+	 * @see https://core.trac.wordpress.org/ticket/50367
 	 */
 	function test_wp_img_tag_add_loading_attr_with_single_quotes() {
 		$img = "<img src='example.png' alt=' width='300' height='225' />";
@@ -2717,8 +2717,8 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/44427
-	 * @https://core.trac.wordpress.org/ticket/50425
+	 * @see https://core.trac.wordpress.org/ticket/44427
+	 * @see https://core.trac.wordpress.org/ticket/50425
 	 */
 	function test_wp_img_tag_add_loading_attr_opt_out() {
 		$img = '<img src="example.png" alt=" width="300" height="225" />';
@@ -2728,7 +2728,7 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/50425
+	 * @see https://core.trac.wordpress.org/ticket/50425
 	 */
 	function test_wp_iframe_tag_add_loading_attr() {
 		$iframe = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
@@ -2782,8 +2782,8 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/44427
-	 * @https://core.trac.wordpress.org/ticket/50425
+	 * @see https://core.trac.wordpress.org/ticket/44427
+	 * @see https://core.trac.wordpress.org/ticket/50425
 	 */
 	function test_wp_get_attachment_image_loading_opt_out() {
 		add_filter( 'wp_lazy_loading_enabled', '__return_false' );
@@ -2794,8 +2794,8 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/44427
-	 * @https://core.trac.wordpress.org/ticket/50425
+	 * @see https://core.trac.wordpress.org/ticket/44427
+	 * @see https://core.trac.wordpress.org/ticket/50425
 	 */
 	function test_wp_get_attachment_image_loading_opt_out_individual() {
 		// The default is already tested above, the filter below ensures that
@@ -2834,9 +2834,9 @@ EOF;
 	}
 
 	/**
-	 * @https://core.trac.wordpress.org/ticket/50425
-	 * @https://core.trac.wordpress.org/ticket/53463
-	 * @https://core.trac.wordpress.org/ticket/53675
+	 * @see https://core.trac.wordpress.org/ticket/50425
+	 * @see https://core.trac.wordpress.org/ticket/53463
+	 * @see https://core.trac.wordpress.org/ticket/53675
 	 * @dataProvider data_wp_lazy_loading_enabled_context_defaults
 	 *
 	 * @param string $context  Function context.
@@ -2863,178 +2863,7 @@ EOF;
 	}
 
 	/**
-<<<<<<< HEAD
-	 * @ticket 53675
-	 * @dataProvider data_wp_get_loading_attr_default
-	 *
-	 * @param string $context
-	 */
-	function test_wp_get_loading_attr_default( $context ) {
-		global $wp_query, $wp_the_query;
-
-		// Return 'lazy' by default.
-		$this->assertSame( 'lazy', wp_get_loading_attr_default( 'test' ) );
-		$this->assertSame( 'lazy', wp_get_loading_attr_default( 'wp_get_attachment_image' ) );
-
-		// Return 'lazy' if not in the loop or the main query.
-		$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
-
-		$wp_query = new WP_Query( array( 'post__in' => array( self::$post_ids['publish'] ) ) );
-		$this->reset_content_media_count();
-		$this->reset_omit_loading_attr_filter();
-
-		while ( have_posts() ) {
-			the_post();
-
-			// Return 'lazy' if in the loop but not in the main query.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
-
-			// Set as main query.
-			$wp_the_query = $wp_query;
-
-			// For contexts other than for the main content, still return 'lazy' even in the loop
-			// and in the main query, and do not increase the content media count.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( 'wp_get_attachment_image' ) );
-
-			// Return `false` if in the loop and in the main query and it is the first element.
-			$this->assertFalse( wp_get_loading_attr_default( $context ) );
-
-			// Return 'lazy' if in the loop and in the main query for any subsequent elements.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
-
-			// Yes, for all subsequent elements.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( $context ) );
-		}
-	}
-
-	function data_wp_get_loading_attr_default() {
-		return array(
-			array( 'the_content' ),
-			array( 'the_post_thumbnail' ),
-		);
-	}
-
-	/**
-	 * @ticket 53675
-	 */
-	function test_wp_omit_loading_attr_threshold_filter() {
-		global $wp_query, $wp_the_query;
-
-		$wp_query     = new WP_Query( array( 'post__in' => array( self::$post_ids['publish'] ) ) );
-		$wp_the_query = $wp_query;
-		$this->reset_content_media_count();
-		$this->reset_omit_loading_attr_filter();
-
-		// Use the filter to alter the threshold for not lazy-loading to the first three elements.
-		add_filter(
-			'wp_omit_loading_attr_threshold',
-			function() {
-				return 3;
-			}
-		);
-
-		while ( have_posts() ) {
-			the_post();
-
-			// Due to the filter, now the first three elements should not be lazy-loaded, i.e. return `false`.
-			for ( $i = 0; $i < 3; $i++ ) {
-				$this->assertFalse( wp_get_loading_attr_default( 'the_content' ) );
-			}
-
-			// For following elements, lazy-load them again.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( 'the_content' ) );
-		}
-	}
-
-	/**
-	 * @ticket 53675
-	 */
-	function test_wp_filter_content_tags_with_wp_get_loading_attr_default() {
-		global $wp_query, $wp_the_query;
-
-		$img1         = get_image_tag( self::$large_id, '', '', '', 'large' );
-		$iframe1      = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
-		$img2         = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$img3         = get_image_tag( self::$large_id, '', '', '', 'thumbnail' );
-		$iframe2      = '<iframe src="https://wordpress.org" width="640" height="360"></iframe>';
-		$lazy_img2    = wp_img_tag_add_loading_attr( $img2, 'the_content' );
-		$lazy_img3    = wp_img_tag_add_loading_attr( $img3, 'the_content' );
-		$lazy_iframe2 = wp_iframe_tag_add_loading_attr( $iframe2, 'the_content' );
-
-		// Use a threshold of 2.
-		add_filter(
-			'wp_omit_loading_attr_threshold',
-			function() {
-				return 2;
-			}
-		);
-
-		// Following the threshold of 2, the first two content media elements should not be lazy-loaded.
-		$content_unfiltered = $img1 . $iframe1 . $img2 . $img3 . $iframe2;
-		$content_expected   = $img1 . $iframe1 . $lazy_img2 . $lazy_img3 . $lazy_iframe2;
-
-		$wp_query     = new WP_Query( array( 'post__in' => array( self::$post_ids['publish'] ) ) );
-		$wp_the_query = $wp_query;
-		$this->reset_content_media_count();
-		$this->reset_omit_loading_attr_filter();
-
-		while ( have_posts() ) {
-			the_post();
-
-			add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
-			$content_filtered = wp_filter_content_tags( $content_unfiltered, 'the_content' );
-			remove_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
-		}
-
-		// After filtering, the first image should not be lazy-loaded while the other ones should be.
-		$this->assertSame( $content_expected, $content_filtered );
-	}
-
-	/**
-	 * @ticket 53675
-	 */
-	public function test_wp_omit_loading_attr_threshold() {
-		$this->reset_omit_loading_attr_filter();
-
-		// Apply filter, ensure default value of 1.
-		$omit_threshold = wp_omit_loading_attr_threshold();
-		$this->assertSame( 1, $omit_threshold );
-
-		// Add a filter that changes the value to 3. However, the filter is not applied a subsequent time in a single
-		// page load by default, so the value is still 1.
-		add_filter(
-			'wp_omit_loading_attr_threshold',
-			function() {
-				return 3;
-			}
-		);
-		$omit_threshold = wp_omit_loading_attr_threshold();
-		$this->assertSame( 1, $omit_threshold );
-
-		// Only by enforcing a fresh check, the filter gets re-applied.
-		$omit_threshold = wp_omit_loading_attr_threshold( true );
-		$this->assertSame( 3, $omit_threshold );
-	}
-
-	private function reset_content_media_count() {
-		// Get current value without increasing.
-		$content_media_count = wp_increase_content_media_count( 0 );
-
-		// Decrease it by its current value to "reset" it back to 0.
-		wp_increase_content_media_count( - $content_media_count );
-	}
-
-	private function reset_omit_loading_attr_filter() {
-		// Add filter to "reset" omit threshold back to null (unset).
-		add_filter( 'wp_omit_loading_attr_threshold', '__return_null', 100 );
-
-		// Force filter application to re-run.
-		wp_omit_loading_attr_threshold( true );
-
-		// Clean up the above filter.
-		remove_filter( 'wp_omit_loading_attr_threshold', '__return_null', 100 );
-=======
-	 * @ticket 50543
+	 * @see https://core.trac.wordpress.org/ticket/50543
 	 */
 	function test_wp_image_file_matches_image_meta() {
 		$image_meta       = wp_get_attachment_metadata( self::$large_id );
@@ -3046,7 +2875,7 @@ EOF;
 	}
 
 	/**
-	 * @ticket 50543
+	 * @see https://core.trac.wordpress.org/ticket/50543
 	 */
 	function test_wp_image_file_matches_image_meta_no_subsizes() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
@@ -3057,7 +2886,7 @@ EOF;
 	}
 
 	/**
-	 * @ticket 50543
+	 * @see https://core.trac.wordpress.org/ticket/50543
 	 */
 	function test_wp_image_file_matches_image_meta_invalid_meta() {
 		$image_meta = ''; // Attachment is not an image.
@@ -3067,14 +2896,13 @@ EOF;
 	}
 
 	/**
-	 * @ticket 50543
+	 * @see https://core.trac.wordpress.org/ticket/50543
 	 */
 	function test_wp_image_file_matches_image_meta_different_meta() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
 		$image_src  = $this->img_url; // Different image.
 
 		$this->assertFalse( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
->>>>>>> 27ccafd0e9 (Media:)
 	}
 }
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2863,6 +2863,7 @@ EOF;
 	}
 
 	/**
+<<<<<<< HEAD
 	 * @ticket 53675
 	 * @dataProvider data_wp_get_loading_attr_default
 	 *
@@ -3032,6 +3033,48 @@ EOF;
 
 		// Clean up the above filter.
 		remove_filter( 'wp_omit_loading_attr_threshold', '__return_null', 100 );
+=======
+	 * @ticket 50543
+	 */
+	function test_wp_image_file_matches_image_meta() {
+		$image_meta       = wp_get_attachment_metadata( self::$large_id );
+		$image_src_full   = wp_get_attachment_image_url( self::$large_id, 'full' );
+		$image_src_medium = wp_get_attachment_image_url( self::$large_id, 'medium' );
+
+		$this->assertTrue( wp_image_file_matches_image_meta( $image_src_full, $image_meta ) );
+		$this->assertTrue( wp_image_file_matches_image_meta( $image_src_medium, $image_meta ) );
+	}
+
+	/**
+	 * @ticket 50543
+	 */
+	function test_wp_image_file_matches_image_meta_no_subsizes() {
+		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$image_src  = wp_get_attachment_image_url( self::$large_id, 'full' );
+		$image_meta['sizes'] = array();
+
+		$this->assertTrue( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
+	}
+
+	/**
+	 * @ticket 50543
+	 */
+	function test_wp_image_file_matches_image_meta_invalid_meta() {
+		$image_meta = ''; // Attachment is not an image.
+		$image_src  = $this->img_url;
+
+		$this->assertFalse( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
+	}
+
+	/**
+	 * @ticket 50543
+	 */
+	function test_wp_image_file_matches_image_meta_different_meta() {
+		$image_meta = wp_get_attachment_metadata( self::$large_id );
+		$image_src  = $this->img_url; // Different image.
+
+		$this->assertFalse( wp_image_file_matches_image_meta( $image_src, $image_meta ) );
+>>>>>>> 27ccafd0e9 (Media:)
 	}
 }
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -2880,6 +2880,7 @@ EOF;
 	function test_wp_image_file_matches_image_meta_no_subsizes() {
 		$image_meta = wp_get_attachment_metadata( self::$large_id );
 		$image_src  = wp_get_attachment_image_url( self::$large_id, 'full' );
+
 		$image_meta['sizes'] = array();
 
 		$this->assertTrue( wp_image_file_matches_image_meta( $image_src, $image_meta ) );


### PR DESCRIPTION
## Description
This ia a backport if an upstream ticket found that addresses an edge case I have seen locally about image sizez:
https://core.trac.wordpress.org/ticket/50543

There are 2 more subsequent tickets that impact on this function:
https://core.trac.wordpress.org/ticket/50722
https://core.trac.wordpress.org/ticket/51865

But so far it seems that they are not required.

## Motivation and context
This appears to be a edge case bug that may affect end users on the releast of ClassicPress 1.5.0

## How has this been tested?
Local testing shows this backport of the upstream change fixes the issue observed, screenshots attached.
Unit tests are also included in the PR.

## Screenshots
### Before
<img width="581" alt="Screenshot 2022-11-29 at 14 31 41" src="https://user-images.githubusercontent.com/1280733/204562069-71ea7834-4a94-4f39-872e-29468ea06f36.png">

### After
<img width="569" alt="Screenshot 2022-11-29 at 14 32 02" src="https://user-images.githubusercontent.com/1280733/204562086-4a7f2610-20c8-4720-8570-ff03b55a16da.png">

## Types of changes
- Bug fix