### PR TITLE
Add dashboard upgrade widget

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -59,7 +59,9 @@ function wp_dashboard_setup() {
 	wp_add_dashboard_widget( 'dashboard_primary', __( 'ClassicPress News' ), 'wp_dashboard_events_news' );
 
 	// ClassicPress upgrade notice
-	wp_add_dashboard_widget( 'dashboard_upgrade', __( 'ClassicPress Upgrade' ), 'cp_dashboard_upgrade' );
+	if ( current_user_can( 'update_core' ) ) {
+		wp_add_dashboard_widget( 'dashboard_upgrade', __( 'ClassicPress Upgrade' ), 'cp_dashboard_upgrade' );
+	}
 
 	if ( is_network_admin() ) {
 
@@ -1456,23 +1458,20 @@ function cp_dashboard_upgrade() {
 	<?php
 	echo '<p>' . sprintf( __( 'Thank you for using ClassicPress %s!' ), $display_version ) . '</p>';
 	echo '<p>' . __( 'We wanted to let you know some important information about ClassicPress.' ) . '</p>';
-	echo '<p>' . __( 'The major version number you are currently using is not being actively developed. Instead we are working hard to bring you a brand new version 2.0.0.' ) . '</p>';
+	echo '<p>' . __( 'The major version number (1.x) you are currently using is not being actively developed. Instead we are working hard to bring you a brand new version 2.0.0.' ) . '</p>';
 	echo '<p>' . sprintf( __( 'Your current version will continue to receive security updates until %s' ), esc_html( date_i18n( get_option( 'date_format' ), 1700956800 ) ) ) . '</p>';
-	echo '<p>' . sprintf( __( 'This date has been chosen because it is when <a href="%s">support</a> for PHP 8.0 ends. PHP 7.4 already unsupported and no longer receives security updates.' ), esc_url( 'https://www.php.net/supported-versions.php' ) ) . '</p>';
+	echo '<p>' . sprintf( __( 'This date has been chosen because it is when <a href="%s">support</a> for PHP 8.0 ends. PHP 7.4 is already unsupported and no longer receives security updates.' ), esc_url( 'https://www.php.net/supported-versions.php' ) ) . '</p>';
 
 	$core_updates = get_core_updates( array( 'dismissed' => true ) );
 
-	if ( current_user_can( 'update_core' ) ) {
-		if ( ! empty( $core_updates ) && version_compare( $core_updates[0]->current, '2.0.0' ) >= 0 ) {
-			echo '<p>' . sprintf( __( 'Version 2.0.0 has now been released. <a href="%s">Upgrade</a> as soon as you are ready and read more about the release on our <a href="%s">forum</a>.' ), esc_url( admin_url( 'update-core.php' ) ), esc_url( 'https://forums.classicpress.net/c/announcements/release-notes/48' ) ) . '</p>';
-		} else {
-			echo '<p>' . sprintf( __( 'You can continue to use ClassicPress %s at this time. You will be notified when a new version is available that supports future versions of PHP.' ), $display_version ) . '</p>';
-		}
+	if ( ! empty( $core_updates ) && version_compare( $core_updates[0]->current, '2.0.0' ) >= 0 ) {
+		echo '<p>' . sprintf( __( 'Version 2.0.0 has now been released. <a href="%s">Upgrade</a> as soon as you are ready and read more about the release on our <a href="%s">forum</a>.' ), esc_url( admin_url( 'update-core.php' ) ), esc_url( 'https://forums.classicpress.net/c/announcements/release-notes/48' ) ) . '</p>';
 	} else {
-		if ( ! empty( $core_updates ) && version_compare( $core_updates[0]->current, '2.0.0' ) >= 0 ) {
-			echo '<p>' . __( 'An update is avilable! Please notify the site administrator.' ) . '</p>';
-		}
+		echo '<p>' . sprintf( __( 'You can continue to use ClassicPress %s at this time. You will be notified when a new version is available that supports future versions of PHP. <a href="%s">Learn more</a> about testing version 2.0.0.' ), $display_version, esc_url( 'https://www.classicpress.net/help-test-classicpress-v2/' ) ) . '</p>';
 	}
+
+	echo '<p>' . __( 'Deprecation notice: Version 1.6 is the last version to support PHP 5.6 - 7.3. The minimum required version for 2.0.0 will be PHP 7.4.' ) . '</p>';
+
 	?>
 	</p>
 	</div>

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -58,6 +58,9 @@ function wp_dashboard_setup() {
 	// ClassicPress News
 	wp_add_dashboard_widget( 'dashboard_primary', __( 'ClassicPress News' ), 'wp_dashboard_events_news' );
 
+	// ClassicPress upgrade notice
+	wp_add_dashboard_widget( 'dashboard_upgrade', __( 'ClassicPress Upgrade' ), 'cp_dashboard_upgrade' );
+
 	if ( is_network_admin() ) {
 
 		/**
@@ -1435,5 +1438,43 @@ function wp_welcome_panel() {
 	?>
 	</p>
 </div>
+	<?php
+}
+
+/**
+ * Display the ClassicPress upgrade widget
+ * Warns about PHP support ending and will prompt for upgrade once available
+ *
+ * @since CP-1.6.0
+ */
+
+function cp_dashboard_upgrade() {
+	$display_version = classicpress_version();
+	?>
+	<div class ="upgrade-widget-content">
+	<p>
+	<?php
+	echo '<p>' . sprintf( __( 'Thank you for using ClassicPress %s!' ), $display_version ) . '</p>';
+	echo '<p>' . __( 'We wanted to let you know some important information about ClassicPress.' ) . '</p>';
+	echo '<p>' . __( 'The major version number you are currently using is not being actively developed. Instead we are working hard to bring you a brand new version 2.0.0.' ) . '</p>';
+	echo '<p>' . sprintf( __( 'Your current version will continue to receive security updates until %s' ), esc_html( date_i18n( get_option( 'date_format' ), 1700956800 ) ) ) . '</p>';
+	echo '<p>' . sprintf( __( 'This date has been chosen because it is when <a href="%s">support</a> for PHP 8.0 ends. PHP 7.4 already unsupported and no longer receives security updates.' ), esc_url( 'https://www.php.net/supported-versions.php' ) ) . '</p>';
+
+	$core_updates = get_core_updates( array( 'dismissed' => true ) );
+
+	if ( current_user_can( 'update_core' ) ) {
+		if ( ! empty( $core_updates ) && version_compare( $core_updates[0]->current, '2.0.0' ) >= 0 ) {
+			echo '<p>' . sprintf( __( 'Version 2.0.0 has now been released. <a href="%s">Upgrade</a> as soon as you are ready and read more about the release on our <a href="%s">forum</a>.' ), esc_url( admin_url( 'update-core.php' ) ), esc_url( 'https://forums.classicpress.net/c/announcements/release-notes/48' ) ) . '</p>';
+		} else {
+			echo '<p>' . sprintf( __( 'You can continue to use ClassicPress %s at this time. You will be notified when a new version is available that supports future versions of PHP.' ), $display_version ) . '</p>';
+		}
+	} else {
+		if ( ! empty( $core_updates ) && version_compare( $core_updates[0]->current, '2.0.0' ) >= 0 ) {
+			echo '<p>' . __( 'An update is avilable! Please notify the site administrator.' ) . '</p>';
+		}
+	}
+	?>
+	</p>
+	</div>
 	<?php
 }


### PR DESCRIPTION
## Description
Add a dashboard widget warning about PHP support, security maintenance status of `v1` and future release of `v2` of ClassicPress

## Motivation and context
Deprecation notice and user warning about PHP support, and `v2`

## How has this been tested?
Local Testing so far only.

## Screenshots
<img width="422" alt="Screenshot 2023-06-29 at 09 31 37" src="https://github.com/ClassicPress/ClassicPress/assets/1280733/be6ba103-d472-41af-a470-805396297432">
<img width="419" alt="Screenshot 2023-06-29 at 09 32 00" src="https://github.com/ClassicPress/ClassicPress/assets/1280733/3a805959-b8f5-42ec-b8da-4693c8907c75">
<img width="419" alt="Screenshot 2023-06-29 at 09 32 18" src="https://github.com/ClassicPress/ClassicPress/assets/1280733/f14eb4e5-e28e-4083-beab-95b61b1a0193">
<img width="418" alt="Screenshot 2023-06-29 at 09 32 33" src="https://github.com/ClassicPress/ClassicPress/assets/1280733/0ac872b5-4e9e-43be-be22-a2c1f8cd9f1d">


## Types of changes
- Enhancement
