### PR TITLE
Use correct checksum endpoint in Site Health

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -331,14 +331,10 @@ class WP_Site_Health_Auto_Updates {
 			require_once ABSPATH . 'wp-admin/includes/update.php';
 		}
 
-		$checksums = get_core_checksums( $wp_version, 'en_US' );
-		$dev       = ( str_contains( $wp_version, '-' ) );
-		// Get the last stable version's files and test against that.
-		if ( ! $checksums && $dev ) {
-			$checksums = get_core_checksums( (float) $wp_version - 0.1, 'en_US' );
-		}
+		$checksums = get_core_checksums( classicpress_version_short(), 'en_US' );
+		$dev       = classicpress_is_dev_install();
 
-		// There aren't always checksums for development releases, so just skip the test if we still can't find any.
+		// There may not be checksums for development releases, so just skip the test if we can't find any.
 		if ( ! $checksums && $dev ) {
 			return false;
 		}

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -343,7 +343,7 @@ class WP_Site_Health_Auto_Updates {
 			$description = sprintf(
 				/* translators: %s: ClassicPress version. */
 				__( "Couldn't retrieve a list of the checksums for ClassicPress %s." ),
-				$wp_version
+				$cp_version
 			);
 			$description .= ' ' . __( 'This could mean that connections are failing to WordPress.org or ClassicPress.net.' );
 			return array(


### PR DESCRIPTION
## Description
As discussed at the weekly core review meeting on May 2, 2024, a Site Health check is misconfigured for the checksum API endpoint.

## Motivation and context
The test is potentially incorrect, the wrong URL could be constructed and the version number reported is WP.
Note, these tests only run if file system access is 'direct'. Can be tested locally by adding `define( 'FS_METHOD', 'direct' );` to `wp-config.php`.

## How has this been tested?
Local testing

## Screenshots
### After
![Screenshot 2024-05-02 at 19 26 59](https://github.com/ClassicPress/ClassicPress/assets/1280733/84f41567-8a48-4b4a-86b8-5838edb4ad04)
![Screenshot 2024-05-02 at 19 27 18](https://github.com/ClassicPress/ClassicPress/assets/1280733/2d5190b9-b971-4d78-a56a-1050a7c7dd6a)


## Types of changes
- Bug fix
