### PR TITLE
Use cp_ table prefix for new installs

### DIFF
--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -248,7 +248,7 @@ switch ( $step ) {
 		</tr>
 		<tr>
 			<th scope="row"><label for="prefix"><?php _e( 'Table Prefix' ); ?></label></th>
-			<td><input name="prefix" id="prefix" type="text" aria-describedby="prefix-desc" value="wp_" size="25"></td>
+			<td><input name="prefix" id="prefix" type="text" aria-describedby="prefix-desc" value="cp_" size="25"></td>
 			<td id="prefix-desc"><?php _e( 'If you want to run multiple ClassicPress installations in a single database, change this.' ); ?></td>
 		</tr>
 	</table>


### PR DESCRIPTION
## Description
When installing a new site the defaul table prefix is still `wp_`.

## Motivation and context
For branding we should change that to `cp_`.

## How has this been tested?
Local testing

## Screenshots
##
![Screenshot 2024-06-20 at 16 48 03](https://github.com/ClassicPress/ClassicPress/assets/1280733/58216535-8594-49a5-b5c1-f4f8f1d6d150)
# Before

### After
![Screenshot 2024-06-20 at 16 48 11](https://github.com/ClassicPress/ClassicPress/assets/1280733/4c5fecb8-6dae-4a2c-8ba7-e2577eaf74a8)

## Types of changes
- Bug fix
