### PR TITLE
Fix fatal error when Block Compatibility is off

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -433,7 +433,9 @@ final class WP_Screen {
 	 * @return bool False.
 	 */
 	public function is_block_editor( ...$args ) {
-		WP_Compat::using_block_function();
+		if ( class_exists( 'WP_Compat' ) ) {
+			WP_Compat::using_block_function();
+		}
 		return false;
 	}
 

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -190,6 +190,9 @@ class WP_Compat {
 	 * This function have to be called from a polyfill
 	 * to map themes and plugins calling those functions.
 	 *
+	 * Make sure that class WP_Compat exists before calling the function
+	 * because it's not defined if Blocks Compatibility option is set to "off".
+	 *
 	 * @return void
 	 */
 	public static function using_block_function() {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7822,7 +7822,9 @@ function wp_untrash_post_set_previous_status( $new_status, $post_id, $previous_s
  * @return bool Whether the post can be edited in the block editor.
  */
 function use_block_editor_for_post( $post ) {
-	WP_Compat::using_block_function();
+	if ( class_exists( 'WP_Compat' ) ) {
+		WP_Compat::using_block_function();
+	}
 	return false;
 }
 
@@ -7839,6 +7841,8 @@ function use_block_editor_for_post( $post ) {
  * @return bool Whether the post type can be edited with the block editor.
  */
 function use_block_editor_for_post_type( $post_type ) {
-	WP_Compat::using_block_function();
+	if ( class_exists( 'WP_Compat' ) ) {
+		WP_Compat::using_block_function();
+	}
 	return false;
 }


### PR DESCRIPTION
Some classes have polyfilled methods that call `WP_Compat::using_block_function();`.
But when Block Compatibility is set to "off" `WP_Compat` class is not defined.

See [WS Form LITE blocks compatibility](https://forums.classicpress.net/t/ws-form-lite-blocks-compatibility/5039)  post on the forum.

This PR adds a check for the class to exists in this way:
```php
if ( class_exists( 'WP_Compat' ) ) {
	WP_Compat::using_block_function();
}
```

Docblock for WP_Compat::using_block_function has been updated to point out this.

## How has this been tested?
1. Install WS Form LITE
2. Go to Posts -> All Posts
3. Click on any of the posts titles
4. No fatal error will show

## Types of changes
- Bug fix
