### PR TITLE
Update theme.php to use correct deprecation function

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2610,7 +2610,7 @@ function add_theme_support( $feature, ...$args ) {
 			_deprecated_argument(
 				"add_theme_support( 'html5' )",
 				'CP-2.0.0',
-				__( 'HTML5 is the default ' )
+				__( 'HTML5 is the default.' )
 			);
 
 			return true;

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2607,10 +2607,10 @@ function add_theme_support( $feature, ...$args ) {
 
 		case 'html5':
 			// Since CP-2.0.0 HTLM5 has been expected as theme default
-			_doing_it_wrong(
+			_deprecated_argument(
 				"add_theme_support( 'html5' )",
-				__( 'HTML5 is the default ' ),
-				'CP-2.0.0'
+				'CP-2.0.0',
+				__( 'HTML5 is the default ' )
 			);
 
 			return true;

--- a/tests/phpunit/tests/theme/support.php
+++ b/tests/phpunit/tests/theme/support.php
@@ -77,7 +77,7 @@ class Tests_Theme_Support extends WP_UnitTestCase {
 	/**
 	 * @PR 200
 	 *
-	 * @expectedIncorrectUsage add_theme_support( 'html5' )
+	 * @expectedDeprecated add_theme_support( 'html5' )
 	 */
 	public function test_supports_html5() {
 		$this->assertTrue( current_theme_supports( 'html5' ) );


### PR DESCRIPTION
When we made HTML5 the default output, we indicated that `add_theme_support( 'html5' )` was deprecated by using the `_doing_it_wrong()` function. This has caused quite a stir in the forum, because it suggests that there's something wrong with using the `add_theme_support()` function altogether.

That is not, in fact, true. We just used the wrong deprecation function. This PR fixes that by replacing `_doing_it_wrong()` with `_deprecated_argument()`. This also necessitates swapping the second and third arguments of the function. The message is also cleaned up to replace the space at the end of the line with a full stop. This now produces the much clearer message:
```
Function add_theme_support( 'html5' ) was called with an argument that is deprecated since version CP-2.0.0! HTML5 is the default.
```