### PR TITLE
Fix for admin console errors

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1266,7 +1266,7 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'farbtastic', '/wp-admin/js/farbtastic.js', array( 'jquery' ), '1.2' );
 
 		$scripts->add( 'iris', '/wp-admin/js/iris.min.js', array( 'jquery-ui-widget' ), '1.1.1', 1 );
-		$scripts->localize(
+		did_action( 'init' ) && $scripts->localize(
 			'iris',
 			'IRIS',
 			array(


### PR DESCRIPTION
## Description
In a current live site build of the 2.1-alpha core code I am seeing and there are other confirmed cases of console errors in browsers.

This only affects admin pages, and can by fixed by adding `define( 'CONCATENATE_SCRIPTS', false );` to `wp-config.php`

## Motivation and context
After some debugging this can be traced back to localisation in `wp-includes/script-loader.php` - throughout the code there is a change to iss if the 'init' hook has fired and we have missed that in one location.

## How has this been tested?
Local testing and on my live sites where this has been seen. After applying the patch without a fresh build the browser cache will need a force refresh

## Screenshots
### Before
![Screenshot 2024-03-19 at 11 04 17](https://github.com/ClassicPress/ClassicPress/assets/1280733/9f789c0d-d4c3-4438-bac5-7ebe7bbbf8d6)

### After
N/A - errors are resolved.

## Types of changes
- Bug fix