### PR TITLE
Add PHPUnit 9 as developer dependency

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -38,6 +38,14 @@ jobs:
           coverage: none
           tools: composer, cs2pr
 
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--no-progress --no-ansi --no-interaction"
+
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
+
       - name: Show debug information
         run: |
           set +e
@@ -52,14 +60,6 @@ jobs:
           composer --version
           grunt --version
           mysql --version
-
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
-        with:
-          composer-options: "--no-progress --no-ansi --no-interaction"
-
-      - name: Make Composer packages available globally
-        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 
       - name: Log PHPCS debug information
         run: phpcs -i

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -161,6 +161,11 @@ jobs:
           sudo locale-gen es_ES.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8
           sudo update-locale LC_ALL="es_ES.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8"
 
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: "--no-progress --no-ansi --no-interaction"
+
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -161,10 +161,6 @@ jobs:
           sudo locale-gen es_ES.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8
           sudo update-locale LC_ALL="es_ES.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8"
 
-      - name: Install PHPUnit and Composer dependencies
-        run: |
-          composer require phpunit/phpunit "9.*" -W --no-progress --no-ansi --no-interaction
-
       - name: Make Composer packages available globally
         run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "1.0.0",
 		"wp-coding-standards/wpcs": "3.1.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.5",
-		"yoast/phpunit-polyfills": "3.0.0"
+		"yoast/phpunit-polyfills": "3.0.0",
+		"phpunit/phpunit": "^9"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
## Description
Add PHPUnit  as a specific developer dependency and clean the workflow test action of a subsequently unnecessary step of unit testing.

## Motivation and context
PHPUnit is currently at version 11, but versions 10 and 11 are unsupported in current unit tests.

An upstream ticket details the issues that need addressing to use newer versions of PHPUnit:
https://core.trac.wordpress.org/ticket/62004

## How has this been tested?
Local testing and GitHub actions will run for the amended testing on this branch.

## Screenshots
N/A

## Types of changes
- Bug fix