### PR TITLE
Add a fallback for empty Update URI

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -111,6 +111,14 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		}
 	}
 
+	// If no Update URI is defined and Requires CP is set fall back to directory URL.
+	if ( ! $plugin_data['UpdateURI'] ) {
+		$plugin_slug = dirname( plugin_basename( $plugin_file ) );
+		if ( filter_var( $plugin_data['RequiresCP'], FILTER_VALIDATE_FLOAT ) !== false ) {
+			$plugin_data['UpdateURI'] = 'https://directory.classicpress.net/wp-json/wp/v2/plugins?byslug=' . preg_replace( '/[^a-zA-Z0-9_\-]/', '', $plugin_slug );
+		}
+	}
+
 	if ( $markup || $translate ) {
 		$plugin_data = _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup, $translate );
 	} else {

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -111,7 +111,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		}
 	}
 
-	// If no Update URI is defined and Requires CP is set fall back to directory URL.
+	// If no Update URI is defined and Requires CP is set fall back to ClassicPress directory URL.
 	if ( ! $plugin_data['UpdateURI'] ) {
 		$plugin_slug = dirname( plugin_basename( $plugin_file ) );
 		if ( filter_var( $plugin_data['RequiresCP'], FILTER_VALIDATE_FLOAT ) !== false ) {


### PR DESCRIPTION
## Description
Add a fallback for empty `Update URI` to ClassicPress directory URL if `Requires CP` is set.

## Motivation and context
As discussed [in the forum](https://forums.classicpress.net/t/plugin-theme-updates-directory-integration/4558) if `Requires CP` is set but `Update URI` is empty, fall back to the ClassicPress directory URL with the slug set to the plugin's base directory name.

## How has this been tested?
- Install and activate the [directory integration plugin](https://github.com/ClassicPress/classicpress-directory-integration)
- Change https://directory.classicpress.net to https://staging-directory.classicpress.net in this PR
- Pick a plugin from https://staging-directory.classicpress.net
- Check that it have the `Requires CP` header field and don't have `Update URI` (swap those conditions to test)
- Edit the plugin version to a lower number

In plugins page an update shows up.

## Types of changes
- New feature

