### PR TITLE
WP-r42632: Themes: Use api v. 1.2 to query theme information.

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3317,7 +3317,7 @@ function wp_ajax_query_themes() {
 		}
 
 		$theme->name           = wp_kses( $theme->name, $themes_allowedtags );
-		$theme->author         = wp_kses( $theme->author, $themes_allowedtags );
+		$theme->author      = wp_kses( $theme->author['display_name'], $themes_allowedtags );
 		$theme->version        = wp_kses( $theme->version, $themes_allowedtags );
 		$theme->description    = wp_kses( $theme->description, $themes_allowedtags );
 		$theme->stars          = wp_star_rating(

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -106,7 +106,7 @@ class Theme_Upgrader extends WP_Upgrader {
 				$this->strings['process_failed']     = __( 'Theme downgrade failed.' );
 				$this->strings['process_success']    = __( 'Theme downgraded successfully.' );
 			}
-	}
+		}
 	}
 
 	/**

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -95,17 +95,17 @@ class Theme_Upgrader extends WP_Upgrader {
 		$this->strings['current_theme_has_errors'] = __( 'The current theme has the following error: "%s".' );
 
 		if ( ! empty( $this->skin->overwrite ) ) {
-		if ( 'update-theme' === $this->skin->overwrite ) {
-			$this->strings['installing_package'] = __( 'Updating the theme&#8230;' );
-			$this->strings['process_failed']     = __( 'Theme update failed.' );
-			$this->strings['process_success']    = __( 'Theme updated successfully.' );
-		}
+			if ( 'update-theme' === $this->skin->overwrite ) {
+				$this->strings['installing_package'] = __( 'Updating the theme&#8230;' );
+				$this->strings['process_failed']     = __( 'Theme update failed.' );
+				$this->strings['process_success']    = __( 'Theme updated successfully.' );
+			}
 
-		if ( 'downgrade-theme' === $this->skin->overwrite ) {
-			$this->strings['installing_package'] = __( 'Downgrading the theme&#8230;' );
-			$this->strings['process_failed']     = __( 'Theme downgrade failed.' );
-			$this->strings['process_success']    = __( 'Theme downgraded successfully.' );
-		}
+			if ( 'downgrade-theme' === $this->skin->overwrite ) {
+				$this->strings['installing_package'] = __( 'Downgrading the theme&#8230;' );
+				$this->strings['process_failed']     = __( 'Theme downgrade failed.' );
+				$this->strings['process_success']    = __( 'Theme downgraded successfully.' );
+			}
 	}
 	}
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -94,6 +94,7 @@ class Theme_Upgrader extends WP_Upgrader {
 		/* translators: %s: Theme error. */
 		$this->strings['current_theme_has_errors'] = __( 'The current theme has the following error: "%s".' );
 
+		if ( ! empty( $this->skin->overwrite ) ) {
 		if ( 'update-theme' === $this->skin->overwrite ) {
 			$this->strings['installing_package'] = __( 'Updating the theme&#8230;' );
 			$this->strings['process_failed']     = __( 'Theme update failed.' );
@@ -105,6 +106,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			$this->strings['process_failed']     = __( 'Theme downgrade failed.' );
 			$this->strings['process_success']    = __( 'Theme downgraded successfully.' );
 		}
+	}
 	}
 
 	/**

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -431,9 +431,9 @@ function themes_api( $action, $args = array() ) {
 	}
 
 	if ( 'query_themes' == $action ) {
-	if ( ! isset( $args->per_page ) ) {
-		$args->per_page = 24;
-	}
+		if ( ! isset( $args->per_page ) ) {
+			$args->per_page = 24;
+		}
 	}
 
 	if ( ! isset( $args->locale ) ) {

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -423,17 +423,25 @@ function get_theme_feature_list( $api = true ) {
  *         for more information on the make-up of possible return objects depending on the value of `$action`.
  */
 function themes_api( $action, $args = array() ) {
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
 
 	if ( is_array( $args ) ) {
 		$args = (object) $args;
 	}
 
+	if ( 'query_themes' == $action ) {
 	if ( ! isset( $args->per_page ) ) {
 		$args->per_page = 24;
+	}
 	}
 
 	if ( ! isset( $args->locale ) ) {
 		$args->locale = get_user_locale();
+	}
+
+	if ( ! isset( $args->wp_version ) ) {
+		$args->wp_version = substr( $wp_version, 0, 3 ); // X.y
 	}
 
 	/**
@@ -467,6 +475,7 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
+<<<<<<< HEAD
 		// include an unmodified $wp_version
 		include ABSPATH . WPINC . '/version.php';
 
@@ -478,8 +487,26 @@ function themes_api( $action, $args = array() ) {
 				'action'  => $action,
 				'request' => serialize( $args ),
 			),
+=======
+		$url = 'http://api.wordpress.org/themes/info/1.2/';
+		$url = add_query_arg(
+			array(
+				'action'  => $action,
+				'request' => $args,
+			),
+			$url
 		);
-		$request   = wp_remote_post( $url, $http_args );
+
+		$http_url = $url;
+		if ( $ssl = wp_http_supports( array( 'ssl' ) ) ) {
+			$url = set_url_scheme( $url, 'https' );
+		}
+
+		$http_args = array(
+			'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),
+>>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
+		);
+		$request   = wp_remote_get( $url, $http_args );
 
 		if ( is_wp_error( $request ) ) {
 			if ( ! wp_doing_ajax() ) {
@@ -492,9 +519,13 @@ function themes_api( $action, $args = array() ) {
 					headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 				);
 			}
+<<<<<<< HEAD
 
 			// Retry request
 			$request = wp_remote_post( $url, $http_args );
+=======
+			$request = wp_remote_get( $http_url, $http_args );
+>>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
 		}
 
 		if ( is_wp_error( $request ) ) {
@@ -508,8 +539,11 @@ function themes_api( $action, $args = array() ) {
 				$request->get_error_message()
 			);
 		} else {
-			$res = maybe_unserialize( wp_remote_retrieve_body( $request ) );
-			if ( ! is_object( $res ) && ! is_array( $res ) ) {
+			$res = json_decode( wp_remote_retrieve_body( $request ), true );
+			if ( is_array( $res ) ) {
+				// Object casting is required in order to match the info/1.0 format.
+				$res = (object) $res;
+			} elseif ( null === $res ) {
 				$res = new WP_Error(
 					'themes_api_failed',
 					sprintf(
@@ -520,6 +554,21 @@ function themes_api( $action, $args = array() ) {
 					wp_remote_retrieve_body( $request )
 				);
 			}
+
+			if ( isset( $res->error ) ) {
+				$res = new WP_Error( 'themes_api_failed', $res->error );
+			}
+		}
+
+		// Back-compat for info/1.2 API, upgrade the theme objects in query_themes to objects.
+		if ( 'query_themes' == $action ) {
+			foreach ( $res->themes as $i => $theme ) {
+				$res->themes[ $i ] = (object) $theme;
+			}
+		}
+		// Back-compat for info/1.2 API, downgrade the feature_list result back to an array.
+		if ( 'feature_list' == $action ) {
+			$res = (array) $res;
 		}
 	}
 

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -475,19 +475,6 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
-<<<<<<< HEAD
-		// include an unmodified $wp_version
-		include ABSPATH . WPINC . '/version.php';
-
-		$url = 'https://api.wordpress.org/themes/info/1.0/';
-
-		$http_args = array(
-			'user-agent' => classicpress_user_agent(),
-			'body'       => array(
-				'action'  => $action,
-				'request' => serialize( $args ),
-			),
-=======
 		$url = 'http://api.wordpress.org/themes/info/1.2/';
 		$url = add_query_arg(
 			array(
@@ -504,7 +491,6 @@ function themes_api( $action, $args = array() ) {
 
 		$http_args = array(
 			'user-agent' => 'WordPress/' . $wp_version . '; ' . home_url( '/' ),
->>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
 		);
 		$request   = wp_remote_get( $url, $http_args );
 
@@ -519,13 +505,7 @@ function themes_api( $action, $args = array() ) {
 					headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 				);
 			}
-<<<<<<< HEAD
-
-			// Retry request
-			$request = wp_remote_post( $url, $http_args );
-=======
 			$request = wp_remote_get( $http_url, $http_args );
->>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
 		}
 
 		if ( is_wp_error( $request ) ) {

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -334,18 +334,7 @@ themes.Collection = Backbone.Collection.extend({
 			data: {
 			// Request data
 				request: _.extend({
-					per_page: 100,
-					fields: {
-						description: true,
-						tested: true,
-						requires: true,
-						rating: true,
-						downloaded: true,
-						downloadLink: true,
-						last_updated: true,
-						homepage: true,
-						num_ratings: true
-					}
+					per_page: 100
 				}, request)
 			},
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -256,7 +256,6 @@ if ( $tab ) {
 		<h3 class="theme-name">{{ data.name }}</h3>
 
 		<div class="theme-actions">
-			<# console.log( data ); #>
 			<# if ( data.installed ) { #>
 				<# if ( data.compatible_wp && data.compatible_php ) { #>
 					<?php

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5820,13 +5820,9 @@ final class WP_Customize_Manager {
 				// Map available theme properties to installed theme properties.
 				$theme->id            = $theme->slug;
 				$theme->screenshot    = array( $theme->screenshot_url );
-<<<<<<< HEAD
-				$theme->authorAndUri  = $theme->author;
+				$theme->authorAndUri  = wp_kses( $theme->author['display_name'], $themes_allowedtags );
 				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
-=======
-				$theme->authorAndUri = wp_kses( $theme->author['display_name'], $themes_allowedtags );
->>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
 
 				if ( isset( $theme->parent ) ) {
 					$theme->parent = $theme->parent['slug'];

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5751,19 +5751,6 @@ final class WP_Customize_Manager {
 			// Arguments for all queries.
 			$wporg_args = array(
 				'per_page' => 100,
-				'fields'   => array(
-					'screenshot_url' => true,
-					'description'    => true,
-					'rating'         => true,
-					'downloaded'     => true,
-					'downloadlink'   => true,
-					'last_updated'   => true,
-					'homepage'       => true,
-					'num_ratings'    => true,
-					'tags'           => true,
-					'parent'         => true,
-					// 'extended_author' => true, @todo: WordPress.org throws a 500 server error when this is here.
-				),
 			);
 
 			$args = array_merge( $wporg_args, $args );
@@ -5807,10 +5794,8 @@ final class WP_Customize_Manager {
 				);
 
 				$theme->name        = wp_kses( $theme->name, $themes_allowedtags );
-				$theme->author      = wp_kses( $theme->author, $themes_allowedtags );
 				$theme->version     = wp_kses( $theme->version, $themes_allowedtags );
 				$theme->description = wp_kses( $theme->description, $themes_allowedtags );
-				$theme->tags        = implode( ', ', $theme->tags );
 				$theme->stars       = wp_star_rating(
 					array(
 						'rating' => $theme->rating,
@@ -5835,9 +5820,13 @@ final class WP_Customize_Manager {
 				// Map available theme properties to installed theme properties.
 				$theme->id            = $theme->slug;
 				$theme->screenshot    = array( $theme->screenshot_url );
+<<<<<<< HEAD
 				$theme->authorAndUri  = $theme->author;
 				$theme->compatibleWP  = is_wp_version_compatible( $theme->requires ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
 				$theme->compatiblePHP = is_php_version_compatible( $theme->requires_php ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+=======
+				$theme->authorAndUri = wp_kses( $theme->author['display_name'], $themes_allowedtags );
+>>>>>>> 212c880d71 (Themes: Use `api.wordpress.org/themes/info/1.2/` to query theme information.)
 
 				if ( isset( $theme->parent ) ) {
 					$theme->parent = $theme->parent['slug'];


### PR DESCRIPTION
WP-r42632: Themes: Use api.wordpress.org/themes/info/1.2/ to query theme information.
See https://core.trac.wordpress.org/ticket/43192.

Also Hide console logging in Theme Installer.

To fix a warning that came out testing this backport added to PR:
WP-r48493: Upgrade/Install: Check if the theme installer skin's `overwrite` property exists in `Theme_Upgrader::install_strings()`.
This ensures consistency with `Plugin_Upgrader::install_strings()` and resolves an issue caused by the property not existing in other upgrader implementations.
