### PR TITLE
Add ESlinting for trailing spaces

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
 		"no-prototype-builtins": "off",
 		"no-redeclare": "off",
 		"no-shadow-restricted-names": "off",
+		"no-trailing-spaces": "error",
 		"no-undef": "off",
 		"no-unused-vars": "off",
 		"no-useless-escape": "off",

--- a/src/wp-admin/js/code-editor.js
+++ b/src/wp-admin/js/code-editor.js
@@ -80,7 +80,7 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			}
 
 			/*
-			 * Note that rules must be sent in the "deprecated" lint.options property 
+			 * Note that rules must be sent in the "deprecated" lint.options property
 			 * to prevent linter from complaining about unrecognized options.
 			 * See <https://github.com/codemirror/CodeMirror/pull/4944>.
 			 */


### PR DESCRIPTION
## Description
This PR futher enhances the new ESLiniting configuration to check for trailing white space at the end of lines.

## Motivation and context
Saving this space in the code reduces (minimally) file sizes for development but is a very easy fix and addition.

## How has this been tested?
Local testing already identified trailing space in one file.

## Screenshots
N/A

## Types of changes
- New feature
