### PR TITLE
Add Nag to Updates Page if running ClassicPress Migration Version

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -235,9 +235,9 @@ function core_upgrade_preamble() {
 				_e( 'NOTICE: You are still running the Migration Version of ClassicPress!' );
 				echo "</h1>\n";
 			} else {
-			echo '<h2>';
-			_e( 'You have the latest version of ClassicPress.' );
-			echo "</h2>\n";
+				echo '<h2>';
+				_e( 'You have the latest version of ClassicPress.' );
+				echo "</h2>\n";
 			}
 		}
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -78,7 +78,12 @@ function list_core_update( $update ) {
 		$message = __( 'You are using a development version of ClassicPress. You can update to the latest nightly build automatically:' );
 	} else {
 		if ( $current ) {
-			$message     = sprintf( __( 'If you need to re-install version %s, you can do so here:' ), $version_string );
+			// Migration Nag 2
+			if ( strstr( classicpress_version(), 'migration' ) ) {
+				$message     = sprintf( __( '<big>Please press <strong>Re-install Now</strong> to complete the conversion to the ClassicPress v%s Official Release.</big>' ), $version_string );
+			} else {
+				$message     = sprintf( __( 'If you need to re-install version %s, you can do so here:' ), $version_string );
+			}
 			$submit      = __( 'Re-install Now' );
 			$form_action = 'update-core.php?action=do-core-reinstall';
 		} else {
@@ -224,9 +229,16 @@ function core_upgrade_preamble() {
 				echo "</p>\n";
 			}
 		} else { // 'latest'
+			if ( strstr( classicpress_version(), 'migration' ) ) {
+				// Migration Nag 1
+				echo '<h1 style="color:red;">';
+				_e( 'NOTICE: You are still running the Migration Version of ClassicPress!' );
+				echo "</h1>\n";
+			} else {
 			echo '<h2>';
 			_e( 'You have the latest version of ClassicPress.' );
 			echo "</h2>\n";
+			}
 		}
 
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';


### PR DESCRIPTION
 Your branch is up to date with 'origin/develop'.
 Changes to be committed:
	modified:   src/wp-admin/update-core.php
Add Nag if User running ClassicPress Migration Version

<!--
Provide a general summary of your changes in the Title above.

We welcome pull requests for bug fixes and minor improvements, but please note
that major changes must be approved and planned.

Please read our contributing guidelines for more information:

https://github.com/ClassicPress/ClassicPress/blob/develop/.github/CONTRIBUTING.md
-->

## Description
Updates messages on the Updates Page to motivate user into completing the migration process to a release version.

## Motivation and context
<!--
Why is this change required? What problem does it solve?

If it fixes an open issue, please link to the issue here.
-->

## How has this been tested?
<!--
Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to see how
your change affects other areas of the code, etc.

Please include automated tests with new or changed code, if applicable.
-->

## Screenshots
![image](https://github.com/ClassicPress/ClassicPress/assets/126414638/421e3b86-ee05-4a81-8bd8-5bfcbafa2032)

### Before
<!--
Insert screenshot(s) of the current behavior (before your changes) here.
-->

### After
<!--
Insert screenshot(s) of the new, proposed behavior (after your changes) here.
-->

## Types of changes
<!--
What types of changes does your code introduce?  Most PRs are one of the following:

- Bug fix
- New feature
- Breaking change
-->
