### PR TITLE
List ClassicPress theme in `$_new_bundled_files`

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -198,8 +198,7 @@ global $_new_bundled_files;
 
 $_new_bundled_files = array(
 	'themes/twentyseventeen/'              => '4.7',
-	'themes/classicpress-twentyseventeen/' => '4.9',
-	'themes/the-classicpress-theme/'       => '6.2',
+	'themes/the-classicpress-theme/'       => '6.2.6',
 );
 
 /**

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -74,6 +74,17 @@ $_old_files = array(
 	// Added in 5.2.3 or older, not included in ClassicPress
 	'wp-includes/sodium_compat',
 
+	// Removed in ClassiPress 2.1.0
+	'wp-includes/js/swfupload',
+	'wp-includes/js/swfobject.js',
+	'wp-includes/js/mediaelement/mediaelement-migrate.js',
+	'wp-includes/js/mediaelement/mediaelement-migrate.min.js',
+	'wp-includes/js/mediaelement/mejs-controls.png',
+	'wp-admin/js/tags-suggest.js',
+	'wp-admin/js/tags-suggest.min.js',
+	'wp-admin/js/user-suggest.js',
+	'wp-admin/js/user-suggest.min.js',
+
 	// Directories.
 	'wp-includes/css/dist',
 	'wp-includes/block-patterns',

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -197,7 +197,9 @@ $_old_requests_files = array(
 global $_new_bundled_files;
 
 $_new_bundled_files = array(
-	'themes/twentyseventeen/' => '4.7',
+	'themes/twentyseventeen/'              => '4.7',
+	'themes/classicpress-twentyseventeen/' => '4.9',
+	'themes/the-classicpress-theme/'       => '6.2',
 );
 
 /**


### PR DESCRIPTION
## Description
This change lists ~~the ClassicPress child 2017 theme and~~ the newly create ClassicPress theme so they should be installed on updates.

## Motivation and context
Fixes reported issue in 2.1.0 launch that the new theme is not being installed.

## How has this been tested?
Will be testing with nightly build updates.

## Screenshots
N/A

## Types of changes
- New feature
