### PR TITLE
Add step to erase and update core CP Pepper plugin

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -208,9 +208,10 @@ $_old_requests_files = array(
 global $_new_bundled_files;
 
 $_new_bundled_files = array(
-	'themes/twentyseventeen/'              => '4.7',
-	'themes/the-classicpress-theme/'       => '6.2.6',
-	'plugins/cp-pepper/'                   => '6.2.7',
+	'themes/twentyseventeen/'         => '4.7',
+	'themes/the-classicpress-theme/'  => '6.2.6',
+	'plugins/cp-pepper/'              => '6.2.7',
+	'plugins/cp-pepper/cp-pepper.php' => '6.2.7',
 );
 
 /**
@@ -730,6 +731,11 @@ function update_core( $from, $to ) {
 				}
 
 				if ( ! $directory ) {
+					// Force update of ClassicPress Pepper for Passwords plugin from 1.0
+					if ( ! $development_build && 'plugins/cp-pepper/cp-pepper.php' === $file ) {
+						$wp_filesystem->delete( $dest . $filename );
+					}
+
 					if ( ! $development_build && $wp_filesystem->exists( $dest . $filename ) ) {
 						continue;
 					}


### PR DESCRIPTION
## Description
This PR adds the specific plugin file for the ClassicPress Pepper for Passwords plugin to the upgrade step and also erases this file during the upgrade.

This will force an upgrade to the core plugin with recently committed changes.

A current fail safe in the upgrade code include - if the file is not in the downloaded update code the process skips.
This code is not called on development builds where files are expected to be under version control.
This code will not be called once the core `$wp_version is bumped to 6.2.7` and above.

## Motivation and context
Fixes #1581

## How has this been tested?
Local testing manually.

## Screenshots
N/A

## Types of changes
- Core plugin update
