### PR TITLE
WP-r57853: Add 2 hooks on deletion of a specific type of post.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3199,6 +3199,7 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	 * the post type slug.
 	 *
 	 * @since 6.6.0
+	 * @since CP-2.1.0
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.
@@ -3228,6 +3229,7 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	 * the post type slug.
 	 *
 	 * @since 6.6.0
+	 * @since CP-2.1.0
 	 *
 	 * @param int     $postid Post ID.
 	 * @param WP_Post $post   Post object.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3195,6 +3195,19 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	/**
 	 * Fires immediately before a post is deleted from the database.
 	 *
+	 * The dynamic portion of the hook name, `$post->post_type`, refers to
+	 * the post type slug.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
+	 */
+	do_action( "delete_post_{$post->post_type}", $postid, $post );
+
+	/**
+	 * Fires immediately before a post is deleted from the database.
+	 *
 	 * @since 1.2.0
 	 * @since 5.5.0 Added the `$post` parameter.
 	 *
@@ -3207,6 +3220,19 @@ function wp_delete_post( $postid = 0, $force_delete = false ) {
 	if ( ! $result ) {
 		return false;
 	}
+
+	/**
+	 * Fires immediately after a post is deleted from the database.
+	 *
+	 * The dynamic portion of the hook name, `$post->post_type`, refers to
+	 * the post type slug.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param int     $postid Post ID.
+	 * @param WP_Post $post   Post object.
+	 */
+	do_action( "deleted_post_{$post->post_type}", $postid, $post );
 
 	/**
 	 * Fires immediately after a post is deleted from the database.


### PR DESCRIPTION
## Posts, Post Types: Introduce `delete_post_{$post->post_type}` and `deleted_post_{$post->post_type}` hooks.

The hooks fire before the general delete_post / deleted_post hooks and have the same parameters.

Props benniledl, swissspidy, dargus.

## Types of changes
- New feature

