### PR TITLE
Fixes potential issue in plugin modal

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -91,7 +91,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	 * @global string $term
 	 */
 	public function prepare_items() {
-		include ABSPATH . 'wp-admin/includes/plugin-install.php';
+		include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 
 		global $tabs, $tab, $paged, $type, $term;
 


### PR DESCRIPTION
## Description
This PR is a Cherry pick of wp-r47198

## Motivation and context

This should fix an issue reported on the forums:
https://forums.classicpress.net/t/php-fatal-error-cannot-redeclare-plugins-api-previously-declared-in-wp-admin-includes-plugin-install-php-101/4885

## How has this been tested?
OP on forum reports this fix is good.

## Screenshots
See forum post

## Types of changes
- Bug fix
