### PR TITLE
add missing end tags for the Go to site link and paragraph

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -225,7 +225,7 @@ function login_footer( $input_id = '' ) {
 
 		/* translators: %s: Site title. */
 		printf( _x( '&larr; Go to %s', 'site' ), get_bloginfo( 'title', 'display' ) );
-
+		echo '</a></p>';
 	}
 	?>
 


### PR DESCRIPTION
Two HTML tags are missing their closing tags.
Reported in forum: https://forums.classicpress.net/t/reporting-a-cosmetic-bug-in-the-login-module/4438

