### PR TITLE
Add our own database version to handle updates

### DIFF
--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -48,7 +48,7 @@ if ( get_option( 'db_upgraded' ) ) {
 	do_action( 'after_db_upgrade' );
 
 } elseif ( ! wp_doing_ajax() && empty( $_POST )
-	&& (int) get_option( 'db_version' ) !== $wp_db_version
+	&& ( (int) get_option( 'db_version' ) !== $wp_db_version || (int) get_option( 'cp_db_version', '20100' ) !== $cp_db_version )
 ) {
 
 	if ( ! is_multisite() ) {

--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -48,7 +48,7 @@ if ( get_option( 'db_upgraded' ) ) {
 	do_action( 'after_db_upgrade' );
 
 } elseif ( ! wp_doing_ajax() && empty( $_POST )
-	&& ( (int) get_option( 'db_version' ) !== $wp_db_version || (int) get_option( 'cp_db_version', '20100' ) !== $cp_db_version )
+	&& ( (int) get_option( 'db_version' ) !== $wp_db_version || (int) get_option( 'cp_db_version', '1438' ) !== $cp_db_version )
 ) {
 
 	if ( ! is_multisite() ) {

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -662,7 +662,7 @@ if ( ! function_exists( 'wp_upgrade' ) ) :
 		}
 
 		// We are up to date. Nothing to do.
-		if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version) {
+		if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version ) {
 			return;
 		}
 
@@ -723,7 +723,7 @@ function upgrade_all() {
 	}
 
 	// We are up to date. Nothing to do.
-	if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version) {
+	if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version ) {
 		return;
 	}
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -646,15 +646,23 @@ if ( ! function_exists( 'wp_upgrade' ) ) :
 	 *
 	 * @global int  $wp_current_db_version The old (current) database version.
 	 * @global int  $wp_db_version         The new database version.
+	 * @global int  $cp_current_db_version The old (current) CP database version.
+	 * @global int  $cp_db_version         The new CP database version.
 	 * @global wpdb $wpdb                  WordPress database abstraction object.
 	 */
 	function wp_upgrade() {
 		global $wp_current_db_version, $wp_db_version, $wpdb;
+		global $cp_current_db_version, $cp_db_version;
 
 		$wp_current_db_version = __get_option( 'db_version' );
+		$cp_current_db_version = __get_option( 'cp_db_version' );
+
+		if ( empty( $cp_current_db_version ) ) {
+			$cp_current_db_version = 20100;
+		}
 
 		// We are up to date. Nothing to do.
-		if ( $wp_db_version == $wp_current_db_version ) {
+		if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version) {
 			return;
 		}
 
@@ -700,14 +708,22 @@ endif;
  *
  * @global int $wp_current_db_version The old (current) database version.
  * @global int $wp_db_version         The new database version.
+ * @global int $cp_current_db_version The old (current) CP database version.
+ * @global int $cp_db_version         The new CP database version.
  */
 function upgrade_all() {
 	global $wp_current_db_version, $wp_db_version;
+	global $cp_current_db_version, $cp_db_version;
 
 	$wp_current_db_version = __get_option( 'db_version' );
+	$cp_current_db_version = __get_option( 'cp_db_version' );
+
+	if ( empty( $cp_current_db_version ) ) {
+		$cp_current_db_version = 20100;
+	}
 
 	// We are up to date. Nothing to do.
-	if ( $wp_db_version == $wp_current_db_version ) {
+	if ( $wp_db_version == $wp_current_db_version && $cp_db_version == $cp_current_db_version) {
 		return;
 	}
 
@@ -860,6 +876,7 @@ function upgrade_all() {
 	maybe_disable_automattic_widgets();
 
 	update_option( 'db_version', $wp_db_version );
+	update_option( 'cp_db_version', $cp_db_version );
 	update_option( 'db_upgraded', true );
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -658,7 +658,7 @@ if ( ! function_exists( 'wp_upgrade' ) ) :
 		$cp_current_db_version = __get_option( 'cp_db_version' );
 
 		if ( empty( $cp_current_db_version ) ) {
-			$cp_current_db_version = 20100;
+			$cp_current_db_version = 1438;
 		}
 
 		// We are up to date. Nothing to do.
@@ -719,7 +719,7 @@ function upgrade_all() {
 	$cp_current_db_version = __get_option( 'cp_db_version' );
 
 	if ( empty( $cp_current_db_version ) ) {
-		$cp_current_db_version = 20100;
+		$cp_current_db_version = 1438;
 	}
 
 	// We are up to date. Nothing to do.

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -68,7 +68,7 @@ header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option
 <body class="wp-core-ui">
 <p id="logo"><a href="<?php echo esc_url( __( 'https://www.classicpress.net/' ) ); ?>"><?php _e( 'ClassicPress' ); ?></a></p>
 
-<?php if ( (int) get_option( 'db_version' ) === $wp_db_version || ! is_blog_installed() ) : ?>
+<?php if ( ( (int) get_option( 'db_version' ) === $wp_db_version && (int) get_option( 'cp_db_version', '20100' ) === $cp_db_version ) || ! is_blog_installed() ) : ?>
 
 <h1><?php _e( 'No Update Required' ); ?></h1>
 <p><?php _e( 'Your ClassicPress database is already up to date!' ); ?></p>

--- a/src/wp-admin/upgrade.php
+++ b/src/wp-admin/upgrade.php
@@ -68,7 +68,7 @@ header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option
 <body class="wp-core-ui">
 <p id="logo"><a href="<?php echo esc_url( __( 'https://www.classicpress.net/' ) ); ?>"><?php _e( 'ClassicPress' ); ?></a></p>
 
-<?php if ( ( (int) get_option( 'db_version' ) === $wp_db_version && (int) get_option( 'cp_db_version', '20100' ) === $cp_db_version ) || ! is_blog_installed() ) : ?>
+<?php if ( ( (int) get_option( 'db_version' ) === $wp_db_version && (int) get_option( 'cp_db_version', '1438' ) === $cp_db_version ) || ! is_blog_installed() ) : ?>
 
 <h1><?php _e( 'No Update Required' ); ?></h1>
 <p><?php _e( 'Your ClassicPress database is already up to date!' ); ?></p>

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -49,6 +49,13 @@ $wp_version = '6.2.5';
 $wp_db_version = 53496;
 
 /**
+ * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.
+ *
+ * @global int $cp_db_version
+ */
+$cp_db_version = 20200;
+
+/**
  * Holds the TinyMCE version.
  *
  * @global string $tinymce_version

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -50,11 +50,11 @@ $wp_db_version = 53496;
 
 /**
  * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.
- * Format: 1 digit major, 2 digits minor, 2 digits patch in which is changed.
+ * Suggestion: use the number on the Pull Request where version is bumped.
  *
  * @global int $cp_db_version
  */
-$cp_db_version = 20200;
+$cp_db_version = 1438;
 
 /**
  * Holds the TinyMCE version.

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -50,6 +50,7 @@ $wp_db_version = 53496;
 
 /**
  * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.
+ * Format: 1 digit major, 2 digits minor, 2 digits patch in which is changed.
  *
  * @global int $cp_db_version
  */


### PR DESCRIPTION
When a change in the database schema or in the options is needed, WordPress uses `$wp_db_version` to trigger those updates.

Even if the same variable could be used, it would be better to introduce one specific to ClassicPress.

## Description
The new `$cp_db_version` located in `src/wp-includes/version.php` can be incremented to trigger an automatic update of the database if `src/wp-admin/includes/schema.php` changes. Can also trigger a new specific function to update options or else.

Initial proposed value is 20200, where 2 is major, 02 is minor and 00 is patch of the version that introduce changes.

## How has this been tested?
- Check out the PR
- Play with `$cp_db_version` value
- Delete `cp_db_version` option (`wp option delete cp_db_version`)

## Types of changes
- New feature