### PR TITLE
Invalidate opcache file for translation-install.php

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -774,6 +774,13 @@ function update_core( $from, $to ) {
 		delete_option( 'update_core' );
 	}
 
+	/*
+	 * `wp_opcache_invalidate()` only exists in WordPress 5.5 or later,
+	 * so don't run it when upgrading from older versions.
+	 */
+	if ( function_exists( 'wp_opcache_invalidate' ) ) {
+		wp_opcache_invalidate( ABSPATH . 'wp-admin/includes/translation-install.php' );
+	}
 	// Update installed language packs from API
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 	maybe_upgrade_translations();


### PR DESCRIPTION
## Description
Recent code changes to enable translation package updates on core upgrade have been reported on Zulip to cause errors such as `**Fatal error**: Uncaught Error: Call to undefined function maybe_upgrade_translations()`

## Motivation and context
This is not 100% re-producible and may be linked to server caching, this PR aims to invalidate caching for the file involved in the above error message as a potential fix for the error message.

## How has this been tested?
Local testing but will need further testing on cache using servers once this change in in nightly builds.

## Screenshots
N/A
## Types of changes
- Bug fix