### PR TITLE
Shallower checkout of PHP.net repository

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -48,6 +48,14 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
+          - php: '8.2'
+            mysql: '5.7'
+            memcached: true
+            experimental: true
+          - php: '8.3'
+            mysql: '5.7'
+            memcached: true
+            experimental: true
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -44,7 +44,7 @@ jobs:
         memcached: [ false ]
         experimental: [ false ]
         include:
-          - php: '7.4'
+          - php: '8.2'
             mysql: '5.7'
             memcached: true
             experimental: false

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -185,7 +185,7 @@ jobs:
         if: ${{ matrix.memcached }}
         run: |
           mkdir php.net
-          git clone https://github.com/php/web-php php.net
+          git clone --depth 1 https://github.com/php/web-php php.net
           php -d error_reporting=E_ERROR -f php.net/supported-versions.php > supported-versions.html
 
       - name: Run PHPUnit default

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -44,7 +44,7 @@ jobs:
         memcached: [ false ]
         experimental: [ false ]
         include:
-          - php: '8.2'
+          - php: '8.0'
             mysql: '5.7'
             memcached: true
             experimental: false

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -51,11 +51,11 @@ jobs:
           - php: '8.2'
             mysql: '5.7'
             memcached: true
-            experimental: true
+            experimental: false
           - php: '8.3'
             mysql: '5.7'
             memcached: true
-            experimental: true
+            experimental: false
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -181,11 +181,17 @@ jobs:
         if: ${{ matrix.memcached }}
         uses: niden/actions-memcached@v7
 
-      - name: Clone PHP.net and create local supported versions for PHPUnit tests
+      - name: Clone PHP.net for PHPUnit tests
+        if: ${{ matrix.memcached }}
+        uses: actions/checkout@v4
+        with:
+          repository: php/web-php
+          fetch-depth: 1
+          path: 'php.net'
+
+      - name: Create HTML of local supported versions
         if: ${{ matrix.memcached }}
         run: |
-          mkdir php.net
-          git clone --depth 1 https://github.com/php/web-php php.net
           php -d error_reporting=E_ERROR -f php.net/supported-versions.php > supported-versions.html
 
       - name: Run PHPUnit default

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -386,12 +386,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	public static function flush_cache() {
 		global $wp_object_cache;
 
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
+		wp_cache_flush_runtime();
 
-		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+		if ( is_object( $wp_object_cache ) && method_exists( $wp_object_cache, '__remoteset' ) ) {
 			$wp_object_cache->__remoteset();
 		}
 

--- a/tests/phpunit/includes/object-cache.php
+++ b/tests/phpunit/includes/object-cache.php
@@ -313,6 +313,16 @@ function wp_cache_flush( $delay = 0 ) {
 }
 
 /**
+ * Removes all cache items from the in-memory runtime cache.
+ *
+ * @return bool True on success, false on failure.
+ */
+function wp_cache_flush_runtime() {
+	global $wp_object_cache;
+	return $wp_object_cache->flush_runtime();
+}
+
+/**
  * Determines whether the object cache implementation supports a particular feature.
  *
  * @since 6.1.0
@@ -325,6 +335,7 @@ function wp_cache_flush( $delay = 0 ) {
 function wp_cache_supports( $feature ) {
 	switch ( $feature ) {
 		case 'get_multiple':
+		case 'flush_runtime':
 			return true;
 		default:
 			return false;
@@ -903,6 +914,20 @@ class WP_Object_Cache {
 	public $blog_prefix = '';
 
 	/**
+	 * Thirty days in seconds.
+	 *
+	 * @var int
+	 */
+	public $thirty_days;
+
+	/**
+	 * Current unix time stamp.
+	 *
+	 * @var int
+	 */
+	public $now;
+
+	/**
 	 * Instantiates the Memcached class.
 	 *
 	 * Instantiates the Memcached class and returns adds the servers specified
@@ -1410,6 +1435,17 @@ class WP_Object_Cache {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Clears the in-memory cache of all data leaving the external cache untouched.
+	 *
+	 * @return bool Always returns true.
+	 */
+	public function flush_runtime() {
+		$this->cache = array();
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Description
During PHPUnit tests the PHP.net document repository is checked out. To save time and RAM we can make a shallower checkout.

## Motivation and context
May help prevent occasioanl Workflow run failures.

## How has this been tested?
Unit tests will run, locally tested and download size reduced from `115.85 MiB` to `34.59 MiB` according to `git` command line.

## Screenshots
### Before
![Screenshot 2024-04-30 at 17 38 49](https://github.com/ClassicPress/ClassicPress/assets/1280733/61efe773-5e1e-42a5-9619-b80412828325)

### After
![Screenshot 2024-04-30 at 17 38 57](https://github.com/ClassicPress/ClassicPress/assets/1280733/039d5e89-3554-4696-8c9e-82177faf816c)

## Types of changes
- Bug fix