### PR TITLE
Order media by update date

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3580,7 +3580,7 @@ function get_adjacent_image_link( $prev = true, $size = 'thumbnail', $text = fal
 				'post_type'      => 'attachment',
 				'post_mime_type' => 'image',
 				'order'          => 'ASC',
-				'orderby'        => 'menu_order ID',
+				'orderby'        => 'menu_order date',
 			)
 		)
 	);


### PR DESCRIPTION
## Description
Fix for #1223 

By default media upload date is not editable, but it can be edited with plugins like [Media Library Assistant](https://wordpress.org/plugins/media-library-assistant/)

This can create odd situations where the "Next" media has a date and time stamp before the "Previous" image, or voce versa.

## Motivation and context
Sorting media attachments by date rather than ID avoids this fringe issue.

## How has this been tested?
Local testing with multiple images on one post in TwentySixteen theme after using the plugin mentioned above.

## Screenshots
N/A

## Types of changes
- Bug fix