### PR TITLE
Fix Volunteer link in Dashboard

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1321,7 +1321,7 @@ function wp_dashboard_events_news() {
 		<ul>
 			<li><a href="https://forums.classicpress.net/" target="_blank"><?php _e( 'Get Help' ); ?> <span aria-hidden="true" class="dashicons dashicons-external"></span></a></li>
 			<li><a href="https://github.com/ClassicPress/ClassicPress/issues/new/choose" target="_blank"><?php _e( 'Feature Requests' ); ?> <span aria-hidden="true" class="dashicons dashicons-external"></span></a></li>
-			<li><a href="https://classicpress.net/volunteer/" target="_blank"><?php _e( 'Volunteer' ); ?> <span aria-hidden="true" class="dashicons dashicons-external"></span></a></li>
+			<li><a href="https://classicpress.net/community/" target="_blank"><?php _e( 'Volunteer' ); ?> <span aria-hidden="true" class="dashicons dashicons-external"></span></a></li>
 			<li><a href="https://classicpress.net/donate/" target="_blank"><?php _e( 'Donate' ); ?> <span aria-hidden="true" class="dashicons dashicons-external"></span></a></li>
 		</ul>
 	</div>


### PR DESCRIPTION
## Description
Updated the non-existent URL `https://classicpress.net/volunteer/` to the correct community page link `https://www.classicpress.net/community/`.

## Motivation and context
It resolves the `Page Not Found` error.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/ff097b54-037e-4d33-9e02-203564526fa9)

### After
![image](https://github.com/user-attachments/assets/17257bd2-d01f-4026-8314-cf35b2ce5e96)

## Types of changes
- Bug fix
