### PR TITLE
Fix: prompt to update core for incompatible plugins and themes

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -420,7 +420,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 	public function display_rows() {
 		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 
 		$plugins_allowedtags = array(
 			'a'       => array(

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -419,6 +419,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	}
 
 	public function display_rows() {
+		$cp_needs_update = find_core_update( classicpress_version(), get_locale() ) !== false;
+
 		$plugins_allowedtags = array(
 			'a'       => array(
 				'href'   => array(),
@@ -651,12 +653,20 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 				if ( ! $compatible_php && ! $compatible_wp ) {
 					_e( 'This plugin does not work with your versions of ClassicPress and PHP.' );
 					if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-						printf(
-							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-							self_admin_url( 'update-core.php' ),
-							esc_url( wp_get_update_php_url() )
-						);
+						if ( $cp_needs_update ) {
+							printf(
+								/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+								' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+								self_admin_url( 'update-core.php' ),
+								esc_url( wp_get_update_php_url() )
+							);
+						} else {
+							printf(
+								/* translators: %s: URL to Update PHP page. */
+								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+								esc_url( wp_get_update_php_url() )
+							);
+						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) ) {
 						printf(
@@ -674,7 +684,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 					}
 				} elseif ( ! $compatible_wp ) {
 					_e( 'This plugin does not work with your version of ClassicPress.' );
-					if ( current_user_can( 'update_core' ) ) {
+					if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -419,7 +419,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	}
 
 	public function display_rows() {
-		$cp_needs_update = find_core_update( classicpress_version(), get_locale() ) !== false;
+		$updates_from_api = get_site_transient( 'update_core' );
+		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 
 		$plugins_allowedtags = array(
 			'a'       => array(

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -705,6 +705,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 * @param array $item
 	 */
 	public function single_row( $item ) {
+
+		$cp_needs_update = find_core_update( classicpress_version(), get_locale() ) !== false;
 		global $status, $page, $s, $totals;
 		static $plugin_id_attrs = array();
 
@@ -1272,12 +1274,20 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			if ( ! $compatible_php && ! $compatible_wp ) {
 				_e( 'This plugin does not work with your versions of ClassicPress and PHP.' );
 				if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-					printf(
-						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-						self_admin_url( 'update-core.php' ),
-						esc_url( wp_get_update_php_url() )
-					);
+					if ( $cp_needs_update ) {
+						printf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+					} else {
+						printf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
 				} elseif ( current_user_can( 'update_core' ) ) {
 					printf(
@@ -1295,7 +1305,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				}
 			} elseif ( ! $compatible_wp ) {
 				_e( 'This plugin does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) ) {
+				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -706,7 +706,9 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 */
 	public function single_row( $item ) {
 
-		$cp_needs_update = find_core_update( classicpress_version(), get_locale() ) !== false;
+		$updates_from_api = get_site_transient( 'update_core' );
+		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+
 		global $status, $page, $s, $totals;
 		static $plugin_id_attrs = array();
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -707,7 +707,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	public function single_row( $item ) {
 
 		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 
 		global $status, $page, $s, $totals;
 		static $plugin_id_attrs = array();

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -988,7 +988,7 @@ function customize_themes_print_templates() {
 								if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 									printf(
 										/* translators: %s: URL to WordPress Updates screen. */
-										' ' . __( '<a href="%s">Please cd .Press</a>.' ),
+										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
 										self_admin_url( 'update-core.php' )
 									);
 								}

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -780,7 +780,7 @@ function wp_prepare_themes_for_js( $themes = null ) {
  */
 function customize_themes_print_templates() {
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 
 	?>
 	<script type="text/html" id="tmpl-customize-themes-details-view">
@@ -879,7 +879,7 @@ function customize_themes_print_templates() {
 													/* translators: %s: URL to Update PHP page. */
 													' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 													esc_url( wp_get_update_php_url() )
-												);											
+												);
 											}
 											wp_update_php_annotation( '</p><p><em>', '</em>' );
 										} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -964,7 +964,7 @@ function customize_themes_print_templates() {
 											/* translators: %s: URL to Update PHP page. */
 											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 											esc_url( wp_get_update_php_url() )
-										);										
+										);
 									}
 									wp_update_php_annotation( '</p><p><em>', '</em>' );
 								} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -780,7 +780,7 @@ function wp_prepare_themes_for_js( $themes = null ) {
  */
 function customize_themes_print_templates() {
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 
 	?>
 	<script type="text/html" id="tmpl-customize-themes-details-view">

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -779,6 +779,9 @@ function wp_prepare_themes_for_js( $themes = null ) {
  * @since 4.2.0
  */
 function customize_themes_print_templates() {
+	$updates_from_api = get_site_transient( 'update_core' );
+	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+
 	?>
 	<script type="text/html" id="tmpl-customize-themes-details-view">
 		<div class="theme-backdrop"></div>
@@ -864,14 +867,22 @@ function customize_themes_print_templates() {
 											'{{{ data.name }}}'
 										);
 										if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-											printf(
-												/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-												' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-												self_admin_url( 'update-core.php' ),
-												esc_url( wp_get_update_php_url() )
-											);
+											if ( $cp_needs_update ) {
+												printf(
+													/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+													' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+													self_admin_url( 'update-core.php' ),
+													esc_url( wp_get_update_php_url() )
+												);
+											} else {
+												printf(
+													/* translators: %s: URL to Update PHP page. */
+													' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+													esc_url( wp_get_update_php_url() )
+												);											
+											}
 											wp_update_php_annotation( '</p><p><em>', '</em>' );
-										} elseif ( current_user_can( 'update_core' ) ) {
+										} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 											printf(
 												/* translators: %s: URL to WordPress Updates screen. */
 												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -893,7 +904,7 @@ function customize_themes_print_templates() {
 											__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 											'{{{ data.name }}}'
 										);
-										if ( current_user_can( 'update_core' ) ) {
+										if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 											printf(
 												/* translators: %s: URL to WordPress Updates screen. */
 												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -941,14 +952,22 @@ function customize_themes_print_templates() {
 								<?php
 								_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 								if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-									printf(
-										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-										self_admin_url( 'update-core.php' ),
-										esc_url( wp_get_update_php_url() )
-									);
+									if ( $cp_needs_update ) {
+										printf(
+											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+											self_admin_url( 'update-core.php' ),
+											esc_url( wp_get_update_php_url() )
+										);
+									} else {
+										printf(
+											/* translators: %s: URL to Update PHP page. */
+											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+											esc_url( wp_get_update_php_url() )
+										);										
+									}
 									wp_update_php_annotation( '</p><p><em>', '</em>' );
-								} elseif ( current_user_can( 'update_core' ) ) {
+								} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 									printf(
 										/* translators: %s: URL to WordPress Updates screen. */
 										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -966,10 +985,10 @@ function customize_themes_print_templates() {
 							<# } else if ( ! data.compatibleWP ) { #>
 								<?php
 								_e( 'This theme does not work with your version of ClassicPress.' );
-								if ( current_user_can( 'update_core' ) ) {
+								if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 									printf(
 										/* translators: %s: URL to WordPress Updates screen. */
-										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+										' ' . __( '<a href="%s">Please cd .Press</a>.' ),
 										self_admin_url( 'update-core.php' )
 									);
 								}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -634,6 +634,9 @@ function wp_theme_update_rows() {
  * @return void|false
  */
 function wp_theme_update_row( $theme_key, $theme ) {
+
+	$updates_from_api = get_site_transient( 'update_core' );
+	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 	$current = get_site_transient( 'update_themes' );
 
 	if ( ! isset( $current->response[ $theme_key ] ) ) {
@@ -727,14 +730,21 @@ function wp_theme_update_row( $theme_key, $theme ) {
 				$theme['Name']
 			);
 			if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-				printf(
-					/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-					' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-					self_admin_url( 'update-core.php' ),
-					esc_url( wp_get_update_php_url() )
-				);
+				if ( $cp_needs_update ) {
+					printf(
+						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+						self_admin_url( 'update-core.php' ),
+						esc_url( wp_get_update_php_url() )
+					);
+				} else {
+					printf(
+						/* translators: %s: URL to Update PHP page. */
+						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+						esc_url( wp_get_update_php_url() )
+					);				}
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
-			} elseif ( current_user_can( 'update_core' ) ) {
+			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -754,7 +764,7 @@ function wp_theme_update_row( $theme_key, $theme ) {
 				__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 				$theme['Name']
 			);
-			if ( current_user_can( 'update_core' ) ) {
+			if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -636,8 +636,8 @@ function wp_theme_update_rows() {
 function wp_theme_update_row( $theme_key, $theme ) {
 
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
-	$current = get_site_transient( 'update_themes' );
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$current          = get_site_transient( 'update_themes' );
 
 	if ( ! isset( $current->response[ $theme_key ] ) ) {
 		return false;
@@ -742,7 +742,7 @@ function wp_theme_update_row( $theme_key, $theme ) {
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);				}
+					);              }
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
 			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -636,7 +636,7 @@ function wp_theme_update_rows() {
 function wp_theme_update_row( $theme_key, $theme ) {
 
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 	$current          = get_site_transient( 'update_themes' );
 
 	if ( ! isset( $current->response[ $theme_key ] ) ) {

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/theme-install.php';
 
 $updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 
 wp_reset_vars( array( 'tab' ) );
 
@@ -302,13 +302,13 @@ if ( $tab ) {
 							self_admin_url( 'update-core.php' ),
 							esc_url( wp_get_update_php_url() )
 						);
-				} else {
-					printf(
+					} else {
+						printf(
 						/* translators: %s: URL to Update PHP page. */
-						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-						esc_url( wp_get_update_php_url() )
-					);					
-				}
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);
+					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
 				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
@@ -516,12 +516,12 @@ if ( $tab ) {
 												esc_url( wp_get_update_php_url() )
 											);
 										} else {
-										printf(
+											printf(
 											/* translators: %s: URL to Update PHP page. */
-											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-											esc_url( wp_get_update_php_url() )
-										);								
-									}
+												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+												esc_url( wp_get_update_php_url() )
+											);
+										}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
 									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 										printf(

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -10,6 +10,9 @@
 require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/theme-install.php';
 
+$updates_from_api = get_site_transient( 'update_core' );
+$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+
 wp_reset_vars( array( 'tab' ) );
 
 if ( ! current_user_can( 'install_themes' ) ) {
@@ -292,14 +295,22 @@ if ( $tab ) {
 				<?php
 				_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 				if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+					if ( $cp_needs_update ) {
+						printf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+				} else {
 					printf(
-						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-						self_admin_url( 'update-core.php' ),
+						/* translators: %s: URL to Update PHP page. */
+						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);
+					);					
+				}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
-				} elseif ( current_user_can( 'update_core' ) ) {
+				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -321,7 +332,7 @@ if ( $tab ) {
 			<# } else if ( ! data.compatible_wp ) { #>
 				<?php
 				_e( 'This theme does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) ) {
+				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -497,14 +508,22 @@ if ( $tab ) {
 									<?php
 									_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 									if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+										if ( $cp_needs_update ) {
+											printf(
+												/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+												' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+												self_admin_url( 'update-core.php' ),
+												esc_url( wp_get_update_php_url() )
+											);
+										} else {
 										printf(
-											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-											self_admin_url( 'update-core.php' ),
+											/* translators: %s: URL to Update PHP page. */
+											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 											esc_url( wp_get_update_php_url() )
-										);
+										);								
+									}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
-									} elseif ( current_user_can( 'update_core' ) ) {
+									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 										printf(
 											/* translators: %s: URL to WordPress Updates screen. */
 											' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -526,7 +545,7 @@ if ( $tab ) {
 								<# } else if ( ! data.compatible_wp ) { #>
 									<?php
 									_e( 'This theme does not work with your version of ClassicPress.' );
-									if ( current_user_can( 'update_core' ) ) {
+									if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 										printf(
 											/* translators: %s: URL to WordPress Updates screen. */
 											' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/theme-install.php';
 
 $updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 
 wp_reset_vars( array( 'tab' ) );
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -376,7 +376,7 @@ if ( ! empty( $_GET['search'] ) ) {
  * This PHP is synchronized with the tmpl-theme template below!
  */
 $updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 
 foreach ( $themes as $theme ) :
 	$aria_action = $theme['id'] . '-action';
@@ -422,13 +422,13 @@ foreach ( $themes as $theme ) :
 								self_admin_url( 'update-core.php' ),
 								esc_url( wp_get_update_php_url() )
 							);
-					} else {
-						printf(
+						} else {
+							printf(
 							/* translators: %s: URL to Update PHP page. */
-							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-							esc_url( wp_get_update_php_url() )
-						);						
-					}
+								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+								esc_url( wp_get_update_php_url() )
+							);
+						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
@@ -486,17 +486,17 @@ foreach ( $themes as $theme ) :
 				if ( $cp_needs_update ) {
 					printf(
 							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-							self_admin_url( 'update-core.php' ),
-							esc_url( wp_get_update_php_url() )
-						);
+						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+						self_admin_url( 'update-core.php' ),
+						esc_url( wp_get_update_php_url() )
+					);
 				} else {
 					printf(
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);				
-			}
+					);
+				}
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
 			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
@@ -794,7 +794,7 @@ function wp_theme_auto_update_setting_template() {
 								/* translators: %s: URL to Update PHP page. */
 								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 								esc_url( wp_get_update_php_url() )
-							);						
+							);
 						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -866,7 +866,7 @@ function wp_theme_auto_update_setting_template() {
 							/* translators: %s: URL to Update PHP page. */
 							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( wp_get_update_php_url() )
-						);						
+						);
 					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
 				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1035,7 +1035,7 @@ function wp_theme_auto_update_setting_template() {
 										/* translators: %s: URL to Update PHP page. */
 										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 										esc_url( wp_get_update_php_url() )
-									);								
+									);
 								}
 								wp_update_php_annotation( '</p><p><em>', '</em>' );
 							} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1110,7 +1110,7 @@ function wp_theme_auto_update_setting_template() {
 												/* translators: %s: URL to Update PHP page. */
 												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 												esc_url( wp_get_update_php_url() )
-											);											
+											);
 										}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
 									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -376,7 +376,7 @@ if ( ! empty( $_GET['search'] ) ) {
  * This PHP is synchronized with the tmpl-theme template below!
  */
 $updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 
 foreach ( $themes as $theme ) :
 	$aria_action = $theme['id'] . '-action';
@@ -423,12 +423,12 @@ foreach ( $themes as $theme ) :
 								esc_url( wp_get_update_php_url() )
 							);
 						} else {
-							printf(
+						printf(
 							/* translators: %s: URL to Update PHP page. */
-								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-								esc_url( wp_get_update_php_url() )
-							);
-						}
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);						
+					}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
@@ -486,17 +486,17 @@ foreach ( $themes as $theme ) :
 				if ( $cp_needs_update ) {
 					printf(
 							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-						self_admin_url( 'update-core.php' ),
-						esc_url( wp_get_update_php_url() )
-					);
+							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
 				} else {
 					printf(
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);
-				}
+					);				
+			}
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
 			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
@@ -794,7 +794,7 @@ function wp_theme_auto_update_setting_template() {
 								/* translators: %s: URL to Update PHP page. */
 								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 								esc_url( wp_get_update_php_url() )
-							);
+							);						
 						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -866,7 +866,7 @@ function wp_theme_auto_update_setting_template() {
 							/* translators: %s: URL to Update PHP page. */
 							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( wp_get_update_php_url() )
-						);
+						);						
 					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
 				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1035,7 +1035,7 @@ function wp_theme_auto_update_setting_template() {
 										/* translators: %s: URL to Update PHP page. */
 										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 										esc_url( wp_get_update_php_url() )
-									);
+									);								
 								}
 								wp_update_php_annotation( '</p><p><em>', '</em>' );
 							} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1110,7 +1110,7 @@ function wp_theme_auto_update_setting_template() {
 												/* translators: %s: URL to Update PHP page. */
 												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 												esc_url( wp_get_update_php_url() )
-											);
+											);											
 										}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
 									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -423,12 +423,12 @@ foreach ( $themes as $theme ) :
 								esc_url( wp_get_update_php_url() )
 							);
 						} else {
-						printf(
+							printf(
 							/* translators: %s: URL to Update PHP page. */
-							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-							esc_url( wp_get_update_php_url() )
-						);						
-					}
+								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+								esc_url( wp_get_update_php_url() )
+							);
+						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
@@ -486,17 +486,17 @@ foreach ( $themes as $theme ) :
 				if ( $cp_needs_update ) {
 					printf(
 							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-							self_admin_url( 'update-core.php' ),
-							esc_url( wp_get_update_php_url() )
-						);
+						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+						self_admin_url( 'update-core.php' ),
+						esc_url( wp_get_update_php_url() )
+					);
 				} else {
 					printf(
 						/* translators: %s: URL to Update PHP page. */
 						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);				
-			}
+					);
+				}
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
 			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
@@ -794,7 +794,7 @@ function wp_theme_auto_update_setting_template() {
 								/* translators: %s: URL to Update PHP page. */
 								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 								esc_url( wp_get_update_php_url() )
-							);						
+							);
 						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
 					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -866,7 +866,7 @@ function wp_theme_auto_update_setting_template() {
 							/* translators: %s: URL to Update PHP page. */
 							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( wp_get_update_php_url() )
-						);						
+						);
 					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
 				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1035,7 +1035,7 @@ function wp_theme_auto_update_setting_template() {
 										/* translators: %s: URL to Update PHP page. */
 										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 										esc_url( wp_get_update_php_url() )
-									);								
+									);
 								}
 								wp_update_php_annotation( '</p><p><em>', '</em>' );
 							} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
@@ -1110,7 +1110,7 @@ function wp_theme_auto_update_setting_template() {
 												/* translators: %s: URL to Update PHP page. */
 												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 												esc_url( wp_get_update_php_url() )
-											);											
+											);
 										}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
 									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -375,6 +375,8 @@ if ( ! empty( $_GET['search'] ) ) {
 /*
  * This PHP is synchronized with the tmpl-theme template below!
  */
+$updates_from_api = get_site_transient( 'update_core' );
+$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 
 foreach ( $themes as $theme ) :
 	$aria_action = $theme['id'] . '-action';
@@ -413,14 +415,22 @@ foreach ( $themes as $theme ) :
 						$theme['name']
 					);
 					if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+						if ( $cp_needs_update ) {
+							printf(
+								/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+								' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+								self_admin_url( 'update-core.php' ),
+								esc_url( wp_get_update_php_url() )
+							);
+					} else {
 						printf(
-							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-							self_admin_url( 'update-core.php' ),
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 							esc_url( wp_get_update_php_url() )
-						);
+						);						
+					}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
-					} elseif ( current_user_can( 'update_core' ) ) {
+					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -440,7 +450,7 @@ foreach ( $themes as $theme ) :
 						__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 						$theme['name']
 					);
-					if ( current_user_can( 'update_core' ) ) {
+					if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -473,14 +483,22 @@ foreach ( $themes as $theme ) :
 		if ( ! $theme['compatibleWP'] && ! $theme['compatiblePHP'] ) {
 			_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 			if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-				printf(
-					/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-					' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-					self_admin_url( 'update-core.php' ),
-					esc_url( wp_get_update_php_url() )
-				);
+				if ( $cp_needs_update ) {
+					printf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+				} else {
+					printf(
+						/* translators: %s: URL to Update PHP page. */
+						' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+						esc_url( wp_get_update_php_url() )
+					);				
+			}
 				wp_update_php_annotation( '</p><p><em>', '</em>' );
-			} elseif ( current_user_can( 'update_core' ) ) {
+			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -496,7 +514,7 @@ foreach ( $themes as $theme ) :
 			}
 		} elseif ( ! $theme['compatibleWP'] ) {
 			_e( 'This theme does not work with your version of ClassicPress.' );
-			if ( current_user_can( 'update_core' ) ) {
+			if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				printf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -764,14 +782,22 @@ function wp_theme_auto_update_setting_template() {
 						'{{{ data.name }}}'
 					);
 					if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-						printf(
-							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-							self_admin_url( 'update-core.php' ),
-							esc_url( wp_get_update_php_url() )
-						);
+						if ( $cp_needs_update ) {
+							printf(
+								/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+								' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+								self_admin_url( 'update-core.php' ),
+								esc_url( wp_get_update_php_url() )
+							);
+						} else {
+							printf(
+								/* translators: %s: URL to Update PHP page. */
+								' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+								esc_url( wp_get_update_php_url() )
+							);						
+						}
 						wp_update_php_annotation( '</p><p><em>', '</em>' );
-					} elseif ( current_user_can( 'update_core' ) ) {
+					} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -793,7 +819,7 @@ function wp_theme_auto_update_setting_template() {
 						__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 						'{{{ data.name }}}'
 					);
-					if ( current_user_can( 'update_core' ) ) {
+					if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 						printf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -828,14 +854,22 @@ function wp_theme_auto_update_setting_template() {
 				<?php
 				_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 				if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-					printf(
-						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-						' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-						self_admin_url( 'update-core.php' ),
-						esc_url( wp_get_update_php_url() )
-					);
+					if ( $cp_needs_update ) {
+						printf(
+							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+							self_admin_url( 'update-core.php' ),
+							esc_url( wp_get_update_php_url() )
+						);
+					} else {
+						printf(
+							/* translators: %s: URL to Update PHP page. */
+							' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+							esc_url( wp_get_update_php_url() )
+						);						
+					}
 					wp_update_php_annotation( '</p><p><em>', '</em>' );
-				} elseif ( current_user_can( 'update_core' ) ) {
+				} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -853,7 +887,7 @@ function wp_theme_auto_update_setting_template() {
 			<# } else if ( ! data.compatibleWP ) { #>
 				<?php
 				_e( 'This theme does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) ) {
+				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 					printf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -989,14 +1023,22 @@ function wp_theme_auto_update_setting_template() {
 							<?php
 							_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 							if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-								printf(
-									/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-									' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-									self_admin_url( 'update-core.php' ),
-									esc_url( wp_get_update_php_url() )
-								);
+								if ( $cp_needs_update ) {
+									printf(
+										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+										self_admin_url( 'update-core.php' ),
+										esc_url( wp_get_update_php_url() )
+									);
+								} else {
+									printf(
+										/* translators: %s: URL to Update PHP page. */
+										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+										esc_url( wp_get_update_php_url() )
+									);								
+								}
 								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							} elseif ( current_user_can( 'update_core' ) ) {
+							} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 								printf(
 									/* translators: %s: URL to WordPress Updates screen. */
 									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -1014,7 +1056,7 @@ function wp_theme_auto_update_setting_template() {
 						<# } else if ( ! data.compatibleWP ) { #>
 							<?php
 							_e( 'This theme does not work with your version of ClassicPress.' );
-							if ( current_user_can( 'update_core' ) ) {
+							if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 								printf(
 									/* translators: %s: URL to WordPress Updates screen. */
 									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -1056,14 +1098,22 @@ function wp_theme_auto_update_setting_template() {
 										'{{{ data.name }}}'
 									);
 									if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-										printf(
-											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-											self_admin_url( 'update-core.php' ),
-											esc_url( wp_get_update_php_url() )
-										);
+										if ( $cp_needs_update ) {
+											printf(
+												/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+												' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+												self_admin_url( 'update-core.php' ),
+												esc_url( wp_get_update_php_url() )
+											);
+										} else {
+											printf(
+												/* translators: %s: URL to Update PHP page. */
+												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+												esc_url( wp_get_update_php_url() )
+											);											
+										}
 										wp_update_php_annotation( '</p><p><em>', '</em>' );
-									} elseif ( current_user_can( 'update_core' ) ) {
+									} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 										printf(
 											/* translators: %s: URL to WordPress Updates screen. */
 											' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -1085,7 +1135,7 @@ function wp_theme_auto_update_setting_template() {
 										__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 										'{{{ data.name }}}'
 									);
-									if ( current_user_can( 'update_core' ) ) {
+									if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 										printf(
 											/* translators: %s: URL to WordPress Updates screen. */
 											' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -475,6 +475,8 @@ function list_plugin_updates() {
  * @since 2.9.0
  */
 function list_theme_updates() {
+	$updates_from_api = get_site_transient( 'update_core' );
+	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 	$themes = get_theme_updates();
 	if ( empty( $themes ) ) {
 		echo '<h2>' . __( 'Themes' ) . '</h2>';
@@ -536,19 +538,25 @@ function list_theme_updates() {
 		if ( ! $compatible_wp && ! $compatible_php ) {
 			$compat .= '<br>' . __( 'This update does not work with your versions of ClassicPress and PHP.' ) . '&nbsp;';
 			if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-				$compat .= sprintf(
-					/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-					__( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-					esc_url( self_admin_url( 'update-core.php' ) ),
-					esc_url( wp_get_update_php_url() )
-				);
-
+				if ( $cp_needs_update ) {
+					$compat .= sprintf(
+						/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+						__( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+						esc_url( self_admin_url( 'update-core.php' ) ),
+						esc_url( wp_get_update_php_url() )
+					);
+				} else {
+					$compat .= sprintf(
+						/* translators: %s: URL to Update PHP page. */
+						__( '<a href="%s">Learn more about updating PHP</a>.' ),
+						esc_url( wp_get_update_php_url() )
+					);				}
 				$annotation = wp_get_update_php_annotation();
 
 				if ( $annotation ) {
 					$compat .= '</p><p><em>' . $annotation . '</em>';
 				}
-			} elseif ( current_user_can( 'update_core' ) ) {
+			} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				$compat .= sprintf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					__( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -569,7 +577,7 @@ function list_theme_updates() {
 			}
 		} elseif ( ! $compatible_wp ) {
 			$compat .= '<br>' . __( 'This update does not work with your version of ClassicPress.' ) . '&nbsp;';
-			if ( current_user_can( 'update_core' ) ) {
+			if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 				$compat .= sprintf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					__( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -476,7 +476,7 @@ function list_plugin_updates() {
  */
 function list_theme_updates() {
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 	$themes           = get_theme_updates();
 	if ( empty( $themes ) ) {
 		echo '<h2>' . __( 'Themes' ) . '</h2>';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -476,8 +476,8 @@ function list_plugin_updates() {
  */
 function list_theme_updates() {
 	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
-	$themes = get_theme_updates();
+	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+	$themes           = get_theme_updates();
 	if ( empty( $themes ) ) {
 		echo '<h2>' . __( 'Themes' ) . '</h2>';
 		echo '<p>' . __( 'Your themes are all up to date.' ) . '</p>';
@@ -550,7 +550,7 @@ function list_theme_updates() {
 						/* translators: %s: URL to Update PHP page. */
 						__( '<a href="%s">Learn more about updating PHP</a>.' ),
 						esc_url( wp_get_update_php_url() )
-					);				}
+					);              }
 				$annotation = wp_get_update_php_annotation();
 
 				if ( $annotation ) {

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -58,7 +58,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 	 */
 	public function content_template() {
 		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
 		/* translators: %s: Theme name. */
 		$details_label = sprintf( __( 'Details for theme: %s' ), '{{ data.theme.name }}' );
 		/* translators: %s: Theme name. */

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -57,6 +57,8 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 	 * @since 4.2.0
 	 */
 	public function content_template() {
+		$updates_from_api = get_site_transient( 'update_core' );
+		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 		/* translators: %s: Theme name. */
 		$details_label = sprintf( __( 'Details for theme: %s' ), '{{ data.theme.name }}' );
 		/* translators: %s: Theme name. */
@@ -117,14 +119,22 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 									'{{{ data.theme.name }}}'
 								);
 								if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-									printf(
-										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-										self_admin_url( 'update-core.php' ),
-										esc_url( wp_get_update_php_url() )
-									);
+									if ( $cp_needs_update ) {
+										printf(
+											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+											self_admin_url( 'update-core.php' ),
+											esc_url( wp_get_update_php_url() )
+										);
+									} else {
+										printf(
+											/* translators: %s: URL to Update PHP page. */
+											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+											esc_url( wp_get_update_php_url() )
+										);										
+									}
 									wp_update_php_annotation( '</p><p><em>', '</em>' );
-								} elseif ( current_user_can( 'update_core' ) ) {
+								} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 									printf(
 										/* translators: %s: URL to WordPress Updates screen. */
 										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -146,7 +156,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 									__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
 									'{{{ data.theme.name }}}'
 								);
-								if ( current_user_can( 'update_core' ) ) {
+								if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 									printf(
 										/* translators: %s: URL to WordPress Updates screen. */
 										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -182,14 +192,22 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 						<?php
 						_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 						if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-							printf(
-								/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-								' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-								self_admin_url( 'update-core.php' ),
-								esc_url( wp_get_update_php_url() )
-							);
+							if ( $cp_needs_update ) {
+								printf(
+									/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+									' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+									self_admin_url( 'update-core.php' ),
+									esc_url( wp_get_update_php_url() )
+								);
+							} else {
+								printf(
+									/* translators: %s: URL to Update PHP page. */
+									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+									esc_url( wp_get_update_php_url() )
+								);
+							}
 							wp_update_php_annotation( '</p><p><em>', '</em>' );
-						} elseif ( current_user_can( 'update_core' ) ) {
+						} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 							printf(
 								/* translators: %s: URL to WordPress Updates screen. */
 								' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -211,7 +229,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 					<# } else if ( ! data.theme.compatibleWP ) { #>
 						<?php
 						_e( 'This theme does not work with your version of ClassicPress.' );
-						if ( current_user_can( 'update_core' ) ) {
+						if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
 							printf(
 								/* translators: %s: URL to WordPress Updates screen. */
 								' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -58,7 +58,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 	 */
 	public function content_template() {
 		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
+		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates );
 		/* translators: %s: Theme name. */
 		$details_label = sprintf( __( 'Details for theme: %s' ), '{{ data.theme.name }}' );
 		/* translators: %s: Theme name. */
@@ -131,7 +131,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 											/* translators: %s: URL to Update PHP page. */
 											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 											esc_url( wp_get_update_php_url() )
-										);										
+										);
 									}
 									wp_update_php_annotation( '</p><p><em>', '</em>' );
 								} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {


### PR DESCRIPTION
See #1441 .
Closes #1441 

## Description
Plugin and themes that contains `Requires at least` are checked against `$wp_version`.
At now that is `6.2.5`, but users running the latest version of ClassicPress are anyway prompted to update.

## How has this been tested?
Local testing.

## Screenshots
### After
<img width="1474" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/566e5328-7830-48db-9693-57039b219a71">

<img width="1101" alt="image" src="https://github.com/ClassicPress/ClassicPress/assets/29772709/a2b99d52-178a-42aa-8fed-979cb6e55f82">

## Types of changes
- Bug fix

