### PR TITLE
Fix `wp-cli` to bring `$cp_version` into scope

### DIFF
--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -19,17 +19,17 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public function __construct() {
-		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'bring_cp_version_in_scope' ) );
+		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'add_cp_version_to_scope' ) );
 		WP_CLI::add_hook( 'before_invoke:core check-update', array( __CLASS__, 'correct_core_check_update' ) );
 	}
 
 	/**
-	 * Put $cp_version into scope.
+	 * Add $cp_version to scope.
 	 *
 	 * @since CP-1.7.3
 	 */
-	public static function bring_cp_version_in_scope() {
-		// Put $cp_version into scope.
+	public static function add_cp_version_to_scope() {
+		// Add $cp_version to scope.
 		if ( ! isset( $GLOBALS['cp_version'] ) ) {
 			global $cp_version;
 			require ABSPATH . WPINC . '/version.php';
@@ -42,7 +42,7 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public static function correct_core_check_update() {
-		// Put $cp_version into scope.
+		// Add $cp_version to scope.
 		global $cp_version;
 
 		// Check for updates. Bail on error.

--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -19,7 +19,21 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public function __construct() {
+		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'bring_cp_version_in_scope' ) );
 		WP_CLI::add_hook( 'before_invoke:core check-update', array( __CLASS__, 'correct_core_check_update' ) );
+	}
+
+	/**
+	 * Put $cp_version into scope.
+	 *
+	 * @since CP-2.0.0
+	 */
+	public static function bring_cp_version_in_scope() {
+		// Put $cp_version into scope.
+		if ( ! isset( $GLOBALS['cp_version'] ) ) {
+			global $cp_version;
+			require ABSPATH . WPINC . '/version.php';
+		}
 	}
 
 	/**
@@ -28,6 +42,8 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public static function correct_core_check_update() {
+		// Put $cp_version into scope.
+		global $cp_version;
 
 		// Check for updates. Bail on error.
 		// When playing with versions, an empty array is returned if it's not on api.
@@ -70,12 +86,6 @@ class Fix_WPCLI {
 		$minor = preg_match( '/ --minor */', $current_command );
 
 		$major = preg_match( '/ --major */', $current_command );
-
-		// Put $cp_version into scope.
-		if ( ! isset( $GLOBALS['cp_version'] ) ) {
-			global $cp_version;
-			require ABSPATH . WPINC . '/version.php';
-		}
 
 		// Prepare output array.
 		$table_output = array();

--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -26,7 +26,7 @@ class Fix_WPCLI {
 	/**
 	 * Put $cp_version into scope.
 	 *
-	 * @since CP-2.0.0
+	 * @since CP-1.7.3
 	 */
 	public static function bring_cp_version_in_scope() {
 		// Put $cp_version into scope.


### PR DESCRIPTION
As reported on Zulip, wp-cli is missing:

- `$cp_version`
- `classicpress_version()`
- `classicpress_version_short()`
- `classicpress_is_dev_install()`

This is due to how wp-cli bootstraps ClassicPress.

## How has this been tested?
`wp eval 'global $cp_version; echo $cp_version . "\n";echo classicpress_version()."\n";echo classicpress_version_short()."\n"; echo classicpress_is_dev_install()."\n";'`

## Types of changes
- Bug fix

