### PR TITLE
Strengthen password

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4978,3 +4978,20 @@ function wp_is_application_passwords_available_for_user( $user ) {
 function wp_cache_set_users_last_changed() {
 	wp_cache_set( 'last_changed', microtime(), 'users' );
 }
+
+/**
+ * Set password hashing options.
+ * For use in function wp_check_password in wp-includes/pluggable.php
+ *
+ * @since CP-2.2.0
+ *
+ * @return array
+ */
+function cp_hash_password_options() {
+    return apply_filters( 'cp_hash_password_options',
+		array(
+			'cost' => 12,
+		)
+	);
+}
+


### PR DESCRIPTION
This PR is intended to address Issue #1054.

That Issue asks for passwords to be hashed with `bcrypt` instead of the current hashing mechanism, which is not very strong. This PR fulfills that request but, rather than hard-coding `bcrypt` as the choice, it sets the hashing mechanism as the PHP default, which is currently `bcrypt`. This enables the algorithm to be changed seamlessly in future without any need to rewrite these functions.

In addition, this PR creates a new filter, `cp_hash_password_options`, through which users can easily modify the options associated with the hashing algorithm (especially the cost).

Further details about the algorithm and the associated cost may be found at https://www.php.net/manual/en/function.password-hash.php

Further down that same page, at https://www.php.net/manual/en/function.password-hash.php#124138, there is a discussion of the use of a "pepper" in addition to the "salt", which is already built-in to the relevant PHP functions. This PR provides a new filter, `cp_pepper_password` which enables a user to set a pepper to be used as part of the hashing mechanism. The docblocks explain how to use this filter.

Finally, all the functions that are currently pluggable remain pluggable for anyone who wishes to override them completely.

Because of what's involved here — we don't want to lock people out! — this PR needs plenty of testing before being merged into core. So I think it best not to aim for v2.1 unless that gets delayed. I have therefore set the milestone as v2.2.