### PR TITLE
Only style the range input control on the Revision screen

### DIFF
--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -11,7 +11,7 @@
 	position: relative;
 	min-height: 50px;
 }
-input[type="range"] {
+.sliders-control input[type="range"] {
 	-moz-appearance: none;
 	appearance: none;
 	height: 4px;
@@ -20,10 +20,10 @@ input[type="range"] {
 	background-color: #00b3bc;
 	pointer-events: none;
 }
-input[type="range"]:focus {
+.sliders-control input[type="range"]:focus {
 	outline: 0;
 }
-input[type="range"]::-webkit-slider-thumb {
+.sliders-control input[type="range"]::-webkit-slider-thumb {
 	appearance: none;
 	pointer-events: all;
 	width: 30px;
@@ -34,7 +34,7 @@ input[type="range"]::-webkit-slider-thumb {
 	cursor: pointer;
 	margin-top: -1.2em;
 }
-input[type="range"]::-moz-range-thumb {
+.sliders-control input[type="range"]::-moz-range-thumb {
 	border: none;
 	pointer-events: all;
 	width: 30px;
@@ -44,22 +44,22 @@ input[type="range"]::-moz-range-thumb {
 	box-shadow: 0 0 0 1px #C6C6C6;
 	cursor: pointer;
 }
-input[type="range"]:hover::-webkit-slider-thumb {
+.sliders-control input[type="range"]:hover::-webkit-slider-thumb {
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-input[type="range"]:hover::-moz-range-thumb {
+.sliders-control input[type="range"]:hover::-moz-range-thumb {
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-input[type="range"]:focus::-webkit-slider-thumb {
+.sliders-control input[type="range"]:focus::-webkit-slider-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1; 
 	border: 1px solid #053a5f;
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-input[type="range"]:focus::-moz-range-thumb {
+.sliders-control input[type="range"]:focus::-moz-range-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1;
 	border: 1px solid #053a5f;

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -12,6 +12,8 @@
 	min-height: 50px;
 }
 .sliders-control input[type="range"] {
+.sliders-control input[type="range"],
+.wp-picker-holder input[type="range"] {
 	-moz-appearance: none;
 	appearance: none;
 	height: 4px;
@@ -24,6 +26,12 @@
 	outline: 0;
 }
 .sliders-control input[type="range"]::-webkit-slider-thumb {
+.sliders-control input[type="range"]:focus,
+.wp-picker-holder input[type="range"]:focus {
+	outline: 0;
+}
+.sliders-control input[type="range"]::-webkit-slider-thumb,
+.wp-picker-holder input[type="range"]::-webkit-slider-thumb {
 	appearance: none;
 	pointer-events: all;
 	width: 30px;
@@ -35,6 +43,8 @@
 	margin-top: -1.2em;
 }
 .sliders-control input[type="range"]::-moz-range-thumb {
+.sliders-control input[type="range"]::-moz-range-thumb,
+.wp-picker-holder input[type="range"]::-moz-range-thumb {
 	border: none;
 	pointer-events: all;
 	width: 30px;
@@ -53,6 +63,18 @@
 	outline-offset: 0.125rem; 
 }
 .sliders-control input[type="range"]:focus::-webkit-slider-thumb {
+.sliders-control input[type="range"]:hover::-webkit-slider-thumb,
+.wp-picker-holder input[type="range"]:hover::-webkit-slider-thumb {
+	outline: 3px solid #053a5f;
+	outline-offset: 0.125rem; 
+}
+.sliders-control input[type="range"]:hover::-moz-range-thumb,
+.wp-picker-holder input[type="range"]:hover::-moz-range-thumb {
+	outline: 3px solid #053a5f;
+	outline-offset: 0.125rem; 
+}
+.sliders-control input[type="range"]:focus::-webkit-slider-thumb,
+.wp-picker-holder input[type="range"]:focus::-webkit-slider-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1; 
 	border: 1px solid #053a5f;
@@ -60,6 +82,8 @@
 	outline-offset: 0.125rem; 
 }
 .sliders-control input[type="range"]:focus::-moz-range-thumb {
+.sliders-control input[type="range"]:focus::-moz-range-thumb,
+.wp-picker-holder input[type="range"]:focus::-moz-range-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1;
 	border: 1px solid #053a5f;

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -11,7 +11,6 @@
 	position: relative;
 	min-height: 50px;
 }
-.sliders-control input[type="range"] {
 .sliders-control input[type="range"],
 .wp-picker-holder input[type="range"] {
 	-moz-appearance: none;
@@ -22,10 +21,6 @@
 	background-color: #00b3bc;
 	pointer-events: none;
 }
-.sliders-control input[type="range"]:focus {
-	outline: 0;
-}
-.sliders-control input[type="range"]::-webkit-slider-thumb {
 .sliders-control input[type="range"]:focus,
 .wp-picker-holder input[type="range"]:focus {
 	outline: 0;
@@ -42,7 +37,6 @@
 	cursor: pointer;
 	margin-top: -1.2em;
 }
-.sliders-control input[type="range"]::-moz-range-thumb {
 .sliders-control input[type="range"]::-moz-range-thumb,
 .wp-picker-holder input[type="range"]::-moz-range-thumb {
 	border: none;
@@ -54,15 +48,6 @@
 	box-shadow: 0 0 0 1px #C6C6C6;
 	cursor: pointer;
 }
-.sliders-control input[type="range"]:hover::-webkit-slider-thumb {
-	outline: 3px solid #053a5f;
-	outline-offset: 0.125rem; 
-}
-.sliders-control input[type="range"]:hover::-moz-range-thumb {
-	outline: 3px solid #053a5f;
-	outline-offset: 0.125rem; 
-}
-.sliders-control input[type="range"]:focus::-webkit-slider-thumb {
 .sliders-control input[type="range"]:hover::-webkit-slider-thumb,
 .wp-picker-holder input[type="range"]:hover::-webkit-slider-thumb {
 	outline: 3px solid #053a5f;
@@ -81,7 +66,6 @@
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-.sliders-control input[type="range"]:focus::-moz-range-thumb {
 .sliders-control input[type="range"]:focus::-moz-range-thumb,
 .wp-picker-holder input[type="range"]:focus::-moz-range-thumb {
 	background-color: red;


### PR DESCRIPTION
This fixes the broken range input control on non-Revision screens, such as theme or plugin settings pages.

Whenever am `<input type="range">` element is added to a theme or plugin settings page, it looks broken because it inherits the styles from the Revisions screen. The range input control styles should be isolated to the Revisions screen only, and appear as a native element on all the other screens.

**Revisions screen**

![image](https://github.com/user-attachments/assets/04273e47-01c4-4af9-bc3d-97dfde3b9a83)

**A theme settings screen (before)**

![image](https://github.com/user-attachments/assets/7458391f-f2fd-4c69-86d0-aea677bb7a21)

**A theme settings screen (after)**

![image](https://github.com/user-attachments/assets/7803269e-76b3-4aed-b5e9-c6fa8b26b013)