### PR TITLE
Add $fixture_replacements for media categories

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -622,6 +622,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 		'MediaCollection.0._links.collection.0.href'       => 'http://example.org/index.php?rest_route=/wp/v2/media',
 		'MediaCollection.0._links.about.0.href'            => 'http://example.org/index.php?rest_route=/wp/v2/types/attachment',
 		'MediaCollection.0._links.replies.0.href'          => 'http://example.org/index.php?rest_route=%2Fwp%2Fv2%2Fcomments&post=10',
+		'MediaCollection.0._links.wp:term.0.href'          => 'http://example.org/index.php?rest_route=%2Fwp%2Fv2%2Fmedia_categories&post=10',
+		'MediaCollection.0._links.wp:term.1.href'          => 'http://example.org/index.php?rest_route=%2Fwp%2Fv2%2Fmedia_tags&post=10',
 		'MediaModel.id'                                    => 10,
 		'MediaModel.guid.rendered'                         => 'http://example.org/?attachment_id=10',
 		'MediaModel.link'                                  => 'http://example.org/?attachment_id=10',


### PR DESCRIPTION
## Description
Since the introduction in core of Media Categories there is some strange behaviour when running PHP unit tests.

Running `composer run phpunit -- --group=restapi` will produce changes in the `tests/qunit/fixtures/wp-api-generated.js` file with changes to the ID used. Thisis viewable using `git diff` locally.

Running `composer run phpunit -- --group=restapi-jsclient` after the above step will revert these changes.

## Motivation and context
On investigation, it seems that adding to the expected `$fixture_replacements` variable in `tests/phpunit/tests/rest-api/rest-schema-setup.php` resolves this issue such that running all PHPUnit tests of the one aimed at testing the REST-API will not result in changes to that generated file.

This may explain why a `grunt precommit` was needed on the original [PR](https://github.com/ClassicPress/ClassicPress/pull/1393). 

## How has this been tested?
Local testing, steps above explain process to reproduce.

## Screenshots
### Before
![Screenshot 2024-05-22 at 18 43 12](https://github.com/ClassicPress/ClassicPress/assets/1280733/967d68b3-b4bf-4744-bd39-b961f4576f63)

## Types of changes
- Bug fix
