### PR TITLE
Conditionally run `imagemin:core` on linux only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -882,9 +882,14 @@ module.exports = function(grunt) {
 
 	grunt.registerTask(
 		'precommit:image',
-		[
-			'imagemin:core'
-		]
+		'Detect OS and only run on linux',
+		function() {
+			if ( /linux/.test( process.platform ) ) {
+				grunt.task.run( [ 'imagemin:core' ] );
+			} else {
+				grunt.log.writeln( 'Image minification should only run on Linux, `precommit:image` skipped.' );
+			}
+		}
 	);
 
 	grunt.registerTask(


### PR DESCRIPTION
## Description
Images included at `wp-admin/images/` and `wp-includes/images/` are minified by a Grunt task.

This task uses [grunt-contrib-imagemin](https://www.npmjs.com/package/grunt-contrib-imagemin) and this task writes files even if there is now file size change.

On MacOS running `grunt precommit:image` results in many file changes (see screen grabs below. This means development on MacOS where `precommit` is needed creates images changes that should not occur.

A [PR](https://github.com/gruntjs/grunt-contrib-imagemin/pull/400) has been made upstream about 6 months ago but it seems that the project is poorly maintained or abandoned.

## Motivation and context
I cannot find a suitable alternative npm package so have created a platform conditional workaround that skips this step on all platforms except Linux.

## How has this been tested?
Local Testing Only

## Screenshots
### Before
`grunt precommit:image` runs an alias task of `imagemin:core`
![Screenshot 2024-03-07 at 09 29 09](https://github.com/ClassicPress/ClassicPress/assets/1280733/ab10973b-dce8-4099-96aa-d6bea4330b48)

But `git status` shows:
![Screenshot 2024-03-07 at 09 32 38](https://github.com/ClassicPress/ClassicPress/assets/1280733/4a5dd2ac-5cb0-4ff8-ad94-2c8795e08086)

### After
![Screenshot 2024-03-07 at 09 34 23](https://github.com/ClassicPress/ClassicPress/assets/1280733/20ea751c-bcb1-4bd0-b997-ab9c013fa747)

Not `git status` shows:
![Screenshot 2024-03-07 at 09 34 34](https://github.com/ClassicPress/ClassicPress/assets/1280733/7c847f1c-6244-482f-9e02-8a5c74892ea5)

## Types of changes
- Bug fix
