### PR TITLE
Remove translation data from update url query

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -37,7 +37,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	$php_version = phpversion();
 
 	$current      = get_site_transient( 'update_core' );
-	$translations = wp_get_installed_translations( 'core' );
 
 	// Invalidate the transient when $cp_version changes
 	if ( is_object( $current ) && $cp_version != $current->version_checked ) {
@@ -99,7 +98,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		'initial_db_version' => get_site_option( 'initial_db_version' ),
 		'extra_stats'        => $extra_stats,
 		'failure_data'       => get_site_option( 'auto_core_update_failed' ),
-		'translations'       => wp_json_encode( $translations ),
 	);
 
 	/**
@@ -110,6 +108,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	 *
 	 * @since 4.9.0
 	 * @since CP-1.0.0 Added `extra_stats`, `failure_data`, and `translations`
+	 * @since CP-2.2.0 Removed `translations`, unsed at the API server
 	 * parameters to query (in WP these are passed in a POST body).
 	 *
 	 * @param array $query {
@@ -124,7 +123,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	 *     @type int    $initial_db_version Database version of ClassicPress at time of installation.
 	 *     @type array  $extra_stats        Failure data from the current update, if any.
 	 *     @type array  $failure_data       Failure data from a previous update, if any.
-	 *     @type array  $translations       Core translations installed on this site.
 	 * }
 	 */
 	$query = apply_filters( 'core_version_check_query_args', $query );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -108,7 +108,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	 *
 	 * @since 4.9.0
 	 * @since CP-1.0.0 Added `extra_stats`, `failure_data`, and `translations`
-	 * @since CP-2.2.0 Removed `translations`, unsed at the API server
+	 * @since CP-2.2.0 Removed `translations`, not used at the API server
 	 * parameters to query (in WP these are passed in a POST body).
 	 *
 	 * @param array $query {


### PR DESCRIPTION
## Description
As reports on the chat channel, sites may fail to detect updates are available for core if there are many translations installed.

## Motivation and context
The URL for checking updates may deliver a 414 response when large amounts of data are added to the update URL as a query parameter.

`[response] => Array ( [code] => 414 [message] => Request-URI Too Long )`

This results in no update being served. The translation data are not used on the API, and this doesn't happen upstream as this same data is posted.

## How has this been tested?
Tested and confirmed by OP on chat channel.

## Screenshots
### Before
![image](https://github.com/ClassicPress/ClassicPress/assets/1280733/8992a207-1416-446b-8fe2-a4028fec6765)

### After
![Screenshot 2024-06-26 at 22 01 25](https://github.com/ClassicPress/ClassicPress/assets/1280733/f82fde61-820a-47d2-9547-9da5d389a687)

## Types of changes
- Bug fix