### PR TITLE
Add option in General Options to disable XML-RPC

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -58,7 +58,7 @@ function wp_get_db_schema( $scope = 'all', $blog_id = null ) {
 	object_relationship_id bigint(20) unsigned NOT NULL default '0',
 	meta_key varchar(255) default NULL,
 	meta_value longtext,
-	PRIMARY KEY (meta_id),	
+	PRIMARY KEY (meta_id),
 	KEY object_relationship_id (object_relationship_id),
 	KEY meta_key (meta_key($max_index_length))
 ) $charset_collate;
@@ -68,7 +68,7 @@ CREATE TABLE $wpdb->object_relationships (
 	left_object_type varchar(255) NOT NULL default '',
 	right_object_type varchar(255) NOT NULL default '',
 	right_object_id bigint(20) unsigned NOT NULL default 0,
-	PRIMARY KEY (relationship_id),	
+	PRIMARY KEY (relationship_id),
 	KEY left_object_id (left_object_id),
 	KEY left_object_type (left_object_type($max_index_length)),
 	KEY right_object_type (right_object_type($max_index_length))
@@ -580,6 +580,8 @@ function populate_options( array $options = array() ) {
 
 		// 6.4.0
 		'wp_attachment_pages_enabled'     => 0,
+
+		'disable_xml_rpc'                 => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -646,7 +646,18 @@ for ( $index = 0; $index <= 2; $index++ ) {
 </p>
 </td>
 </tr>
-
+<tr>
+<th scope="row"><?php _e( 'Disable XML-RPC' ); ?></th>
+<td> <fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Disable XML-RPC' );
+	?>
+</span></legend><label for="disable_xml_rpc">
+<input name="disable_xml_rpc" type="checkbox" id="disable_xml_rpc" value="1" <?php checked( '1', get_option( 'disable_xml_rpc' ) ); ?>>
+	<?php _e( 'XML-RPC server disabled' ); ?></label>
+</fieldset></td>
+</tr>
 
 <?php do_settings_fields( 'general', 'default' ); ?>
 </table>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -101,6 +101,7 @@ $allowed_options            = array(
 		'timezone_string',
 		'WPLANG',
 		'new_admin_email',
+		'disable_xml_rpc',
 	),
 	'discussion' => array(
 		'default_pingback_flag',

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4834,6 +4834,7 @@ function sanitize_option( $option, $value ) {
 		case 'start_of_week':
 		case 'site_icon':
 		case 'fileupload_maxk':
+		case 'disable_xml_rpc':
 			$value = absint( $value );
 			break;
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3339,6 +3339,9 @@ function feed_links_extra( $args = array() ) {
  * @since 2.0.0
  */
 function rsd_link() {
+	if ( '1' === get_option( 'disable_xml_rpc', 0 ) ) {
+		return;
+	}
 	printf(
 		'<link rel="EditURI" type="application/rsd+xml" title="RSD" href="%s">' . "\n",
 		esc_url( site_url( 'xmlrpc.php?rsd', 'rpc' ) )

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -30,6 +30,12 @@ if ( isset( $HTTP_RAW_POST_DATA ) ) {
 /** Include the bootstrap for setting up ClassicPress environment */
 require_once __DIR__ . '/wp-load.php';
 
+if ( get_option( 'disable_xml_rpc', 0 ) === '1' ) {
+	status_header( 410 );
+	header( 'Content-Type: text/plain' );
+	die( 'XML-RPC services are disabled on this site....' );
+}
+
 if ( isset( $_GET['rsd'] ) ) { // http://cyber.law.harvard.edu/blogs/gems/tech/rsd.html
 	header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true );
 	echo '<?xml version="1.0" encoding="' . get_option( 'blog_charset' ) . '"?' . '>';

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -30,7 +30,7 @@ if ( isset( $HTTP_RAW_POST_DATA ) ) {
 /** Include the bootstrap for setting up ClassicPress environment */
 require_once __DIR__ . '/wp-load.php';
 
-if ( get_option( 'disable_xml_rpc', 0 ) === '1' ) {
+if ( '1' === get_option( 'disable_xml_rpc', 0 ) ) {
 	status_header( 410 );
 	header( 'Content-Type: text/plain' );
 	die( 'XML-RPC services are disabled on this site.' );

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -1,6 +1,4 @@
 <?php
-require_once ABSPATH . 'xmlrpc.php';
-
 /**
  * XML-RPC protocol support for ClassicPress
  *

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -1,4 +1,6 @@
 <?php
+require_once ABSPATH . 'xmlrpc.php';
+
 /**
  * XML-RPC protocol support for ClassicPress
  *
@@ -33,7 +35,7 @@ require_once __DIR__ . '/wp-load.php';
 if ( get_option( 'disable_xml_rpc', 0 ) === '1' ) {
 	status_header( 410 );
 	header( 'Content-Type: text/plain' );
-	die( 'XML-RPC services are disabled on this site....' );
+	die( 'XML-RPC services are disabled on this site.' );
 }
 
 if ( isset( $_GET['rsd'] ) ) { // http://cyber.law.harvard.edu/blogs/gems/tech/rsd.html


### PR DESCRIPTION
## Description
Add a new option (`disable_xml_rpc`), default `0` that can be toggled from Settings > General menu.

## Motivation and context
See https://github.com/ClassicPress/ClassicPress/issues/1034

## How has this been tested?
Local testing.

## Screenshots
<img width="849" alt="image" src="https://github.com/user-attachments/assets/59d7d060-9994-4e3d-a485-fe4437ab0e9d">

## Types of changes
- New feature

