### PR TITLE
WP-r56235: Editor: Fix open_basedir warnings on Edit Post screen

### DIFF
--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -508,9 +508,13 @@ final class _WP_Editors {
 							// Try to load langs/[locale].js and langs/[locale]_dlg.js.
 							if ( ! in_array( $name, $loaded_langs, true ) ) {
 								$path = str_replace( content_url(), '', $plugurl );
-								$path = WP_CONTENT_DIR . $path . '/langs/';
+								$path = realpath( WP_CONTENT_DIR . $path . '/langs/' );
 
-								$path = trailingslashit( realpath( $path ) );
+								if ( ! $path ) {
+									continue;
+								}
+
+								$path = trailingslashit( $path );
 
 								if ( @is_file( $path . $mce_locale . '.js' ) ) {
 									$strings .= @file_get_contents( $path . $mce_locale . '.js' ) . "\n";


### PR DESCRIPTION
WP-r56235: Editir: Fix open_basedir warnings on the classic Edit Post screen when additional TinyMCE plugins are used.

WP:Props: rembem, MadtownLems, njsamsatli, sabernhardt, azaozz.
Fixes: https://core.trac.wordpress.org/ticket/54354.

---

Merges https://core.trac.wordpress.org/changeset/56235 / WordPress/wordpress-develop@e77bf1ec99 to ClassicPress.


## How has this been tested?
Local MAMP stack with `open_basedir` restrictions activated and `it_IT` locale.

## Screenshots

### Before
<img width="679" alt="Schermata 2024-03-15 alle 10 45 35" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/ee400c02-17e8-4524-84db-9508f7c86ba2">


### After
<img width="658" alt="Schermata 2024-03-15 alle 10 45 00" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/43f543b9-3e9b-40a7-a4cc-fcc181a31303">


## Types of changes
- Bug fix

