### PR TITLE
Update edit-form-advanced.php to generate correct notice when attempting to publish empty post

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -231,7 +231,7 @@ if ( 'auto-draft' === $post->post_status ) {
 		$post->post_title = '';
 		if ( '' === $post->post_content && '' === $post->post_excerpt ) {
 			$message = false;
-			$notice = __( 'You can\'t publish an empty post.' );
+			$notice  = __( 'You can\'t publish an empty post.' );
 		}
 	}
 	$autosave    = false;

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -229,6 +229,10 @@ $form_extra = '';
 if ( 'auto-draft' === $post->post_status ) {
 	if ( 'edit' === $action ) {
 		$post->post_title = '';
+		if ( '' === $post->post_content && '' === $post->post_excerpt ) {
+			$message = false;
+			$notice = __( 'You can\'t publish an empty post.' );
+		}
 	}
 	$autosave    = false;
 	$form_extra .= "<input type='hidden' id='auto_draft' name='auto_draft' value='1'>";


### PR DESCRIPTION
This PR addresses https://github.com/ClassicPress/ClassicPress/issues/1032

Note that attempting to save an empty post already results in the post not being published but saved as an auto-draft. The issue addressed by this PR is that a message appears, which inaccurately states that the post has been published. This PR replaces that with a warning that says: "You can't publish an empty post."

I'm not wedded to that text; I just took it from the Issue referred to above. If someone has a better suggestion, I'll be happy to go with that.