### PR TITLE
Fix customizer in `+dev` installations

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1265,7 +1265,7 @@ function wp_default_scripts( $scripts ) {
 
 		$scripts->add( 'farbtastic', '/wp-admin/js/farbtastic.js', array( 'jquery' ), '1.2' );
 
-		$scripts->add( 'iris', '/wp-admin/js/iris.min.js', array( 'jquery-ui-widget' ), '1.1.1', 1 );
+		$scripts->add( 'iris', "/wp-admin/js/iris$suffix.js", array( 'jquery-ui-widget' ), '1.1.1', 1 );
 		did_action( 'init' ) && $scripts->localize(
 			'iris',
 			'IRIS',


### PR DESCRIPTION
In [this commit](https://github.com/ClassicPress/ClassicPress/commit/cdeb0f4c5251b4390b5bdced0c51bb273745a451)
  `$scripts->add( 'iris', "/wp-admin/js/iris$suffix.js"...` was changed to `$scripts->add( 'iris', '/wp-admin/js/iris.min.js'` and that breaks customizer in `+dev` installations.

:question: I wonder also if it's right to have the minified `/wp-admin/js/iris.min.js` in the source.

## Description
This PR reverts the change,

## Screenshots
### Before
<img width="348" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/dabd3c70-a2ba-43b7-adc3-f823c162b8be">
<img width="513" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/d50f73e3-03c2-4c0a-ab03-471ace67150b">


### After
<img width="450" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/90864032-911a-4f7f-97b2-cbe616d730b1">


## Types of changes
<!--
What types of changes does your code introduce?  Most PRs are one of the following:

- Bug fix
- New feature
- Breaking change
-->
