### PR TITLE
change cp_attributes to account for the space (or not) at the beginning

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4385,12 +4385,12 @@ function cp_attributes( $element, $attrs = array(), $context = '' ) {
 				$out .= sanitize_key( $attr ) . '="' . $value . '" ';
 			}
 		} else {
-			$value = ( 'href' === $attr || 'src' === $attr ) ?
+			$value = ( 'href' === $attr || 'src' === $attr || 'action' === $attr ) ?
 				esc_url( $value ) : esc_attr( $value );
 			$out .= sanitize_key( $attr ) . '="' . $value . '" ';
 		}
 	}
-	return trim( $out );
+	return empty( $out ) ? $out : ' ' . trim( $out );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1474,11 +1474,11 @@ function do_html5_header() {
 		return;
 	}
 	echo "<!DOCTYPE html>\n"; ?>
-<html <?php echo cp_attributes( 'html', get_language_attributes() ); ?>>
-	<head <?php echo cp_attributes( 'head' ); ?>>
+<html<?php echo cp_attributes( 'html', get_language_attributes() ); ?>>
+	<head<?php echo cp_attributes( 'head' ); ?>>
 		<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<?php
-	echo '<meta ' . cp_attributes(
+	echo '<meta' . cp_attributes(
 		'meta',
 		array(
 			'name' => 'viewport',
@@ -1487,7 +1487,7 @@ function do_html5_header() {
 	) . ">\n";
 
 	if ( is_singular() && pings_open() ) {
-		echo '<link ' . cp_attributes(
+		echo '<link' . cp_attributes(
 			'link',
 			array(
 				'rel' => 'pingback',
@@ -1499,7 +1499,7 @@ function do_html5_header() {
 	?>
 	</head>
 
-	<body <?php echo cp_attributes( 'body', array( 'class' => get_body_class() ) ); ?>>
+	<body<?php echo cp_attributes( 'body', array( 'class' => get_body_class() ) ); ?>>
 	<?php
 	wp_body_open();
 }

--- a/tests/phpunit/tests/formatting/cpAttributes.php
+++ b/tests/phpunit/tests/formatting/cpAttributes.php
@@ -8,14 +8,14 @@
 class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 
 	function test_attributes_removes_quotes_in_string() {
-		$this->assertSame( 'role="main"', cp_attributes( 'body', 'role="main"' ) );
-		$this->assertSame( 'role="main"', cp_attributes( 'div', "role='main'" ) );
-		$this->assertSame( 'role="main" class="test"', cp_attributes( 'div', 'role="main" class="test"' ) );
-		$this->assertSame( 'id="main" class="test"', cp_attributes( 'div', "id='main' class='test'" ) );
-		$this->assertSame( 'title="O&#039;toole"', cp_attributes( 'img', 'title="O\'toole"' ) );
-		$this->assertSame( 'title="O&#039;toole"', cp_attributes( 'img', "title='O'toole'" ) );
-		$this->assertSame( 'role="main" class="test"', cp_attributes( 'main', 'role=\'main\' class="test"' ) );
-		$this->assertSame( 'id="main" class="site-main" role="main"', cp_attributes( 'main', 'id=main&class=site-main&role="main"' ) );
+		$this->assertSame( ' role="main"', cp_attributes( 'body', 'role="main"' ) );
+		$this->assertSame( ' role="main"', cp_attributes( 'div', "role='main'" ) );
+		$this->assertSame( ' role="main" class="test"', cp_attributes( 'div', 'role="main" class="test"' ) );
+		$this->assertSame( ' id="main" class="test"', cp_attributes( 'div', "id='main' class='test'" ) );
+		$this->assertSame( ' title="O&#039;toole"', cp_attributes( 'img', 'title="O\'toole"' ) );
+		$this->assertSame( ' title="O&#039;toole"', cp_attributes( 'img', "title='O'toole'" ) );
+		$this->assertSame( ' role="main" class="test"', cp_attributes( 'main', 'role=\'main\' class="test"' ) );
+		$this->assertSame( ' id="main" class="site-main" role="main"', cp_attributes( 'main', 'id=main&class=site-main&role="main"' ) );
 	}
 
 	function test_attributes_empty() {
@@ -24,8 +24,8 @@ class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 	}
 
 	function test_attributes_empty_value() {
-		$this->assertSame( 'disabled=""', cp_attributes( 'input', array( 'disabled' => '' ) ) );
-		$this->assertSame( 'disabled=""', cp_attributes( 'input', 'disabled' ) );
+		$this->assertSame( ' disabled=""', cp_attributes( 'input', array( 'disabled' => '' ) ) );
+		$this->assertSame( ' disabled=""', cp_attributes( 'input', 'disabled' ) );
 	}
 
 	// This is used as a filter to verify the context.
@@ -36,14 +36,14 @@ class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 
 	function test_attributes_empty_context_finds_caller_name() {
 		add_filter( 'cp_attributes', array( $this, 'context_getter' ), 10, 3 );
-		$this->assertSame( 'context="passed context"', cp_attributes( 'p', '', 'passed context' ) );
-		$this->assertSame( 'context="test_attributes_empty_context_finds_caller_name"', cp_attributes( 'p', '' ) );
+		$this->assertSame( ' context="passed context"', cp_attributes( 'p', '', 'passed context' ) );
+		$this->assertSame( ' context="test_attributes_empty_context_finds_caller_name"', cp_attributes( 'p', '' ) );
 		remove_filter( 'cp_attributes', array( $this, 'context_getter' ), 10 );
 	}
 
 	function test_attributes_escape_src_url() {
 		$this->assertSame(
-			'id="main" src="http://example.org/one?z=5&#038;x=3" data-s="example.org/one?z=5&amp;x=3"',
+			' id="main" src="http://example.org/one?z=5&#038;x=3" data-s="example.org/one?z=5&amp;x=3"',
 			cp_attributes(
 				'iframe',
 				array(
@@ -57,7 +57,7 @@ class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 
 	function test_attributes_escape_href_url() {
 		$this->assertSame(
-			'title="0.25&quot; in height" href="http://example.org/one?z=5&#038;x=3" data-h="example.org/one?x=5&amp;y=3"',
+			' title="0.25&quot; in height" href="http://example.org/one?z=5&#038;x=3" data-h="example.org/one?x=5&amp;y=3"',
 			cp_attributes(
 				'a',
 				array(
@@ -71,7 +71,7 @@ class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 
 	function test_attributes_remove_duplicate() {
 		$this->assertSame(
-			'font="latin latin2" class="one two"',
+			' font="latin latin2" class="one two"',
 			cp_attributes(
 				'section',
 				array(
@@ -84,7 +84,7 @@ class Tests_Formatting_CpAttributes extends WP_UnitTestCase {
 
 	function test_attributes_escape_special_characters() {
 		$this->assertSame(
-			'title="2 &lt; 3" data="John &amp; Sons"',
+			' title="2 &lt; 3" data="John &amp; Sons"',
 			cp_attributes(
 				'nav',
 				array(


### PR DESCRIPTION
## Description
To account for easy output of a HTML tag with no attributes, the `cp_attributes` function should handle the leading space. This PR changes the function to handle the space (and URL escaping for action attributes). Spaces are removed from the HTML surrounding the calls to `cp_attributes`, including in tests.

## Motivation and context
When using the new `cp_attributes` function, cases of plain tags, like `<li>`, failed unit tests with `<li >`. This should be handled correctly by the function, from the outset.

## How has this been tested?
unit tests, local theme calls to the function
