### PR TITLE
Fix parsed variable names

### DIFF
--- a/src/wp-includes/bookmark.php
+++ b/src/wp-includes/bookmark.php
@@ -176,7 +176,7 @@ function get_bookmarks( $args = '' ) {
 		$parsed_args['exclude']       = '';  //ignore exclude, category, and category_name params if using include
 		$parsed_args['category']      = '';
 		$parsed_args['category_name'] = '';
-		$inclinks           = preg_split( '/[\s,]+/', $r['include'] );
+		$inclinks           = preg_split( '/[\s,]+/', $parsed_args['include'] );
 
 		if ( count( $inclinks ) ) {
 			foreach ( $inclinks as $inclink ) {
@@ -194,7 +194,7 @@ function get_bookmarks( $args = '' ) {
 
 	$exclusions = '';
 	if ( ! empty( $parsed_args['exclude'] ) ) {
-		$exlinks = preg_split( '/[\s,]+/', $r['exclude'] );
+		$exlinks = preg_split( '/[\s,]+/', $parsed_args['exclude'] );
 		if ( count( $exlinks ) ) {
 			foreach ( $exlinks as $exlink ) {
 				if ( empty( $exclusions ) ) {
@@ -231,7 +231,7 @@ function get_bookmarks( $args = '' ) {
 	$join           = '';
 
 	if ( ! empty( $parsed_args['category'] ) ) {
-		$incategories = preg_split( '/[\s,]+/', $r['category'] );
+		$incategories = preg_split( '/[\s,]+/', $parsed_args['category'] );
 		if ( count( $incategories ) ) {
 			foreach ( $incategories as $incat ) {
 				if ( empty( $category_query ) ) {
@@ -301,7 +301,7 @@ function get_bookmarks( $args = '' ) {
 	$query .= " ORDER BY $orderby $order";
 
 	if ( -1 != $parsed_args['limit'] ) {
-		$query .= ' LIMIT ' . $r['limit'];
+		$query .= ' LIMIT ' . $parsed_args['limit'];
 	}
 
 	$results = $wpdb->get_results( $query );


### PR DESCRIPTION
## Description
With `WP_DEBUG` and `WP_DEBUG_DISPLAY` set as true I noted some errors in the sidebar of one of my sites about an undefined variable, this is due to some instances of `$r` having been missed when backporting and updating to use of `$parsed_args`.

## Motivation and context
This is a bug fix

## How has this been tested?
Tested on on of my production sites. Force re-produced locally as Links Manager needs to be enabled and in use.

## Screenshots
### Before
<img width="370" alt="Screenshot 2023-01-21 at 15 42 02" src="https://user-images.githubusercontent.com/1280733/213874657-dcded20c-e6a4-4c29-95e1-638ee22a76bf.png">

### After
<img width="362" alt="Screenshot 2023-01-21 at 15 42 34" src="https://user-images.githubusercontent.com/1280733/213874672-bd5ad8ca-68e1-4203-9ff0-8bc4d4304297.png">

## Types of changes
- Bug fix
