### PR TITLE
Fix: Test errors in PHP 8.2 tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.0', '7.4' ]
+        php: [ '8.2' '8.1', '8.0', '7.4' ]
         mysql: [ '5.7' ]
         memcached: [ false ]
         experimental: [ false ]
@@ -48,7 +48,7 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
-          - php: '8.2'
+          - php: '8.3'
             mysql: '5.7'
             memcached: false
             experimental: true

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.1', '8.0', '7.4' ]
+        php: [ '8.3', '8.2', '8.1', '8.0', '7.4' ]
         mysql: [ '5.7' ]
         memcached: [ false ]
         experimental: [ false ]
@@ -48,10 +48,6 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
-          - php: '8.3'
-            mysql: '5.7'
-            memcached: false
-            experimental: true
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2' '8.1', '8.0', '7.4' ]
+        php: [ '8.2', '8.1', '8.0', '7.4' ]
         mysql: [ '5.7' ]
         memcached: [ false ]
         experimental: [ false ]

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -46,7 +46,7 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 
 		$readme = file_get_contents( ABSPATH . 'readme.html' );
 
-		preg_match( '#Recommendations.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
+		preg_match( '#Recommended.*MySQL</a> version <strong>([0-9.]*)#s', $readme, $matches );
 
 		$this->assertSame( $matches[1], $reflection_property->getValue( $this->instance ) );
 	}

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -34,11 +34,26 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	protected static $subscriber_user_id;
 
 	/**
+<<<<<<< HEAD
 	 * Whether any attachments have been created in the current test run.
 	 *
 	 * @var bool
 	 */
 	private $attachments_created = false;
+=======
+	 * Path to test file 1.
+	 *
+	 * @var string
+	 */
+	private $test_file;
+
+	/**
+	 * Path to test file 2.
+	 *
+	 * @var string
+	 */
+	private $test_file2;
+>>>>>>> 4a71feb890 (Code Modernization: Explicitly declare all properties created in `set_up()` methods of various test classes.)
 
 	/**
 	 * Set up before class.

--- a/tests/phpunit/tests/file.php
+++ b/tests/phpunit/tests/file.php
@@ -5,12 +5,14 @@
  */
 class Tests_File extends WP_UnitTestCase {
 
+	const BADCHARS = '"\'[]*&?$';
+
+	private $dir;
+
 	public function set_up() {
 		parent::set_up();
 
 		$this->dir = untrailingslashit( get_temp_dir() );
-
-		$this->badchars = '"\'[]*&?$';
 	}
 
 	/**
@@ -115,7 +117,7 @@ class Tests_File extends WP_UnitTestCase {
 
 	public function test_unique_filename_is_sanitized() {
 		$name     = __FUNCTION__;
-		$filename = wp_unique_filename( $this->dir, $name . $this->badchars . '.txt' );
+		$filename = wp_unique_filename( $this->dir, $name . self::BADCHARS . '.txt' );
 
 		// Make sure the bad characters were all stripped out.
 		$this->assertSame( $name . '.txt', $filename );

--- a/tests/phpunit/tests/hooks/addFilter.php
+++ b/tests/phpunit/tests/hooks/addFilter.php
@@ -218,12 +218,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_action() {
-<<<<<<< HEAD
-		$this->hook          = new Wp_Hook();
-		$this->action_output = '';
-=======
 		$this->hook = new WP_Hook();
->>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -237,12 +232,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_last_action() {
-<<<<<<< HEAD
-		$this->hook          = new Wp_Hook();
-		$this->action_output = '';
-=======
 		$this->hook = new WP_Hook();
->>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -256,12 +246,7 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_recurse_and_add_action() {
-<<<<<<< HEAD
-		$this->hook          = new Wp_Hook();
-		$this->action_output = '';
-=======
 		$this->hook = new WP_Hook();
->>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 

--- a/tests/phpunit/tests/hooks/addFilter.php
+++ b/tests/phpunit/tests/hooks/addFilter.php
@@ -10,6 +10,23 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 
 	public $hook;
 
+	/**
+	 * Temporary storage for action output.
+	 *
+	 * Used in the following tests:
+	 * - `test_remove_and_add_action()`
+	 * - `test_remove_and_add_last_action()`
+	 * - `test_remove_and_recurse_and_add_action()`
+	 *
+	 * @var array
+	 */
+	private $action_output = '';
+
+	public function tear_down() {
+		$this->action_output = '';
+		parent::tear_down();
+	}
+
 	public function test_add_filter_with_function() {
 		$callback      = '__return_null';
 		$hook          = new WP_Hook();
@@ -201,8 +218,12 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_action() {
+<<<<<<< HEAD
 		$this->hook          = new Wp_Hook();
 		$this->action_output = '';
+=======
+		$this->hook = new WP_Hook();
+>>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -216,8 +237,12 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_add_last_action() {
+<<<<<<< HEAD
 		$this->hook          = new Wp_Hook();
 		$this->action_output = '';
+=======
+		$this->hook = new WP_Hook();
+>>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 
@@ -231,8 +256,12 @@ class Tests_WP_Hook_Add_Filter extends WP_UnitTestCase {
 	}
 
 	public function test_remove_and_recurse_and_add_action() {
+<<<<<<< HEAD
 		$this->hook          = new Wp_Hook();
 		$this->action_output = '';
+=======
+		$this->hook = new WP_Hook();
+>>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		$this->hook->add_filter( 'remove_and_add_action', '__return_empty_string', 10, 0 );
 

--- a/tests/phpunit/tests/includes/factory.php
+++ b/tests/phpunit/tests/includes/factory.php
@@ -1,6 +1,12 @@
 <?php
 
 class TestFactoryFor extends WP_UnitTestCase {
+
+	/**
+	 * @var WP_UnitTest_Factory_For_Term
+	 */
+	private $category_factory;
+
 	public function set_up() {
 		parent::set_up();
 		$this->category_factory = new WP_UnitTest_Factory_For_Term( null, 'category' );

--- a/tests/phpunit/tests/post/query.php
+++ b/tests/phpunit/tests/post/query.php
@@ -5,6 +5,25 @@
  * @group post
  */
 class Tests_Post_Query extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for a post ID for tests using filter callbacks.
+	 *
+	 * Used in the `test_posts_pre_query_filter_should_respect_set_found_posts()` method.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->post_id );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @group taxonomy
 	 */
@@ -702,7 +721,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	 * @ticket 42469
 	 */
 	public function test_found_posts_should_be_integer_not_string() {
-		$this->post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		$q = new WP_Query(
 			array(
@@ -717,7 +736,7 @@ class Tests_Post_Query extends WP_UnitTestCase {
 	 * @ticket 42469
 	 */
 	public function test_found_posts_should_be_integer_even_if_found_posts_filter_returns_string_value() {
-		$this->post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		add_filter( 'found_posts', '__return_empty_string' );
 

--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -18,19 +18,6 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		self::$author_user_id = $factory->user->create( array( 'role' => 'author' ) );
 	}
 
-<<<<<<< HEAD
-	public function set_up() {
-		parent::set_up();
-		$this->post_type = rand_str( 20 );
-	}
-
-	public function tear_down() {
-		unset( $GLOBALS['wp_post_types'][ $this->post_type ] );
-		parent::tear_down();
-	}
-
-=======
->>>>>>> 278081ed1d (Code Modernization: Remove dynamic properties in `Tests_Post_Revisions`.)
 	/**
 	 * Note: Test needs reviewing when https://core.trac.wordpress.org/ticket/16215 is fixed because I'm not sure the test current tests the "correct" behavior
 	 * @ticket 20982

--- a/tests/phpunit/tests/post/revisions.php
+++ b/tests/phpunit/tests/post/revisions.php
@@ -5,6 +5,9 @@
  * @group revision
  */
 class Tests_Post_Revisions extends WP_UnitTestCase {
+
+	const POST_TYPE = 'test-revision';
+
 	protected static $admin_user_id;
 	protected static $editor_user_id;
 	protected static $author_user_id;
@@ -15,6 +18,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		self::$author_user_id = $factory->user->create( array( 'role' => 'author' ) );
 	}
 
+<<<<<<< HEAD
 	public function set_up() {
 		parent::set_up();
 		$this->post_type = rand_str( 20 );
@@ -25,6 +29,8 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+=======
+>>>>>>> 278081ed1d (Code Modernization: Remove dynamic properties in `Tests_Post_Revisions`.)
 	/**
 	 * Note: Test needs reviewing when https://core.trac.wordpress.org/ticket/16215 is fixed because I'm not sure the test current tests the "correct" behavior
 	 * @ticket 20982
@@ -317,7 +323,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_view_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -327,7 +333,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);
@@ -358,7 +364,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_restore_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -373,7 +379,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 		//create a post as Editor
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);
@@ -403,7 +409,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_restore_caps_before_publish() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'post',
 				'capabilities'    => array(
@@ -421,7 +427,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_status' => 'draft',
 			)
 		);
@@ -462,7 +468,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 	 */
 	public function test_revision_diff_caps_cpt() {
 		register_post_type(
-			$this->post_type,
+			self::POST_TYPE,
 			array(
 				'capability_type' => 'event',
 				'map_meta_cap'    => true,
@@ -472,7 +478,7 @@ class Tests_Post_Revisions extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create(
 			array(
-				'post_type'   => $this->post_type,
+				'post_type'   => self::POST_TYPE,
 				'post_author' => self::$editor_user_id,
 			)
 		);

--- a/tests/phpunit/tests/post/slashes.php
+++ b/tests/phpunit/tests/post/slashes.php
@@ -6,25 +6,6 @@
  * @ticket 21767
  */
 class Tests_Post_Slashes extends WP_UnitTestCase {
-<<<<<<< HEAD
-	public function set_up() {
-		parent::set_up();
-
-		$this->author_id = self::factory()->user->create( array( 'role' => 'editor' ) );
-
-		wp_set_current_user( $this->author_id );
-
-		// it is important to test with both even and odd numbered slashes as
-		// kses does a strip-then-add slashes in some of its function calls
-		$this->slash_1 = 'String with 1 slash \\';
-		$this->slash_2 = 'String with 2 slashes \\\\';
-		$this->slash_3 = 'String with 3 slashes \\\\\\';
-		$this->slash_4 = 'String with 4 slashes \\\\\\\\';
-		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
-		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
-		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
-=======
-
 	/*
 	 * It is important to test with both even and odd numbered slashes,
 	 * as KSES does a strip-then-add slashes in some of its function calls.
@@ -50,7 +31,6 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		parent::set_up();
 
 		wp_set_current_user( self::$author_id );
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 	}
 
 	/**
@@ -58,23 +38,15 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	 *
 	 */
 	public function test_edit_post() {
-		$id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		$_POST               = array();
-<<<<<<< HEAD
-		$_POST['post_ID']    = $id;
-		$_POST['post_title'] = $this->slash_1;
-		$_POST['content']    = $this->slash_5;
-		$_POST['excerpt']    = $this->slash_7;
-		$_POST               = add_magic_quotes( $_POST ); // the edit_post() function will strip slashes
-=======
 		$_POST['post_ID']    = $post_id;
 		$_POST['post_title'] = self::SLASH_1;
 		$_POST['content']    = self::SLASH_5;
 		$_POST['excerpt']    = self::SLASH_7;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
@@ -84,20 +56,12 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		$this->assertSame( self::SLASH_7, $post->post_excerpt );
 
 		$_POST               = array();
-<<<<<<< HEAD
-		$_POST['post_ID']    = $id;
-		$_POST['post_title'] = $this->slash_2;
-		$_POST['content']    = $this->slash_4;
-		$_POST['excerpt']    = $this->slash_6;
-		$_POST               = add_magic_quotes( $_POST );
-=======
 		$_POST['post_ID']    = $post_id;
 		$_POST['post_title'] = self::SLASH_2;
 		$_POST['content']    = self::SLASH_4;
 		$_POST['excerpt']    = self::SLASH_6;
 
 		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
@@ -112,7 +76,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	 *
 	 */
 	public function test_wp_insert_post() {
-		$id   = wp_insert_post(
+		$post_id = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
 				'post_title'   => self::SLASH_1,
@@ -122,13 +86,13 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 				'slashed'      => false,
 			)
 		);
-		$post = get_post( $id );
+		$post    = get_post( $post_id );
 
 		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
 		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
 		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
-		$id   = wp_insert_post(
+		$post_id = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
 				'post_title'   => self::SLASH_2,
@@ -137,7 +101,7 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 				'post_type'    => 'post',
 			)
 		);
-		$post = get_post( $id );
+		$post    = get_post( $post_id );
 
 		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
 		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );
@@ -149,24 +113,17 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	 *
 	 */
 	public function test_wp_update_post() {
-		$id = self::factory()->post->create();
+		$post_id = self::factory()->post->create();
 
 		wp_update_post(
 			array(
-<<<<<<< HEAD
-				'ID'           => $id,
-				'post_title'   => $this->slash_1,
-				'post_content' => $this->slash_3,
-				'post_excerpt' => $this->slash_5,
-=======
 				'ID'           => $post_id,
 				'post_title'   => self::SLASH_1,
 				'post_content' => self::SLASH_3,
 				'post_excerpt' => self::SLASH_5,
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 			)
 		);
-		$post = get_post( $id );
+		$post    = get_post( $post_id );
 
 		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
 		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
@@ -174,20 +131,13 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 
 		wp_update_post(
 			array(
-<<<<<<< HEAD
-				'ID'           => $id,
-				'post_title'   => $this->slash_2,
-				'post_content' => $this->slash_4,
-				'post_excerpt' => $this->slash_6,
-=======
 				'ID'           => $post_id,
 				'post_title'   => self::SLASH_2,
 				'post_content' => self::SLASH_4,
 				'post_excerpt' => self::SLASH_6,
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 			)
 		);
-		$post = get_post( $id );
+		$post = get_post( $post_id );
 
 		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
 		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );

--- a/tests/phpunit/tests/post/slashes.php
+++ b/tests/phpunit/tests/post/slashes.php
@@ -6,6 +6,7 @@
  * @ticket 21767
  */
 class Tests_Post_Slashes extends WP_UnitTestCase {
+<<<<<<< HEAD
 	public function set_up() {
 		parent::set_up();
 
@@ -22,6 +23,34 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		$this->slash_5 = 'String with 5 slashes \\\\\\\\\\';
 		$this->slash_6 = 'String with 6 slashes \\\\\\\\\\\\';
 		$this->slash_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+=======
+
+	/*
+	 * It is important to test with both even and odd numbered slashes,
+	 * as KSES does a strip-then-add slashes in some of its function calls.
+	 */
+
+	const SLASH_1 = 'String with 1 slash \\';
+	const SLASH_2 = 'String with 2 slashes \\\\';
+	const SLASH_3 = 'String with 3 slashes \\\\\\';
+	const SLASH_4 = 'String with 4 slashes \\\\\\\\';
+	const SLASH_5 = 'String with 5 slashes \\\\\\\\\\';
+	const SLASH_6 = 'String with 6 slashes \\\\\\\\\\\\';
+	const SLASH_7 = 'String with 7 slashes \\\\\\\\\\\\\\';
+
+	protected static $author_id;
+	protected static $post_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$author_id = $factory->user->create( array( 'role' => 'editor' ) );
+		self::$post_id   = $factory->post->create();
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		wp_set_current_user( self::$author_id );
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 	}
 
 	/**
@@ -32,32 +61,50 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		$id = self::factory()->post->create();
 
 		$_POST               = array();
+<<<<<<< HEAD
 		$_POST['post_ID']    = $id;
 		$_POST['post_title'] = $this->slash_1;
 		$_POST['content']    = $this->slash_5;
 		$_POST['excerpt']    = $this->slash_7;
 		$_POST               = add_magic_quotes( $_POST ); // the edit_post() function will strip slashes
+=======
+		$_POST['post_ID']    = $post_id;
+		$_POST['post_title'] = self::SLASH_1;
+		$_POST['content']    = self::SLASH_5;
+		$_POST['excerpt']    = self::SLASH_7;
+
+		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_5, $post->post_content );
-		$this->assertSame( $this->slash_7, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_5, $post->post_content );
+		$this->assertSame( self::SLASH_7, $post->post_excerpt );
 
 		$_POST               = array();
+<<<<<<< HEAD
 		$_POST['post_ID']    = $id;
 		$_POST['post_title'] = $this->slash_2;
 		$_POST['content']    = $this->slash_4;
 		$_POST['excerpt']    = $this->slash_6;
 		$_POST               = add_magic_quotes( $_POST );
+=======
+		$_POST['post_ID']    = $post_id;
+		$_POST['post_title'] = self::SLASH_2;
+		$_POST['content']    = self::SLASH_4;
+		$_POST['excerpt']    = self::SLASH_6;
+
+		$_POST = add_magic_quotes( $_POST ); // The edit_post() function will strip slashes.
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 
 		$post_id = edit_post();
 		$post    = get_post( $post_id );
 
-		$this->assertSame( $this->slash_2, $post->post_title );
-		$this->assertSame( $this->slash_4, $post->post_content );
-		$this->assertSame( $this->slash_6, $post->post_excerpt );
+		$this->assertSame( self::SLASH_2, $post->post_title );
+		$this->assertSame( self::SLASH_4, $post->post_content );
+		$this->assertSame( self::SLASH_6, $post->post_excerpt );
 	}
 
 	/**
@@ -68,33 +115,33 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 		$id   = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
-				'post_title'   => $this->slash_1,
-				'post_content' => $this->slash_3,
-				'post_excerpt' => $this->slash_5,
+				'post_title'   => self::SLASH_1,
+				'post_content' => self::SLASH_3,
+				'post_excerpt' => self::SLASH_5,
 				'post_type'    => 'post',
 				'slashed'      => false,
 			)
 		);
 		$post = get_post( $id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
 		$id   = wp_insert_post(
 			array(
 				'post_status'  => 'publish',
-				'post_title'   => $this->slash_2,
-				'post_content' => $this->slash_4,
-				'post_excerpt' => $this->slash_6,
+				'post_title'   => self::SLASH_2,
+				'post_content' => self::SLASH_4,
+				'post_excerpt' => self::SLASH_6,
 				'post_type'    => 'post',
 			)
 		);
 		$post = get_post( $id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $post->post_excerpt );
 	}
 
 	/**
@@ -106,31 +153,45 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 
 		wp_update_post(
 			array(
+<<<<<<< HEAD
 				'ID'           => $id,
 				'post_title'   => $this->slash_1,
 				'post_content' => $this->slash_3,
 				'post_excerpt' => $this->slash_5,
+=======
+				'ID'           => $post_id,
+				'post_title'   => self::SLASH_1,
+				'post_content' => self::SLASH_3,
+				'post_excerpt' => self::SLASH_5,
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 			)
 		);
 		$post = get_post( $id );
 
-		$this->assertSame( wp_unslash( $this->slash_1 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_3 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_5 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_1 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_3 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_5 ), $post->post_excerpt );
 
 		wp_update_post(
 			array(
+<<<<<<< HEAD
 				'ID'           => $id,
 				'post_title'   => $this->slash_2,
 				'post_content' => $this->slash_4,
 				'post_excerpt' => $this->slash_6,
+=======
+				'ID'           => $post_id,
+				'post_title'   => self::SLASH_2,
+				'post_content' => self::SLASH_4,
+				'post_excerpt' => self::SLASH_6,
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 			)
 		);
 		$post = get_post( $id );
 
-		$this->assertSame( wp_unslash( $this->slash_2 ), $post->post_title );
-		$this->assertSame( wp_unslash( $this->slash_4 ), $post->post_content );
-		$this->assertSame( wp_unslash( $this->slash_6 ), $post->post_excerpt );
+		$this->assertSame( wp_unslash( self::SLASH_2 ), $post->post_title );
+		$this->assertSame( wp_unslash( self::SLASH_4 ), $post->post_content );
+		$this->assertSame( wp_unslash( self::SLASH_6 ), $post->post_excerpt );
 	}
 
 	/**
@@ -138,9 +199,9 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 	 */
 	public function test_wp_trash_untrash() {
 		$post = array(
-			'post_title'   => $this->slash_1,
-			'post_content' => $this->slash_3,
-			'post_excerpt' => $this->slash_5,
+			'post_title'   => self::SLASH_1,
+			'post_content' => self::SLASH_3,
+			'post_excerpt' => self::SLASH_5,
 		);
 		$id   = wp_insert_post( wp_slash( $post ) );
 
@@ -149,17 +210,17 @@ class Tests_Post_Slashes extends WP_UnitTestCase {
 
 		$post = get_post( $id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_3, $post->post_content );
-		$this->assertSame( $this->slash_5, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_3, $post->post_content );
+		$this->assertSame( self::SLASH_5, $post->post_excerpt );
 
 		$untrashed = wp_untrash_post( $id );
 		$this->assertNotEmpty( $untrashed );
 
 		$post = get_post( $id );
 
-		$this->assertSame( $this->slash_1, $post->post_title );
-		$this->assertSame( $this->slash_3, $post->post_content );
-		$this->assertSame( $this->slash_5, $post->post_excerpt );
+		$this->assertSame( self::SLASH_1, $post->post_title );
+		$this->assertSame( self::SLASH_3, $post->post_content );
+		$this->assertSame( self::SLASH_5, $post->post_excerpt );
 	}
 }

--- a/tests/phpunit/tests/theme/WPTheme.php
+++ b/tests/phpunit/tests/theme/WPTheme.php
@@ -2,9 +2,6 @@
 /**
  * @group themes
  */
-<<<<<<< HEAD:tests/phpunit/tests/theme/WPTheme.php
-class Tests_Theme_WPTheme extends WP_UnitTestCase {
-=======
 class Tests_Theme_wpTheme extends WP_UnitTestCase {
 
 	/**
@@ -21,7 +18,6 @@ class Tests_Theme_wpTheme extends WP_UnitTestCase {
 	 */
 	private $orig_theme_dir;
 
->>>>>>> e119438d26 (Code Modernization: Remove dynamic properties in theme tests.):tests/phpunit/tests/theme/wpTheme.php
 	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( DIR_TESTDATA . '/themedir1' );

--- a/tests/phpunit/tests/theme/WPTheme.php
+++ b/tests/phpunit/tests/theme/WPTheme.php
@@ -2,7 +2,26 @@
 /**
  * @group themes
  */
+<<<<<<< HEAD:tests/phpunit/tests/theme/WPTheme.php
 class Tests_Theme_WPTheme extends WP_UnitTestCase {
+=======
+class Tests_Theme_wpTheme extends WP_UnitTestCase {
+
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
+>>>>>>> e119438d26 (Code Modernization: Remove dynamic properties in theme tests.):tests/phpunit/tests/theme/wpTheme.php
 	public function set_up() {
 		parent::set_up();
 		$this->theme_root = realpath( DIR_TESTDATA . '/themedir1' );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -63,6 +63,16 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $this->role_test_wp_roles_init );
+<<<<<<< HEAD
+=======
+
+		parent::tear_down();
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_post( self::$block_id, true );
+	}
+>>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -26,11 +26,6 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	protected static $super_admin = null;
 
 	/**
-	 * @var int $block_id
-	 */
-	protected static $block_id;
-
-	/**
 	 * Temporary storage for roles for tests using filter callbacks.
 	 *
 	 * Used in the `test_wp_roles_init_action()` method.
@@ -63,16 +58,6 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $this->role_test_wp_roles_init );
-<<<<<<< HEAD
-=======
-
-		parent::tear_down();
-	}
-
-	public static function wpTearDownAfterClass() {
-		wp_delete_post( self::$block_id, true );
-	}
->>>>>>> dfb4737c43 (Code Modernization: Explicitly declare all properties in various tests.)
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/user/slashes.php
+++ b/tests/phpunit/tests/user/slashes.php
@@ -148,7 +148,11 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 			array(
 				'user_login'   => 'slash_example_user_3',
 				'role'         => 'subscriber',
+<<<<<<< HEAD
 				'user_email'   => 'user3@example.com',
+=======
+				'email'        => 'user3@example.com',
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 				'first_name'   => self::SLASH_1,
 				'last_name'    => self::SLASH_3,
 				'nickname'     => self::SLASH_5,
@@ -169,7 +173,11 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 			array(
 				'user_login'   => 'slash_example_user_4',
 				'role'         => 'subscriber',
+<<<<<<< HEAD
 				'user_email'   => 'user4@example.com',
+=======
+				'email'        => 'user3@example.com',
+>>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 				'first_name'   => self::SLASH_2,
 				'last_name'    => self::SLASH_4,
 				'nickname'     => self::SLASH_6,

--- a/tests/phpunit/tests/user/slashes.php
+++ b/tests/phpunit/tests/user/slashes.php
@@ -148,11 +148,7 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 			array(
 				'user_login'   => 'slash_example_user_3',
 				'role'         => 'subscriber',
-<<<<<<< HEAD
-				'user_email'   => 'user3@example.com',
-=======
 				'email'        => 'user3@example.com',
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 				'first_name'   => self::SLASH_1,
 				'last_name'    => self::SLASH_3,
 				'nickname'     => self::SLASH_5,
@@ -173,11 +169,7 @@ class Tests_User_Slashes extends WP_UnitTestCase {
 			array(
 				'user_login'   => 'slash_example_user_4',
 				'role'         => 'subscriber',
-<<<<<<< HEAD
-				'user_email'   => 'user4@example.com',
-=======
 				'email'        => 'user3@example.com',
->>>>>>> bafecbeab5 (Code Modernization: Remove dynamic properties in `Tests_*_Slashes`.)
 				'first_name'   => self::SLASH_2,
 				'last_name'    => self::SLASH_4,
 				'nickname'     => self::SLASH_6,


### PR DESCRIPTION
## Description
Currently PHP 8.2 based GitHub tests are experimental. This PR aims to backport upstream fixes as found in [ticket 56033](https://core.trac.wordpress.org/ticket/56033) to resolve these issue.

## Motivation and context
This PR should allow removal of the `experimental` flag from the PHP 8.2 tests and we can formally support PHP 8.2

## How has this been tested?
Local testing during backporting and merge now show 0 errors.
Will need to ensure GitHub tests are passing and removal of the PHP 8.2 experimental flag can also be implemented as part of this PR.

## Screenshots
N/A

## Types of changes
- Bug fix
