### PR TITLE
Add experimental MySQL Testing

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -33,7 +33,7 @@ jobs:
   # - Clone PHP.net if needed for unit tests.
   # - Run PHPUnit Tests.
   test-php:
-    name: "PHP ${{ matrix.php }}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
+    name: "PHP ${{ matrix.php }} on MySQL ${{matrix.mysql}}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -56,6 +56,14 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
+          - php: '8.2'
+            mysql: '8.0'
+            memcached: false
+            experimental: true
+          - php: '8.3'
+            mysql: '8.0'
+            memcached: false
+            experimental: true
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.3', '8.2', '8.1', '8.0', '7.4' ]
-        mysql: [ '5.7' ]
+        mysql: [ '5.7', '8.0' ]
         memcached: [ false ]
         experimental: [ false ]
         include:
@@ -56,14 +56,18 @@ jobs:
             mysql: '5.7'
             memcached: true
             experimental: false
+          - php: '8.0'
+            mysql: '8.0'
+            memcached: true
+            experimental: false
           - php: '8.2'
             mysql: '8.0'
-            memcached: false
-            experimental: true
+            memcached: true
+            experimental: false
           - php: '8.3'
             mysql: '8.0'
-            memcached: false
-            experimental: true
+            memcached: true
+            experimental: false
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/tests/phpunit/tests/query/results.php
+++ b/tests/phpunit/tests/query/results.php
@@ -156,7 +156,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		self::$post_ids[] = $factory->post->create(
 			array(
 				'post_title' => 'no-comments',
-				'post_date'  => '2009-10-01 00:00:00',
+				'post_date'  => '2009-10-15 00:00:00',
 			)
 		);
 		self::$post_ids[] = $factory->post->create(


### PR DESCRIPTION
## Description
This PR adds experimental PHPUnit tests to PHP 8.2 and 8.3 in combinations with MySQL8.

## Motivation and context
Currently all testing runs using MySQL 5.7, this is no longer under active development with minimal future support from developers.
https://www.mysql.com/news-and-events/web-seminars/migrating-from-mysql-5-7-to-mysql-8/

Testing therefore should be extended to more current and supported versions of MySQL to allow work on any failing tests.

## How has this been tested?
Unit tests will run on this PR.

## Screenshots
N/A

## Types of changes
- New feature