### PR TITLE
Add unit testing for PHP 8.4

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -68,6 +68,10 @@ jobs:
             mysql: '8.0'
             memcached: true
             experimental: false
+          - php: '8.4'
+            mysql: '8.0'
+            memcached: false
+            experimental: true
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)


### PR DESCRIPTION
## Description

PHP 8.4 is due for full release and is currently in release candidate for testing.
This replaces #1572 to keep fixes for PHP8.4 for later.

## Motivation and context
This PR adds PHP 8.4 to the suite of PHPUnit testing as `experimental` so any issues can be identified and corrected.

## How has this been tested?
Unit tests will run on GitHub

## Screenshots
N/A

## Types of changes
- New feature