### PR TITLE
Add relationshps between (a) posts and attachments and (b) posts and featured images

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4472,6 +4472,18 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 		 * @param WP_Post $post_before  Post object before the update.
 		 */
 		do_action( 'post_updated', $post_id, $post_after, $post_before );
+
+		/**
+		 * Updates the relationship between the post and any attachment.
+		 *
+		 * @since CP-2.2.0
+		 *
+		 * @param  int      $post_id          Post ID.
+		 * @param  WP_Post  $post_after       Post object following the update.
+		 * @param  WP_Post  $post_before      Post object before the update.
+		 * @param  string   $post->post_type  Post type.
+		 */
+		cp_update_post_attachment_relationship( $post_id, $post_after, $post_before, $post->post_type );
 	}
 
 	/**
@@ -4503,6 +4515,17 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	 * @param bool    $update  Whether this is an existing post being updated.
 	 */
 	do_action( 'save_post', $post_id, $post, $update );
+
+	/**
+	 * Creates a relationship between the post and any attachment.
+	 *
+	 * @since CP-2.2.0
+	 *
+	 * @param  int      $post_id  Post ID.
+	 * @param  WP_Post  $post     Post object.
+	 * @param  bool     $update   Whether this is an existing post being updated.
+	 */
+	cp_create_post_attachment_relationship( $post_id, $post, $update );
 
 	/**
 	 * Fires once a post has been saved.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7522,8 +7522,32 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 	$thumbnail_id = absint( $thumbnail_id );
 	if ( $post && $thumbnail_id && get_post( $thumbnail_id ) ) {
 		if ( wp_get_attachment_image( $thumbnail_id, 'thumbnail' ) ) {
+
+			/**
+			 * Creates a relationship between a post, page, or custom post and its thumbnail.
+			 *
+			 * @since CP-2.2.0
+			 *
+			 * @param  int     $thumbnail_id     Thumbnail ID.
+			 * @param  string  $post->post_type  Name of post type.
+			 * @param  int     $post->ID         Post ID.
+			 */
+			cp_add_object_relationship( $thumbnail_id, 'thumbnail', $post->post_type, $post->ID );
+
 			return update_post_meta( $post->ID, '_thumbnail_id', $thumbnail_id );
 		} else {
+		
+			/**
+			 * Deletes a relationship between a post, page, or custom post and its thumbnail.
+			 *
+			 * @since CP-2.2.0
+			 *
+			 * @param  int     $thumbnail_id     Thumbnail ID.
+			 * @param  string  $post->post_type  Name of post type.
+			 * @param  int     $post->ID         Post ID.
+			 */
+			cp_delete_object_relationship( $thumbnail_id, 'thumbnail', $post->post_type, $post->ID );
+
 			return delete_post_meta( $post->ID, '_thumbnail_id' );
 		}
 	}
@@ -7541,6 +7565,19 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 function delete_post_thumbnail( $post ) {
 	$post = get_post( $post );
 	if ( $post ) {
+		
+		/**
+		 * Deletes a relationship between a post, page, or custom post and its thumbnail.
+		 *
+		 * @since CP-2.2.0
+		 *
+		 * @param  int     $thumbnail_id     Thumbnail ID.
+		 * @param  string  $post->post_type  Name of post type.
+		 * @param  int     $post->ID         Post ID.
+		 */
+		$thumbnail_id = get_post_thumbnail_id( $post );
+		cp_delete_object_relationship( $thumbnail_id, 'thumbnail', $post->post_type, $post->ID );
+
 		return delete_post_meta( $post->ID, '_thumbnail_id' );
 	}
 	return false;


### PR DESCRIPTION
There is currently no sensible way to find which media files are being used on which posts or pages (and which are not being used at all). This problem was even the subject of an article in WP Tavern: https://wptavern.com/the-problem-with-image-attachments-in-wordpress

After that article, a plugin was created to address the problem: see https://wordpress.org/plugins/find-posts-using-attachment/

That plugin has had mixed reviews, and it works by relying on querying post meta to find posts. That's a notoriously slow and problematic query, and it won't scale.

This PR presents its results in a manner inspired by that plugin, but it generates those results in a very different way. rather than rely on querying metadata, it uses the object relationships table that is the subject of PR #1429. For this reason, that PR must be merged before this one.

But this PR has wider implications because it provides an easy way not only to find either a featured image or an attachment (a media file used in the post's content) from a post but also to find a post from either a featured image or an attachment. **Note:** "post" here includes pages and all custom post types.

Once PR #1429 and this PR are merged, relationships between new posts and their associated featured image or attachments will automatically be kept up to date. Older posts and their associates will be brought up to date when re-saved.

Closes #1435.