### PR TITLE
WP-r58009: Fix implicit nullable parameter type deprecation on PHP 8.4

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -355,7 +355,7 @@ function export_wp( $args = array() ) {
 	 *
 	 * @param int[] $post_ids Optional. Array of post IDs to filter the query by.
 	 */
-	function wxr_authors_list( array $post_ids = null ) {
+	function wxr_authors_list( ?array $post_ids = null ) {
 		global $wpdb;
 
 		if ( ! empty( $post_ids ) ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5197,7 +5197,7 @@ function wp_show_heic_upload_error( $plupload_settings ) {
  * @param array  $image_info Optional. Extended image information (passed by reference).
  * @return array|false Array of image information or false on failure.
  */
-function wp_getimagesize( $filename, array &$image_info = null ) {
+function wp_getimagesize( $filename, ?array &$image_info = null ) {
 	// Don't silence errors when in debug mode, unless running unit tests.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG
 		&& ! defined( 'WP_RUN_CORE_TESTS' )


### PR DESCRIPTION
In PHP 8.4, declaring function or method parameters with a default value of `null` is deprecated if the type is not nullable.

PHP applications are recommended to ''explicitly'' declare the type as nullable. All type declarations that have a default value of `null`, but without declaring `null` in the type declaration, will emit a deprecation notice: {{{
function test( array $value = null ) {}
}}}
`Deprecated: Implicitly marking parameter $value as nullable is deprecated, the explicit nullable type must be used instead`

**Recommended Changes**

Change the implicit nullable type declaration to a nullable type declaration, available since PHP 7.1: {{{#!diff
- function test( string $test = null ) {}
+ function test( ?string $test = null ) {} }}}

This commit updates the affected instances in core to use a nullable type declaration.

References:
* [https://wiki.php.net/rfc/deprecate-implicitly-nullable-types PHP RFC: Deprecate implicitly nullable parameter types]
* [https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated PHP.Watch: PHP 8.4: Implicitly nullable parameter declarations deprecated]

Follow-up to https://core.trac.wordpress.org/changeset/28731, https://core.trac.wordpress.org/changeset/50552, https://core.trac.wordpress.org/changeset/57337, https://core.trac.wordpress.org/changeset/57985.

WP:Props ayeshrajans, jrf, audrasjb, jorbin.
Fixes https://core.trac.wordpress.org/ticket/60786.

Conflicts:
- src/wp-includes/l10n/class-wp-translation-controller.php
- src/wp-includes/l10n/class-wp-translation-file.php

---

Merges https://core.trac.wordpress.org/changeset/58009 / WordPress/wordpress-develop@b39b75c7fe to ClassicPress.

## Types of changes
- Bug fix

