### PR TITLE
Update about.php with correct forum link

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -116,7 +116,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 					/* translators: link to ClassicPress 1.0.0 changelog */
 					__( 'For a list of new features and other changes from WordPress %1$s, see the <a href="%2$s"><strong>ClassicPress 2.0.0 (Bella) release notes</strong></a>.' ),
 					'6.2.x',
-					'https://forums.classicpress.net/t/classicpress-2-0-0-bella-release-notes/910'
+					'https://forums.classicpress.net/t/classicpress-2-0-0-bella-release-notes/5099'
 				);
 				?>
 			</p>


### PR DESCRIPTION
## Description
This PR updates the release announcement link for the "Bella" release from the about.php page in admin.

## Motivation and context
Correct link will avoid redirect path on the server for a slightly faster user experience.

## How has this been tested?
Local testing.

## Screenshots
N/A

## Types of changes
- Bug fix
