### PR TITLE
WP-r58715: Filesystem API: Add a return value for `wp_delete_file()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7419,8 +7419,10 @@ function wp_validate_boolean( $value ) {
  * Deletes a file.
  *
  * @since 4.2.0
+ * @since 6.7.0 A return value was added.
  *
  * @param string $file The path to the file to delete.
+ * @return bool True on success, false on failure.
  */
 function wp_delete_file( $file ) {
 	/**
@@ -7431,9 +7433,12 @@ function wp_delete_file( $file ) {
 	 * @param string $file Path to the file to delete.
 	 */
 	$delete = apply_filters( 'wp_delete_file', $file );
+
 	if ( ! empty( $delete ) ) {
-		@unlink( $delete );
+		return @unlink( $delete );
 	}
+
+	return false;
 }
 
 /**
@@ -7466,9 +7471,7 @@ function wp_delete_file_from_directory( $file, $directory ) {
 		return false;
 	}
 
-	wp_delete_file( $file );
-
-	return true;
+	return wp_delete_file( $file );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7419,7 +7419,7 @@ function wp_validate_boolean( $value ) {
  * Deletes a file.
  *
  * @since 4.2.0
- * @since 6.7.0 A return value was added.
+ * @since CP-2.2.0 A return value was added.
  *
  * @param string $file The path to the file to delete.
  * @return bool True on success, false on failure.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7419,7 +7419,7 @@ function wp_validate_boolean( $value ) {
  * Deletes a file.
  *
  * @since 4.2.0
- * @since CP-2.2.0 A return value was added.
+ * @since 6.7.0 A return value was added.
  *
  * @param string $file The path to the file to delete.
  * @return bool True on success, false on failure.

--- a/tests/phpunit/tests/functions/wpDeleteFile.php
+++ b/tests/phpunit/tests/functions/wpDeleteFile.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Tests for wp_delete_file().
+ *
+ * @group functions
+ *
+ * @covers ::wp_delete_file
+ */
+class Tests_Functions_WpDeleteFile extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 61590
+	 */
+	public function test_wp_delete_file() {
+		$file = wp_tempnam( 'a_file_that_exists.txt' );
+
+		$this->assertTrue( wp_delete_file( $file ), 'File deletion failed.' );
+		$this->assertFileDoesNotExist( $file, 'The file was not deleted.' );
+	}
+
+	/**
+	 * @ticket 61590
+	 */
+	public function test_wp_delete_file_with_empty_path() {
+		$this->assertFalse( wp_delete_file( '' ) );
+	}
+
+	/**
+	 * @ticket 61590
+	 */
+	public function test_wp_delete_file_with_file_that_does_not_exist() {
+		$file = DIR_TESTDATA . '/a_file_that_does_not_exist.txt';
+
+		$this->assertFileDoesNotExist( $file, "$file already existed as a file before testing." );
+		$this->assertFalse( wp_delete_file( $file ), 'Attempting to delete a non-existent file should return false.' );
+	}
+}


### PR DESCRIPTION
Backport of https://core.trac.wordpress.org/changeset/58715

## Description
This addresses a discrepancy where using `unlink()` allows for checking if it was successful via the return value, but `wp_delete_file()` did not have a return value, making it impossible to verify the result without doing overhead checks if the file still exists.
This also brings more consistency with the other `wp_delete_*()` functions.

## How has this been tested?
Unit tests were added in upstream.

## Types of changes
- New feature

