### PR TITLE
Fix incomplete `preg_match` regex in `get_the_post_thumbnail()`

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -162,7 +162,7 @@ function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr =
 			$attr = array( 'loading' => $loading );
 		} elseif ( is_array( $attr ) && ! array_key_exists( 'loading', $attr ) ) {
 			$attr['loading'] = $loading;
-		} elseif ( is_string( $attr ) && ! preg_match( '/(^|&)loading=', $attr ) ) {
+		} elseif ( is_string( $attr ) && ! preg_match( '/(^|&)loading=/', $attr ) ) {
 			$attr .= '&loading=' . $loading;
 		}
 


### PR DESCRIPTION
## Description
As reported on the [forums](https://forums.classicpress.net/t/upgrade-to-1-5-0-two-issues-cant-edit-archives-tags-and-categories-and-warning-preg-match-no-ending-delimiter/4495/7) - there is an issue in 1.5.0 related to post thumbails.

## Motivation and context
This is a bug introduced in version 1.5.0 that produces PHP warnings for some users.

It seems it may be theme dependent and requires that the theme supports `post-thumbnails` and also calls the `get_the_post_thumbnail()` function with a string passed for the third function parameter, an optional query string of attributes.

## How has this been tested?
By making some changes to the TwentySeveneteen theme locally I was able to produce the Warning locally on a post with a Featured Image. I then applied the proposed fix - adding a trailing slash to the Regex as per this PR and that resolved the PHP Warning.

## Screenshots
### 
<img width="252" alt="Screenshot 2023-01-07 at 10 07 29" src="https://user-images.githubusercontent.com/1280733/211145110-1efd3d46-b7a1-40a7-a200-732959bf2eb2.png">
Before

### After
<img width="253" alt="Screenshot 2023-01-07 at 10 07 41" src="https://user-images.githubusercontent.com/1280733/211145116-8312e495-4071-4c9e-8fe7-5770b0cdbfd1.png">


## Types of changes
- Bug fix