### PR TITLE
Update for QUnit testsing and Sinon dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "postcss": "8.4.38",
         "qunit": "^2.19.4",
         "rollup": "4.17.2",
-        "sinon": "^17.0.0",
+        "sinon": "17.0.1",
         "sinon-test": "^3.1.5",
         "source-map-loader": "^5.0.0",
         "sync-request": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postcss": "8.4.38",
     "qunit": "^2.19.4",
     "rollup": "4.17.2",
-    "sinon": "^17.0.0",
+    "sinon": "17.0.1",
     "sinon-test": "^3.1.5",
     "source-map-loader": "^5.0.0",
     "sync-request": "6.1.0",

--- a/tests/qunit/wp-admin/js/widgets/test-media-image-widget.js
+++ b/tests/qunit/wp-admin/js/widgets/test-media-image-widget.js
@@ -90,12 +90,12 @@
 			syncContainer: document.createElement( 'div' ),
 			model: imageWidgetModelInstance
 		});
-		assert.equal( imageWidgetControlInstance.$el.find( 'img' ).length, 0, 'No images should be rendered' );
+		assert.equal( imageWidgetControlInstance.el.querySelectorAll( 'img' ).length, 0, 'No images should be rendered' );
 		imageWidgetControlInstance.model.set({ error: false, url: 'http://s.w.org/style/images/wp-header-logo.png' });
 
 		// Due to renderPreview being deferred.
 		setTimeout( function() {
-			assert.equal( imageWidgetControlInstance.$el.find( 'img[src="http://s.w.org/style/images/wp-header-logo.png"]' ).length, 1, 'One image should be rendered' );
+			assert.equal( imageWidgetControlInstance.el.querySelectorAll( 'img' ).length, 1, 'One image should be rendered' );
 			done();
 		}, 50 );
 

--- a/tests/qunit/wp-admin/js/widgets/test-media-video-widget.js
+++ b/tests/qunit/wp-admin/js/widgets/test-media-video-widget.js
@@ -46,12 +46,12 @@
 			syncContainer: document.createElement( 'div' ),
 			model: videoWidgetModelInstance
 		});
-		assert.equal( videoWidgetControlInstance.$el.find( 'a' ).length, 0, 'No video links should be rendered' );
+		assert.equal( videoWidgetControlInstance.el.querySelectorAll( 'source' ).length, 0, 'No video links should be rendered' );
 		videoWidgetControlInstance.model.set({ error: false, url: 'https://videos.files.wordpress.com/AHz0Ca46/wp4-7-vaughan-r8-mastered_hd.mp4' });
 
 		// Due to renderPreview being deferred.
 		setTimeout( function() {
-			assert.equal( videoWidgetControlInstance.$el.find( 'a[href="https://videos.files.wordpress.com/AHz0Ca46/wp4-7-vaughan-r8-mastered_hd.mp4"]' ).length, 1, 'One video link should be rendered' );
+			assert.equal( videoWidgetControlInstance.el.querySelectorAll( 'source' ).length, 1, 'One video link should be rendered' );
 			done();
 		}, 50 );
 


### PR DESCRIPTION
## Description
A recent [Renovate PR](https://github.com/ClassicPress/ClassicPress/pull/1432) ran tests following the release of Sinon 17.0.2 but this broke some of the QUnit tests. This change fixes the project to the previous, working version of Sinon.

This change also includes minor change to some test assertions to use vanilla JavaScript.

## Motivation and context
Working unit tests without errors should be a priority.

As a point of interest some of the failing tests attempt to defer test assertions, but on checking I don't believe that these tests run at all. The same appears to happen upstream.

## How has this been tested?
Local Testing

## Screenshots
### Before
![Screenshot 2024-05-15 at 12 05 43](https://github.com/ClassicPress/ClassicPress/assets/1280733/fc28a7e6-b1eb-43dd-8f13-40fec60ecafb)

### After
![Screenshot 2024-05-15 at 12 04 22](https://github.com/ClassicPress/ClassicPress/assets/1280733/a64d0308-0d91-45c9-af92-713237055630)

## Types of changes
- Bug Fix  / Workaround

