### PR TITLE
Bump `$wp_version` to 6.2.5

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -39,7 +39,7 @@ $cp_version = '2.0.0+dev';
  *
  * @global string $wp_version
  */
-$wp_version = '6.2.3';
+$wp_version = '6.2.5';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
From WordPress:
A cross-site scripting (XSS) vulnerability **affecting the Avatar block type**; reported by [John Blackbourn](https://johnblackbourn.com/) of the WordPress security team.

This vulnerability does not affect ClassicPress but this PR bumps `$wp_version` to 6.2.5 to stay in sync with upstream 6.2 branch.
