### PR TITLE
WP-r56495: HTTP API: Update `WP_Http` class to avoid PHP deprecation

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -326,11 +326,11 @@ class WP_Http {
 		);
 
 		// Ensure redirects follow browser behavior.
-		$options['hooks']->register( 'requests.before_redirect', array( get_class(), 'browser_redirect_compatibility' ) );
+		$options['hooks']->register( 'requests.before_redirect', array( static::class, 'browser_redirect_compatibility' ) );
 
 		// Validate redirected URLs.
 		if ( function_exists( 'wp_kses_bad_protocol' ) && $parsed_args['reject_unsafe_urls'] ) {
-			$options['hooks']->register( 'requests.before_redirect', array( get_class(), 'validate_redirects' ) );
+			$options['hooks']->register( 'requests.before_redirect', array( static::class, 'validate_redirects' ) );
 		}
 
 		if ( $parsed_args['stream'] ) {


### PR DESCRIPTION
This changeset prevents a PHP 8.3 deprecation shown when enabling debug and calling `get_class()` without arguments.

For more info about this deprecation, see https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#get_class_and_get_parent_class.

WP:Props ipajen, rajinsharwar, SergeyBiryukov, jrf. Fixes https://core.trac.wordpress.org/ticket/58876.

---

Merges https://core.trac.wordpress.org/changeset/56495 / WordPress/wordpress-develop@98284ae792 to ClassicPress.

