### PR TITLE
Ajax pagination in the new Media Library grid view

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2979,6 +2979,7 @@ function wp_ajax_query_attachments() {
 		'post__not_in',
 		'year',
 		'monthnum',
+		'paged',
 	);
 
 	foreach ( get_taxonomies_for_attachments( 'objects' ) as $t ) {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3052,7 +3052,7 @@ function wp_ajax_query_attachments() {
 		'success' => true,
 	);
 
-	wp_send_json( $response, 200 );
+	wp_send_json( $response );
 }
 
 /**

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3046,8 +3046,8 @@ function wp_ajax_query_attachments() {
 	$response = array(
 		'data'    => $posts,
 		'headers' => array(
-			'total_posts' => $total_posts,
-			'max_pages'   => $max_pages,
+			'total_posts' => (int) $total_posts,
+			'max_pages'   => (int) $max_pages,
 		),
 		'success' => true,
 	);

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -2979,7 +2979,6 @@ function wp_ajax_query_attachments() {
 		'post__not_in',
 		'year',
 		'monthnum',
-		'paged',
 	);
 
 	foreach ( get_taxonomies_for_attachments( 'objects' ) as $t ) {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3043,7 +3043,16 @@ function wp_ajax_query_attachments() {
 	header( 'X-WP-Total: ' . (int) $total_posts );
 	header( 'X-WP-TotalPages: ' . (int) $max_pages );
 
-	wp_send_json_success( $posts );
+	$response = array(
+		'data'    => $posts,
+		'headers' => array(
+			'total_posts' => $total_posts,
+			'max_pages'   => $max_pages,
+		),
+		'success' => true,
+	);
+
+	wp_send_json( $response, 200 );
 }
 
 /**

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,6 +133,7 @@ if ( 'grid' === $mode ) {
 			'delete_failed'    => __( 'Failed to delete attachment.' ),
 			'confirm_delete'   => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
 			'confirm_multiple' => __( "You are about to permanently delete these items from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
+			'items'            => __( 'items' ),
 		)
 	);
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,7 +133,7 @@ if ( 'grid' === $mode ) {
 			'delete_failed'    => __( 'Failed to delete attachment.' ),
 			'confirm_delete'   => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
 			'confirm_multiple' => __( "You are about to permanently delete these items from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
-			'items'            => __( 'items' ),
+	
 		)
 	);
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,7 +133,7 @@ if ( 'grid' === $mode ) {
 			'delete_failed'    => __( 'Failed to delete attachment.' ),
 			'confirm_delete'   => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
 			'confirm_multiple' => __( "You are about to permanently delete these items from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
-	
+			'includes_url'     => includes_url(),
 		)
 	);
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,7 +133,6 @@ if ( 'grid' === $mode ) {
 			'delete_failed'    => __( 'Failed to delete attachment.' ),
 			'confirm_delete'   => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
 			'confirm_multiple' => __( "You are about to permanently delete these items from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
-			'includes_url'     => includes_url(),
 		)
 	);
 

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -452,9 +452,24 @@ document.addEventListener( 'DOMContentLoaded', function() {
 							pageLink.setAttribute( 'disabled', true );
 							pageLink.setAttribute( 'inert', true );
 						} else if ( pageLink.className.includes( 'next-page' ) ) {
-							pageLink.href = result.headers.max_pages == 1 ? pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 1 ) : pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 2 );
+							if ( result.headers.max_pages === 1 ) {
+								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 1 );
+								pageLink.setAttribute( 'disabled', true );
+								pageLink.setAttribute( 'inert', true );
+							} else {
+								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 2 );
+								pageLink.removeAttribute( 'disabled'  );
+								pageLink.removeAttribute( 'inert'  );
+							}
 						} else if ( pageLink.className.includes( 'last-page' ) ) {
 							pageLink.href = pageLink.href.replace( pageLink.href.split( '?paged=' )[1], result.headers.max_pages );
+							if ( result.headers.max_pages === 1 ) {
+								pageLink.setAttribute( 'disabled', true );
+								pageLink.setAttribute( 'inert', true );
+							} else {
+								pageLink.removeAttribute( 'disabled'  );
+								pageLink.removeAttribute( 'inert'  );
+							}
 						}
 						document.getElementById( 'current-page-selector' ).value = 1;
 						document.querySelector( '.total-pages' ).textContent = result.headers.max_pages;

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -453,11 +453,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 							pageLink.setAttribute( 'inert', true );
 						} else if ( pageLink.className.includes( 'next-page' ) ) {
 							if ( result.headers.max_pages === 1 ) {
-								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 1 );
+								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], '1' );
 								pageLink.setAttribute( 'disabled', true );
 								pageLink.setAttribute( 'inert', true );
 							} else {
-								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 2 );
+								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], '2' );
 								pageLink.removeAttribute( 'disabled'  );
 								pageLink.removeAttribute( 'inert'  );
 							}

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -446,6 +446,24 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						mediaGrid.appendChild( gridItem );
 					} );
 
+					// Reset pagination
+					document.querySelectorAll( '.pagination-links a' ).forEach( function( pageLink ) {
+						if ( pageLink.className.includes( 'first-page' ) || pageLink.className.includes( 'prev-page' ) ) {
+							pageLink.setAttribute( 'disabled', true );
+							pageLink.setAttribute( 'inert', true );
+						} else if ( pageLink.className.includes( 'next-page' ) ) {
+							pageLink.href = result.headers.max_pages == 1 ? pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 1 ) : pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 2 );
+						} else if ( pageLink.className.includes( 'last-page' ) ) {
+							pageLink.href = pageLink.href.replace( pageLink.href.split( '?paged=' )[1], result.headers.max_pages );
+						}
+						document.getElementById( 'current-page-selector' ).value = 1;
+						document.querySelector( '.total-pages' ).textContent = result.headers.max_pages;
+						document.querySelector( '.displaying-num' ).textContent = result.headers.total_posts + ' ' + _wpMediaGridSettings.items;
+
+						queryParams.set( 'paged', 1 );
+						history.replaceState( null, null, '?' + queryParams.toString() );
+					} );
+
 					// Open modal to show details about file, or select files for deletion
 					document.querySelectorAll( '.media-item' ).forEach( function( item ) {
 						item.addEventListener( 'click', function() {
@@ -460,7 +478,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					// Update the count at the bottom of the page
 					document.querySelector( '.no-media' ).setAttribute( 'hidden', true );
 					document.querySelector( '.load-more-count' ).removeAttribute( 'hidden' );
-					document.querySelector( '.load-more-count' ).textContent = count.replace( /[0-9]+/g, result.data.length );
+					document.querySelector( '.load-more-count' ).textContent = count.replace( /[0-9]+/g, result.headers.total_posts ).replace( /[0-9]+/, result.data.length );
 				}
 			} else {
 				console.error( _wpMediaGridSettings.failed_update, result.data.message );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -434,9 +434,23 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					// Clear existing grid
 					mediaGrid.innerHTML = '';
 
+					// Reset pagination
+					document.querySelectorAll( '.pagination-links a' ).forEach( function( pageLink ) {
+						pageLink.setAttribute( 'href', pageLink.href.replace( pageLink.href.split( '?paged=' )[1], 1 ) );
+						pageLink.setAttribute( 'disabled', true );
+						pageLink.setAttribute( 'inert', true );
+					} );
+
+					document.getElementById( 'current-page-selector' ).setAttribute( 'value', 1 );
+					document.querySelector( '.total-pages' ).textContent = 1;
+					document.querySelector( '.displaying-num' ).textContent = document.querySelector( '.displaying-num' ).textContent.replace( /[0-9]+/, 0 );
+
 					// Update the count at the bottom of the page
 					document.querySelector( '.load-more-count' ).setAttribute( 'hidden', true );
 					document.querySelector( '.no-media' ).removeAttribute( 'hidden' );
+					
+					queryParams.set( 'paged', paged );
+					history.replaceState( null, null, '?' + queryParams.toString() );
 				} else {
 
 					// Clear existing grid
@@ -504,10 +518,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					document.querySelector( '.no-media' ).setAttribute( 'hidden', true );
 					document.querySelector( '.load-more-count' ).removeAttribute( 'hidden' );
 					document.querySelector( '.load-more-count' ).textContent = count.replace( /[0-9]+/g, result.headers.total_posts ).replace( /[0-9]+/, result.data.length );
-
-					// Reset paged variable
-					paged = '1';
 				}
+
+				// Reset paged variable
+				paged = '1';
 			} else {
 				console.error( _wpMediaGridSettings.failed_update, result.data.message );
 			}

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -458,21 +458,21 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								pageLink.removeAttribute( 'disabled'  );
 								pageLink.removeAttribute( 'inert'  );
 								if ( pageLink.className.includes( 'prev-page' ) ) {
-									pageLink.href.replace( pageLink.href.split( '?paged=' )[1], parseInt( paged - 1 ) );
+									pageLink.setAttribute( 'href', pageLink.href.replace( pageLink.href.split( '?paged=' )[1], parseInt( paged ) - 1 ) );
 								}
 							}
 						} else if ( pageLink.className.includes( 'next-page' ) ) {
 							if ( result.headers.max_pages === parseInt( paged ) ) {
-								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], paged );
+								pageLink.setAttribute( 'href', pageLink.href.replace( pageLink.href.split( '?paged=' )[1], paged ) );
 								pageLink.setAttribute( 'disabled', true );
 								pageLink.setAttribute( 'inert', true );								
 							} else {
-								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], parseInt( paged + 1 ) );
+								pageLink.setAttribute( 'href', pageLink.href.replace( pageLink.href.split( '?paged=' )[1], parseInt( paged ) + 1 ) );
 								pageLink.removeAttribute( 'disabled'  );
 								pageLink.removeAttribute( 'inert'  );
 							}
 						} else if ( pageLink.className.includes( 'last-page' ) ) {
-							pageLink.href = pageLink.href.replace( pageLink.href.split( '?paged=' )[1], result.headers.max_pages );
+							pageLink.setAttribute( 'href', pageLink.href.replace( pageLink.href.split( '?paged=' )[1], result.headers.max_pages ) );
 							if ( result.headers.max_pages === parseInt( paged ) ) {
 								pageLink.setAttribute( 'disabled', true );
 								pageLink.setAttribute( 'inert', true );
@@ -481,7 +481,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								pageLink.removeAttribute( 'inert'  );
 							}
 						}
-						document.getElementById( 'current-page-selector' ).value = paged ? paged : 1;
+						document.getElementById( 'current-page-selector' ).setAttribute( 'value', paged ? paged : 1 );
 						document.querySelector( '.total-pages' ).textContent = result.headers.max_pages;
 						document.querySelector( '.displaying-num' ).textContent = document.querySelector( '.displaying-num' ).textContent.replace( /[0-9]+/, result.headers.total_posts );
 

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -493,7 +493,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								pageLink.removeAttribute( 'inert'  );
 							}
 						}
+
+						// Update both HTML and DOM
 						document.getElementById( 'current-page-selector' ).setAttribute( 'value', paged ? paged : 1 );
+						document.getElementById( 'current-page-selector' ).value = paged ? paged : 1;
 						document.querySelector( '.total-pages' ).textContent = result.headers.max_pages;
 						document.querySelector( '.displaying-num' ).textContent = document.querySelector( '.displaying-num' ).textContent.replace( /[0-9]+/, result.headers.total_posts );
 
@@ -659,6 +662,12 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	mediaCatSelect.addEventListener( 'change', updateGrid );
 	search.addEventListener( 'input', function() {
 		var searchtimer;
+		clearTimeout( searchtimer );
+		searchtimer = setTimeout( updateGrid, 200 );
+	} );
+	document.getElementById( 'current-page-selector' ).addEventListener( 'change', function( e ) {
+		var searchtimer;
+		paged = e.target.value;
 		clearTimeout( searchtimer );
 		searchtimer = setTimeout( updateGrid, 200 );
 	} );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -462,7 +462,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								}
 							}
 						} else if ( pageLink.className.includes( 'next-page' ) ) {
-							if ( result.headers.max_pages == paged ) { // == because integer compared to string
+							if ( result.headers.max_pages === parseInt( paged ) ) {
 								pageLink.href.replace( pageLink.href.split( '?paged=' )[1], paged );
 								pageLink.setAttribute( 'disabled', true );
 								pageLink.setAttribute( 'inert', true );								
@@ -473,7 +473,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 							}
 						} else if ( pageLink.className.includes( 'last-page' ) ) {
 							pageLink.href = pageLink.href.replace( pageLink.href.split( '?paged=' )[1], result.headers.max_pages );
-							if ( result.headers.max_pages == paged ) { // == because integer compared to string
+							if ( result.headers.max_pages === parseInt( paged ) ) {
 								pageLink.setAttribute( 'disabled', true );
 								pageLink.setAttribute( 'inert', true );
 							} else {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -429,10 +429,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} )
 		.then( function( result ) {
 			if ( result.success ) {
-				if ( result.data.length === 0 ) {
 
-					// Clear existing grid
-					mediaGrid.innerHTML = '';
+				// Clear existing grid
+				mediaGrid.innerHTML = '';
+
+				if ( result.data.length === 0 ) {
 
 					// Reset pagination
 					document.querySelectorAll( '.pagination-links a' ).forEach( function( pageLink ) {
@@ -449,12 +450,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					document.querySelector( '.load-more-count' ).setAttribute( 'hidden', true );
 					document.querySelector( '.no-media' ).removeAttribute( 'hidden' );
 					
-					queryParams.set( 'paged', paged );
+					queryParams.set( 'paged', 1 );
 					history.replaceState( null, null, '?' + queryParams.toString() );
 				} else {
-
-					// Clear existing grid
-					mediaGrid.innerHTML = '';
 
 					// Populate grid with new items
 					result.data.forEach( function( attachment ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -458,7 +458,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						}
 						document.getElementById( 'current-page-selector' ).value = 1;
 						document.querySelector( '.total-pages' ).textContent = result.headers.max_pages;
-						document.querySelector( '.displaying-num' ).textContent = result.headers.total_posts + ' ' + _wpMediaGridSettings.items;
+						document.querySelector( '.displaying-num' ).textContent = document.querySelector( '.displaying-num' ).textContent.replace( /[0-9]+/, result.headers.total_posts );
 
 						queryParams.set( 'paged', 1 );
 						history.replaceState( null, null, '?' + queryParams.toString() );


### PR DESCRIPTION
In the Media Library grid view, as merged into the ClassicPress nightly version, it's possible to select specific attributes of the media from three dropdowns  (according to file type, month, and media category), as well as by searching, in order to generate a grid of matching media via AJAX. 

Independently, it's also possible to use the pagination feature. But this causes a page reload, which causes the parameters to be lost and so always calls ALL the media.

This may be problematic on sites that have a large number of media files that match a given type, month, or media category. If that number exceeds the number of items per page selected in the Screen Options, there is no way to see the media files above that number without resorting to pagination, which then shows all the media items.

This PR makes pagination work properly (via AJAX) when a type, date, or media category (or combination thereof) has been selected. So someone looking for (say) item 200 within a file type, month, or media category (or combination thereof) on a site using the default setting of 80 items per page can now select page 3 to find it.