### PR TITLE
Update Requests to 2.0.9

### DIFF
--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,11 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-<<<<<<< HEAD
-	const VERSION = '2.0.5';
-=======
 	const VERSION = '2.0.9';
->>>>>>> 2130a90861 (External Libraries: Update Requests to `2.0.9`.)
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,11 @@ class Requests {
 	 *
 	 * @var string
 	 */
+<<<<<<< HEAD
 	const VERSION = '2.0.5';
+=======
+	const VERSION = '2.0.9';
+>>>>>>> 2130a90861 (External Libraries: Update Requests to `2.0.9`.)
 
 	/**
 	 * Selected transport name


### PR DESCRIPTION
## Description
Fix a bug that affects server on cURL 2.79 that blocks the ability to update core, plugins and themes for users

## How has this been tested?
Tested on a server with cURL 2.79

## Types of changes
- Bug Fix