### PR TITLE
Improve string representation for translators

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3351,7 +3351,7 @@ function wp_ajax_quick_edit_attachment() {
 	</th>
 	<td class="title column-title has-row-actions column-primary" data-colname="' . esc_html__( 'File' ) . '">
 		<strong class="has-media-icon">
-			<a href="' . esc_url( home_url( '/wp-admin/post.php?post=' . $id . '&amp;action=edit' ) ) . '" aria-label="' . esc_attr__( '“' ) . esc_attr( $attachment->post_title ) . esc_attr__( '” (Edit)' ) . '">
+			<a href="' . esc_url( home_url( '/wp-admin/post.php?post=' . $id . '&amp;action=edit' ) ) . '" aria-label="' . esc_attr__( sprintf( '“%s” (Edit)', $attachment->post_title ) ) . '">
 				<span class="media-icon image-icon">
 					<img width="60" height="60" src="' . esc_url( wp_get_attachment_image_src( $id )[0] ) . '" class="attachment-60x60 size-60x60" alt="" decoding="async" loading="lazy">
 				</span>' . esc_html( $attachment->post_title ) . '
@@ -3365,18 +3365,18 @@ function wp_ajax_quick_edit_attachment() {
 		<div class="row-actions">
 			<span class="edit"><a href="' . esc_url( home_url( '/wp-admin/post.php?post=' . $id . '&amp;action=edit' ) ) . '" aria-label="Edit “' . esc_attr( $attachment->post_title ) . '”">' . esc_html__( 'Edit' ) . '</a> | </span>
 
-			<span class="delete"><a href="post.php?action=delete&amp;post=' . $id . '&amp;_wpnonce=' . esc_attr( $nonce ) . '" class="submitdelete aria-button-if-js" onclick="return showNotice.warn();" aria-label="' . esc_attr__( 'Delete “' ) . esc_attr( $attachment->post_title ) . esc_attr__( '” permanently' ) . '" role="button">' . esc_html__( 'Delete Permanently' ) . '</a> | </span>
+			<span class="delete"><a href="post.php?action=delete&amp;post=' . $id . '&amp;_wpnonce=' . esc_attr( $nonce ) . '" class="submitdelete aria-button-if-js" onclick="return showNotice.warn();" aria-label="' . esc_attr__( sprintf( 'Delete “%s” permanently', $attachment->post_title ) ) . '" role="button">' . esc_html__( 'Delete Permanently' ) . '</a> | </span>
 
-			<span class="view"><a href="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( 'View “' ) . esc_attr( $attachment->post_title ) . esc_attr__( '”' ) . '" rel="bookmark">' . esc_html__( 'View' ) . '</a> | </span>
+			<span class="view"><a href="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( sprintf( 'View “%s”', $attachment->post_title ) ) . '" rel="bookmark">' . esc_html__( 'View' ) . '</a> | </span>
 
 			<span class="copy">
 				<span class="copy-to-clipboard-container">
-					<button type="button" class="button-link copy-attachment-url media-library" data-clipboard-text="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( 'Copy “' ) . esc_attr( $attachment->post_title ) . esc_attr__( '” URL to clipboard' ) . '">' . esc_html__( 'Copy URL' ) . '</button>
+					<button type="button" class="button-link copy-attachment-url media-library" data-clipboard-text="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( sprintf( 'Copy “%s” URL to clipboard', $attachment->post_title ) ) . '">' . esc_html__( 'Copy URL' ) . '</button>
 					<span class="success hidden" aria-hidden="true">' . esc_html__( 'Copied!' ) . '</span>
 				</span> |
 			</span>
 
-			<span class="download"><a href="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( 'Download “' ) . esc_attr( $attachment->post_title ) . esc_attr__( '”' ) . '" download="">' . esc_html__( 'Download file' ) . '</a></span>
+			<span class="download"><a href="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( sprintf( 'Download “%s”', $attachment->post_title ) ) . '" download="">' . esc_html__( 'Download file' ) . '</a></span>
 		</div>
 		<button type="button" class="toggle-row">
 			<span class="screen-reader-text">' . esc_html__( 'Show more details' ) . '</span>


### PR DESCRIPTION
## Description
Improvements introduced in `src/wp-admin/includes/ajax-actions.php` have resulted in a suboptimal experience for translators; strings for translating are fragmented.

Code such as:
`esc_attr__( '“' ) . esc_attr( $attachment->post_title ) . esc_attr__( '” (Edit)' )` creates 2 string for translation rather than one.

Replacing such instantaces with:
`esc_attr__( sprintf( '“%s” (Edit)', $attachment->post_title ) )`

retains the security while enhancing the experience for translators.

## Motivation and context
Enhanced experience for translators.

## How has this been tested?
Local syntax and Unit testing only, would benefit from user level testing of these strings.

## Screenshots
N/A

## Types of changes
- Translation enhancement
