### PR TITLE
Update general-template.php to add `enterkeyhint="search"` to search-form

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -310,7 +310,7 @@ function get_search_form( $args = array() ) {
 				/* translators: Hidden accessibility text. */
 				_x( 'Search for:', 'label' ) .
 				'</span>
-				<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s">
+				<input type="search" class="search-field" placeholder="' . esc_attr_x( 'Search &hellip;', 'placeholder' ) . '" value="' . get_search_query() . '" name="s" enterkeyhint="search">
 			</label>
 			<input type="submit" class="search-submit" value="' . esc_attr_x( 'Search', 'submit button' ) . '">
 		</form>';


### PR DESCRIPTION
This is a very simple addition, which just ensures that the right icon is presented for the Enter key on virtual keyboards. See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint. It's widely recognized: https://caniuse.com/?search=enterkeyhint

This PR is motivated by the fact that I have noticed that the icon for search is often incorrect on a virtual keyboard on my Android phone. This PR corrects it.