### PR TITLE
Upstream security enhancements - changeset 58479

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -157,11 +157,30 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 			</p>
+				<?php
+				printf(
+				/* translators: %s: WordPress version. */
+					__( '<strong>WordPress version %s</strong> addressed some security issues.' ),
+					'6.2.6'
+				);
+				?>
+				<?php
+				printf(
+					/* translators: %s: HelpHub URL. */
+					__( 'For more information, see <a href="%s">the release notes</a>.' ),
+					sprintf(
+						/* translators: %s: WordPress version. */
+						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+						sanitize_title( '6.2.6' )
+					)
+				);
+				?>
+			</p>
 			<p>
 				<?php
 				printf(
 					/* translators: %s: WordPress version. */
-					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					__( '<strong>WordPress version %s</strong> addressed some security issues.' ),
 					'6.2.3'
 				);
 				?>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -176,6 +176,26 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 			</p>
+			</p>
+				<?php
+				printf(
+				/* translators: %s: WordPress version. */
+					__( '<strong>WordPress version %s</strong> addressed some security issues.' ),
+					'6.2.4'
+				);
+				?>
+				<?php
+				printf(
+					/* translators: %s: HelpHub URL. */
+					__( 'For more information, see <a href="%s">the release notes</a>.' ),
+					sprintf(
+						/* translators: %s: WordPress version. */
+						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+						sanitize_title( '6.2.4' )
+					)
+				);
+				?>
+			</p>
 			<p>
 				<?php
 				printf(

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4740,12 +4740,13 @@ EOF;
  * Escapes an HTML tag name.
  *
  * @since 2.5.0
+ * @since 6.5.5 Allow hyphens in tag names (i.e. custom elements).
  *
  * @param string $tag_name
  * @return string
  */
 function tag_escape( $tag_name ) {
-	$safe_tag = strtolower( preg_replace( '/[^a-zA-Z0-9_:]/', '', $tag_name ) );
+	$safe_tag = strtolower( preg_replace( '/[^a-zA-Z0-9-_:]/', '', $tag_name ) );
 	/**
 	 * Filters a string cleaned and escaped for output as an HTML tag.
 	 *

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6073,6 +6073,9 @@ function validate_file( $file, $allowed_files = array() ) {
 		return 0;
 	}
 
+	// Normalize path for Windows servers
+	$file = wp_normalize_path( $file );
+
 	// `../` on its own is not allowed:
 	if ( '../' === $file ) {
 		return 1;

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -39,7 +39,7 @@ $cp_version = '2.1.1+dev';
  *
  * @global string $wp_version
  */
-$wp_version = '6.2.5';
+$wp_version = '6.2.6';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
## Description
Grouped backport of changes made upstream in WordPress 6.2.6 consistent with `6.5.5`

## Motivation and context
Security enhancements and associated version and about changes.

## How has this been tested?
Local tests passing, backport

## Screenshots
N/A

## Types of changes
- Bug fix