### PR TITLE
Introduce polyfill for str_contains()

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -501,8 +501,6 @@ if ( ! function_exists( 'is_iterable' ) ) {
 		return ( is_array( $var ) || $var instanceof Traversable );
 	}
 }
-<<<<<<< HEAD
-=======
 
 if ( ! function_exists( 'array_key_first' ) ) {
 	/**
@@ -511,7 +509,7 @@ if ( ! function_exists( 'array_key_first' ) ) {
 	 * Get the first key of the given array without affecting
 	 * the internal array pointer.
 	 *
-	 * @since 5.9.0
+	 * @since WP-5.9.0
 	 *
 	 * @param array $arr An array.
 	 * @return string|int|null The first key of array if the array
@@ -531,7 +529,7 @@ if ( ! function_exists( 'array_key_last' ) ) {
 	 * Get the last key of the given array without affecting the
 	 * internal array pointer.
 	 *
-	 * @since 5.9.0
+	 * @since WP-5.9.0
 	 *
 	 * @param array $arr An array.
 	 * @return string|int|null The last key of array if the array
@@ -553,7 +551,7 @@ if ( ! function_exists( 'str_contains' ) ) {
 	 * Performs a case-sensitive check indicating if needle is
 	 * contained in haystack.
 	 *
-	 * @since 5.9.0
+	 * @since WP-5.9.0
 	 *
 	 * @param string $haystack The string to search in.
 	 * @param string $needle   The substring to search for in the haystack.
@@ -573,4 +571,3 @@ if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 if ( ! defined( 'IMG_WEBP' ) ) {
 	define( 'IMG_WEBP', IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
 }
->>>>>>> 3cc8f1237a (General: Introduce polyfill for `str_contains()` added in PHP 8.0.)

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -501,3 +501,76 @@ if ( ! function_exists( 'is_iterable' ) ) {
 		return ( is_array( $var ) || $var instanceof Traversable );
 	}
 }
+<<<<<<< HEAD
+=======
+
+if ( ! function_exists( 'array_key_first' ) ) {
+	/**
+	 * Polyfill for array_key_first() function added in PHP 7.3.
+	 *
+	 * Get the first key of the given array without affecting
+	 * the internal array pointer.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array $arr An array.
+	 * @return string|int|null The first key of array if the array
+	 *                         is not empty; `null` otherwise.
+	 */
+	function array_key_first( array $arr ) {
+		foreach ( $arr as $key => $value ) {
+			return $key;
+		}
+	}
+}
+
+if ( ! function_exists( 'array_key_last' ) ) {
+	/**
+	 * Polyfill for `array_key_last()` function added in PHP 7.3.
+	 *
+	 * Get the last key of the given array without affecting the
+	 * internal array pointer.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array $arr An array.
+	 * @return string|int|null The last key of array if the array
+	 *.                        is not empty; `null` otherwise.
+	 */
+	function array_key_last( array $arr ) {
+		if ( empty( $arr ) ) {
+			return null;
+		}
+		end( $arr );
+		return key( $arr );
+	}
+}
+
+if ( ! function_exists( 'str_contains' ) ) {
+	/**
+	 * Polyfill for `str_contains()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if needle is
+	 * contained in haystack.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the haystack.
+	 * @return bool True if `$needle` is in `$haystack`, otherwise false.
+	 */
+	function str_contains( $haystack, $needle ) {
+		return ( '' === $needle || false !== strpos( $haystack, $needle ) );
+	}
+}
+
+// IMAGETYPE_WEBP constant is only defined in PHP 7.1 or later.
+if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
+	define( 'IMAGETYPE_WEBP', 18 );
+}
+
+// IMG_WEBP constant is only defined in PHP 7.0.10 or later.
+if ( ! defined( 'IMG_WEBP' ) ) {
+	define( 'IMG_WEBP', IMAGETYPE_WEBP ); // phpcs:ignore PHPCompatibility.Constants.NewConstants.imagetype_webpFound
+}
+>>>>>>> 3cc8f1237a (General: Introduce polyfill for `str_contains()` added in PHP 8.0.)

--- a/tests/phpunit/tests/compat/strContains.php
+++ b/tests/phpunit/tests/compat/strContains.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @group compat
+ *
+ * @covers ::str_contains
+ */
+class Tests_Compat_strContains extends WP_UnitTestCase {
+
+	/**
+	 * Test that str_contains() is always available (either from PHP or WP).
+	 *
+	 * @ticket 49652
+	 */
+	public function test_is_str_contains_availability() {
+		$this->assertTrue( function_exists( 'str_contains' ) );
+	}
+
+	/**
+	 * @dataProvider data_str_contains
+	 *
+	 * @ticket 49652
+	 *
+	 * @param bool   $expected Whether or not `$haystack` is expected to contain `$needle`.
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in `$haystack`.
+	 */
+	public function test_str_contains( $expected, $haystack, $needle ) {
+		if ( ! function_exists( 'str_contains' ) ) {
+			$this->markTestSkipped( 'str_contains() is not available.' );
+		} else {
+			$this->assertSame(
+				$expected,
+				str_contains( $haystack, $needle )
+			);
+		}
+
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_str_contains() {
+		return array(
+			'empty needle'              => array(
+				'expected' => true,
+				'haystack' => 'This is a Test',
+				'needle'   => '',
+			),
+			'empty haystack and needle' => array(
+				'expected' => true,
+				'haystack' => '',
+				'needle'   => '',
+			),
+			'empty haystack'            => array(
+				'expected' => false,
+				'haystack' => '',
+				'needle'   => 'test',
+			),
+			'start of string'           => array(
+				'expected' => true,
+				'haystack' => 'This is a Test',
+				'needle'   => 'This',
+			),
+			'middle of string'          => array(
+				'expected' => true,
+				'haystack' => 'The needle in middle of string.',
+				'needle'   => 'middle',
+			),
+			'end of string'             => array(
+				'expected' => true,
+				'string'   => 'The needle is at end.',
+				'needle'   => 'end',
+			),
+			'lowercase'                 => array(
+				'expected' => true,
+				'string'   => 'This is a test',
+				'needle'   => 'test',
+			),
+			'uppercase'                 => array(
+				'expected' => true,
+				'string'   => 'This is a TEST',
+				'needle'   => 'TEST',
+			),
+			'camelCase'                 => array(
+				'expected' => true,
+				'string'   => 'String contains camelCase.',
+				'needle'   => 'camelCase',
+			),
+			'with hyphen'               => array(
+				'expected' => true,
+				'string'   => 'String contains foo-bar needle.',
+				'needle'   => 'foo-bar',
+			),
+			'missing'                   => array(
+				'expected' => false,
+				'haystack' => 'This is a camelcase',
+				'needle'   => 'camelCase',
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Description
This PR is a backport of changeset [52039](https://core.trac.wordpress.org/changeset/52039). It introduces some polyfills for newly introduced PHP functions for compatibility reasons.

## Motivation and context
This should help with new installs for user still on PHP 5.6.x (although they should be strongly encouraged to move to at lease PHP 7.4 for security reasons.

## How has this been tested?
Upstream patch.
Locally installed fresh vanilla site on PHP 5.6.40

## Screenshots
N/A

## Types of changes
- Bug fix
