### PR TITLE
Enable background images for non-image files in AJAX call in new Media Library grid display

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,6 +133,7 @@ if ( 'grid' === $mode ) {
 			'delete_failed'    => __( 'Failed to delete attachment.' ),
 			'confirm_delete'   => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
 			'confirm_multiple' => __( "You are about to permanently delete these items from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
+			'includes_url'     => includes_url(),
 		)
 	);
 


### PR DESCRIPTION
When the new Media Library grid is displayed, background images are supplied for non-image files:

![Screenshot at 2024-10-19 07-45-45](https://github.com/user-attachments/assets/b035b8f8-c0d7-4924-abca-f7bc7105b375)

But when a faceted search is made using one of the dropdown select filters or the search box, no such backgrounds are seen:

![Screenshot at 2024-10-19 07-48-07](https://github.com/user-attachments/assets/075dc7cf-32a9-4d71-873e-543711a97928)

This PR remedies that:

![Screenshot at 2024-10-19 07-49-45](https://github.com/user-attachments/assets/cfbf79fe-e91f-4d58-9c3a-6e3afe776e5f)
