### PR TITLE
Media category uploads

### DIFF
--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -139,6 +139,7 @@ $core_actions_post = array(
 	'toggle-auto-updates',
 	'send-password-reset',
 	'quick-edit-attachment',
+	'media-cat-upload',
 );
 
 // Deprecated.

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -387,6 +387,20 @@ input[type="radio"].disabled:checked:before {
 	display: none;
 }
 
+.upload-category {
+	margin: 0.5em 0;
+}
+
+#upload-category {
+	display: flex;	
+	margin-top: 0.5em;
+}
+
+.media-modal #upload-category {
+	margin-left: auto;
+	margin-right: auto;
+}
+
 .wp-admin .button-cancel {
 	display: inline-block;
 	min-height: 28px;

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2585,6 +2585,37 @@ function wp_ajax_upload_attachment() {
 }
 
 /**
+ * Updates the upload media category.
+ *
+ * Activated only if media storage option has been set to 'category'.
+ *
+ * @since CP-2.2.0
+ */
+function wp_ajax_media_cat_upload() {
+	$response = __( 'The upload media category folder has been updated.' );
+
+	if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+		$new_value = wp_unslash( $_POST['new_value'] );
+		update_option( 'media_cat_upload_folder', sanitize_url( '/' . $new_value ) );
+
+		if ( $new_value === '' ) {
+			$response = __( 'You need to choose a media category folder before you can upload a file.' );
+		}
+	} elseif ( $_SERVER['REQUEST_METHOD'] === 'GET' ) {
+		$new_value = get_option( 'media_cat_upload_folder' );
+	}
+
+	// Response in array.
+	$array_result = array(
+		'data'    => $new_value,
+		'success' => $response,
+	);
+
+	// Convert array to JSON.
+	wp_send_json( $array_result );
+}
+
+/**
  * Ajax handler for image editing.
  *
  * @since 3.1.0

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -428,6 +428,17 @@ function media_handle_upload( $file_id, $post_id, $post_data = array(), $overrid
 		// The image sub-sizes are created during wp_generate_attachment_metadata().
 		// This is generally slow and may cause timeouts or out of memory errors.
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
+
+		/**
+		 * If media storage is by media category, set the appropriate category for the attachment.
+		 *
+		 * @since CP-2.2.0
+		 */
+		$storefolders = get_option( 'uploads_use_yearmonth_folders' );
+		if ( $storefolders === '3' ) {
+			$cat_subfolder = get_option( 'media_cat_upload_folder' );
+			wp_set_object_terms( $attachment_id, array( trim( $cat_subfolder, '/' ) ), 'media_category' ); // using array avoids string splitting
+		}
 	}
 
 	return $attachment_id;
@@ -508,6 +519,17 @@ function media_handle_sideload( $file_array, $post_id = 0, $desc = null, $post_d
 
 	if ( ! is_wp_error( $attachment_id ) ) {
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file ) );
+
+		/**
+		 * If media storage is by media category, set the appropriate category for the attachment.
+		 *
+		 * @since CP-2.2.0
+		 */
+		$storefolders = get_option( 'uploads_use_yearmonth_folders' );
+		if ( $storefolders === '3' ) {
+			$cat_subfolder = get_option( 'media_cat_upload_folder' );
+			wp_set_object_terms( $attachment_id, array( trim( $cat_subfolder, '/' ) ), 'media_category' ); // using array avoids string splitting
+		}
 	}
 
 	return $attachment_id;
@@ -3876,3 +3898,47 @@ function bulk_edit_attachments( $attachment_data = null ) {
 		'locked'  => $locked,
 	);
 }
+
+/*
+ * Outputs a select box to select upload media category.
+ *
+ * Displays only if media storage option has been set to 'category'.
+ *
+ * @since CP-2.2.0
+ */
+function cp_select_upload_media_category() {
+	$media_select = '';
+	$storefolders = get_option( 'uploads_use_yearmonth_folders' );
+	if ( $storefolders === '3' ) {
+		$cat_subfolder = get_option( 'media_cat_upload_folder' );
+
+		$media_terms = get_terms(
+			array(
+				'taxonomy'   => 'media_category',
+				'hide_empty' => false,
+			)
+		);
+
+		if ( ! empty( $media_terms ) ) {
+			$media_select .= '<div class="upload-category"><label for="upload-category"><strong>' . esc_html__( 'Please choose the upload media category' ) . '</strong></label>';
+			$media_select .= '<select id="upload-category" name="upload-category" class="attachment-filters">';
+			$media_select .= '<option value=""' . selected( in_array( $cat_subfolder, array( '', '/' ) ), true, false ) . '>&nbsp;' . esc_html__( 'Media category' ) . '&nbsp;</option>';
+			foreach ( $media_terms as $media_term ) {
+				$ancestor_ids = get_ancestors( $media_term->term_id, 'media_category' );
+				$count = count( $ancestor_ids );
+				$spaces = '';
+				$slug = $media_term->slug;
+				if ( $count > 0 ) {
+					foreach ( $ancestor_ids as $ancestor_id ) {
+						$spaces .= '&nbsp;';
+						$slug = get_term( $ancestor_id, 'media_category' )->slug . '/' . $slug;
+					}
+				}
+				$media_select .= '<option class="level-' . esc_attr( $count ) . '" value="' . esc_attr( $slug ) . '"' . selected( '/' . $slug, $cat_subfolder, false ) . '>' . esc_html( $spaces . $media_term->name ) . '</option>';
+			}
+			$media_select .= '</select></div>';
+		}
+	}
+	echo $media_select;
+}
+

--- a/src/wp-admin/media-new.php
+++ b/src/wp-admin/media-new.php
@@ -72,6 +72,14 @@ if ( get_user_setting( 'uploader' ) || isset( $_GET['browser-uploader'] ) ) {
 ?>
 <div class="wrap">
 	<h1><?php echo esc_html( $title ); ?></h1>
+	<?php
+	/**
+	 * Enable selection of media category.
+	 *
+	 * @since CP-2.2.0
+	 */
+	cp_select_upload_media_category();
+	?>
 
 	<form enctype="multipart/form-data" method="post" action="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="<?php echo esc_attr( $form_class ); ?>" id="file-form">
 

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -51,11 +51,26 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 /**
  * Get upload organization preference.
  *
- * @since CP-2.1.0
+ * @since CP-2.2.0
  *
- * New option based on year only.
+ * New options based on year and media category added.
  */
 $storefolders = (int) get_option( 'uploads_use_yearmonth_folders' );
+
+$media_attribute = $media_requires = '';
+
+$media_terms = get_terms(
+	array(
+		'taxonomy'   => 'media_category',
+		'hide_empty' => false,
+	)
+);
+
+if ( empty( $media_terms ) ) {
+	$media_attribute = 'disabled';
+	$media_requires = ' <em>' . __( 'This option requires that at least one media category has been created.' ) . '</em> <a href="' . admin_url( 'edit-tags.php?taxonomy=media_category&post_type=attachment' ) . '">' . __( 'Create one now.' ) . '</a>';
+}
+
 /**
  * Get attachment page preference.
  *
@@ -186,7 +201,15 @@ if ( isset( $GLOBALS['wp_settings']['media']['embeds'] ) ) :
 <label for="uploads_use_year_folders"><?php _e( 'Organize uploads into year-based folders.' ); ?></label><br>
 
 <input id="uploads_use_yearmonth_folders" type="radio" name="uploads_use_yearmonth_folders" value="1"<?php checked( 1, $storefolders ); ?>>
-<label for="uploads_use_yearmonth_folders"><?php _e( 'Organize uploads into month- and year-based folders.' ); ?></label>
+<label for="uploads_use_yearmonth_folders"><?php _e( 'Organize uploads into month- and year-based folders.' ); ?></label><br>
+
+<input id="uploads_use_category_folders" type="radio" name="uploads_use_yearmonth_folders" value="3"
+	<?php checked( 3, $storefolders ); ?>
+	<?php echo esc_attr( $media_attribute ); ?>>
+<label for="uploads_use_category_folders">
+	<?php _e( 'Organize uploads according to media category.' ); ?>
+	<?php echo $media_requires; ?>
+</label>
 </td>
 </tr>
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -174,6 +174,12 @@ if ( 'grid' === $mode ) {
 			?>
 			<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action aria-button-if-js"><?php echo esc_html_x( 'Add New', 'file' ); ?></a>
 			<?php
+			/**
+			 * Enable selection of media category.
+			 *
+			 * @since CP-2.2.0
+			 */
+			cp_select_upload_media_category();
 		}
 		?>
 
@@ -383,7 +389,13 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 if ( current_user_can( 'upload_files' ) ) {
 	?>
 	<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html_x( 'Add New', 'file' ); ?></a>
-						<?php
+	<?php
+	/**
+	 * Enable selection of media category.
+	 *
+	 * @since CP-2.2.0
+	 */
+	cp_select_upload_media_category();
 }
 
 if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1608,6 +1608,10 @@
 	margin: 0.5em 0;
 }
 
+.uploader-inline p.media-cat-upload-info {
+	font-size: 1.25em;
+}
+
 .uploader-inline .media-progress-bar {
 	display: none;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2495,6 +2495,9 @@ function _wp_upload_dir( $time = null ) {
 		}
 		$y      = substr( $time, 0, 4 );
 		$subdir = "/$y";
+	} elseif ( $storefolders === '3' ) {
+		// Generate the media category directories.
+		$subdir = get_option( 'media_cat_upload_folder' );
 	}
 
 	$dir .= $subdir;

--- a/src/wp-includes/js/plupload/handlers.js
+++ b/src/wp-includes/js/plupload/handlers.js
@@ -1,6 +1,108 @@
 /* global plupload, pluploadL10n, ajaxurl, post_id, wpUploaderInit, deleteUserSetting, setUserSetting, getUserSetting, shortform */
 var topWin = window.dialogArguments || opener || parent || top, uploader, uploader_init;
 
+/**
+ * Choose media category upload folder if media uploads are organized by media category.
+ *
+ * @since CP-2.2.0
+ */
+document.addEventListener( 'DOMContentLoaded', function() {
+	var uploadCatSelect = document.getElementById( 'upload-category' ),
+		plUploader = document.getElementById( 'plupload-upload-ui' ),
+		asyncUploader = document.getElementById( 'async-upload-wrap' );
+
+	// Ensure that nothing can be uploaded if the media upload category has not been set.
+	if ( uploadCatSelect != null ) {
+		if ( uploadCatSelect.value == '' ) {
+			plUploader.setAttribute( 'inert', true );
+			asyncUploader.setAttribute( 'inert', true );
+
+			// Prevent uploading file into browser window
+			window.addEventListener( 'dragover', function( e ) {
+				e.preventDefault();
+			}, false );
+			window.addEventListener( 'drop', function( e ) {
+				e.preventDefault();
+			}, false );
+		}
+
+		// Set up variables when a change of upload category is made.
+		uploadCatSelect.addEventListener( 'change', function( e ) {
+			var div,
+				uploadCatFolder = new URLSearchParams( {
+					action: 'media-cat-upload',
+					option: 'media_cat_upload_folder',
+					new_value: e.target.value
+				} );
+
+			// Prevent accumulation of notices.
+			if ( document.getElementById( 'message' ) != null ) {
+				document.getElementById( 'message' ).remove();
+			}
+
+			// Update upload category.
+			fetch( ajaxurl, {
+				method: 'POST',
+				body: uploadCatFolder,
+				credentials: 'same-origin'
+			} )
+			.then( function( response ) {
+				if ( response.ok ) {
+					return response.json(); // no errors
+				}
+				throw new Error( response.status );
+			} )
+			.then( function( response ) {
+				if ( response.success ) {
+					if ( response.data == '' ) {
+						div = document.createElement( 'div' );
+						div.id = 'message';
+						div.className = 'notice notice-error is-dismissible';
+						div.innerHTML = '<p>' + response.success + '</p><button class="notice-dismiss" type="button"></button>';
+						document.querySelector( '.wrap h1' ).after( div );
+
+						// Disable uploads.
+						plUploader.setAttribute( 'inert', true );
+						asyncUploader.setAttribute( 'inert', true );
+
+						// Prevent uploading file into browser window
+						window.addEventListener( 'dragover', function( e ) {
+							e.preventDefault();
+						}, false );
+						window.addEventListener( 'drop', function( e ) {
+							e.preventDefault();
+						}, false );
+					} else {
+						div = document.createElement( 'div' );
+						div.id = 'message';
+						div.className = 'updated notice notice-success is-dismissible';
+						div.innerHTML = '<p>' + response.success + '</p><button class="notice-dismiss" type="button"></button>';
+						document.querySelector( '.wrap h1' ).after( div );
+
+						// Enable uploads.
+						plUploader.removeAttribute( 'inert' );
+						asyncUploader.removeAttribute( 'inert' );
+					}
+				}
+			} )
+			.catch( function( error ) {
+				div = document.createElement( 'div' );
+				div.id = 'message';
+				div.className = 'notice notice-error is-dismissible';
+				div.innerHTML = '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>';
+				document.querySelector( '.wrap h1' ).after( div );
+			} );
+		} );
+
+		// Make notices dismissible.
+		document.addEventListener( 'click', function( e ) {
+			if ( e.target.className === 'notice-dismiss' ) {
+				document.querySelector( '.is-dismissible' ).remove();
+			}
+		} );
+	}
+} );
+
 // Progress and success handlers for media multi uploads.
 function fileQueued( fileObj ) {
 	// Get rid of unused form.

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -283,6 +283,21 @@ function wp_print_media_templates() {
 					do_action( 'post-plupload-upload-ui' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 				}
 
+				global $pagenow;
+				if ( $pagenow !== 'upload.php' ) {
+					$storefolders = get_option( 'uploads_use_yearmonth_folders' );
+					if ( $storefolders === '3' ) {
+						$cat_subfolder = get_option( 'media_cat_upload_folder' );
+						$cat_object = get_term_by( 'slug', trim( $cat_subfolder, '/' ), 'media_category' );
+						printf(
+							/* translators: 1: Name of media category, 2: Link to Media page in admin. */
+							__( '<p class="media-cat-upload-info">Any files you upload here will be associated with the %1$s media category.</p><p class="media-cat-upload-info">If you want to change this to a different media category, you can do so on the main <a href="%2$s">Media</a> page.</p>' ),
+							'<strong>' . esc_html( $cat_object->name ) . '</strong>',
+							esc_url( home_url( '/wp-admin/upload.php' ) )
+						);
+					}
+				}
+
 				$max_upload_size = wp_max_upload_size();
 				if ( ! $max_upload_size ) {
 					$max_upload_size = 0;


### PR DESCRIPTION
This PR supersedes PR #1414, which I will therefore close.

Here are some screenshots of what it makes happen:

![Screenshot at 2024-08-24 15-28-50](https://github.com/user-attachments/assets/3e007b93-df9b-4fff-9d85-24a00d0210b8)

![Screenshot at 2024-08-24 15-29-22](https://github.com/user-attachments/assets/b41ced5b-e1a2-4e1d-902e-ac6ed1800861)

![Screenshot at 2024-08-24 15-30-37](https://github.com/user-attachments/assets/b39b4ba2-e429-4b4c-9159-e111ea4a6451)

![Screenshot at 2024-08-24 15-31-07](https://github.com/user-attachments/assets/eb9c2d8f-bb6a-4212-a02a-300575ee708d)

The big difference with this PR is that it does not attempt to place a select dropdown within the uploader used on posts, pages, and widgets. The Javascript uploader library currently used by ClassicPress (Plupload) has no hooks available for such a purpose, and it causes any additional JavaScript to behave inconsistently. Instead, this PR simply adds a message about the current media upload category, together with a clickable link to the main Media library page, where the media category can be changed:

![Screenshot at 2024-08-24 15-31-44](https://github.com/user-attachments/assets/dd44583c-9bcf-465d-b619-bb3fcd909c89)

Note that this does not force uploads to use media categories. In fact, none of the additional features visible above will show on a site unless the use has gone to `Settings > Media` and selected `Organize uploads according to media category.`:

![Screenshot at 2024-08-24 15-39-47](https://github.com/user-attachments/assets/d47e2b01-6538-4426-8555-c1d3988dad02)
