### PR TITLE
Add `SameSite` value to Auth and Settings cookies 

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -306,6 +306,12 @@ function wp_cookie_constants() {
 	if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 		define( 'COOKIE_DOMAIN', false );
 	}
+	/**
+	 * @since 1.6.0
+	 */
+	if ( ! defined( 'COOKIE_SAMESITE' ) ) {
+		define( 'COOKIE_SAMESITE', 'Lax' );
+	}
 }
 
 /**

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -960,7 +960,7 @@ function wp_user_settings() {
 	 *
 	 * @param string $same_site SameSite parameter value, default is 'Lax'.
 	 */
-	$same_site = apply_filters( 'wp_settings_cookie_same_site', 'Lax' );
+	$same_site = apply_filters( 'wp_settings_cookie_same_site', COOKIE_SAMESITE );
 
 	// lets check PHP version if it's 7.3.0+.
 	if ( version_compare( PHP_VERSION, '7.3.0' ) >= 0 ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -953,7 +953,7 @@ function wp_user_settings() {
 
 
 	/**
-	 * Allows to manage SameSite Settings Cookie header part.
+	 * Allows to manage SameSite Settings Cookie header part in User Settings cookies.
 	 * Possible values are Lax|Strict|None.
 	 * It's natively supported since PHP 7.3.0.
 	 *

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -950,8 +950,50 @@ function wp_user_settings() {
 
 	// The cookie is not set in the current browser or the saved value is newer.
 	$secure = ( 'https' === parse_url( admin_url(), PHP_URL_SCHEME ) );
-	setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH, null, $secure );
-	setcookie( 'wp-settings-time-' . $user_id, time(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH, null, $secure );
+
+
+	/**
+	 * Allows to manage SameSite Settings Cookie header part.
+	 * Possible values are Lax|Strict|None.
+	 * It's natively supported since PHP 7.3.0.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param string $same_site SameSite parameter value, default is 'Lax'.
+	 */
+	$same_site = apply_filters( 'wp_settings_cookie_same_site', 'Lax' );
+
+	// lets check PHP version if it's 7.3.0+.
+	if ( version_compare( PHP_VERSION, '7.3.0' ) >= 0 ) {
+		// lets use new setcookie function shipped with php 7.3.0 .
+		setcookie(
+			'wp-settings-' . $user_id,
+			$settings,
+			array(
+				'expires'  => time() + YEAR_IN_SECONDS,
+				'path'     => SITECOOKIEPATH,
+				'domain'   => null,
+				'secure'   => $secure,
+				'httponly' => false,
+				'samesite' => $same_site,
+			)
+		);
+		setcookie(
+			'wp-settings-time-' . $user_id,
+			time(),
+			array(
+				'expires'  => time() + YEAR_IN_SECONDS,
+				'path'     => SITECOOKIEPATH,
+				'domain'   => null,
+				'secure'   => $secure,
+				'httponly' => false,
+				'samesite' => $same_site,
+			)
+		);
+	} else {
+		setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; Samesite=' . $same_site, null, $secure );
+		setcookie( 'wp-settings-time-' . $user_id, time(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; Samesite=' . $same_site, null, $secure );
+	}
 	$_COOKIE[ 'wp-settings-' . $user_id ] = $settings;
 }
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -990,8 +990,8 @@ function wp_user_settings() {
 			)
 		);
 	} else {
-		setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; Samesite=' . $same_site, null, $secure );
-		setcookie( 'wp-settings-time-' . $user_id, time(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; Samesite=' . $same_site, null, $secure );
+		setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; SameSite=' . $same_site, null, $secure );
+		setcookie( 'wp-settings-time-' . $user_id, time(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH . '; SameSite=' . $same_site, null, $secure );
 	}
 	$_COOKIE[ 'wp-settings-' . $user_id ] = $settings;
 }

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -951,7 +951,6 @@ function wp_user_settings() {
 	// The cookie is not set in the current browser or the saved value is newer.
 	$secure = ( 'https' === parse_url( admin_url(), PHP_URL_SCHEME ) );
 
-
 	/**
 	 * Allows to manage SameSite Settings Cookie header part in User Settings cookies.
 	 * Possible values are Lax|Strict|None.

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -992,7 +992,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 		 *
 		 * @param string $same_site SameSite parameter value, default is 'Lax'.
 		 */
-		$same_site = apply_filters( 'wp_auth_cookie_same_site', 'Lax' );
+		$same_site = apply_filters( 'wp_auth_cookie_same_site', COOKIE_SAMESITE );
 
 		// lets check PHP version if it's 7.3.0+.
 		if ( version_compare( PHP_VERSION, '7.3.0' ) >= 0 ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -987,7 +987,9 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 		/**
 		 * Allows to manage SameSite Auth Cookie header part.
 		 * Possible values are Lax|Strict|None.
-		 * It's natively supported since PHP 7.3.0 .
+		 * It's natively supported since PHP 7.3.0.
+		 *
+		 * @since 1.6.0
 		 *
 		 * @param string $same_site SameSite parameter value, default is 'Lax'.
 		 */

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -985,7 +985,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 
 
 		/**
-		 * Allows to manage SameSite Auth Cookie header part.
+		 * Allows to manage SameSite Auth Cookie header part in auth cookies.
 		 * Possible values are Lax|Strict|None.
 		 * It's natively supported since PHP 7.3.0.
 		 *

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1048,11 +1048,11 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 				);
 			}
 		} else {
-			setcookie( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure, true );
-			setcookie( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure, true );
-			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+			setcookie( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH . '; SameSite=' . $same_site, COOKIE_DOMAIN, $secure, true );
+			setcookie( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH . '; SameSite=' . $same_site, COOKIE_DOMAIN, $secure, true );
+			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH . '; SameSite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
 			if ( COOKIEPATH != SITECOOKIEPATH ) {
-				setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+				setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH . '; SameSite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
 			}
 		}
 	}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -983,13 +983,80 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			return;
 		}
 
-		setcookie( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
-		setcookie( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
-		setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
-		if ( COOKIEPATH != SITECOOKIEPATH ) {
-			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+
+		/**
+		 * Allows to manage SameSite Auth Cookie header part.
+		 * Possible values are Lax|Strict|None.
+		 * It's natively supported since PHP 7.3.0 .
+		 *
+		 * @param string $same_site SameSite parameter value, default is 'Lax'.
+		 */
+		$same_site = apply_filters( 'wp_auth_cookie_same_site', 'Lax' );
+
+		// lets check PHP version if it's 7.3.0+.
+		if ( version_compare( PHP_VERSION, '7.3.0' ) >= 0 ) {
+			// lets use new setcookie function shipped with php 7.3.0 .
+			setcookie(
+				$auth_cookie_name,
+				$auth_cookie,
+				array(
+					'expires'  => $expire,
+					'path'     => PLUGINS_COOKIE_PATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure,
+					'httponly' => true,
+					'samesite' => $same_site,
+				)
+			);
+			setcookie(
+				$auth_cookie_name,
+				$auth_cookie,
+				array(
+					'expires'  => $expire,
+					'path'     => ADMIN_COOKIE_PATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure,
+					'httponly' => true,
+					'samesite' => $same_site,
+				)
+			);
+			setcookie(
+				LOGGED_IN_COOKIE,
+				$logged_in_cookie,
+				array(
+					'expires'  => $expire,
+					'path'     => COOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure_logged_in_cookie,
+					'httponly' => true,
+					'samesite' => $same_site,
+				)
+			);
+			if ( COOKIEPATH != SITECOOKIEPATH ) {
+				setcookie(
+					LOGGED_IN_COOKIE,
+					$logged_in_cookie,
+					array(
+						'expires'  => $expire,
+						'path'     => SITECOOKIEPATH,
+						'domain'   => COOKIE_DOMAIN,
+						'secure'   => $secure_logged_in_cookie,
+						'httponly' => true,
+						'samesite' => $same_site,
+					)
+				);
+			}
+		} else {
+			setcookie( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure, true );
+			setcookie( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure, true );
+			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+			if ( COOKIEPATH != SITECOOKIEPATH ) {
+				setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+			}
 		}
-	}
+ 	}
+
+
 endif;
 
 if ( ! function_exists( 'wp_clear_auth_cookie' ) ) :

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -983,7 +983,6 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			return;
 		}
 
-
 		/**
 		 * Allows to manage SameSite Auth Cookie header part in auth cookies.
 		 * Possible values are Lax|Strict|None.

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1055,7 +1055,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 				setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH . '; Samesite=' . $same_site, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
 			}
 		}
- 	}
+	}
 
 
 endif;


### PR DESCRIPTION
This PR fix #1227 and also add `SameSite` value to Auth cookies. 

## Description
This PR adds `SameSite=Lax` to Auth and Settings cookies.
Edit: introduced COOKIE_SAMESITE constant to have a default value everywhere.
It introduces `wp_settings_cookie_same_site` and `wp_auth_cookie_same_site` filters to change default (`Lax`) value.
**We should choose if the default value have to be `Lax` or `None` to comply with `SemVer`.**

## How has this been tested?
Unit tests are passing.
No new test were added.
Tested on local MAMP stack with PHP 5.6 and 8.0.

## Types of changes
- New feature

