### PR TITLE
 Fix deprecated jQuery warning message

### DIFF
--- a/src/wp-content/themes/twentysixteen/js/functions.js
+++ b/src/wp-content/themes/twentysixteen/js/functions.js
@@ -28,7 +28,7 @@
 		// Add menu items with submenus to aria-haspopup="true".
 		container.find( '.menu-item-has-children' ).attr( 'aria-haspopup', 'true' );
 
-		container.find( '.dropdown-toggle' ).click( function( e ) {
+		container.find( '.dropdown-toggle' ).on( 'click', function( e ) {
 			var _this            = $( this ),
 				screenReaderSpan = _this.find( '.screen-reader-text' );
 


### PR DESCRIPTION
Fix for deprecated jQuery in TwentySixteen theme.