### PR TITLE
Support Ports on Multisite Domains

### DIFF
--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -139,7 +139,7 @@ function network_step1( $errors = false ) {
 	$hostname = preg_replace( '/(?::80|:443)$/', '', get_clean_basedomain() );
 	$has_ports = strstr( $hostname, ':' );
 	if ( ( false !== $has_ports && ! in_array( $has_ports, array( ':80', ':443' ), true ) ) ) {
-		echo '<div class="notice notice-warning"><p><strong>' . __( 'Warning:' ) . '</strong> ' . __( 'Install a network of sites with your server address is experimental.' ) . '</p></div>';
+		echo '<div class="notice notice-warning"><p><strong>' . __( 'Warning:' ) . '</strong> ' . __( 'Installing a network of sites with your server address is experimental.' ) . '</p></div>';
 		echo '<p>' . sprintf(
 			/* translators: %s: Port number. */
 			__( 'Use port numbers such as %s at your own risk.' ),

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -136,20 +136,8 @@ function network_step1( $errors = false ) {
 		die();
 	}
 
-	$hostname  = get_clean_basedomain();
-	$has_ports = strstr( $hostname, ':' );
-	if ( ( false !== $has_ports && ! in_array( $has_ports, array( ':80', ':443' ), true ) ) ) {
-		echo '<div class="error"><p><strong>' . __( 'Error:' ) . '</strong> ' . __( 'You cannot install a network of sites with your server address.' ) . '</p></div>';
-		echo '<p>' . sprintf(
-			/* translators: %s: Port number. */
-			__( 'You cannot use port numbers such as %s.' ),
-			'<code>' . $has_ports . '</code>'
-		) . '</p>';
-		echo '<a href="' . esc_url( admin_url() ) . '">' . __( 'Go to Dashboard' ) . '</a>';
-		echo '</div>';
-		require_once ABSPATH . 'wp-admin/admin-footer.php';
-		die();
-	}
+	// Strip standard port from hostname.
+	$hostname = preg_replace( '/(?::80|:443)$/', '', get_clean_basedomain() );
 
 	echo '<form method="post">';
 

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -136,8 +136,16 @@ function network_step1( $errors = false ) {
 		die();
 	}
 
-	// Strip standard port from hostname.
 	$hostname = preg_replace( '/(?::80|:443)$/', '', get_clean_basedomain() );
+	$has_ports = strstr( $hostname, ':' );
+	if ( ( false !== $has_ports && ! in_array( $has_ports, array( ':80', ':443' ), true ) ) ) {
+		echo '<div class="notice notice-warning"><p><strong>' . __( 'Warning:' ) . '</strong> ' . __( 'Install a network of sites with your server address is experimental.' ) . '</p></div>';
+		echo '<p>' . sprintf(
+			/* translators: %s: Port number. */
+			__( 'Use port numbers such as %s at your own risk.' ),
+			'<code>' . $has_ports . '</code>'
+		) . '</p>';
+	}
 
 	echo '<form method="post">';
 

--- a/src/wp-admin/network/site-info.php
+++ b/src/wp-admin/network/site-info.php
@@ -68,6 +68,11 @@ if ( isset( $_REQUEST['action'] ) && 'update-site' === $_REQUEST['action'] ) {
 		$blog_data['scheme'] = $update_parsed_url['scheme'];
 		$blog_data['domain'] = $update_parsed_url['host'];
 		$blog_data['path']   = $update_parsed_url['path'];
+		if ( isset( $update_parsed_url['port'] ) ) {
+			$blog_data['domain'] .= ':' . $update_parsed_url['port'];
+		}
+
+		$blog_data['path'] = $update_parsed_url['path'];
 	}
 
 	$existing_details     = get_site( $id );

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -522,10 +522,9 @@ function wp_prepare_site_data( $data, $defaults, $old_site = null ) {
 function wp_normalize_site_data( $data ) {
 	// Sanitize domain if passed.
 	if ( array_key_exists( 'domain', $data ) ) {
-		$data['domain'] = trim( $data['domain'] );
-		$data['domain'] = preg_replace( '/\s+/', '', sanitize_user( $data['domain'], true ) );
+		$data['domain'] = preg_replace( '/[^a-z0-9\-.:]+/i', '', $data['domain'] );
 		if ( is_subdomain_install() ) {
-			$data['domain'] = str_replace( '@', '', $data['domain'] );
+			$data['domain'] = str_replace( ':', '', $data['domain'] );
 		}
 	}
 

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -1392,7 +1392,8 @@ if ( is_multisite() ) :
 						'domain' => 'with-port.com:8888',
 					),
 					array(
-						'domain' => 'with-port.com:8888',					),
+						'domain' => 'with-port.com:8888',
+					),
 				),
 				array(
 					array(

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -1140,6 +1140,22 @@ if ( is_multisite() ) :
 						'lang_id'  => 1,
 					),
 				),
+				array(
+					array(
+						'domain' => 'example.com:8888',
+					),
+					array(
+						'domain'     => 'example.com:8888',
+						'path'       => '/',
+						'network_id' => 1,
+						'public'     => 1,
+						'archived'   => 0,
+						'mature'     => 0,
+						'spam'       => 0,
+						'deleted'    => 0,
+						'lang_id'    => 0,
+					),
+				),
 			);
 		}
 
@@ -1240,6 +1256,16 @@ if ( is_multisite() ) :
 						'spam'     => 1,
 						'deleted'  => 1,
 						'lang_id'  => 1,
+					),
+				),
+				array(
+					array(
+						'domain'     => 'example.com:8888',
+						'network_id' => 2,
+					),
+					array(
+						'domain'  => 'example.com:8888',
+						'site_id' => 2,
 					),
 				),
 			);
@@ -1358,8 +1384,15 @@ if ( is_multisite() ) :
 						'domain' => '<yet>/another-invalid-domain.com',
 					),
 					array(
-						'domain' => 'another-invalid-domain.com',
+						'domain' => 'yetanother-invalid-domain.com',
 					),
+				),
+				array(
+					array(
+						'domain' => 'with-port.com:8888',
+					),
+					array(
+						'domain' => 'with-port.com:8888',					),
 				),
 				array(
 					array(


### PR DESCRIPTION
This PR is copied from https://github.com/WordPress/wordpress-develop/pull/5675/files.

## Description
WordPress don't allow custom ports in MultiSite.
Can be a plus for ClassicPress to let users do this.

## Motivation and context
Having users doing tests on LAMP-like stacks, it's easier to test pull request for multisite on those stacks that use non standard port.

## How has this been tested?
Localhost and unit tests

## Types of changes
- New feature

