### PR TITLE
Update settings cookies to add SameSite and array structure

### DIFF
--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -38,7 +38,16 @@ if ( $key ) {
 	$redirect_url = remove_query_arg( 'key' );
 
 	if ( remove_query_arg( false ) !== $redirect_url ) {
-		setcookie( $activate_cookie, $key, 0, $activate_path, COOKIE_DOMAIN, is_ssl(), true );
+		$cookie_coptions = array(
+			'expires' => 0,
+			'path' => $activate_path,
+			'domain' => COOKIE_DOMAIN,
+			'secure' => is_ssl(),
+			'httponly' => true,
+			'samesite' => 'Strict',
+		);
+
+		setcookie( $activate_cookie, $key, $cookie_coptions );
 		wp_safe_redirect( $redirect_url );
 		exit;
 	} else {
@@ -49,7 +58,16 @@ if ( $key ) {
 if ( null === $result && isset( $_COOKIE[ $activate_cookie ] ) ) {
 	$key    = $_COOKIE[ $activate_cookie ];
 	$result = wpmu_activate_signup( $key );
-	setcookie( $activate_cookie, ' ', time() - YEAR_IN_SECONDS, $activate_path, COOKIE_DOMAIN, is_ssl(), true );
+
+	$cookie_coptions = array(
+		'expires' => time() - YEAR_IN_SECONDS,
+		'path' => $activate_path,
+		'domain' => COOKIE_DOMAIN,
+		'secure' => is_ssl(),
+		'httponly' => true,
+		'samesite' => 'Strict',
+	);
+	setcookie( $activate_cookie, ' ', $cookie_coptions );
 }
 
 if ( null === $result || ( is_wp_error( $result ) && 'invalid_key' === $result->get_error_code() ) ) {

--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -223,7 +223,15 @@ switch ( $action ) {
 
 		// Session cookie flag that the post was saved.
 		if ( isset( $_COOKIE['wp-saving-post'] ) && $_COOKIE['wp-saving-post'] === $post_id . '-check' ) {
-			setcookie( 'wp-saving-post', $post_id . '-saved', time() + DAY_IN_SECONDS, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, is_ssl() );
+			$cookie_options = array(
+				'expires' => time() + DAY_IN_SECONDS,
+				'path' => ADMIN_COOKIE_PATH,
+				'domain' => COOKIE_DOMAIN,
+				'secure' => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Strict',
+			);
+			setcookie( 'wp-saving-post', $post_id . '-saved', $cookie_options );
 		}
 
 		redirect_post( $post_id ); // Send user on their way while we keep working.

--- a/src/wp-includes/class-wp-recovery-mode-cookie-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-cookie-service.php
@@ -47,10 +47,20 @@ final class WP_Recovery_Mode_Cookie_Service {
 
 		$expire = time() + $length;
 
-		setcookie( RECOVERY_MODE_COOKIE, $value, $expire, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+		$cookie_options = array(
+			'expires' => $expire,
+			'path' => COOKIEPATH,
+			'domain' => COOKIE_DOMAIN,
+			'secure' => is_ssl(),
+			'httponly' => true,
+			'samesite' => 'Strict',
+		);
+
+		setcookie( RECOVERY_MODE_COOKIE, $value, $cookie_options );
 
 		if ( COOKIEPATH !== SITECOOKIEPATH ) {
-			setcookie( RECOVERY_MODE_COOKIE, $value, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+			$cookie_options['path'] = SITECOOKIEPATH;
+			setcookie( RECOVERY_MODE_COOKIE, $value, $cookie_options );
 		}
 	}
 

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -563,9 +563,18 @@ function wp_set_comment_cookies( $comment, $user, $cookies_consent = true ) {
 
 	$secure = ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) );
 
-	setcookie( 'comment_author_' . COOKIEHASH, $comment->comment_author, $comment_cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN, $secure );
-	setcookie( 'comment_author_email_' . COOKIEHASH, $comment->comment_author_email, $comment_cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN, $secure );
-	setcookie( 'comment_author_url_' . COOKIEHASH, esc_url( $comment->comment_author_url ), $comment_cookie_lifetime, COOKIEPATH, COOKIE_DOMAIN, $secure );
+	$cookie_options = array(
+		'expires' => $comment_cookie_lifetime,
+		'path' => COOKIEPATH,
+		'domain' => COOKIE_DOMAIN,
+		'secure' => $secure,
+		'httponly' => true,
+		'samesite' => 'Strict',
+	);
+
+	setcookie( 'comment_author_' . COOKIEHASH, $comment->comment_author, $cookie_options );
+	setcookie( 'comment_author_email_' . COOKIEHASH, $comment->comment_author_email, $cookie_options );
+	setcookie( 'comment_author_url_' . COOKIEHASH, esc_url( $comment->comment_author_url ), $cookie_options );
 }
 
 /**

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1152,7 +1152,7 @@ function wp_user_settings() {
 	}
 
 	// The cookie is not set in the current browser or the saved value is newer.
-	$cookie_options = array (
+	$cookie_options = array(
 		'expires' => time() + YEAR_IN_SECONDS,
 		'path' => SITECOOKIEPATH,
 		'domain' => '',

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1152,9 +1152,16 @@ function wp_user_settings() {
 	}
 
 	// The cookie is not set in the current browser or the saved value is newer.
-	$secure = ( 'https' === parse_url( admin_url(), PHP_URL_SCHEME ) );
-	setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH, '', $secure );
-	setcookie( 'wp-settings-time-' . $user_id, time(), time() + YEAR_IN_SECONDS, SITECOOKIEPATH, '', $secure );
+	$cookie_options = array (
+		'expires' => time() + YEAR_IN_SECONDS,
+		'path' => SITECOOKIEPATH,
+		'domain' => '',
+		'secure' => ( 'https' === parse_url( admin_url(), PHP_URL_SCHEME ) ),
+		'samesite' => 'Strict',
+	);
+
+	setcookie( 'wp-settings-' . $user_id, $settings, $cookie_options );
+	setcookie( 'wp-settings-time-' . $user_id, time(), $cookie_options );
 	$_COOKIE[ 'wp-settings-' . $user_id ] = $settings;
 }
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1086,11 +1086,26 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			return;
 		}
 
-		setcookie( $auth_cookie_name, $auth_cookie, $expire, PLUGINS_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
-		setcookie( $auth_cookie_name, $auth_cookie, $expire, ADMIN_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
-		setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, COOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+		$cookie_options = array(
+			'expires' => $expire,
+			'path' => '',
+			'domain' => COOKIE_DOMAIN,
+			'secure' => $secure,
+			'httponly' => true,
+			'samesite' => 'Strict',
+		);
+
+		$cookie_options['path'] = PLUGINS_COOKIE_PATH;
+		setcookie( $auth_cookie_name, $auth_cookie, $cookie_options );
+
+		$cookie_options['path'] = ADMIN_COOKIE_PATH;
+		setcookie( $auth_cookie_name, $auth_cookie, $cookie_options );
+
+		$cookie_options['path'] = COOKIEPATH;
+		setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $cookie_options );
 		if ( COOKIEPATH != SITECOOKIEPATH ) {
-			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $expire, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_logged_in_cookie, true );
+			$cookie_options['path'] = SITECOOKIEPATH;
+			setcookie( LOGGED_IN_COOKIE, $logged_in_cookie, $cookie_options );
 		}
 	}
 endif;


### PR DESCRIPTION
## Description
Fixes #1227 

This change updated the usage of `setcookie()` in core so that the SameSite flag is set as Strict for settings cookies, this may help avoid some CSRF cookie exploits.

## Motivation and context
This fixes an open issue (#1227) and enhances cookie security.

## How has this been tested?
Local and personal live site testing. Note below that the for right SameSite column now says Strict.

## Screenshots
### Before
![Screenshot 2024-03-29 at 15 43 55](https://github.com/ClassicPress/ClassicPress/assets/1280733/0a658bac-8b97-4f3a-a12b-bc531f0cc203)

### After
![Screenshot 2024-03-29 at 15 44 03](https://github.com/ClassicPress/ClassicPress/assets/1280733/3b57a493-b9bd-4095-8474-772eee8531a0)

## Types of changes
- Enhancement