### PR TITLE
Update readme.html and supported version tests

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -206,19 +206,6 @@ jobs:
         if: ${{ matrix.memcached }}
         uses: niden/actions-memcached@v7
 
-      - name: Clone PHP.net for PHPUnit tests
-        if: ${{ matrix.memcached }}
-        uses: actions/checkout@v4
-        with:
-          repository: php/web-php
-          fetch-depth: 1
-          path: 'php.net'
-
-      - name: Create HTML of local supported versions
-        if: ${{ matrix.memcached }}
-        run: |
-          php -d error_reporting=E_ERROR -f php.net/supported-versions.php > supported-versions.html
-
       - name: Run PHPUnit default
         env:
           WP_DB_HOST: 127.0.0.1:3306

--- a/src/readme.html
+++ b/src/readme.html
@@ -107,7 +107,7 @@
 
 	<h3>Recommended Setup</h3>
 	<ul>
-		<li><a href="https://secure.php.net/">PHP</a> version <strong>8.0</strong> or greater.</li>
+		<li><a href="https://secure.php.net/">PHP</a> version <strong>8.3</strong> or greater.</li>
 		<li><a href="https://www.mysql.com/">MySQL</a> version <strong>5.7</strong> or greater, or <a
 				href="https://mariadb.org/">MariaDB</a> version <strong>10.4</strong> or greater.</li>
 		<li><a href="https://httpd.apache.org/">Apache</a> with <code>mod_rewrite</code> module, <a

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -210,8 +210,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	/**
 	 * Allows tests to be skipped on some automated runs.
 	 *
-	 * For test runs on GitHub Actions for something other than trunk,
-	 * we want to skip tests that only need to run for trunk.
+	 * For test runs on GitHub Actions for something other than develop,
+	 * we want to skip tests that only need to run for develop.
 	 */
 	public function skipOnAutomatedBranches() {
 		// https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
@@ -222,8 +222,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 			// We're on GitHub Actions.
 			$skipped = array( 'pull_request', 'pull_request_target' );
 
-			if ( in_array( $github_event_name, $skipped, true ) || 'refs/heads/trunk' !== $github_ref ) {
-				$this->markTestSkipped( 'For automated test runs, this test is only run on trunk' );
+			if ( in_array( $github_event_name, $skipped, true ) || 'refs/heads/develop' !== $github_ref ) {
+				$this->markTestSkipped( 'For automated test runs, this test is only run on develop' );
 			}
 		}
 	}


### PR DESCRIPTION
## Description
The readme.html file recommends PHP 8.0 or greater. Since ClassicPress 2.1.0 PHP 8.2 and 8.3 are fully supported. And since PHP no longer supports PHP 8.0 the readme file needs updating.

Further, the tests of the readme file happen on every new pull request, since these tests require accessing remote URLs this is prone to being slow and breaking.

## Motivation and context
- Update readme.html with supported and more secure recommendations for implemented PHP version.
- Reduce testing overhead and errors

## How has this been tested?
Local testing still works and passes, these tests should now be skipped on PR tests.

## Screenshots
Local run of `composer run phpunit -- --group=external-http` returns:

![Screenshot 2024-10-16 at 11 16 30](https://github.com/user-attachments/assets/1bbd201b-f74f-411a-b954-3ce8c3b1dc2a)


## Types of changes
- Enhancement
