### PR TITLE
Update post.js to fix bug in metaboxes created for custom non-hierarchical taxonomies

### DIFF
--- a/src/wp-admin/js/post.js
+++ b/src/wp-admin/js/post.js
@@ -561,7 +561,7 @@ jQuery( function($) {
 	if ( $('#tagsdiv-post_tag').length ) {
 		window.tagBox && window.tagBox.init();
 	} else {
-		$('.meta-box-sortables').children('div.postbox').each(function(){
+		$('.meta-box-sortables').children('details.postbox').each(function(){
 			if ( this.id.indexOf('tagsdiv-') === 0 ) {
 				window.tagBox && window.tagBox.init();
 				return false;


### PR DESCRIPTION
This PR is to fix the bug reported at https://forums.classicpress.net/t/custom-taxonomies-dont-work/5163

The bug is isolated to the non-hierarchical taxonomies’ (i.e. like tags) metaboxes on the edit screen of a custom post type.

Metaboxes on regular posts, and hierarchical taxonomies (i.e. like categories) on any post type work fine. The bug also does not affect non-hierarchical taxonomies added via Quick Edit.

The cause is that, while the correct JavaScript file is being loaded, it is not being initiated. The reason for this is that the code looks for a `div` while, in version 2 of ClassicPress, we replaced a lot of old JavaScript with HTML5 disclosure widgets. So the bugfix here is simply to replace `div` with `details` on a specific line.