### PR TITLE
Simplify implementation of auto-update message

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -196,14 +196,9 @@ function dismissed_updates() {
  *
  * @since 2.7.0
  *
- * @global string $required_php_version   The required PHP version string.
- * @global string $required_mysql_version The required MySQL version string.
  */
 function core_upgrade_preamble() {
-	global $required_php_version, $required_mysql_version;
-
-	$wp_version = get_bloginfo( 'version' );
-	$updates    = get_core_updates();
+	$updates = get_core_updates();
 
 	if ( ! isset( $updates[0]->response ) || 'latest' === $updates[0]->response ) {
 		if ( ! isset( $updates[0]->response ) ) {
@@ -226,21 +221,14 @@ function core_upgrade_preamble() {
 			echo '<h2>';
 			_e( 'You have the latest version of ClassicPress.' );
 			echo "</h2>\n";
-		}
 
-		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-		$upgrader            = new WP_Automatic_Updater();
-		$future_minor_update = (object) array(
-			'current'       => $wp_version . '.1.next.minor',
-			'version'       => $wp_version . '.1.next.minor',
-			'php_version'   => $required_php_version,
-			'mysql_version' => $required_mysql_version,
-		);
-		$should_auto_update  = $upgrader->should_update( 'core', $future_minor_update, ABSPATH );
-		if ( $should_auto_update ) {
-			echo '<p>';
-			_e( 'Future security updates will be applied automatically.' );
-			echo "</p>\n";
+			$should_auto_update = defined( 'WP_AUTO_UPDATE_CORE' ) ? WP_AUTO_UPDATE_CORE : true;
+
+			if ( false !== $should_auto_update ) {
+				echo '<p>';
+				_e( 'Future security updates should be applied automatically.' );
+				echo "</p>\n";
+			}
 		}
 	} else {
 		echo '<div class="notice notice-warning"><p>';


### PR DESCRIPTION
## Description
ClassicPress contains code that should display a message about auto-updates but this message is never shown to users as per #387 

This PR simplifies the implementation of the checks used to display the message bypassing the need for comparison of version numbers and the update API, rather checking if local updates are allowed.

This PR currently only checked for the defined `WP_AUTO_UPDATE_CORE` constant. If this solution is agreed as appropriate it may be worth checking that filters are not in use if these override the constant. (For example `automatic_updater_disabled` and `auto_update_core`)

## Motivation and context
Fixes #387

## How has this been tested?
Local testing, note this cannot easily be testing on `git` clones as the code detects use of a version control system and bypasses update checks.

## Screenshots
### Before
![Screenshot 2024-08-06 at 09 06 14](https://github.com/user-attachments/assets/9a9ddb05-75f6-412c-84f9-104a8aca5eac)

### After
![Screenshot 2024-08-06 at 09 05 32](https://github.com/user-attachments/assets/37a077d9-dd3f-470c-9ed2-eb7285c3b04f)

## Types of changes
- Bug fix
