### PR TITLE
Improve CSS on Post Edit and Dashboard Screens

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2042,6 +2042,7 @@ html.wp-toolbar {
 	margin: 0;
 	line-height: 1.4;
 	border-bottom: 1px solid #c3c4c7;
+	container-type: inline-size;
 }
 
 .postbox-container summary > div {
@@ -2055,6 +2056,45 @@ html.wp-toolbar {
 
 #poststuff .postbox-container summary > div {
 	width: 91%;
+}
+
+/* If the width of the `summary` container is greater than 300px */
+@container (min-width: 300px) {
+	#poststuff .postbox-container summary > div {
+		width: 93%;
+	}
+}
+
+/* If the width of the `summary` container is greater than 1200px */
+@container (min-width: 500px) {
+	#poststuff .postbox-container summary > div {
+		width: 96%;
+	}
+}
+
+/* If the width of the `summary` container is greater than 1200px */
+@container (min-width: 800px) {
+	#poststuff .postbox-container summary > div {
+		width: 97%;
+	}
+}
+
+/* If the width of the `summary` container is greater than 1200px */
+@container (min-width: 1000px) {
+	#poststuff .postbox-container summary > div {
+		width: 98%;
+	}
+}
+
+/* If the width of the `summary` container is greater than 1200px */
+@container (min-width: 1400px) {
+	#poststuff .postbox-container summary > div {
+		width: 99%;
+	}
+}
+
+.postbox-container summary > div > span {
+	margin-right: -0.75em;
 }
 
 #wpbody-content .metabox-holder {
@@ -2074,7 +2114,7 @@ details summary > * {
 
 .metabox-holder details > summary::marker,
 .metabox-holder details > summary::-webkit-details-marker {
-	font-size: 1.5em;
+	font-size: 1.3em;
 	cursor: pointer;
 }
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2065,28 +2065,28 @@ html.wp-toolbar {
 	}
 }
 
-/* If the width of the `summary` container is greater than 1200px */
+/* If the width of the `summary` container is greater than 500px */
 @container (min-width: 500px) {
 	#poststuff .postbox-container summary > div {
 		width: 96%;
 	}
 }
 
-/* If the width of the `summary` container is greater than 1200px */
+/* If the width of the `summary` container is greater than 800px */
 @container (min-width: 800px) {
 	#poststuff .postbox-container summary > div {
 		width: 97%;
 	}
 }
 
-/* If the width of the `summary` container is greater than 1200px */
+/* If the width of the `summary` container is greater than 1000px */
 @container (min-width: 1000px) {
 	#poststuff .postbox-container summary > div {
 		width: 98%;
 	}
 }
 
-/* If the width of the `summary` container is greater than 1200px */
+/* If the width of the `summary` container is greater than 1400px */
 @container (min-width: 1400px) {
 	#poststuff .postbox-container summary > div {
 		width: 99%;


### PR DESCRIPTION
This PR is designed to address the issues noted at https://forums.classicpress.net/t/summary-marker-is-too-big/5331/7.

The marker is set to a size of `1.3em` and container queries (and a negative right margin) are added to ensure that the up and down buttons are kept close to the right edge of the bounding `summary` element.

I have tested this in Firefox and Web (a Safari clone) on Linux.

Screenshots below demonstrate the improvement (ignore the background color, which just reflects the different sites used for the comparison).

Before:
![Screenshot at 2024-08-17 15-59-11](https://github.com/user-attachments/assets/e0d77fe4-c58d-4f85-9ef4-6229d0ba7847)

After:
![Screenshot at 2024-08-17 15-59-57](https://github.com/user-attachments/assets/6a05c605-c086-4bec-a451-9a3043d25b0f)
