### PR TITLE
Allow for spaces in config-sample `defines`

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -332,7 +332,7 @@ switch ( $step ) {
 				continue;
 			}
 
-			if ( ! preg_match( '/^define\(\'([A-Z_]+)\',([ ]+)/', $line, $match ) ) {
+			if ( ! preg_match( '/^define\(\s*\'([A-Z_]+)\',([ ]+)/', $line, $match ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Description
During the setup process for a fresh install the `wp-config.php` file is created or the contents displayed to the new user for manual creation. Since the layout of the `wp-config-sample.php` was made more readable some of the values fail to populate in either the created file or in the displayed file for manual creation.

## Motivation and context
The above essentially breaks the setup process for new users, the file needs to be amended before it will work and connect to the database and allow a new installation.

This PR corrects the creation process and now populates several values into `wp-config.php` to re-enable a more effective fresh install process.

## How has this been tested?
Locally tested both methods of creation of the wp-config.php file, both automatic and manual, with and without this change.

## Screenshots
N/A

## Types of changes
- Bug fix
