### PR TITLE
Add Directory Plugin dashboard widget 

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -92,7 +92,10 @@ function wp_dashboard_setup() {
 	wp_add_dashboard_widget( 'dashboard_primary', __( 'ClassicPress News' ), 'wp_dashboard_events_news' );
 
 	// ClassicPress directory notice
-	if ( current_user_can( 'install_plugins' ) ) {
+	if (
+		current_user_can( 'install_plugins' ) &&
+		! is_file( WP_PLUGIN_DIR . '/classicpress-directory-integration/classicpress-directory-integration.php' )
+	) {
 		wp_add_dashboard_widget( 'dashboard_directory', __( 'ClassicPress Directory' ), 'cp_dashboard_directory' );
 	}
 

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1825,7 +1825,7 @@ function cp_dashboard_directory() {
 	<div class ="directory-widget-content">
 	<p>
 	<?php
-	echo '<p>' . __( 'We wanted to let you know some information about ClassicPress Directory.' ) . '</p>';
+	echo '<p>' . __( 'We would like to let you know about the ClassicPress Directory.' ) . '</p>';
 	echo '<p>' . sprintf( __( 'You can browse the new directory at <a href="%1$s" target="_blank">%1$s</a>.' ), esc_url( 'https://directory.classicpress.net' ) ) . '</p>';
 	$url = wp_nonce_url(
 		add_query_arg(

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -91,6 +91,11 @@ function wp_dashboard_setup() {
 	// ClassicPress News.
 	wp_add_dashboard_widget( 'dashboard_primary', __( 'ClassicPress News' ), 'wp_dashboard_events_news' );
 
+	// ClassicPress directory notice
+	if ( current_user_can( 'install_plugins' ) ) {
+		wp_add_dashboard_widget( 'dashboard_directory', __( 'ClassicPress Directory' ), 'cp_dashboard_directory' );
+	}
+
 	if ( is_network_admin() ) {
 
 		/**
@@ -1803,3 +1808,37 @@ function wp_dashboard_site_health() {
  * @since 2.5.0
  */
 function wp_dashboard_empty() {}
+
+/**
+ * Display the ClassicPress Directory
+ * Inform users about the new ClassicPress directory
+ * and allow to install the ClassicPress Directory Integration plugin.
+ *
+ * @since CP-2.1.0
+ */
+
+function cp_dashboard_directory() {
+	?>
+	<div class ="directory-widget-content">
+	<p>
+	<?php
+	echo '<p>' . __( 'We wanted to let you know some information about ClassicPress Directory.' ) . '</p>';
+	echo '<p>' . sprintf( __( 'You can browse the new directory at <a href="%1$s" target="_blank">%1$s</a>.' ), esc_url( 'https://directory.classicpress.net' ) ) . '</p>';
+	$url = wp_nonce_url(
+		add_query_arg(
+			array(
+				'action' => 'install-plugin',
+				'plugin' => 'classicpress-directory-integration',
+				'from'   => 'index',
+			),
+			self_admin_url( 'update.php' )
+		),
+		'install-plugin_' . 'classicpress-directory-integration'
+	);
+	echo '<p>' . sprintf( __( '<a href="%1$s">Install</a> the ClassicPress Directory Integration plugin to install plugins from the Plugins Menu.' ), $url ) . '</p>';
+
+	?>
+	</p>
+	</div>
+	<?php
+}

--- a/src/wp-admin/update.php
+++ b/src/wp-admin/update.php
@@ -111,6 +111,7 @@ if ( isset( $_GET['action'] ) ) {
 
 		check_admin_referer( 'install-plugin_' . $plugin );
 
+		// Allow some plugin slugs to bypass WP plugins_api() and point to ClassicPress Directory API.
 		$cp_plugins = array(
 			'classicpress-directory-integration',
 		);

--- a/src/wp-admin/update.php
+++ b/src/wp-admin/update.php
@@ -117,7 +117,7 @@ if ( isset( $_GET['action'] ) ) {
 		);
 
 		if ( in_array( $plugin, $cp_plugins ) ) {
-			$response = wp_remote_get( 'https://staging-directory.classicpress.net/wp-json/wp/v2/plugins?byslug=vars' ); // CHANGE ME
+			$response = wp_remote_get( 'https://directory.classicpress.net/wp-json/wp/v2/plugins?byslug=' . $plugin );
 			if ( ! is_wp_error( $response ) ) {
 				$json = wp_remote_retrieve_body( $response );
 				$cp_api = json_decode( $json, true );


### PR DESCRIPTION
This PR adds a dashboard widget informing about the new directory and let users install the plugin with one click.

<img width="622" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/0206d8ad-24ec-4da7-a84e-a4143a3d21d8">


## Description
To achieve this I've changed `src/wp-admin/update.php` to allow some plugin slug to bypass WP `plugins_api()` for certain slugs and point to ClassicPress Directory API.

## To DO
- [x] Add condition to check if plugin is already installed
- [x] Point at the right endpoint and not at my plugin (currently it installs "Vars")
- [x] Fix wording (**help needed**)
- [x] Add comments to code

## How has this been tested?
Local tests.

## Types of changes
- New feature

