### PR TITLE
WP-r58174: Fix get_sample_permalink to return the right permalink 

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1416,7 +1416,7 @@ function get_sample_permalink( $post, $title = null, $name = null ) {
 	$original_filter = $post->filter;
 
 	// Hack: get_permalink() would return plain permalink for drafts, so we will fake that our post is published.
-	if ( in_array( $post->post_status, array( 'draft', 'pending', 'future' ), true ) ) {
+	if ( in_array( $post->post_status, array( 'auto-draft', 'draft', 'pending', 'future' ), true ) ) {
 		$post->post_status = 'publish';
 		$post->post_name   = sanitize_title( $post->post_name ? $post->post_name : $post->post_title, $post->ID );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -865,7 +865,11 @@ function get_post_mime_type( $post = null ) {
  * @return string|false Post status on success, false on failure.
  */
 function get_post_status( $post = null ) {
+	if ( $post instanceof WP_Post && isset( $post->filter ) && 'sample' === $post->filter ) {
+		// Skip normalization
+	} else {
 	$post = get_post( $post );
+	}
 
 	if ( ! is_object( $post ) ) {
 		return false;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -867,7 +867,7 @@ function get_post_mime_type( $post = null ) {
 function get_post_status( $post = null ) {
 	// Normalize the post object if necessary, skip normalization if called from get_sample_permalink().
 	if ( ! $post instanceof WP_Post || ! isset( $post->filter ) || 'sample' !== $post->filter ) {
-	$post = get_post( $post );
+		$post = get_post( $post );
 	}
 
 	if ( ! is_object( $post ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -865,9 +865,8 @@ function get_post_mime_type( $post = null ) {
  * @return string|false Post status on success, false on failure.
  */
 function get_post_status( $post = null ) {
-	if ( $post instanceof WP_Post && isset( $post->filter ) && 'sample' === $post->filter ) {
-		// Skip normalization
-	} else {
+	// Normalize the post object if necessary, skip normalization if called from get_sample_permalink().
+	if ( ! $post instanceof WP_Post || ! isset( $post->filter ) || 'sample' !== $post->filter ) {
 	$post = get_post( $post );
 	}
 

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -716,6 +716,28 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 		$this->assertEquals( $post_original, $post, 'get_sample_permalink() modifies the post object.' );
 	}
 
+	/**
+	 * @ticket 59283
+	 */
+	public function test_get_sample_permalink_should_return_pretty_permalink_for_posts_with_post_status_auto_draft() {
+		$permalink_structure = '%postname%';
+		$this->set_permalink_structure( "/$permalink_structure/" );
+
+		$future_date = gmdate( 'Y-m-d H:i:s', time() + 100 );
+		$p           = self::factory()->post->create(
+			array(
+				'post_status' => 'auto-draft',
+				'post_name'   => 'foo',
+				'post_date'   => $future_date,
+			)
+		);
+
+		$found    = get_sample_permalink( $p );
+		$expected = trailingslashit( home_url( $permalink_structure ) );
+
+		$this->assertSame( $expected, $found[0] );
+	}
+
 	public function test_post_exists_should_match_title() {
 		$p = self::factory()->post->create(
 			array(


### PR DESCRIPTION
### Posts: Ensure get_sample_permalink returns the right permalink for auto-draft posts.

Backport of:
- https://core.trac.wordpress.org/changeset/58175
- https://core.trac.wordpress.org/changeset/58174

## Description
The post editor uses the permalink_template property from the posts REST API to render the post slug input or not. For auto-drafts or newly created posts, this property was not set properly. This PR solves by fixing the get_sample_permalink function used to compute this property.

WP:Props youknowriad, mcsf, antonvlasenko, azaozz, peterwilsoncc, andrewserong, hellofromTonya, spacedmonkey.
Fixes https://core.trac.wordpress.org/ticket/59283.


## Types of changes
- Bug fix

