### PR TITLE
Update admin-bar.php to display current status of `WP_DEBUG` in adminbar on admin screens

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -800,15 +800,12 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 		}
 
 		/**
-		 * Displays the current status of 'WP_DEBUG'.
+		 * Displays a message to administrators when 'WP_DEBUG' is set to true.
 		 *
 		 * @since CP-2.1.0
 		 */
-		if ( current_user_can( 'manage_options' ) ) {
-			$label = __( 'Debugging Disabled' );
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
-				$label = '<strong style="font-weight:700;">' . __( 'Debugging Enabled' ) . '</strong>';
-			}
+		if ( current_user_can( 'manage_options' ) && defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
+			$label = '<strong style="font-weight:700;">' . __( 'Debugging Enabled' ) . '</strong>';
 			$wp_admin_bar->add_node(
 				array(
 					'id'     => 'cp-debugging',

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -805,11 +805,10 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 		 * @since CP-2.1.0
 		 */
 		if ( current_user_can( 'manage_options' ) && defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
-			$label = '<strong style="font-weight:700;">' . __( 'Debugging Enabled' ) . '</strong>';
 			$wp_admin_bar->add_node(
 				array(
 					'id'     => 'cp-debugging',
-					'title'  => $label,
+					'title'  => '<strong style="font-weight:700;">' . __( 'Debugging Enabled' ) . '</strong>',
 				)
 			);
 		}

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -798,6 +798,24 @@ function wp_admin_bar_edit_menu( $wp_admin_bar ) {
 				);
 			}
 		}
+
+		/**
+		 * Displays the current status of 'WP_DEBUG'.
+		 *
+		 * @since CP-2.1.0
+		 */
+		if ( current_user_can( 'manage_options' ) ) {
+			$label = __( 'Debugging Disabled' );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
+				$label = '<strong style="font-weight:700;">' . __( 'Debugging Enabled' ) . '</strong>';
+			}
+			$wp_admin_bar->add_node(
+				array(
+					'id'     => 'cp-debugging',
+					'title'  => $label,
+				)
+			);
+		}
 	} else {
 		$current_object = $wp_the_query->get_queried_object();
 


### PR DESCRIPTION
This PR implements the feature request in Issue https://github.com/ClassicPress/ClassicPress/issues/1062.

Note, however, that while some of the code used here is similar to that shown by one comment in that thread, that code is designed to show the status of `WP_DEBUG` on the public-facing pages of a site, which is the opposite of what the feature request called for.

Some admins might want not to see this. In such cases, it could be removed in the same way as any other item on the adminbar or simply hidden from view by a simple bit of CSS: `#wp-admin-bar-cp-debugging { display: none; }`