### PR TITLE
Bugfix for focus within Edit Image modal

### DIFF
--- a/src/wp-admin/js/image-edit.js
+++ b/src/wp-admin/js/image-edit.js
@@ -695,8 +695,8 @@
 				wrap = document.querySelector( '.imgedit-wrap' ),
 				index = 0;
 
-			if ( ! elementToSetFocusTo.length ) {
-				tabbables = [ ...wrap.querySelectorAll( 'a[href], button, input, textarea, select, [tabindex]:not( [tabindex="-1"] )' ) ];
+			if ( elementToSetFocusTo == null ) {
+				tabbables = [ ...wrap.querySelectorAll( 'button' ) ];
 
 				elementToSetFocusTo = tabbables[ index ];
 				while ( ! isVisible( tabbables[ index ] ) ) {


### PR DESCRIPTION
This is a simple bugfix to ensure that focus works as expected when hitting the Edit Image button within the Media Item modal on the Media Grid page. It simply replaces a check for `length` (which isn't working) with a check for `null` (which does). It also significantly shortens the list of potential tabbable items to reflect the fact that they are, in fact, all buttons.

As the image below shows, the `Crop` button (or whichever button is the first not to be disabled) now gets focus, whereas it did not before.

![Screenshot at 2024-09-15 16-31-30](https://github.com/user-attachments/assets/30d4a7df-3c42-418a-897c-5714d79fce05)
