### PR TITLE
WP-r55763: Embeds: Add protocol validation for WordPress Embed code.

### DIFF
--- a/src/wp-includes/js/wp-embed.js
+++ b/src/wp-includes/js/wp-embed.js
@@ -43,6 +43,7 @@
 
 		var iframes = document.querySelectorAll( 'iframe[data-secret="' + data.secret + '"]' ),
 			blockquotes = document.querySelectorAll( 'blockquote[data-secret="' + data.secret + '"]' ),
+			allowedProtocols = new RegExp( '^https?:$', 'i' ),
 			i, source, height, sourceURL, targetURL;
 
 		for ( i = 0; i < blockquotes.length; i++ ) {
@@ -77,6 +78,11 @@
 
 				sourceURL.href = source.getAttribute( 'src' );
 				targetURL.href = data.value;
+
+				/* Only follow link if the protocol is in the allow list. */
+				if ( ! allowedProtocols.test( targetURL.protocol ) ) {
+					continue;
+				}
 
 				/* Only continue if link hostname matches iframe's hostname. */
 				if ( targetURL.host === sourceURL.host ) {


### PR DESCRIPTION
Validate that links within auto-discovered embeds are using the `http` or `https` protocols before following links.

WP:Props xknown, dd32, peterwilsoncc.

