### PR TITLE
Update comment-template.php to add a filter to the comment form tag

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2713,17 +2713,40 @@ function comment_form( $args = array(), $post = null ) {
 
 		else :
 
+			/**
+			 * Filters additional comment form attributes.
+			 *
+			 * The following attributes are allowed:
+			 * `accept-charset`, `autocapitalize`, `autocomplete`, `enctype`, `novalidate`
+			 * Pass attribute names as the array key.
+			 * Pass attribute values as the array value, or `true` in the case of attributes that require no value, for example `novalidate`.
+			 *
+			 * @since CP-2.1.0
+			 *
+			 * @param array   An associative array containing the additional attributes for the form.
+			 */
+			$comment_form_attrs = (array) apply_filters( 'comment_form_attrs', array() );
+
+			$comment_form_attributes = '';
+			if ( ! empty( $comment_form_attrs ) ) {
+				$allowed_attributes = array( 'accept-charset', 'autocapitalize', 'autocomplete', 'enctype', 'novalidate' );
+				foreach ( $comment_form_attrs as $comment_form_attr_name => $comment_form_attr_value ) {
+					if ( in_array( $comment_form_attr_name, $allowed_attributes ) ) {
+						if ( 'true' === $comment_form_attr_value ) {
+							$comment_form_attributes .= ' ' . esc_attr( $comment_form_attr_name );
+						} else {
+							$comment_form_attributes .= ' ' . esc_attr( $comment_form_attr_name ) . '="' . esc_attr( $comment_form_attr_value ) . '"';
+						}
+					}
+				}
+			}
+
 			printf(
-				'<form action="%s" method="post" id="%s" class="%s" %s>',
+				'<form action="%s" method="post" id="%s" class="%s"%s>',
 				esc_url( $args['action'] ),
 				esc_attr( $args['id_form'] ),
 				esc_attr( $args['class_form'] ),
-				/**
-				 * Fires inside the comment form tag.
-				 *
-				 * @since CP-2.1.0
-				 */
-				esc_attr( apply_filters( 'comment_form_tag', null ) )
+				$comment_form_attributes
 			);
 
 			/**

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2714,14 +2714,20 @@ function comment_form( $args = array(), $post = null ) {
 		else :
 
 			printf(
-				'<form action="%s" method="post" id="%s" class="%s">',
+				'<form action="%s" method="post" id="%s" class="%s" %s>',
 				esc_url( $args['action'] ),
 				esc_attr( $args['id_form'] ),
-				esc_attr( $args['class_form'] )
+				esc_attr( $args['class_form'] ),
+				/**
+				 * Fires inside the comment form tag.
+				 *
+				 * @since CP-2.1.0
+				 */
+				apply_filters( 'comment_form_tag', null, $args )
 			);
 
 			/**
-			 * Fires at the top of the comment form, inside the form tag.
+			 * Fires at the top of the comment form, just after the form tag.
 			 *
 			 * @since 3.0.0
 			 */

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2723,7 +2723,7 @@ function comment_form( $args = array(), $post = null ) {
 				 *
 				 * @since CP-2.1.0
 				 */
-				apply_filters( 'comment_form_tag', null, $args )
+				esc_attr( apply_filters( 'comment_form_tag', null ) )
 			);
 
 			/**

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2718,8 +2718,8 @@ function comment_form( $args = array(), $post = null ) {
 			 *
 			 * The following attributes are allowed:
 			 * `accept-charset`, `autocapitalize`, `autocomplete`, `enctype`, `novalidate`
-			 * Pass attribute names as the array key.
-			 * Pass attribute values as the array value, or `true` in the case of attributes that require no value, for example `novalidate`.
+			 * Pass attribute names as a string array key.
+			 * Pass attribute values as a string array value, or boolean `true` in the case of attributes that require no value, for example `novalidate`.
 			 *
 			 * @since CP-2.1.0
 			 *
@@ -2732,10 +2732,16 @@ function comment_form( $args = array(), $post = null ) {
 				$allowed_attributes = array( 'accept-charset', 'autocapitalize', 'autocomplete', 'enctype', 'novalidate' );
 				foreach ( $comment_form_attrs as $comment_form_attr_name => $comment_form_attr_value ) {
 					if ( in_array( $comment_form_attr_name, $allowed_attributes ) ) {
-						if ( 'true' === $comment_form_attr_value ) {
+						if ( true === $comment_form_attr_value ) {
 							$comment_form_attributes .= ' ' . esc_attr( $comment_form_attr_name );
-						} else {
+						} elseif ( is_string( $comment_form_attr_value ) ) {
 							$comment_form_attributes .= ' ' . esc_attr( $comment_form_attr_name ) . '="' . esc_attr( $comment_form_attr_value ) . '"';
+						} else {
+							_doing_it_wrong(
+								"apply_filters( 'comment_form_attrs', array() )",
+								__( 'Array values must only be a string or `true` boolean' ),
+								'CP-2.1.0'
+							);
 						}
 					}
 				}


### PR DESCRIPTION
There is currently no easy way to modify the default CP comment form tag. I have a couple of sites where I need to be able to allow file uploads with the comment, but I have to resort to using an output buffer to grab the whole form, like this:
```
ob_start();
comment_form();
$form = ob_get_clean();
```
and then I have to unpack and fiddle with the `$form` variable.

This PR adds a filter that would enable attributes to be added to the form tag very easily with a function like this:
```
function my_comment_tag( $tag, $args ) {
	return 'enctype="multipart/form-data"';
}
add_filter( 'comment_form_tag', 'my_comment_tag', 10, 2 );
```

This PR also corrects a misleading statement in the docblock immediately following the above change.

