### PR TITLE
Fix compatibility issue between CP v.2 and WooCommerce v.3.9.5

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1288,7 +1288,7 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 						' </span>';
 					}
 					elseif ( 'woocommerce-product-data' === $box['id'] ) {
-						echo '<span aria-hidden="true"></span>';
+						echo '<span></span>';
 					}
 					echo $box['title'];
 					echo '</h2>';

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1287,6 +1287,9 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 							__( 'Warning:' ) .
 						' </span>';
 					}
+					elseif ( 'woocommerce-product-data' === $box['id'] ) {
+						echo '<span aria-hidden="true"></span>';
+					}
 					echo $box['title'];
 					echo '</h2>';
 

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1286,8 +1286,7 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 							/* translators: Hidden accessibility text. */
 							__( 'Warning:' ) .
 						' </span>';
-					}
-					elseif ( 'woocommerce-product-data' === $box['id'] ) {
+					} elseif ( 'woocommerce-product-data' === $box['id'] ) {
 						echo '<span></span>';
 					}
 					echo $box['title'];


### PR DESCRIPTION
This adds an empty `span` to a specific product metabox whenever WooCommerce is active. It fixes the problem reported at https://forums.classicpress.net/t/woocommerce-3-9-5-broken-in-rc1-nightly/5094/1

It does so by implementing in the core `template.php` file the fix identified at https://forums.classicpress.net/t/woocommerce-3-9-5-broken-in-rc1-nightly/5094/3?u=simone