### PR TITLE
Use classicpress as example database name at setup

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -223,7 +223,7 @@ switch ( $step ) {
 	<table class="form-table" role="presentation">
 		<tr>
 			<th scope="row"><label for="dbname"><?php _e( 'Database Name' ); ?></label></th>
-			<td><input name="dbname" id="dbname" type="text" aria-describedby="dbname-desc" size="25" placeholder="wordpress"<?php echo $autofocus; ?>></td>
+			<td><input name="dbname" id="dbname" type="text" aria-describedby="dbname-desc" size="25" placeholder="classicpress"<?php echo $autofocus; ?>></td>
 			<td id="dbname-desc"><?php _e( 'The name of the database you want to use with ClassicPress.' ); ?></td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description
During new setup, the `wp-admin/setup-config.php` page displays a database name placeholder of `wordpress` in the text field, this should be changed.

## Motivation and context
Branding as ClassicPress in as many places as possible, especially for new installs.

## How has this been tested?
Locally tested, see screenshots below.

## Screenshots
### Before
![Screenshot 2024-01-13 at 18 02 16](https://github.com/ClassicPress/ClassicPress/assets/1280733/476cd106-a551-4c26-bf20-6d26bc6e9cba)

### After
![Screenshot 2024-01-13 at 18 01 58](https://github.com/ClassicPress/ClassicPress/assets/1280733/01f514b2-127a-426c-8986-d05b76fc3ba0)

## Types of changes
- Bug fix
