### PR TITLE
Add a filter to change classicpress.net urls in HTTP requests

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -272,6 +272,29 @@ class WP_Http {
 
 		$parsed_url = parse_url( $url );
 
+		/**
+		 * Filters the URL value of an HTTP request.
+		 *
+		 * For security reasons it allows only to change classicpress.net URLs.
+		 *
+		 * Must return a classicpress.net URL.
+		 *
+		 * @since CP-2.1
+		 *
+		 * @param string $url         The HTTP request url
+		 * @param array  $parsed_args HTTP request arguments.
+		 */
+		$filtered_url = apply_filters( 'cp_dot_net_urls', $url, $parsed_args );
+
+		$parsed_filtered_url = parse_url( $filtered_url );
+
+		if ( substr( $parsed_url['host'], -16 ) === 'classicpress.net' && substr( $parsed_filtered_url['host'], -16 ) === 'classicpress.net' ) {
+			$url = $filtered_url;
+			$parsed_url = $parsed_filtered_url;
+		} else {
+			_doing_it_wrong( 'cp_dot_net_urls', 'Filter \'cp_dot_net_urls\' only works for classicpress.net urls.', 'CP-2.1' );
+		}
+
 		if ( empty( $url ) || empty( $parsed_url['scheme'] ) ) {
 			$response = new WP_Error( 'http_request_failed', __( 'A valid URL was not provided.' ) );
 			/** This action is documented in wp-includes/class-wp-http.php */

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -238,6 +238,30 @@ class WP_Http {
 		}
 
 		/**
+		 * Filters the URL value of an HTTP request.
+		 *
+		 * For security reasons it allows only to change classicpress.net URLs.
+		 *
+		 * Must return a classicpress.net URL.
+		 *
+		 * @since CP-2.1
+		 *
+		 * @param string $url         The HTTP request url
+		 * @param array  $parsed_args HTTP request arguments.
+		 */
+		$filtered_url = apply_filters( 'cp_dot_net_urls', $url, $parsed_args );
+
+		if ( $url !== $filtered_url ) {
+			$parsed_filtered_url = parse_url( $filtered_url );
+			$pre_parsed_url = parse_url( $url );
+			if ( substr( $pre_parsed_url['host'], -16 ) === 'classicpress.net' && substr( $parsed_filtered_url['host'], -16 ) === 'classicpress.net' ) {
+				$url = $filtered_url;
+			} else {
+				_doing_it_wrong( 'cp_dot_net_urls', 'Filter \'cp_dot_net_urls\' only works for classicpress.net urls.', 'CP-2.1' );
+			}
+		}
+
+		/**
 		 * Filters the preemptive return value of an HTTP request.
 		 *
 		 * Returning a non-false value from the filter will short-circuit the HTTP request and return
@@ -271,29 +295,6 @@ class WP_Http {
 		}
 
 		$parsed_url = parse_url( $url );
-
-		/**
-		 * Filters the URL value of an HTTP request.
-		 *
-		 * For security reasons it allows only to change classicpress.net URLs.
-		 *
-		 * Must return a classicpress.net URL.
-		 *
-		 * @since CP-2.1
-		 *
-		 * @param string $url         The HTTP request url
-		 * @param array  $parsed_args HTTP request arguments.
-		 */
-		$filtered_url = apply_filters( 'cp_dot_net_urls', $url, $parsed_args );
-
-		$parsed_filtered_url = parse_url( $filtered_url );
-
-		if ( substr( $parsed_url['host'], -16 ) === 'classicpress.net' && substr( $parsed_filtered_url['host'], -16 ) === 'classicpress.net' ) {
-			$url = $filtered_url;
-			$parsed_url = $parsed_filtered_url;
-		} else {
-			_doing_it_wrong( 'cp_dot_net_urls', 'Filter \'cp_dot_net_urls\' only works for classicpress.net urls.', 'CP-2.1' );
-		}
 
 		if ( empty( $url ) || empty( $parsed_url['scheme'] ) ) {
 			$response = new WP_Error( 'http_request_failed', __( 'A valid URL was not provided.' ) );

--- a/tests/phpunit/tests/http/cpDotNetUrls.php
+++ b/tests/phpunit/tests/http/cpDotNetUrls.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @group http
+ * @covers ::wp_get_http_headers
+ */
+class Tests_HTTP_cpDotNetUrls extends WP_UnitTestCase {
+
+	/**
+	 * Set up the environment
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Hook a mocked HTTP request response.
+		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Test with a valid filter
+	 */
+	public function test_http_request_cp_dot_net_urls_valid() {
+		add_filter( 'cp_dot_net_urls', array( $this, 'good_url_filter' ), 10, 2 );
+
+		$result = wp_get_http_headers( 'https://directory.classicpress.net' );
+		$this->assertSame( $result, 'https://staging-directory.classicpress.net' );
+
+		$result = wp_get_http_headers( 'https://example.com' );
+		$this->assertSame( $result, 'https://example.com' );
+	}
+
+	/**
+	 * Test with an invalid filter
+	 * @expectedIncorrectUsage cp_dot_net_urls
+	 */
+	public function test_http_request_cp_dot_net_dest_url_invalid() {
+		add_filter( 'cp_dot_net_urls', array( $this, 'hijack_cp' ), 10, 2 );
+
+		$url = 'https://directory.classicpress.net';
+		$result = wp_get_http_headers( $url );
+		$this->assertSame( $result, $url );
+	}
+
+	/**
+	 * Test with an invalid filter
+	 * @expectedIncorrectUsage cp_dot_net_urls
+	 */
+	public function test_http_request_cp_dot_net_src_url_invalid() {
+		add_filter( 'cp_dot_net_urls', array( $this, 'hijack_example' ), 10, 2 );
+
+		$url = 'https://example.com';
+		$result = wp_get_http_headers( $url );
+		$this->assertSame( $result, $url );
+	}
+
+	public function good_url_filter( $url, $parsed_args ) {
+		return preg_replace( '/directory\.classicpress\.net/', 'staging-directory.classicpress.net', $url );
+	}
+
+	public function hijack_cp( $url, $parsed_args ) {
+		return preg_replace( '/classicpress\.net/', 'bad.co', $url );
+	}
+
+	public function hijack_example( $url, $parsed_args ) {
+		return preg_replace( '/example\.com/', 'classicpress.net', $url );
+	}
+
+	/**
+	 * Mock the HTTP request response
+	 *
+	 * @param false|array|WP_Error $response    A preemptive return value of an HTTP request. Default false.
+	 * @param array                $parsed_args HTTP request arguments.
+	 * @param string               $url         The request URL.
+	 * @return false|array|WP_Error Response data.
+	 */
+	public function mock_http_request( $response, $parsed_args, $url ) {
+		return array( 'headers' => $url );
+	}
+}


### PR DESCRIPTION
Add a filter `cp_dot_net_urls` in class `WP_Http` to change the request URL if it's a `classicpress.net` one.

## Description
With this filter you can change the request URL.

For security purposes only hosts ending in `classicpress.net` can be filtered and only to a value that ends in `classicpress.net`. If a hooked function tries to filter the value in a different way a "Doing it wrong" is thrown and the URL is not changed.

Example:
```php
add_filter( 'cp_dot_net_urls',  'xsx_test_filter', 10, 2 );
function xsx_test_filter( $url, $parsed_args ) {
	return preg_replace( '/directory\.classicpress\.net/', 'staging-directory.classicpress.net', $url );
}
```

## Motivation and context
This (as in the example) helps to switch requests to staging classicpress.net hosts.

## How has this been tested?
- Local testing
- Unit tests

## Types of changes
- New feature

