### PR TITLE
Remove unnecessary use of `utf8_encode()` in KSES tests

### DIFF
--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2103,7 +2103,7 @@ HTML;
 			// $allowedentitynames values testing.
 			'nbsp'               => array(
 				'input'    => array( '', 'nbsp' ),
-				'expected' => utf8_encode( chr( 160 ) ),
+				'expected' => "\u{00A0}",
 			),
 			'iexcl'              => array(
 				'input'    => array( '', 'iexcl' ),


### PR DESCRIPTION
## Description

WP-r57861: Tests: Remove unnecessary use of `utf8_encode()` in KSES tests.

One of the tests for the `wp_kses_xml_named_entities()` function used `utf8_encode( chr( 160 ) )` to set an expectation of a Unicode character for a non-breaking space.

It is understandable that this expectation was previously set this way, as it is not possible for a developer to distinguish between a ''breaking'' space and a ''non-breaking'' space visually, so the chances of the test accidentally breaking on an incorrect save when the plain Unicode character would be used, was high.

However, the `utf8_encode()` function is deprecated as of PHP 8.2, and its use needs to be removed from the WP codebase.

PHP 7.0 has introduced [https://wiki.php.net/rfc/unicode_escape Unicode escape sequences], which allows to create a text string using Unicode characters referenced by their codepoint. By switching the test case to provide the test expectation using a Unicode escape sequence, we remove the use of the deprecated PHP function and still preserve the safeguard against the test accidentally breaking.

Follow-up to https://core.trac.wordpress.org/changeset/52229.

WP:Props jrf, afercia, poena, SergeyBiryukov.
See https://core.trac.wordpress.org/ticket/55603, https://core.trac.wordpress.org/ticket/60705.

---

Merges https://core.trac.wordpress.org/changeset/57861 / WordPress/wordpress-develop@8d0aed455b to ClassicPress.

## Motivation and context
Fixes deprecation notice seen during tests.

## How has this been tested?
Upstream and local testing, see screenshots below.

## Screenshots
### Before
![Screenshot 2024-05-22 at 16 31 48](https://github.com/ClassicPress/ClassicPress/assets/1280733/1184c174-a355-4c23-a71b-30210b925e0a)

### After
![Screenshot 2024-05-22 at 16 28 18](https://github.com/ClassicPress/ClassicPress/assets/1280733/f4628661-f67e-401a-95a3-a504fb38942f)


## Types of changes
- Bug fix