### PR TITLE
Fix for PHP error for password reset cookie

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2221,7 +2221,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		/* translators: %s: User login. */
 		$message  = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user->user_login ), 'login' ) . "\r\n\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . str_replace( '.', '%2e', rawurlencode( $user_login ) ), 'login' ) . "\r\n\r\n";
 
 		$message .= wp_login_url() . "\r\n";
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2221,7 +2221,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		/* translators: %s: User login. */
 		$message  = sprintf( __( 'Username: %s' ), $user->user_login ) . "\r\n\r\n";
 		$message .= __( 'To set your password, visit the following address:' ) . "\r\n\r\n";
-		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . str_replace( '.', '%2e', rawurlencode( $user_login ) ), 'login' ) . "\r\n\r\n";
+		$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . str_replace( '.', '%2e', rawurlencode( $user->user_login ) ), 'login' ) . "\r\n\r\n";
 
 		$message .= wp_login_url() . "\r\n";
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -866,6 +866,14 @@ switch ( $action ) {
 		list( $rp_path ) = explode( '?', wp_unslash( $_SERVER['REQUEST_URI'] ) );
 		$rp_cookie       = 'wp-resetpass-' . COOKIEHASH;
 
+		$referer = wp_get_referer();
+
+		if ( $referer ) {
+			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );
+		} else {
+			$secure = false;
+		}
+
 		$cookie_options = array(
 			'expires' => 0,
 			'path' => $rp_path,


### PR DESCRIPTION
## Description
This fixes a PHP error encountered when resetting passwords, something like this:
`Undefined variable $secure in /var/www/vhosts/URL/httpdocs/wp-login.php on line 873`

## Motivation and context
Cookie should be correctly set and errors avoided.

## How has this been tested?
Local testing

## Screenshots
N/A

## Types of changes
- Bug fix
