### PR TITLE
Update `wp_kses`* functions to accept `null` as `$content` parameter

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -974,6 +974,9 @@ function wp_kses_version() {
  * @return string Content with fixed HTML tags
  */
 function wp_kses_split( $content, $allowed_html, $allowed_protocols ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	global $pass_allowed_html, $pass_allowed_protocols;
 
 	$pass_allowed_html      = $allowed_html;
@@ -1722,6 +1725,9 @@ function wp_kses_bad_protocol( $content, $allowed_protocols ) {
  * @return string Filtered content.
  */
 function wp_kses_no_null( $content, $options = null ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	if ( ! isset( $options['slash_zero'] ) ) {
 		$options = array( 'slash_zero' => 'remove' );
 	}
@@ -1746,6 +1752,9 @@ function wp_kses_no_null( $content, $options = null ) {
  * @return string Fixed string with quoted slashes.
  */
 function wp_kses_stripslashes( $content ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	return preg_replace( '%\\\\"%', '"', $content );
 }
 
@@ -1802,6 +1811,9 @@ function wp_kses_html_error( $attr ) {
  * @return string Sanitized content.
  */
 function wp_kses_bad_protocol_once( $content, $allowed_protocols, $count = 1 ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	$content  = preg_replace( '/(&#0*58(?![;0-9])|&#x0*3a(?![;a-f0-9]))/i', '$1;', $content );
 	$content2 = preg_split( '/:|&#0*58;|&#x0*3a;|&colon;/i', $content, 2 );
 
@@ -1877,6 +1889,9 @@ function wp_kses_bad_protocol_once2( $scheme, $allowed_protocols ) {
  * @return string Content with normalized entities.
  */
 function wp_kses_normalize_entities( $content, $context = 'html' ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	// Disarm all entities by converting & to &amp;
 	$content = str_replace( '&', '&amp;', $content );
 
@@ -2028,6 +2043,9 @@ function valid_unicode( $i ) {
  * @return string Content after decoded entities.
  */
 function wp_kses_decode_entities( $content ) {
+	if ( is_null( $content ) ) {
+		return '';
+	}
 	$content = preg_replace_callback( '/&#([0-9]+);/', '_wp_kses_decode_entities_chr', $content );
 	$content = preg_replace_callback( '/&#[Xx]([0-9A-Fa-f]+);/', '_wp_kses_decode_entities_chr_hexdec', $content );
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2154,7 +2154,7 @@ HTML;
 
 	/**
 	 * Test that passing a null value as content doesn't
-	 * trigger error and retunr an empty string
+	 * trigger error and return an empty string
 	 *
 	 * @since CP-2.0
 	 */

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2151,4 +2151,30 @@ HTML;
 
 		return $this->text_array_to_dataprovider( $required_kses_globals );
 	}
+
+	/**
+	 * Test that passing a null value as content doesn't
+	 * trigger error and retunr an empty string
+	 *
+	 * @since CP-2.0
+	 */
+	public function test_wp_kses_null_content() {
+		$result = wp_kses_stripslashes( null, '' );
+		$this->assertSame( $result, '' );
+
+		$result = wp_kses_no_null( null, array() );
+		$this->assertSame( $result, '' );
+
+		$result = wp_kses_split( null, array(), array() );
+		$this->assertSame( $result, '' );
+
+		$result = wp_kses_bad_protocol_once( null, array() );
+		$this->assertSame( $result, '' );
+
+		$result = wp_kses_normalize_entities( null );
+		$this->assertSame( $result, '' );
+
+		$result = wp_kses_decode_entities( null );
+		$this->assertSame( $result, '' );
+	}
 }


### PR DESCRIPTION
Update `wp_kses`* functions to accept `null` as `$content` parameter.

## Motivation and context
Starting from PHP 8.1: [(source)](https://www.php.net/manual/en/migration81.deprecated.php)
> Scalar types for built-in functions are nullable by default. This behaviour is deprecated to align with the behaviour of user-defined functions, where scalar types need to be marked as nullable explicitly.

`wp_kses`* functions pass `$content` to `preg_replace` and similar, triggering a deprecation if `$content` is `null`.

Many plugins are using those functions without checking if the `$content` is null.
Said that is up to plugin developers to do this check, this PR helps with many plugins not doing that.

## How has this been tested?
Unit tests.

Tested also with this code:
```php
	echo 'wp_kses_stripslashes: ';
	$x=wp_kses_stripslashes(null, '');
	var_dump($x);

	echo 'wp_kses_no_null: ';
	$x=wp_kses_no_null(null, []);
	var_dump($x);

	echo 'wp_kses_split: ';
	$x=wp_kses_split(null, [], []);
	var_dump($x);

	echo 'wp_kses_bad_protocol_once: ';
	$x=wp_kses_bad_protocol_once(null, []);
	var_dump($x);

	echo 'wp_kses_normalize_entities: ';
	$x=wp_kses_normalize_entities(null);
	var_dump($x);

	echo 'wp_kses_decode_entities: ';
	$x=wp_kses_decode_entities(null);
	var_dump($x);
```

Output:
```
wp_kses_stripslashes: string(0) ""
wp_kses_no_null: string(0) ""
wp_kses_split: string(0) ""
wp_kses_bad_protocol_once: string(0) ""
wp_kses_normalize_entities: string(0) ""
wp_kses_decode_entities: string(0) ""
```
