### PR TITLE
Hide console notices & logging in Theme Installer

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3331,7 +3331,7 @@ function wp_ajax_query_themes() {
 		$theme->num_ratings    = number_format_i18n( $theme->num_ratings );
 		$theme->preview_url    = set_url_scheme( $theme->preview_url );
 		$theme->compatible_wp  = is_wp_version_compatible( $theme->requires );
-		$theme->compatible_php = is_php_version_compatible( $theme->requires_php );
+		// $theme->compatible_php = is_php_version_compatible( $theme->requires_php );
 	}
 
 	wp_send_json_success( $api );

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -256,7 +256,6 @@ if ( $tab ) {
 		<h3 class="theme-name">{{ data.name }}</h3>
 
 		<div class="theme-actions">
-			<# console.log( data ); #>
 			<# if ( data.installed ) { #>
 				<# if ( data.compatible_wp && data.compatible_php ) { #>
 					<?php


### PR DESCRIPTION
## Description
As discussed on Slack on 15 December 2022, PHP notices were being logged to the console with Query Monitor plugin installed when trying to install a new Theme.

## Motivation and context
This warning should not be happening. On looking more into this it was noted that the ClassicPress code is using http://api.wordpress.org/themes/info/1.0/ endpoint and that endpoint doesn’t return the necessary data in the `requires` fields, upstream is using 1.2 now but we can’t just swap over as the return is now a JSON object rather than serialised PHP.

Also noted during this investigation, theme data is logged to the console, that comes from code added in PR #621

## How has this been tested?
Locally testing shows console is now clean.

## Screenshots
### Before
<img width="1481" alt="Screenshot 2022-12-15 at 19 00 15" src="https://user-images.githubusercontent.com/1280733/207944964-4ef91bcd-1565-40c7-85f9-02a5701ccfc9.png">

### After
<img width="1477" alt="Screenshot 2022-12-15 at 18 59 54" src="https://user-images.githubusercontent.com/1280733/207944996-47102aab-fda8-46cb-be83-95b8b3c7c82c.png">


## Types of changes
- Bug fix
