### PR TITLE
WP-r57393: Grouped Backports to the 6.2 branch

### DIFF
--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -69,6 +69,30 @@ class File_Upload_Upgrader {
 				wp_die( $file['error'] );
 			}
 
+			if ( 'pluginzip' === $form || 'themezip' === $form ) {
+				$archive_is_valid = false;
+
+				/** This filter is documented in wp-admin/includes/file.php */
+				if ( class_exists( 'ZipArchive', false ) && apply_filters( 'unzip_file_use_ziparchive', true ) ) {
+					$archive          = new ZipArchive();
+					$archive_is_valid = $archive->open( $file['file'], ZIPARCHIVE::CHECKCONS );
+
+					if ( true === $archive_is_valid ) {
+						$archive->close();
+					}
+				} else {
+					require_once ABSPATH . 'wp-admin/includes/class-pclzip.php';
+
+					$archive          = new PclZip( $file['file'] );
+					$archive_is_valid = is_array( $archive->properties() );
+				}
+
+				if ( true !== $archive_is_valid ) {
+					wp_delete_file( $file['file'] );
+					wp_die( __( 'Incompatible Archive.' ) );
+				}
+			}
+
 			$this->filename = $_FILES[ $form ]['name'];
 			$this->package  = $file['file'];
 

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -597,13 +597,11 @@ function populate_options( array $options = array() ) {
 			$autoload = 'yes';
 		}
 
-		if ( is_array( $value ) ) {
-			$value = serialize( $value );
-		}
-
 		if ( ! empty( $insert ) ) {
 			$insert .= ', ';
 		}
+
+		$value = maybe_serialize( sanitize_option( $option, $value ) );
 
 		$insert .= $wpdb->prepare( '(%s, %s, %s)', $option, $value, $autoload );
 	}

--- a/src/wp-admin/update.php
+++ b/src/wp-admin/update.php
@@ -154,6 +154,10 @@ if ( isset( $_GET['action'] ) ) {
 
 		check_admin_referer( 'plugin-upload' );
 
+		if ( isset( $_FILES['pluginzip']['name'] ) && ! str_ends_with( strtolower( $_FILES['pluginzip']['name'] ), '.zip' ) ) {
+			wp_die( __( 'Only .zip archives may be uploaded.' ) );
+		}
+
 		$file_upload = new File_Upload_Upgrader( 'pluginzip', 'package' );
 
 		// Used in the HTML title tag.
@@ -301,6 +305,10 @@ if ( isset( $_GET['action'] ) ) {
 		}
 
 		check_admin_referer( 'theme-upload' );
+
+		if ( isset( $_FILES['themezip']['name'] ) && ! str_ends_with( strtolower( $_FILES['themezip']['name'] ), '.zip' ) ) {
+			wp_die( __( 'Only .zip archives may be uploaded.' ) );
+		}
 
 		$file_upload = new File_Upload_Upgrader( 'themezip', 'package' );
 


### PR DESCRIPTION
## Description

- Install: When populating options, maybe_serialize instead of always serialize.
- Uploads: Check for and verify ZIP archives.

Merges https://core.trac.wordpress.org/changeset/57388 and https://core.trac.wordpress.org/changeset/57389 to the 6.2 branch.

WP:Props costdev, peterwilsoncc, azaozz, tykoted, johnbillion, desrosj, afragen, jorbin, xknown.

---

Merges https://core.trac.wordpress.org/changeset/57393 / WordPress/wordpress-develop@867c01b844 to ClassicPress.

## Motivation and context
Backport from release of WP 6.4.2 and backported versions

## How has this been tested?
Unit tests will run and this is a clean backport

## Screenshots
N/A

## Types of changes
- Bug fix
