### PR TITLE
WP-r55752: Code Modernization: Declare properties in `Text_Diff_Engine_native`

### DIFF
--- a/src/wp-includes/Text/Diff/Engine/native.php
+++ b/src/wp-includes/Text/Diff/Engine/native.php
@@ -28,6 +28,16 @@
  */
 class Text_Diff_Engine_native {
 
+    public $xchanged;
+    public $ychanged;
+    public $xv;
+    public $yv;
+    public $xind;
+    public $yind;
+    public $seq;
+    public $in_seq;
+    public $lcs;
+
     function diff($from_lines, $to_lines)
     {
         array_walk($from_lines, array('Text_Diff', 'trimNewlines'));


### PR DESCRIPTION
Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it is an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()`, et al. methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods built in.
* For unknown ''use'' of dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the properties, as used in the class methods, fall in the “known property” category.

Reference: [https://wiki.php.net/rfc/deprecate_dynamic_properties PHP RFC: Deprecate dynamic properties].

Follow-up to https://core.trac.wordpress.org/changeset/53942, https://core.trac.wordpress.org/changeset/53948, https://core.trac.wordpress.org/changeset/53949, https://core.trac.wordpress.org/changeset/53952, https://core.trac.wordpress.org/changeset/53953, https://core.trac.wordpress.org/changeset/53954, https://core.trac.wordpress.org/changeset/53957, https://core.trac.wordpress.org/changeset/54037.

WP:Props jrf, thomask.
See https://core.trac.wordpress.org/ticket/58298.

---

Merges https://core.trac.wordpress.org/changeset/55752 / WordPress/wordpress-develop@0746cc7324 to ClassicPress.

## Types of changes
- Bug fix

