### PR TITLE
Fix: Enable Actions on code merge

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -24,7 +24,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Checkout repository
@@ -72,7 +72,7 @@ jobs:
   precommit:
     name: Pre-commit checks
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: ${{ true }}
 

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -22,7 +22,7 @@ jobs:
   test-js:
     name: QUnit Tests
     runs-on: ubuntu-22.04
-    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
   php-comatibility:
     name: Check PHP compatibility
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,7 @@ jobs:
   test-php:
     name: "PHP ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ClassicPress/ClassicPress-v2' || github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
GitHub actions have a protection to ensure they only run on pull requests and within this repository. Currently, checks are not running on merge to `develop` following the repository migration, this PR fixes this issue.

## Motivation and context
Testing should run after merges to the `develop` branch,

## How has this been tested?
Visual changes seem correct, will know for sure when this is merged.

## Screenshots
N/A

## Types of changes
- Bug fix