### PR TITLE
Fix HTML paragraphs for backport information

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -157,6 +157,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 			</p>
+			<p>
 				<?php
 				printf(
 				/* translators: %s: WordPress version. */
@@ -176,7 +177,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 			</p>
-			</p>
+			<p>
 				<?php
 				printf(
 				/* translators: %s: WordPress version. */


### PR DESCRIPTION
## Description
In the admin `about.php` page there is a list of WordPress backported versions where security changes have been adopted, I noticed the layout was a bit off and tracked this to some malformed paragraph tags.

## Motivation and context
Consistent layout styling creates a better user impression and we should use syntactically correct HTML. Notice the alignments of version numbers below.

## How has this been tested?
Local testing, see screen shots below.

## Screenshots
### Before
![Screenshot 2024-07-10 at 09 35 44](https://github.com/ClassicPress/ClassicPress/assets/1280733/2f891c88-75c9-4d84-9a18-ad3b5c76ca8e)

### After
![Screenshot 2024-07-10 at 09 35 34](https://github.com/ClassicPress/ClassicPress/assets/1280733/59e151f6-b08d-4c95-8cf0-18ea8fda18ed)

## Types of changes
- Bug fix