### PR TITLE
Restore automatic installation for WordPress Import Tool

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -71,14 +71,6 @@ $parent_file = 'tools.php';
 	</div>
 <?php endif; ?>
 <p><?php _e( 'If you have posts or comments in another system, ClassicPress can import those into this site. To get started, choose a system to import from below:' ); ?></p>
-
-<?php
-printf(
-	__( 'If you need a ClassicPress Importer, follow <a href="%s">these instructions</a> to install it manually.' ),
-	esc_url( 'https://docs.classicpress.net/user-guides/using-classicpress/tools-import-screen/' )
-);
-?>
-</p>
 <?php
 // Registered (already installed) importers. They're stored in the global $wp_importers.
 $importers = get_importers();

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -225,8 +225,8 @@ function wp_get_popular_importers() {
 			'importer-id' => 'tumblr',
 		),
 		'wordpress'   => array(
-			'name'        => 'ClassicPress',
-			'description' => __( 'Import posts, pages, comments, custom fields, categories, and tags from a ClassicPress export file.' ),
+			'name'        => 'WordPress',
+			'description' => __( 'Install the WordPress importer to import posts, pages, comments, custom fields, categories, and tags from a WordPress export file.' ),
 			'plugin-slug' => 'wordpress-importer',
 			'importer-id' => 'wordpress',
 		),

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -141,6 +141,7 @@ function wp_get_popular_importers() {
 
 	$locale            = get_user_locale();
 	$cache_key         = 'popular_importers_' . md5( $locale . $wp_version );
+	echo $cache_key;
 	$popular_importers = get_site_transient( $cache_key );
 
 	if ( ! $popular_importers ) {
@@ -149,7 +150,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => $wp_version,
 			),
-			'https://api-v1.classicpress.net/core/importers/1.0/'
+			'https://api-v1.classicpress.net/core/importers/2.0/'
 		);
 		$options = array( 'user-agent' => classicpress_user_agent() );
 
@@ -223,6 +224,12 @@ function wp_get_popular_importers() {
 			'description' => __( 'Import posts &amp; media from Tumblr using their API.' ),
 			'plugin-slug' => 'tumblr-importer',
 			'importer-id' => 'tumblr',
+		),
+		'wordpress'   => array(
+			'name'        => 'ClassicPress',
+			'description' => __( 'Import posts, pages, comments, custom fields, categories, and tags from a ClassicPress export file.' ),
+			'plugin-slug' => 'wordpress-importer',
+			'importer-id' => 'wordpress',
 		),
 	);
 }

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -141,7 +141,6 @@ function wp_get_popular_importers() {
 
 	$locale            = get_user_locale();
 	$cache_key         = 'popular_importers_' . md5( $locale . $wp_version );
-	echo $cache_key;
 	$popular_importers = get_site_transient( $cache_key );
 
 	if ( ! $popular_importers ) {


### PR DESCRIPTION
## Description
At the moment, when a user wishes to import an exported WXR file, they are told that the default Import tool (WordPress Importer plugin) is incompatible with ClassicPress. But the latest version (0.8.2) is now compatible with ClassicPress v2.
Closes #1339.

### Wording
I've left the default description used un WordPress because the tool is in the WP repo and it's not designed (even if it works) for ClassicPress.

## To do

- [x] https://github.com/ClassicPress/ClassicPress-APIs/pull/101 must be merged and then this PR can be tested.

## Types of changes
- Bug fix

