### PR TITLE
Update `ramsey/composer-install` to v3

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -43,7 +43,7 @@ jobs:
           composer --version
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 
@@ -109,7 +109,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -54,7 +54,7 @@ jobs:
           mysql --version
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v3
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 


### PR DESCRIPTION
## Description
Update `ramsey/composer-install` to version 3 in GitHub actions

## Motivation and context
Version update in action should remove warnings in GitHub actions.

## How has this been tested?
PR tests will run.

## Screenshots
This PR should remove these warnings:
![Screenshot 2024-07-09 at 11 43 17](https://github.com/ClassicPress/ClassicPress/assets/1280733/13ac4bad-79ed-4041-97ee-03d0f21cf7f2)


## Types of changes
- Bug fix