### PR TITLE
Fix JS error when esc is pressed in plugin pages

### DIFF
--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -92,7 +92,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			if ( iframe != null ) {
 				iframe.remove();
 			}
-			closeButton.remove();
+			if ( closeButton != null ) {
+				closeButton.remove();
+			}
 		}
 	} );
 

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -83,22 +83,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	} );
 
 	/*
-	 * Remove iframe contents when closing modal dialog with Escape key
-	 *
-	 * @since CP-2.1.0
-	 */
-	document.addEventListener( 'keydown', function( e ) {
-		if ( e.key === 'Escape' ) {
-			if ( iframe != null ) {
-				iframe.remove();
-			}
-			if ( closeButton != null ) {
-				closeButton.remove();
-			}
-		}
-	} );
-
-	/*
 	 * Called when iframe has loaded
 	 *
 	 * @since CP-2.1.0


### PR DESCRIPTION
Pressing help in various "plugin" screens this error shows up in console.

In #1487 this was noticed with the "Debug Bar" plugin installed, but on my local installation it also appears without that plugin.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'remove')
    at HTMLDocument.<anonymous> (plugin-install.js?ver=cp_679f8e:95:16)
```

## How has this been tested?
Local testing. After this change the console has no errors.

## Types of changes
- Bug fix
