### PR TITLE
Initialize the local `$checkout` variable in `WP_Automatic_Updater::is_vcs_checkout()`

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -146,6 +146,7 @@ class WP_Automatic_Updater {
 		}
 
 		$check_dirs = array_unique( $check_dirs );
+		$checkout   = false;
 
 		// Search all directories we've found for evidence of version control.
 		foreach ( $vcs_dirs as $vcs_dir ) {

--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -706,4 +706,28 @@ class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
 			'string with only carriage returns' => array( 'dir' => "\r\r" ),
 		);
 	}
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_vcs_checkout()` returns `false`
+	 * when none of the checked directories are allowed.
+	 *
+	 * @ticket 58563
+	 *
+	 * @covers WP_Automatic_Updater::is_vcs_checkout
+	 */
+	public function test_is_vcs_checkout_should_return_false_when_no_directories_are_allowed() {
+		$updater_mock = $this->getMockBuilder( 'WP_Automatic_Updater' )
+			// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
+			->setMethods( array( 'is_allowed_dir' ) )
+			->getMock();
+
+		/*
+		 * As none of the directories should be allowed, simply mocking `WP_Automatic_Updater`
+		 * and forcing `::is_allowed_dir()` to return `false` removes the need to run the test
+		 * in a separate process due to setting the `open_basedir` PHP directive.
+		 */
+		$updater_mock->expects( $this->any() )->method( 'is_allowed_dir' )->willReturn( false );
+
+		$this->assertFalse( $updater_mock->is_vcs_checkout( get_temp_dir() ) );
+	}
 }


### PR DESCRIPTION
## Description
WP-r56124: Upgrade/Install: Initialize the local `$checkout` variable in `WP_Automatic_Updater::is_vcs_checkout()`.

This avoids an `Undefined variable $checkout` PHP warning if all of the directories checked for access are disallowed due to the PHP `open_basedir` restrictions.

Follow-up to https://core.trac.wordpress.org/changeset/55425.

WP:Props jqz, costdev, audrasjb.
Fixes https://core.trac.wordpress.org/ticket/58563.

---

Merges https://core.trac.wordpress.org/changeset/56124 / WordPress/wordpress-develop@62b286f9b2 to ClassicPress.

## Motivation and context
Backport that fixes an issue reports on the forums:
https://forums.classicpress.net/t/warning-undefined-variable-checkout/5194/2

## How has this been tested?
Backport and this includes unit tests.

## Screenshots
N/A

## Types of changes
- Bug fix
