### PR TITLE
Remove experimental PHP 8.4 test

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -68,10 +68,6 @@ jobs:
             mysql: '8.0'
             memcached: true
             experimental: false
-          - php: '8.4'
-            mysql: '8.0'
-            memcached: false
-            experimental: true
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -549,7 +549,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url' => 'http://[exam]ple.com/caniload.php',
 			),
 			'a host whose IPv4 address cannot be resolved' => array(
-				'url' => 'http://exampleeeee.com/caniload.php',
+				'url' => 'http://example.invalid/caniload.php',
 			),
 			'an external request when not allowed'         => array(
 				'url'           => 'http://192.168.0.1/caniload.php',


### PR DESCRIPTION
## Description
PHP 8.4 tests are running as standard, the definition to run the additional test as `experimental` can now be removed.

## Motivation and context
Experimental tests no longer needed and this also reduced the number of tests GitHub runs.

## How has this been tested?
GitHub actions will run.

## Screenshots
N/A

## Types of changes
- Bug fix
