### PR TITLE
Remove Safari fallbacks from SortableJS

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -74,8 +74,6 @@
 					dataTransfer.setDragImage( ghostImage, 30, 20 );
 				},
 				dataIdAttr: 'data-id', // HTML attribute that is used by the `toArray()` method in OnEnd
-				forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for all webkit browsers
-				//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari only
 
 				// Get position of menu item when chosen
 				onChoose: function( e ) {

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -1898,8 +1898,6 @@
 					document.body.appendChild( ghostImage );
 					dataTransfer.setDragImage( ghostImage, 30, 20 );
 				},
-				forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-				//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 				onStart: function( e ) {
 					if ( e.item.querySelector( 'details' ).hasAttribute( 'open' ) ) {
 						e.item.querySelector( 'details' ).removeAttribute( 'open' );

--- a/src/wp-admin/js/gallery.js
+++ b/src/wp-admin/js/gallery.js
@@ -15,8 +15,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			placeholder: 'sorthelper',
 			handle: 'div.filename',
 			dataIdAttr: 'data-id', // HTML attribute that is used by the `toArray()` method in OnEnd
-			forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for all webkit browsers
-			//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari only
 			fallbackTolerance: 2,
 
 			// Element dropped

--- a/src/wp-admin/js/nav-menu.js
+++ b/src/wp-admin/js/nav-menu.js
@@ -220,8 +220,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		Sortable.create( editMenu, {
 			group: 'menu',
 			handle: '.item-move',
-			forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-			//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 
 			// Get position of menu item when chosen
 			onChoose: function( e ) {

--- a/src/wp-admin/js/postbox.js
+++ b/src/wp-admin/js/postbox.js
@@ -146,8 +146,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		Sortable.create( document.getElementById( column.id ), {
 			group: 'widgets',
 			handle: '.hndle',
-			forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-			//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 			onStart: dragStart,
 			onEnd: dragEnd,
 			onChange: updateLocations

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -9,7 +9,7 @@
 document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Set variables for the whole file
-	var newMultiValue,
+	var newMultiValue, timeNow,
 		widgetList = document.getElementById( 'widget-list' ),
 		sortables = document.querySelectorAll( '.widgets-sortables' ),
 		sidebarWrappers = document.querySelectorAll( '.widgets-holder-wrap' ),
@@ -125,7 +125,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			removeButton.disabled = true;
 		}
 
-		else {
+		else if ( e.target.tagName === 'INPUT' || e.target.tagName === 'BUTTON' ) {
 
 			// Add chooser
 			if ( e.target.closest( 'ul' ).id === 'widget-list' ) {
@@ -192,7 +192,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.addEventListener( 'keyup', function( e ) {
 			if ( e.target.closest( '.widget-top' ).hasAttribute( 'open' ) && e.key === 'Escape' ) {
 				e.target.closest( '.widget-top' ).removeAttribute( 'open' );
-				document.querySelector( '.chooser' ).classList.remove( 'chooser' );
+				if ( document.querySelector( '.chooser' ) != null ) {
+					document.querySelector( '.chooser' ).classList.remove( 'chooser' );
+				}
 			}
 		} );
 
@@ -498,10 +500,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 
 	function saveWidget( widget, del, animate, order ) {
-		var data, xhr, id,
+		var data,
 			sidebarId = widget.closest( 'ul.widgets-sortables' ).id,
 			form = widget.querySelector( 'form' ),
 			isAdd = widget.querySelector( 'input.add_new' ).value;
+
+		// Prevent duplicates
+		if ( Number.isInteger( timeNow ) && timeNow + 50 > Date.now() ) {
+			return false;
+		}
+		timeNow = Date.now();
 
 		if ( ! isAdd || form.checkValidity ) {
 
@@ -519,75 +527,72 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			/*
 			 * Prepare data for posting to database
-			 *
-			 * Note that using fetch API causes a 400 error
 			 */
-			xhr = new XMLHttpRequest();
-			xhr.open( 'POST', ajaxurl, true );
+			fetch( ajaxurl, {
+				method: 'POST',
+				headers: {
+					'Accept': 'text/html',
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: data
+			} )
+			.then( function( response ) {
+				if ( response.ok ) {
+					return response.text(); // no errors
+				}
+				throw new Error( response.status );
+			} )
+			.then( function( responseText ) {
+				var id = widget.querySelector( 'input.widget-id' ).value;
 
-			// Send the proper header information along with the request
-			xhr.setRequestHeader( 'Accept', 'text/html' );
-			xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded' );
-
-			xhr.onreadystatechange = function() {
-
-				// Call a function when the state changes.
-				if ( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
-
-					// Request finished. Do processing here.
-					id = widget.querySelector( 'input.widget-id' ).value;
-
-					if ( del ) {
-						if ( ! widget.querySelector( 'input.widget_number' ).value ) {
-							document.getElementById('#available-widgets').querySelectorAll( 'input.widget-id' ).forEach( function( widgetId ) {
-								if ( widgetId.value === id ) {
-									widgetId.closest( 'li.widget' ).style.display = 'block';
-								}
-							} );
-						}
-
-						if ( animate ) {
-							order = 0;
-							widget.removeAttribute( 'open' );
-							widget.remove();
-							saveOrder( sidebarId );
-						} else {
-							widget.remove();
-						}
-					} else {
-						if ( xhr.response && xhr.response.length > 2 ) {
-							widget.querySelector( '.widget-content' ).innerHTML = xhr.response;
-
-							var title = widget.querySelector( 'input[id*="-title"]' ).value || '';
-							if ( title ) {
-								title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+				if ( del ) {
+					if ( ! widget.querySelector( 'input.widget_number' ).value ) {
+						document.getElementById( '#available-widgets' ).querySelectorAll( 'input.widget-id' ).forEach( function( widgetId ) {
+							if ( widgetId.value === id ) {
+								widgetId.closest( 'li.widget' ).style.display = 'block';
 							}
-							widget.querySelector( '.in-widget-title' ).innerHTML = title;
-
-							// Re-disable the save button.
-							widget.querySelector( '.widget-control-save' ).disabled = true;
-							widget.querySelector( '.widget-control-save' ).value = wp.i18n.__( 'Saved' );
-
-							widget.classList.remove( 'widget-dirty' );
-
-							// Trigger event so that media, text, and HTML widgets get their fields
-							document.dispatchEvent( new CustomEvent( 'widget-updated', {
-								detail: { widget: widget }
-							} ) );
-						}
-						document.querySelectorAll( '.spinner' ).forEach( function( spinner ) {
-							spinner.classList.remove( 'is-active' );
 						} );
 					}
 
-					if ( order ) {
+					if ( animate ) {
+						order = 0;
+						widget.removeAttribute( 'open' );
+						widget.remove();
 						saveOrder( sidebarId );
+					} else {
+						widget.remove();
 					}
-				}
-			};
+				} else {
+					if ( responseText && responseText.length > 2 ) {
+						widget.querySelector( '.widget-content' ).innerHTML = responseText;
 
-			// Post data to database.
-			xhr.send( data );
+						let title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+						if ( title ) {
+							title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+						}
+						widget.querySelector( '.in-widget-title' ).innerHTML = title;
+
+						widget.querySelector( '.widget-control-save' ).disabled = true;
+						widget.querySelector( '.widget-control-save' ).value = wp.i18n.__( 'Saved' );
+
+						widget.classList.remove( 'widget-dirty' );
+
+						document.dispatchEvent( new CustomEvent('widget-updated', {
+							detail: { widget: widget }
+						}));
+					}
+					document.querySelectorAll( '.spinner' ).forEach( function( spinner ) {
+						spinner.classList.remove( 'is-active' );
+					} );
+				}
+
+				if ( order ) {
+					saveOrder( sidebarId );
+				}
+			} )
+			.catch( function( error ) {
+				console.error( 'Error:', error );
+			} );
 		}
 	}
 
@@ -637,46 +642,44 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 
 	function removeInactiveWidgets() {
-		var data, xhr;
-
-		document.querySelector( '.remove-inactive-widgets' ).querySelector( '.spinner' ).classList.add( 'is-active' );
-
-		data = new URLSearchParams( {
+		var data = new URLSearchParams( {
 			action : 'delete-inactive-widgets',
 			removeinactivewidgets : document.getElementById( '_wpnonce_remove_inactive_widgets' ).value
 		} );
 
+		document.querySelector( '.remove-inactive-widgets' ).querySelector( '.spinner' ).classList.add( 'is-active' );
+
 		/*
-		 * Prepare to make call to database.
-		 *
-		 * Note that using fetch API triggers a bug in Firefox.
-		 * https://bugzilla.mozilla.org/show_bug.cgi?id=1280189
+		 * Make call to database.
 		 */
-		xhr = new XMLHttpRequest();
-		xhr.open( 'POST', ajaxurl, true );
-
-		// Send the appropriate header information along with the request
-		xhr.setRequestHeader( 'Accept', 'text/html' );
-		xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded' );
-
-		xhr.onreadystatechange = function() {
-
-			// Call a function when the state changes
-			if ( xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200 ) {
-
-				// Remove widget from screen
-				document.getElementById( 'wp_inactive_widgets' ).querySelectorAll( 'li.widget' ).forEach( function( widget ) {
-					widget.remove();
-				} );
-
-				// Hide spinner
-				document.querySelectorAll( '.spinner' ).forEach( function( spinner ) {
-					spinner.classList.remove( 'is-active' );
-				} );
+		fetch( ajaxurl, {
+			method: 'POST',
+			headers: {
+				'Accept': 'text/html',
+				'Content-Type': 'application/x-www-form-urlencoded'
+			},
+			body: data
+		} )
+		.then( function( response ) {
+			if ( response.ok ) {
+				return response.text(); // no errors
 			}
-		};
+			throw new Error( response.status );
+		} )
+		.then( function() {
+			// Remove widget from screen
+			document.getElementById( 'wp_inactive_widgets' ).querySelectorAll( 'li.widget' ).forEach( function( widget ) {
+				widget.remove();
+			} );
 
-		xhr.send( data );
+			// Hide spinner
+			document.querySelectorAll( '.spinner' ).forEach( function( spinner ) {
+				spinner.classList.remove( 'is-active' );
+			} );
+		} )
+		.catch( function( error ) {
+			console.error( 'Error:', error );
+		} );
 	}
 
 

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -227,8 +227,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		},
 		sort: false,
 		setData: ghostImage,
-		forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-		//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 		onChoose: function( e ) {
 			var multi;
 			if ( e.item.className.includes( 'widget' ) ) {
@@ -281,8 +279,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			filter: 'input, select, textarea, label, button, fieldset, legend, datalist, output, option, optgroup',
 			preventOnFilter: false, // ensures correct position of cursor in input fields
 			setData: ghostImage,
-			forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-			//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 			onStart: sortableStart,
 			onChange: sortableChange
 		} );
@@ -301,8 +297,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		filter: 'input, select, textarea, label, button, fieldset, legend, datalist, output, option, optgroup',
 		preventOnFilter: false, // ensures correct position of cursor in input fields
 		setData: ghostImage,
-		forceFallback: navigator.vendor.match(/apple/i) ? true : false, // forces fallback for webkit browsers
-		//forceFallback: 'GestureEvent' in window ? true : false, // forces fallback for Safari
 		onStart: sortableStart,
 		onChange: sortableChange,
 		onAdd: function() {


### PR DESCRIPTION
When we transitioned from using the jQuery UI `sortable` module to `SortableJS`, we included a polyfill (labeled `forceFallback`) for Safari, because that browser had a bug which meant that it did not implement HTML5 drag and drop properly.

Recent testing shows that that bug in Safari has now been fixed, and that the polyfill is now counter-productive. See https://forums.classicpress.net/t/unable-to-move-menu-items-after-migrate-from-wp/5457 and https://forums.classicpress.net/t/screen-elements-shifted-to-rh-sidebar/5479.

Removing the `forceFallback`s makes things work properly on Safari, as testing reported at the end of the first thread above confirms. That's what this PR accomplishes.