### PR TITLE
Change to non-resolving URL for tests

### DIFF
--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -549,7 +549,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url' => 'http://[exam]ple.com/caniload.php',
 			),
 			'a host whose IPv4 address cannot be resolved' => array(
-				'url' => 'http://exampleeeeee.com/caniload.php',
+				'url' => 'http://example.invalid/caniload.php',
 			),
 			'an external request when not allowed'         => array(
 				'url'           => 'http://192.168.0.1/caniload.php',

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -549,7 +549,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url' => 'http://[exam]ple.com/caniload.php',
 			),
 			'a host whose IPv4 address cannot be resolved' => array(
-				'url' => 'http://exampleeeee.com/caniload.php',
+				'url' => 'http://exampleeeeee.com/caniload.php',
 			),
 			'an external request when not allowed'         => array(
 				'url'           => 'http://192.168.0.1/caniload.php',


### PR DESCRIPTION
## Description
Recently failing PHPUnit tests are due to a website having registered a URL presumed not to exist for testing purposes.

Issue also reported [upstream](https://core.trac.wordpress.org/ticket/62307) to WordPress.

## Motivation and context
This fix amends the URL to one that does not resolve again and therefore restores testing functionality.

## How has this been tested?
Local testing works and GitHub Actions on this test should now pass.

## Screenshots
### Before
![Screenshot 2024-10-27 at 11 51 45](https://github.com/user-attachments/assets/e249822a-f3e5-47d2-8be8-a6562156cb00)

### After
![Screenshot 2024-10-27 at 11 52 09](https://github.com/user-attachments/assets/0122ea97-5b14-4f68-b907-2602f19301c5)

## Types of changes
- Bug fix