### PR TITLE
Fix for QUnit skipped tests

### DIFF
--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -646,6 +646,16 @@
 			<# } #>
 		</script>
 
+		<script type="text/html" id="tmpl-wp-media-widget-image-fields">
+			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_'; #>
+			<# if ( data.url ) { #>
+			<p class="media-widget-image-link">
+				<label for="{{ elementIdPrefix }}linkUrl"><?php esc_html_e( 'Link to:' ); ?></label>
+				<input id="{{ elementIdPrefix }}linkUrl" type="text" class="widefat link" value="{{ data.link_url }}" placeholder="https://" pattern="((\w+:)?\/\/\w.*|\w+:(?!\/\/$)|\/|\?|#).*">
+			</p>
+			<# } #>
+		</script>
+
 		<script type="text/html" id="tmpl-widget-media-media_video-control">
 			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_' #>
 			<p>

--- a/tests/qunit/wp-admin/js/widgets/test-media-image-widget.js
+++ b/tests/qunit/wp-admin/js/widgets/test-media-image-widget.js
@@ -3,7 +3,7 @@
 /* eslint-env qunit */
 /* eslint-disable no-magic-numbers */
 
-( function() {
+( function( setTimeout ) {
 	'use strict';
 
 	QUnit.module( 'Image Media Widget' );
@@ -84,6 +84,8 @@
 		var imageWidgetControlInstance, imageWidgetModelInstance, done;
 		done = assert.async();
 
+		assert.expect( 2 );
+
 		imageWidgetModelInstance = new wp.mediaWidgets.modelConstructors.media_image();
 		imageWidgetControlInstance = new wp.mediaWidgets.controlConstructors.media_image({
 			el: document.createElement( 'div' ),
@@ -99,7 +101,7 @@
 			done();
 		}, 50 );
 
-		done();
+		this.clock.tick( 51 );
 	});
 
 	QUnit.test( 'image media model', function( assert ) {
@@ -114,4 +116,4 @@
 		});
 	});
 
-})();
+})( window.setTimeout );

--- a/tests/qunit/wp-admin/js/widgets/test-media-video-widget.js
+++ b/tests/qunit/wp-admin/js/widgets/test-media-video-widget.js
@@ -3,7 +3,7 @@
 /* eslint-env qunit */
 /* eslint-disable no-magic-numbers */
 
-( function() {
+( function( setTimeout ) {
 	'use strict';
 
 	QUnit.module( 'Video Media Widget' );
@@ -40,22 +40,24 @@
 		var videoWidgetControlInstance, videoWidgetModelInstance, done;
 		done = assert.async();
 
+		assert.expect( 2 );
+
 		videoWidgetModelInstance = new wp.mediaWidgets.modelConstructors.media_video();
 		videoWidgetControlInstance = new wp.mediaWidgets.controlConstructors.media_video({
 			el: document.createElement( 'div' ),
 			syncContainer: document.createElement( 'div' ),
 			model: videoWidgetModelInstance
 		});
-		assert.equal( videoWidgetControlInstance.$el.find( 'a' ).length, 0, 'No video links should be rendered' );
+		assert.equal( videoWidgetControlInstance.$el.find( 'source' ).length, 0, 'No video links should be rendered' );
 		videoWidgetControlInstance.model.set({ error: false, url: 'https://videos.files.wordpress.com/AHz0Ca46/wp4-7-vaughan-r8-mastered_hd.mp4' });
 
 		// Due to renderPreview being deferred.
 		setTimeout( function() {
-			assert.equal( videoWidgetControlInstance.$el.find( 'a[href="https://videos.files.wordpress.com/AHz0Ca46/wp4-7-vaughan-r8-mastered_hd.mp4"]' ).length, 1, 'One video link should be rendered' );
+			assert.equal( videoWidgetControlInstance.$el.find( 'source[src="https://videos.files.wordpress.com/AHz0Ca46/wp4-7-vaughan-r8-mastered_hd.mp4"]' ).length, 1, 'One video link should be rendered' );
 			done();
 		}, 50 );
 
-		done();
+		this.clock.tick( 51 );
 	});
 
 	QUnit.test( 'video media model', function( assert ) {
@@ -70,4 +72,4 @@
 		});
 	});
 
-})();
+})( window.setTimeout );

--- a/tests/qunit/wp-includes/js/tinymce/plugins/wptextpattern/plugin.js
+++ b/tests/qunit/wp-includes/js/tinymce/plugins/wptextpattern/plugin.js
@@ -120,25 +120,25 @@
 		// Wait once for conversions to be triggered,
 		// and once for the `canUndo` flag to be set.
 		setTimeout( function() {
-		setTimeout( function() {
-			if ( typeof args[0] === 'string' ) {
-				args[0] = args[0].split( '' );
-			}
+			setTimeout( function() {
+				if ( typeof args[0] === 'string' ) {
+					args[0] = args[0].split( '' );
+				}
 
-			if ( typeof args[0] === 'function' ) {
-				args[0]();
-			} else {
-				mceType( args[0].shift() );
-			}
+				if ( typeof args[0] === 'function' ) {
+					args[0]();
+				} else {
+					mceType( args[0].shift() );
+				}
 
-			if ( ! args[0].length ) {
-				[].shift.call( args );
-			}
+				if ( ! args[0].length ) {
+					[].shift.call( args );
+				}
 
-			if ( args.length ) {
-				type.apply( null, args );
-			}
-		} );
+				if ( args.length ) {
+					type.apply( null, args );
+				}
+			} );
 		} );
 	}
 


### PR DESCRIPTION
## Description
A recent Sinon update (17.0.2) surfaced some testing issues, the major problems were resolved with the release of Sinon-Test 3.6.1 and Sinon 18, however, while investigating the issues it was noted that 2 QUnit tests never execute.

## Motivation and context
These tests have been made functional in this PR:
- a new template section has been added to `index.html`
- the `clock()` feature in Sinon is used to ensure the tests execute
- testing is updated to assert 2 tests are expected to avoid such issues arising again
- tests are updated to check the more modern HTML implementation
- layout in anohter test file using `setTimeout` has been improved as an aside

## How has this been tested?
Local testing of QUnit tests in a browser and on command line in both `local` and `compiled` states. Note in the screen shots below the same number of tests run but as expected, 2 more assertions.

## Screenshots
### Before
![Screenshot 2024-05-18 at 10 43 26](https://github.com/ClassicPress/ClassicPress/assets/1280733/a60a0a7d-2a56-4dd4-8933-5632e8376e68)
![Screenshot 2024-05-16 at 10 34 25](https://github.com/ClassicPress/ClassicPress/assets/1280733/a5773f83-216a-4f5e-afc2-750f85135139)

### After
![Screenshot 2024-05-18 at 10 43 07](https://github.com/ClassicPress/ClassicPress/assets/1280733/f8ad88c6-6c6b-4bf4-9c9e-8ad501c5e550)
![Screenshot 2024-05-16 at 10 25 09](https://github.com/ClassicPress/ClassicPress/assets/1280733/cdf6a38e-7fc0-4ba0-b2ad-958559c2ea0b)

## Types of changes
- Bug fix
