### PR TITLE
Fix fatal with some translations

### DIFF
--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -84,8 +84,9 @@ if ( $is_privacy_notice ) {
 
 	$plugins_url = current_user_can( 'activate_plugins' ) ? admin_url( 'plugins.php' ) : __( 'https://wordpress.org/plugins/' );
 	$themes_url  = current_user_can( 'switch_themes' ) ? admin_url( 'themes.php' ) : __( 'https://wordpress.org/themes/' );
+	$license_url = 'https://www.gnu.org/licenses/old-licenses/gpl-2.0.html';
 
-	printf( __( 'Every plugin and theme in ClassicPress.net&#8217;s directory is 100%% GPL or a similarly free and compatible license, so you can feel safe finding <a href="%1$s">plugins</a> and <a href="%2$s">themes</a> there. If you get a plugin or theme from another source, make sure to ask them if it&#8217;s GPL first. If they don&#8217;t respect the ClassicPress license, we don&#8217;t recommend them.' ), $plugins_url, $themes_url );
+	printf( __( 'Every plugin and theme in ClassicPress.net&#8217;s directory is 100%% GPL or a similarly free and compatible license, so you can feel safe finding <a href="%1$s">plugins</a> and <a href="%2$s">themes</a> there. If you get a plugin or theme from another source, make sure to ask them if it&#8217;s <a href="%3$s">GPL</a> first. If they don&#8217;t respect the ClassicPress license, we don&#8217;t recommend them.' ), $plugins_url, $themes_url, $license_url );
 	?>
 	</p>
 


### PR DESCRIPTION
## Description
In `wp-admin/freedoms.php` we removed a link to WordPress that it's already in place in (some) translations.
Can be checked with italian.

That throws a fatal error for a missing argument in `sprintf`.

Adding a link to GPL solves the issue, and the string is no more localized.

## How has this been tested?
Local testing

## Screenshots

### Before
Italian:
<img width="1100" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/4900f2ce-73d4-49fc-8842-de3e2a64fa57">
English:
<img width="1083" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/8accbcbd-c17d-4569-ae35-e9f16c17aaae">


### After
<img width="1124" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/f0e6b507-aa70-4c7f-ab66-284332afd0e1">


## Types of changes
- Bug fix

