### PR TITLE
Avoid call to non-existent `is_taxonomy_viewable()` function

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -728,7 +728,7 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 			);
 		} elseif ( 'term' === $current_screen->base && isset( $tag ) && is_object( $tag ) && ! is_wp_error( $tag ) ) {
 			$tax = get_taxonomy( $tag->taxonomy );
-			if ( is_taxonomy_viewable( $tax ) ) {
+			if ( $tax->public ) {
 				$wp_admin_bar->add_menu(
 					array(
 						'id'    => 'view',


### PR DESCRIPTION
## Description
As reported on the [forums](https://forums.classicpress.net/t/upgrade-to-1-5-0-two-issues-cant-edit-archives-tags-and-categories-and-warning-preg-match-no-ending-delimiter/4495), version 1.5.0 includes a call to a function we have not backported.

## Motivation and context
This PR reverts to the previous way of checking if a taxonomy (or category) is public and restores functionality of the aility to edit categories.

## How has this been tested?
Comparison to previous and upstream code. Localhost testing complete (see screen shots)

## Screenshots
### Before
<img width="615" alt="Screenshot 2023-01-06 at 17 48 33" src="https://user-images.githubusercontent.com/1280733/211069534-e5dd0645-11be-4543-963a-0e1f5263eacd.png">

### After
<img width="829" alt="Screenshot 2023-01-06 at 17 48 20" src="https://user-images.githubusercontent.com/1280733/211069566-61097c48-9748-492e-89aa-329705aa34b2.png">


## Types of changes
- Bug fix
