### PR TITLE
Add new translation endpoint and update functionality

### DIFF
--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -207,6 +207,7 @@ function wp_install_language_form( $languages ) {
  * Download a language pack.
  *
  * @since 4.0.0
+ * @since CP-2.1.0 Added `$force` parameter to allow updates
  *
  * @see wp_get_available_translations()
  *

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -212,6 +212,7 @@ function wp_install_language_form( $languages ) {
  * @see wp_get_available_translations()
  *
  * @param string $download Language code to download.
+ * @param bool   $force    Optional. If set to true, language pack will be overwritten.
  * @return string|false Returns the language code if successfully downloaded
  *                      (or already installed), or false on failure.
  */

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 			$options['method']   = 'GET';
 			$url                 = add_query_arg(
 				$stats,
-				'https://api-v1.classicpress.net/translations/core/1.0.0/translations.json'
+				'https://api-v1.classicpress.net/translations/core/2.0.0/translations.json'
 			);
 			$request             = wp_remote_request( $url, $options );
 		} else {

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -774,6 +774,10 @@ function update_core( $from, $to ) {
 		delete_option( 'update_core' );
 	}
 
+	// Update installed language packs from API
+	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+	maybe_upgrade_translations();
+
 	/**
 	 * Fires after WordPress core has been successfully updated.
 	 *


### PR DESCRIPTION
## Description
This PR updates the translation API endpoint URL.

It further extends the `wp_download_language_pack()` function to allow language packs to be installed and overwritten, and adds `maybe_upgrade_translations()` to the update code so new language packs can be installed during updates.

**This change is contingent on getting some language packs ready on the API before `2.1.0` is released.**

## Motivation and context
The ClassicPress implementation of languages is different than upstream. 

## How has this been tested?
Local testing of the API and amended `wp_download_language_pack()` function.
The update process has not been tested but sould trigger in nightly builds to confirm it works.

## Screenshots
N/A

## Types of changes
- New feature