### PR TITLE
Add two polyfills to fix Query Monitor

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -395,6 +395,34 @@ class WP_Compat {
 			}
 		}
 
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.2.0
+			 *
+			 * @return array array().
+			 */
+			function parse_blocks( ...$args ) {
+				WP_Compat::using_block_function();
+				return array();
+			}
+		}
+
+		if ( ! function_exists( 'get_dynamic_block_names' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.2.0
+			 *
+			 * @return string ''.
+			 */
+			function get_dynamic_block_names( ...$args ) {
+				WP_Compat::using_block_function();
+				return '';
+			}
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -41,6 +41,8 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'register_block_pattern_category' ) );
 		$this->assertTrue( function_exists( 'unregister_block_pattern_category' ) );
 		$this->assertTrue( function_exists( 'wp_is_block_theme' ) );
+		$this->assertTrue( function_exists( 'parse_blocks' ) );
+		$this->assertTrue( function_exists( 'get_dynamic_block_names' ) );
 	}
 
 	/**


### PR DESCRIPTION
Since 3.16.4 Query Monitor [removes back-compat code for pre WordPress 5.0](https://github.com/johnbillion/query-monitor/commit/10eedafd54f858d74f3165d2cffd35770a116633).
This triggers a fatal error that renders Query Monitor unusable on some screens.

<img width="435" alt="image" src="https://github.com/user-attachments/assets/bb59038c-0ea6-4bba-b692-772c5e845dcd">


## Description
This PR adds polyfills for:
- `parse_blocks`
- `get_dynamic_block_names`

## Motivation and context
Restore Query Monitor and maybe other plugins functionality.

## How has this been tested?
Local testing.
Unit tests for new polyfills.

## Types of changes
- New feature

