### PR TITLE
WP-r59202: Update file size meta data when editing images.

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -715,13 +715,8 @@ function image_edit_apply_changes( $image, $changes ) {
 					$w    = $size['width'];
 					$h    = $size['height'];
 
-<<<<<<< HEAD
-					$scale = 1 / _image_get_preview_ratio( $w, $h ); // Discard preview scaling.
-					$image->crop( $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );
-=======
 					$scale = isset( $sel->r ) ? $sel->r : 1 / _image_get_preview_ratio( $w, $h ); // Discard preview scaling.
 					$image->crop( (int) ( $sel->x * $scale ), (int) ( $sel->y * $scale ), (int) ( $sel->w * $scale ), (int) ( $sel->h * $scale ) );
->>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.)
 				} else {
 					$scale = isset( $sel->r ) ? $sel->r : 1 / _image_get_preview_ratio( imagesx( $image ), imagesy( $image ) ); // Discard preview scaling.
 					$image = _crop_image_resource( $image, $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -715,10 +715,15 @@ function image_edit_apply_changes( $image, $changes ) {
 					$w    = $size['width'];
 					$h    = $size['height'];
 
+<<<<<<< HEAD
 					$scale = 1 / _image_get_preview_ratio( $w, $h ); // Discard preview scaling.
 					$image->crop( $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );
+=======
+					$scale = isset( $sel->r ) ? $sel->r : 1 / _image_get_preview_ratio( $w, $h ); // Discard preview scaling.
+					$image->crop( (int) ( $sel->x * $scale ), (int) ( $sel->y * $scale ), (int) ( $sel->w * $scale ), (int) ( $sel->h * $scale ) );
+>>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.)
 				} else {
-					$scale = 1 / _image_get_preview_ratio( imagesx( $image ), imagesy( $image ) ); // Discard preview scaling.
+					$scale = isset( $sel->r ) ? $sel->r : 1 / _image_get_preview_ratio( imagesx( $image ), imagesy( $image ) ); // Discard preview scaling.
 					$image = _crop_image_resource( $image, $sel->x * $scale, $sel->y * $scale, $sel->w * $scale, $sel->h * $scale );
 				}
 				break;

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -809,6 +809,7 @@ function wp_restore_image( $post_id ) {
 				$backup_sizes[ "full-$suffix" ] = array(
 					'width'  => $meta['width'],
 					'height' => $meta['height'],
+					'filesize' => $meta['filesize'],
 					'file'   => $parts['basename'],
 				);
 			}
@@ -820,6 +821,14 @@ function wp_restore_image( $post_id ) {
 		$meta['file']   = _wp_relative_upload_path( $restored_file );
 		$meta['width']  = $data['width'];
 		$meta['height'] = $data['height'];
+		if ( isset( $data['filesize'] ) ) {
+			/*
+			 * Restore the original filesize if it was backed up.
+			 *
+			 * See https://core.trac.wordpress.org/ticket/59684.
+			 */
+			$meta['filesize'] = $data['filesize'];
+		}
 	}
 
 	foreach ( $default_sizes as $default_size ) {
@@ -964,8 +973,9 @@ function wp_save_image( $post_id ) {
 		}
 	}
 
+	$saved_image = wp_save_image_file( $new_path, $img, $post->post_mime_type, $post_id );
 	// Save the full-size file, also needed to create sub-sizes.
-	if ( ! wp_save_image_file( $new_path, $img, $post->post_mime_type, $post_id ) ) {
+	if ( ! $saved_image ) {
 		$return->error = esc_js( __( 'Unable to save the image.' ) );
 		return $return;
 	}
@@ -984,6 +994,7 @@ function wp_save_image( $post_id ) {
 			$backup_sizes[ $tag ] = array(
 				'width'  => $meta['width'],
 				'height' => $meta['height'],
+				'filesize' => $meta['filesize'],
 				'file'   => $basename,
 			);
 		}
@@ -994,6 +1005,7 @@ function wp_save_image( $post_id ) {
 		$size           = $img->get_size();
 		$meta['width']  = $size['width'];
 		$meta['height'] = $size['height'];
+		$meta['filesize'] = $saved_image['filesize'];
 
 		if ( $success ) {
 			$sizes = get_intermediate_image_sizes();

--- a/src/wp-admin/js/image-edit.js
+++ b/src/wp-admin/js/image-edit.js
@@ -114,17 +114,12 @@
 	 * @return {void}
 	 */
 	init : function(postid) {
-		var t = this, old = $('#image-editor-' + t.postid),
-			x = t.intval( $('#imgedit-x-' + postid).val() ),
-			y = t.intval( $('#imgedit-y-' + postid).val() );
+		var t = this, old = $('#image-editor-' + t.postid);
 
 		if ( t.postid !== postid && old.length ) {
 			t.close(t.postid);
 		}
 
-		t.hold.w = t.hold.ow = x;
-		t.hold.h = t.hold.oh = y;
-		t.hold.xy_ratio = x / y;
 		t.hold.sizer = parseFloat( $('#imgedit-sizer-' + postid).val() );
 		t.postid = postid;
 		$('#imgedit-response-' + postid).empty();
@@ -146,6 +141,29 @@
 		});
 
 		$( document ).on( 'image-editor-ui-ready', this.focusManager );
+	},
+
+	/**
+	 * Calculate the image size and save it to memory.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @memberof imageEdit
+	 *
+	 * @param {number} postid The post ID.
+	 *
+	 * @return {void}
+	 */
+	calculateImgSize: function( postid ) {
+		var t = this,
+		x = t.intval( $( '#imgedit-x-' + postid ).val() ),
+		y = t.intval( $( '#imgedit-y-' + postid ).val() );
+
+		t.hold.w = t.hold.ow = x;
+		t.hold.h = t.hold.oh = y;
+		t.hold.xy_ratio = x / y;
+		t.hold.sizer = parseFloat( $( '#imgedit-sizer-' + postid ).val() );
+		t.currentCropSelection = null;
 	},
 
 	/**
@@ -335,7 +353,7 @@
 			for ( n in history ) {
 				i = history[n];
 				if ( i.hasOwnProperty('c') ) {
-					op[n] = { 'c': { 'x': i.c.x, 'y': i.c.y, 'w': i.c.w, 'h': i.c.h } };
+					op[n] = { 'c': { 'x': i.c.x, 'y': i.c.y, 'w': i.c.w, 'h': i.c.h, 'r': i.c.r } };
 				} else if ( i.hasOwnProperty('r') ) {
 					op[n] = { 'r': i.r.r };
 				} else if ( i.hasOwnProperty('f') ) {
@@ -668,6 +686,7 @@
 		if ( 'undefined' === typeof this.hold.sizer ) {
 			this.init( postid );
 		}
+		this.calculateImgSize( postid );
 
 		this.initCrop(postid, img, parent);
 		this.setCropSelection( postid, { 'x1': 0, 'y1': 0, 'x2': 0, 'y2': 0, 'width': img.innerWidth(), 'height': img.innerHeight() } );
@@ -759,13 +778,16 @@
 				 *
 				 * @return {void}
 				 */
-				parent.children().on( 'mousedown, touchstart', function(e){
-					var ratio = false, sel, defRatio;
+				parent.children().on( 'mousedown touchstart', function(e) {
+					var ratio = false,
+					 	sel = t.iasapi.getSelection(),
+					 	cx = t.intval( $( '#imgedit-crop-width-' + postid ).val() ),
+					 	cy = t.intval( $( '#imgedit-crop-height-' + postid ).val() );
 
-					if ( e.shiftKey ) {
-						sel = t.iasapi.getSelection();
-						defRatio = t.getSelRatio(postid);
-						ratio = ( sel && sel.width && sel.height ) ? sel.width + ':' + sel.height : defRatio;
+					if ( cx && cy ) {
+						ratio = t.getSelRatio( postid );
+					} else if ( e.shiftKey && sel && sel.width && sel.height ) {
+						ratio = sel.width + ':' + sel.height;
 					}
 
 					t.iasapi.setOptions({
@@ -809,9 +831,23 @@
 			 * @return {void}
 			 */
 			onSelectChange: function(img, c) {
+<<<<<<< HEAD:src/wp-admin/js/image-edit.js
 				var sizer = imageEdit.hold.sizer;
 				selW.val( imageEdit.round(c.width / sizer) );
 				selH.val( imageEdit.round(c.height / sizer) );
+=======
+				var sizer = imageEdit.hold.sizer,
+					oldSel = imageEdit.currentCropSelection;
+
+				if ( oldSel != null && oldSel.width == c.width && oldSel.height == c.height ) {
+					return;
+				}
+
+				selW.val( Math.min( imageEdit.hold.w, imageEdit.round( c.width / sizer ) ) );
+				selH.val( Math.min( imageEdit.hold.h, imageEdit.round( c.height / sizer ) ) );
+
+				t.currentCropSelection = c;
+>>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.):src/js/_enqueues/lib/image-edit.js
 			}
 		});
 	},
@@ -829,7 +865,11 @@
 	 * @return {boolean}
 	 */
 	setCropSelection : function(postid, c) {
-		var sel;
+		var sel,
+			selW = $( '#imgedit-sel-width-' + postid ),
+			selH = $( '#imgedit-sel-height-' + postid ),
+			sizer = this.hold.sizer,
+			hold = this.hold;
 
 		c = c || 0;
 
@@ -842,7 +882,15 @@
 			return false;
 		}
 
-		sel = { 'x': c.x1, 'y': c.y1, 'w': c.width, 'h': c.height };
+		// adjust the selection within the bounds of the image on 100% scale
+		var excessW = hold.w - ( Math.round( c.x1 / sizer ) + parseInt( selW.val() ) );
+		var excessH = hold.h - ( Math.round( c.y1 / sizer ) + parseInt( selH.val() ) );
+		var x = Math.round( c.x1 / sizer ) + Math.min( 0, excessW );
+		var y = Math.round( c.y1 / sizer ) + Math.min( 0, excessH );
+
+		// use 100% scaling to prevent rounding errors
+		sel = { 'r': 1, 'x': x, 'y': y, 'w': selW.val(), 'h': selH.val() };
+
 		this.setDisabled($('.imgedit-crop', '#imgedit-panel-' + postid), 1);
 		$('#imgedit-selection-' + postid).val( JSON.stringify(sel) );
 	},
@@ -958,6 +1006,11 @@
 		}
 
 		this.addStep({ 'r': { 'r': angle, 'fw': this.hold.h, 'fh': this.hold.w }}, postid, nonce);
+
+		// Clear the selection fields after rotating.
+		$( '#imgedit-sel-width-' + postid ).val( '' );
+		$( '#imgedit-sel-height-' + postid ).val( '' );
+		this.currentCropSelection = null;
 	},
 
 	/**
@@ -980,6 +1033,11 @@
 		}
 
 		this.addStep({ 'f': { 'f': axis, 'fw': this.hold.w, 'fh': this.hold.h }}, postid, nonce);
+
+		// Clear the selection fields after flipping.
+		$( '#imgedit-sel-width-' + postid ).val( '' );
+		$( '#imgedit-sel-height-' + postid ).val( '' );
+		this.currentCropSelection = null;
 	},
 
 	/**
@@ -1012,8 +1070,16 @@
 		}
 
 		// Clear the selection fields after cropping.
+<<<<<<< HEAD:src/wp-admin/js/image-edit.js
 		$('#imgedit-sel-width-' + postid).val('');
 		$('#imgedit-sel-height-' + postid).val('');
+=======
+		$( '#imgedit-sel-width-' + postid ).val( '' );
+		$( '#imgedit-sel-height-' + postid ).val( '' );
+		$( '#imgedit-start-x-' + postid ).val( '0' );
+		$( '#imgedit-start-y-' + postid ).val( '0' );
+		this.currentCropSelection = null;
+>>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.):src/js/_enqueues/lib/image-edit.js
 	},
 
 	/**
@@ -1101,6 +1167,8 @@
 			img = $('#image-preview-' + postid), imgh = img.height(), imgw = img.width(),
 			sizer = this.hold.sizer, x1, y1, x2, y2, ias = this.iasapi;
 
+		this.currentCropSelection = null;
+
 		if ( false === this.validateNumeric( el ) ) {
 			return;
 		}
@@ -1124,18 +1192,19 @@
 			if ( x2 > imgw ) {
 				x1 = 0;
 				x2 = imgw;
-				elX.val( Math.round( x2 / sizer ) );
+				elX.val( Math.min( this.hold.w, Math.round( x2 / sizer ) ) );
 			}
 
 			if ( y2 > imgh ) {
 				y1 = 0;
 				y2 = imgh;
-				elY.val( Math.round( y2 / sizer ) );
+				elY.val( Math.min( this.hold.h, Math.round( y2 / sizer ) ) );
 			}
 
 			ias.setSelection( x1, y1, x2, y2 );
 			ias.update();
 			this.setCropSelection(postid, ias.getSelection());
+			this.currentCropSelection = ias.getSelection();
 		}
 	},
 

--- a/src/wp-admin/js/image-edit.js
+++ b/src/wp-admin/js/image-edit.js
@@ -831,11 +831,6 @@
 			 * @return {void}
 			 */
 			onSelectChange: function(img, c) {
-<<<<<<< HEAD:src/wp-admin/js/image-edit.js
-				var sizer = imageEdit.hold.sizer;
-				selW.val( imageEdit.round(c.width / sizer) );
-				selH.val( imageEdit.round(c.height / sizer) );
-=======
 				var sizer = imageEdit.hold.sizer,
 					oldSel = imageEdit.currentCropSelection;
 
@@ -847,7 +842,6 @@
 				selH.val( Math.min( imageEdit.hold.h, imageEdit.round( c.height / sizer ) ) );
 
 				t.currentCropSelection = c;
->>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.):src/js/_enqueues/lib/image-edit.js
 			}
 		});
 	},
@@ -1070,16 +1064,11 @@
 		}
 
 		// Clear the selection fields after cropping.
-<<<<<<< HEAD:src/wp-admin/js/image-edit.js
-		$('#imgedit-sel-width-' + postid).val('');
-		$('#imgedit-sel-height-' + postid).val('');
-=======
 		$( '#imgedit-sel-width-' + postid ).val( '' );
 		$( '#imgedit-sel-height-' + postid ).val( '' );
 		$( '#imgedit-start-x-' + postid ).val( '0' );
 		$( '#imgedit-start-y-' + postid ).val( '0' );
 		this.currentCropSelection = null;
->>>>>>> c8b744d12b (Media: Fix admin image cropping calculations.):src/js/_enqueues/lib/image-edit.js
 	},
 
 	/**

--- a/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImageEditor.php
@@ -120,4 +120,84 @@ class Tests_Ajax_wpAjaxImageEditor extends WP_Ajax_UnitTestCase {
 			$this->assertSame( array(), $files_that_should_not_exist );
 		}
 	}
+
+	/**
+	 * Ensure the filesize is updated after editing an image.
+	 *
+	 * Tests that the image meta data file size is updated after editing an image,
+	 * this includes both the full size image and all the generated sizes.
+	 *
+	 * @ticket 59684
+	 */
+	public function test_filesize_updated_after_editing_an_image() {
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+
+		$filename = DIR_TESTDATA . '/images/canola.jpg';
+		$contents = file_get_contents( $filename );
+
+		$upload              = wp_upload_bits( wp_basename( $filename ), null, $contents );
+		$id                  = $this->_make_attachment( $upload );
+		$original_image_meta = wp_get_attachment_metadata( $id );
+
+		$_REQUEST['action']  = 'image-editor';
+		$_REQUEST['context'] = 'edit-attachment';
+		$_REQUEST['postid']  = $id;
+		$_REQUEST['target']  = 'all';
+		$_REQUEST['do']      = 'save';
+		$_REQUEST['history'] = '[{"c":{"x":5,"y":8,"w":289,"h":322}}]';
+
+		wp_save_image( $id );
+
+		$post_edit_meta = wp_get_attachment_metadata( $id );
+
+		$pre_file_sizes         = array_combine( array_keys( $original_image_meta['sizes'] ), array_column( $original_image_meta['sizes'], 'filesize' ) );
+		$pre_file_sizes['full'] = $original_image_meta['filesize'];
+
+		$post_file_sizes         = array_combine( array_keys( $post_edit_meta['sizes'] ), array_column( $post_edit_meta['sizes'], 'filesize' ) );
+		$post_file_sizes['full'] = $post_edit_meta['filesize'];
+
+		foreach ( $pre_file_sizes as $size => $size_filesize ) {
+			// These are asserted individually as each image size needs to be checked separately.
+			$this->assertNotSame( $size_filesize, $post_file_sizes[ $size ], "Filesize for $size should have changed after editing an image." );
+		}
+	}
+
+	/**
+	 * Ensure the filesize is restored after restoring the original image.
+	 *
+	 * Tests that the image meta data file size is restored after restoring the original image,
+	 * this includes both the full size image and all the generated sizes.
+	 *
+	 * @ticket 59684
+	 */
+	public function test_filesize_restored_after_restoring_original_image() {
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+
+		$filename = DIR_TESTDATA . '/images/canola.jpg';
+		$contents = file_get_contents( $filename );
+
+		$upload              = wp_upload_bits( wp_basename( $filename ), null, $contents );
+		$id                  = $this->_make_attachment( $upload );
+		$original_image_meta = wp_get_attachment_metadata( $id );
+
+		$_REQUEST['action']  = 'image-editor';
+		$_REQUEST['context'] = 'edit-attachment';
+		$_REQUEST['postid']  = $id;
+		$_REQUEST['target']  = 'all';
+		$_REQUEST['do']      = 'save';
+		$_REQUEST['history'] = '[{"c":{"x":5,"y":8,"w":289,"h":322}}]';
+
+		wp_save_image( $id );
+		wp_restore_image( $id );
+
+		$post_restore_meta = wp_get_attachment_metadata( $id );
+
+		$pre_file_sizes         = array_combine( array_keys( $original_image_meta['sizes'] ), array_column( $original_image_meta['sizes'], 'filesize' ) );
+		$pre_file_sizes['full'] = $original_image_meta['filesize'];
+
+		$post_restore_file_sizes         = array_combine( array_keys( $post_restore_meta['sizes'] ), array_column( $post_restore_meta['sizes'], 'filesize' ) );
+		$post_restore_file_sizes['full'] = $post_restore_meta['filesize'];
+
+		$this->assertSameSetsWithIndex( $pre_file_sizes, $post_restore_file_sizes, 'Filesize should have restored after restoring the original image.' );
+	}
 }


### PR DESCRIPTION
Fixes an error in which the file size meta data retained the original upload's values follow a user editing the images in the media screen.

The original images' file sizes are now stored in the backup image data to allow for them to be restored when a user restores the original image.

WP:Props ankit-k-gupta, antpb, audrasjb, chaion07, gauravsingh7, joedolson, oglekler, pls78, rajinsharwar, sayedulsayem, vertisoft. 

Fixes https://core.trac.wordpress.org/ticket/59684.

## How has this been tested?
Unit tests and locally cropping an image.

## Types of changes
- Bug fix

