### PR TITLE
Change a "WordPress" occurrence with "ClassicPress" on the Privacy Policy Guide page

### DIFF
--- a/src/wp-admin/includes/class-wp-privacy-policy-content.php
+++ b/src/wp-admin/includes/class-wp-privacy-policy-content.php
@@ -534,7 +534,7 @@ final class WP_Privacy_Policy_Content {
 			/* translators: Privacy policy tutorial. */
 			$strings[] = '<p class="privacy-policy-tutorial">' . __( 'In this subsection you should note what analytics package you use, how users can opt out of analytics tracking, and a link to your analytics provider&#8217;s privacy policy, if any.' ) . '</p>';
 			/* translators: Privacy policy tutorial. */
-			$strings[] = '<p class="privacy-policy-tutorial">' . __( 'By default ClassicPress does not collect any analytics data. However, many web hosting accounts collect some anonymous analytics data. You may also have installed a WordPress plugin that provides analytics services. In that case, add information from that plugin here.' ) . '</p>';
+			$strings[] = '<p class="privacy-policy-tutorial">' . __( 'By default ClassicPress does not collect any analytics data. However, many web hosting accounts collect some anonymous analytics data. You may also have installed a plugin that provides analytics services. In that case, add information from that plugin here.' ) . '</p>';
 		}
 
 		/* translators: Default privacy policy heading. */


### PR DESCRIPTION
## Description

Change a "WordPress" occurrence with "ClassicPress" on the Privacy Policy Guide page. "WordPress" should not be present here, as this page is about ClassicPress and ClassicPress privacy and additional plugins.

## Motivation and context

Keeping "WordPress" makes sense, as one can have both WordPress and ClassicPress plugins, but it makes the guide confusing, and also invalid long-term, when WordPress plugins might not be compatible with ClassicPress.

## Screenshots

![policyguide](https://github.com/user-attachments/assets/cfe29b57-3964-4ccc-b077-6bae78c12857)

## Types of changes

- Bug fix (branding/typo)
