### PR TITLE
Add support for Require CP header in plugins

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -85,6 +85,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		'DomainPath'  => 'Domain Path',
 		'Network'     => 'Network',
 		'RequiresWP'  => 'Requires at least',
+		'RequiresCP'  => 'Requires CP',
 		'RequiresPHP' => 'Requires PHP',
 		'UpdateURI'   => 'Update URI',
 		// Site Wide Only is deprecated in favor of Network.


### PR DESCRIPTION
`get_plugin_data()` and so `get_plugins()` don't return the `Requires CP` header value.

This is very useful for directory integration. This is a small change so can be included in version 1.5.0.
