### PR TITLE
Eliminate error when using Customizer

### DIFF
--- a/src/wp-admin/js/common.js
+++ b/src/wp-admin/js/common.js
@@ -838,7 +838,7 @@ $( function() {
 			menu: $adminMenuWrap.height()
 		},
 		$headerEnd = $( '.wp-header-end' ),
-		topMenuItems = $adminmenu[0].querySelectorAll( 'li.wp-has-submenu' );
+		topMenuItems = document.body.className.includes( 'wp-admin' ) ? $adminmenu[0].querySelectorAll( 'li.wp-has-submenu' ) : [];
 
 	/**
 	 * Makes the fly-out submenu header clickable, when the menu is folded.


### PR DESCRIPTION
When using the Customizer, one of the files called is `~wp-admin/js/common.js`, which is also called in the back-end. In the Customizer, this produces the following error:

![Screenshot at 2024-10-15 11-21-28](https://github.com/user-attachments/assets/7d5874ad-0ef4-4a38-b741-59a580ce4acb)

That's because the `$adminmenu` variable is, naturally enough, accessible only in the back-end.

This PR adds a check to see whether the file `~wp-admin/js/common.js` is being called on the back-end or in the Customizer. In the latter, it now sets the JS variable, `topMenuItems`, to an empty array. (It's an array rather than a string because the code that uses it runs a `forEach` loop.) This eliminates the current error.