### PR TITLE
Update SCSS files for SASS 1.79.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -300,7 +300,7 @@ module.exports = function(grunt) {
 				ext: '.css',
 				src: ['wp-admin/css/colors/*/colors.scss'],
 				options: {
-					silenceDeprecations: ['legacy-js-api'],
+					api: 'modern',
 					implementation: require( 'sass' )
 				}
 			}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -300,6 +300,7 @@ module.exports = function(grunt) {
 				ext: '.css',
 				src: ['wp-admin/css/colors/*/colors.scss'],
 				options: {
+					silenceDeprecations: ['legacy-js-api'],
 					implementation: require( 'sass' )
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "grunt-legacy-util": "2.0.1",
         "grunt-replace": "2.0.2",
         "grunt-rtlcss": "2.0.2",
-        "grunt-sass": "3.1.0",
+        "grunt-sass": "github:mattyrob/grunt-sass#add/modern-api",
         "grunt-webpack": "7.0.0",
         "ink-docstrap": "1.3.2",
         "install-changed": "^1.1.0",
@@ -7017,9 +7017,9 @@
     },
     "node_modules/grunt-sass": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-sass/-/grunt-sass-3.1.0.tgz",
-      "integrity": "sha512-90s27H7FoCDcA8C8+R0GwC+ntYD3lG6S/jqcavWm3bn9RiJTmSfOvfbFa1PXx4NbBWuiGQMLfQTj/JvvqT5w6A==",
+      "resolved": "git+ssh://git@github.com/mattyrob/grunt-sass.git#f6c3e356f70ce4a246bb5df250b0b7a1b7418ca9",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-legacy-util": "2.0.1",
     "grunt-replace": "2.0.2",
     "grunt-rtlcss": "2.0.2",
-    "grunt-sass": "3.1.0",
+    "grunt-sass": "github:mattyrob/grunt-sass#add/modern-api",
     "grunt-webpack": "7.0.0",
     "ink-docstrap": "1.3.2",
     "install-changed": "^1.1.0",

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -115,20 +115,20 @@ textarea:focus {
 	.button:hover,
 	.button.focus,
 	.button:focus {
-		border-color: darken( #7e8993, 5% );
-		color: darken( #32373c, 5% );
+		border-color: color.adjust( #7e8993, $lightness: -5% );
+		color: color.adjust( #32373c, $lightness: -5% );
 	}
 
 	.button.focus,
 	.button:focus {
 		border-color: #7e8993;
-		color: darken( #32373c, 5% );
+		color: color.adjust( #32373c, $lightness: -5% );
 		box-shadow: 0 0 0 1px #32373c;
 	}
 
 	.button:active {
 		border-color: #7e8993;
-		color: darken( #32373c, 5% );
+		color: color.adjust( #32373c, $lightness: -5% );
 		box-shadow: none;
 	}
 
@@ -136,7 +136,7 @@ textarea:focus {
 	.button.active:focus,
 	.button.active:hover {
 		border-color: $button-color;
-		color: darken( #32373c, 5% );
+		color: color.adjust( #32373c, $lightness: -5% );
 		box-shadow: inset 0 2px 5px -3px $button-color;
 	}
 
@@ -154,16 +154,16 @@ textarea:focus {
 		.button.hover,
 		.button:hover,
 		.button-secondary:hover{
-			border-color: darken($highlight-color, 10);
-			color: darken($highlight-color, 10);
+			border-color: color.adjust($highlight-color, $lightness: -10%);
+			color: color.adjust($highlight-color, $lightness: -10%);
 		}
 
 		.button.focus,
 		.button:focus,
 		.button-secondary:focus {
-			border-color: lighten($highlight-color, 10);
-			color: darken($highlight-color, 20);;
-			box-shadow: 0 0 0 1px lighten($highlight-color, 10);
+			border-color: color.adjust($highlight-color, $lightness: 10%);
+			color: color.adjust($highlight-color, $lightness: -20%);
+			box-shadow: 0 0 0 1px color.adjust($highlight-color, $lightness: 10%);
 		}
 
 		.button-primary {
@@ -225,14 +225,14 @@ textarea:focus {
 	}
 
 	.wrap .page-title-action:hover {
-		color: darken($highlight-color, 10);
-		border-color: darken($highlight-color, 10);
+		color: color.adjust($highlight-color, $lightness: -10%);
+		border-color: color.adjust($highlight-color, $lightness: -10%);
 	}
 
 	.wrap .page-title-action:focus {
-		border-color: lighten($highlight-color, 10);
-		color: darken($highlight-color, 20);;
-		box-shadow: 0 0 0 1px lighten($highlight-color, 10);
+		border-color: color.adjust($highlight-color, $lightness: 10%);
+		color: color.adjust($highlight-color, $lightness: -20%);
+		box-shadow: 0 0 0 1px color.adjust($highlight-color, $lightness: 10%);
 	}
 }
 
@@ -539,7 +539,7 @@ ul#adminmenu > li.current > a.current:after {
 
 .wp-pointer .wp-pointer-content h3 {
 	background-color: $highlight-color;
-	border-color: darken( $highlight-color, 5% );
+	border-color: color.adjust( $highlight-color, $lightness: -5% );
 }
 
 .wp-pointer .wp-pointer-content h3:before {
@@ -632,7 +632,7 @@ body.more-filters-opened .more-filters:focus:before {
 
 .nav-menus-php .item-edit:focus:before {
 	box-shadow:
-		0 0 0 1px lighten($button-color, 10),
+		0 0 0 1px color.adjust($button-color, $lightness: 10%),
 		0 0 2px 1px $button-color;
 }
 
@@ -711,7 +711,7 @@ div#wp-responsive-toggle a:before {
 	#customize-save-button-wrapper .save:focus,
 	#publish-settings:focus {
 		box-shadow:
-			0 0 0 1px lighten($button-color, 10),
+			0 0 0 1px color.adjust($button-color, $lightness: 10%),
 			0 0 2px 1px $button-color;
 	}
 
@@ -772,7 +772,7 @@ div#wp-responsive-toggle a:before {
 	.wp-full-overlay .collapse-sidebar:hover .collapse-sidebar-arrow,
 	.wp-full-overlay .collapse-sidebar:focus .collapse-sidebar-arrow {
 		box-shadow:
-			0 0 0 1px lighten($button-color, 10),
+			0 0 0 1px color.adjust($button-color, $lightness: 10%),
 			0 0 2px 1px $button-color;
 	}
 

--- a/src/wp-admin/css/colors/_mixins.scss
+++ b/src/wp-admin/css/colors/_mixins.scss
@@ -9,8 +9,8 @@
 
 	&:hover,
 	&:focus {
-		background: lighten( $button-color, 3% );
-		border-color: darken( $button-color, 3% );
+		background: color.adjust( $button-color, $lightness: 3% );
+		border-color: color.adjust( $button-color, $lightness: -3% );
 		color: $button-text-color;
 	}
 
@@ -21,8 +21,8 @@
 	}
 
 	&:active {
-		background: darken( $button-color, 5% );
-		border-color: darken( $button-color, 5% );
+		background: color.adjust( $button-color, $lightness: -5% );
+		border-color: color.adjust( $button-color, $lightness: -5% );
 		color: $button-text-color;
 	}
 
@@ -31,7 +31,7 @@
 	&.active:hover {
 		background: $button-color;
 		color: $button-text-color;
-		border-color: darken( $button-color, 15% );
-		box-shadow: inset 0 2px 5px -3px darken( $button-color, 50% );
+		border-color: color.adjust( $button-color, $lightness: -15% );
+		box-shadow: inset 0 2px 5px -3px color.adjust( $button-color, $lightness: -50% );
 	}
 }

--- a/src/wp-admin/css/colors/_variables.scss
+++ b/src/wp-admin/css/colors/_variables.scss
@@ -6,7 +6,7 @@ $scheme-name: "default" !default;
 
 $text-color: #fff !default;
 $base-color: #23282d !default;
-$icon-color: hsl( hue( $base-color ), 7%, 95% ) !default;
+$icon-color: hsl( color.channel( $base-color, "hue", $space: hsl ), 7%, 95% ) !default;
 $highlight-color: #0073aa !default;
 $notification-color: #d54e21 !default;
 
@@ -16,7 +16,7 @@ $notification-color: #d54e21 !default;
 $body-background: #f1f1f1 !default;
 
 $link: #0073aa !default;
-$link-focus: lighten( $link, 10% ) !default;
+$link-focus: color.adjust( $link, $lightness: 10% ) !default;
 
 $button-color: $highlight-color !default;
 $button-text-color: $text-color !default;
@@ -38,8 +38,8 @@ $menu-current-icon: $menu-highlight-icon !default;
 $menu-current-background: $menu-highlight-background !default;
 
 $menu-submenu-text: mix( $base-color, $text-color, 30% ) !default;
-$menu-submenu-background: darken( $base-color, 7% ) !default;
-$menu-submenu-background-alt: desaturate( lighten( $menu-background, 7% ), 7% ) !default;
+$menu-submenu-background: color.adjust( $base-color, $lightness: -7% ) !default;
+$menu-submenu-background-alt: color.adjust( color.adjust( $menu-background, $lightness: 7% ), $saturation: -7% ) !default;
 
 $menu-submenu-focus-text: $highlight-color !default;
 $menu-submenu-current-text: $text-color !default;
@@ -54,8 +54,8 @@ $menu-collapse-icon: $menu-icon !default;
 $menu-collapse-focus-text: $text-color !default;
 $menu-collapse-focus-icon: $menu-highlight-icon !default;
 
-$adminbar-avatar-frame: lighten( $menu-background, 7% ) !default;
-$adminbar-input-background: lighten( $menu-background, 7% ) !default;
+$adminbar-avatar-frame: color.adjust( $menu-background, $lightness: 7% ) !default;
+$adminbar-input-background: color.adjust( $menu-background, $lightness: 7% ) !default;
 
 $adminbar-recovery-exit-text: $menu-bubble-text !default;
 $adminbar-recovery-exit-background: $menu-bubble-background !default;

--- a/src/wp-admin/css/colors/blue/colors.scss
+++ b/src/wp-admin/css/colors/blue/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "blue";
 $base-color: #52accc;
 $icon-color: #e5f8ff;

--- a/src/wp-admin/css/colors/coffee/colors.scss
+++ b/src/wp-admin/css/colors/coffee/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "coffee";
 $base-color: #59524c;
 $highlight-color: #c7a589;

--- a/src/wp-admin/css/colors/ectoplasm/colors.scss
+++ b/src/wp-admin/css/colors/ectoplasm/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "ectoplasm";
 $base-color: #523f6d;
 $icon-color: #ece6f6;

--- a/src/wp-admin/css/colors/light/colors.scss
+++ b/src/wp-admin/css/colors/light/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "light";
 $base-color: #e5e5e5;
 $icon-color: #999;

--- a/src/wp-admin/css/colors/midnight/colors.scss
+++ b/src/wp-admin/css/colors/midnight/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "midnight";
 $base-color: #363b3f;
 $highlight-color: #e14d43;

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "modern";
 $base-color: #1e1e1e;
 $highlight-color: #3858e9;
@@ -5,7 +7,7 @@ $menu-submenu-focus-text: #33f078;
 $notification-color: $highlight-color;
 
 $link: $highlight-color;
-$link-focus: darken($highlight-color, 10%);
+$link-focus: color.adjust($highlight-color, $lightness: -10%);
 
 $dashboard-accent-1: #273fcc;
 $dashboard-accent-2: #627eff;

--- a/src/wp-admin/css/colors/ocean/colors.scss
+++ b/src/wp-admin/css/colors/ocean/colors.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $scheme-name: "ocean";
 $base-color: #738e96;
 $icon-color: #f2fcff;

--- a/src/wp-admin/css/colors/sunrise/colors.scss
+++ b/src/wp-admin/css/colors/sunrise/colors.scss
@@ -1,7 +1,9 @@
+@use 'sass:color';
+
 $scheme-name: "sunrise";
 $base-color: #cf4944;
 $highlight-color: #dd823b;
 $notification-color: #ccaf0b;
-$menu-submenu-focus-text: lighten( $highlight-color, 35% );
+$menu-submenu-focus-text: color.adjust( $highlight-color, $lightness: 35% );
 
 @import "../_admin.scss";


### PR DESCRIPTION
## Description
Recent updates to `SASS` have resulted in deprecation notices during the build process. This PR aims to address these notices.

Broadly there are scss syntax changes for `SASS` due to deprecation of `lighten()`, `darken()` and `hue()` but these are all relatively easily replaced.

The API is also deprecated and this is [reported](https://github.com/sindresorhus/grunt-sass/issues/311) in an upstream dependency - for now the warning can be silenced in `Gruntfile.js`.

## Motivation and context
More modern `scss` files, quieter command line reporting during builds

## How has this been tested?
Local testing and comparison of output `css` shows near identical output, there are 2 minor changes: as listed below but visually I could not see any differences in admin pages.
```
diff -r ../build/wp-admin/css/current-colors/ectoplasm/colors.css ../build/wp-admin/css/colors/ectoplasm/colors.css
167c167
<   box-shadow: inset 0 2px 5px -3px black;
---
>   box-shadow: inset 0 2px 5px -3px hsl(70.5263157895, 45.2380952381%, -0.5882352941%);
diff -r ../build/wp-admin/css/current-colors/light/colors.css ../build/wp-admin/css/colors/light/colors.css
167c167
<   box-shadow: inset 0 2px 5px -3px black;
---
>   box-shadow: inset 0 2px 5px -3px hsl(192, 96.1538461538%, -9.2156862745%);
```

## Screenshots
### Before
![Screenshot 2024-09-28 at 16 10 14](https://github.com/user-attachments/assets/3a72b777-83f9-4e06-9e6c-a5b556199a43)

### After
![Screenshot 2024-09-28 at 16 13 27](https://github.com/user-attachments/assets/b5e7194a-953f-49ad-a5ea-645ad8d344ee)

## Types of changes
- Enhancement