### PR TITLE
Update the Requests library to version 2.0.11

### DIFF
--- a/src/wp-includes/Requests/src/Autoload.php
+++ b/src/wp-includes/Requests/src/Autoload.php
@@ -166,7 +166,7 @@ if (class_exists('WpOrg\Requests\Autoload') === false) {
 				if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS') || REQUESTS_SILENCE_PSR0_DEPRECATIONS !== true) {
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 					trigger_error(
-						'The PSR-0 `Requests_...` class names in the Request library are deprecated.'
+						'The PSR-0 `Requests_...` class names in the Requests library are deprecated.'
 						. ' Switch to the PSR-4 `WpOrg\Requests\...` class names at your earliest convenience.',
 						E_USER_DEPRECATED
 					);

--- a/src/wp-includes/Requests/src/Capability.php
+++ b/src/wp-includes/Requests/src/Capability.php
@@ -28,7 +28,7 @@ interface Capability {
 	 *
 	 * Note: this does not automatically mean that the capability will be supported for your chosen transport!
 	 *
-	 * @var array<string>
+	 * @var string[]
 	 */
 	const ALL = [
 		self::SSL,

--- a/src/wp-includes/Requests/src/Cookie.php
+++ b/src/wp-includes/Requests/src/Cookie.php
@@ -36,8 +36,8 @@ class Cookie {
 	/**
 	 * Cookie attributes
 	 *
-	 * Valid keys are (currently) path, domain, expires, max-age, secure and
-	 * httponly.
+	 * Valid keys are `'path'`, `'domain'`, `'expires'`, `'max-age'`, `'secure'` and
+	 * `'httponly'`.
 	 *
 	 * @var \WpOrg\Requests\Utility\CaseInsensitiveDictionary|array Array-like object
 	 */
@@ -46,8 +46,7 @@ class Cookie {
 	/**
 	 * Cookie flags
 	 *
-	 * Valid keys are (currently) creation, last-access, persistent and
-	 * host-only.
+	 * Valid keys are `'creation'`, `'last-access'`, `'persistent'` and `'host-only'`.
 	 *
 	 * @var array
 	 */
@@ -66,11 +65,13 @@ class Cookie {
 	/**
 	 * Create a new cookie object
 	 *
-	 * @param string $name
-	 * @param string $value
+	 * @param string                                                  $name           The name of the cookie.
+	 * @param string                                                  $value          The value for the cookie.
 	 * @param array|\WpOrg\Requests\Utility\CaseInsensitiveDictionary $attributes Associative array of attribute data
-	 * @param array $flags
-	 * @param int|null $reference_time
+	 * @param array                                                   $flags          The flags for the cookie.
+	 *                                                                                Valid keys are `'creation'`, `'last-access'`,
+	 *                                                                                `'persistent'` and `'host-only'`.
+	 * @param int|null                                                $reference_time Reference time for relative calculations.
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $name argument is not a string.
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $value argument is not a string.
@@ -279,7 +280,11 @@ class Cookie {
 	public function normalize() {
 		foreach ($this->attributes as $key => $value) {
 			$orig_value = $value;
-			$value      = $this->normalize_attribute($key, $value);
+
+			if (is_string($key)) {
+				$value = $this->normalize_attribute($key, $value);
+			}
+
 			if ($value === null) {
 				unset($this->attributes[$key]);
 				continue;
@@ -299,7 +304,7 @@ class Cookie {
 	 * Handles parsing individual attributes from the cookie values.
 	 *
 	 * @param string $name Attribute name
-	 * @param string|boolean $value Attribute value (string value, or true if empty/flag)
+	 * @param string|int|bool $value Attribute value (string/integer value, or true if empty/flag)
 	 * @return mixed Value if available, or null if the attribute value is invalid (and should be skipped)
 	 */
 	protected function normalize_attribute($name, $value) {

--- a/src/wp-includes/Requests/src/Cookie.php
+++ b/src/wp-includes/Requests/src/Cookie.php
@@ -470,11 +470,17 @@ class Cookie {
 	 * @param \WpOrg\Requests\Iri|null $origin URI for comparing cookie origins
 	 * @param int|null $time Reference time for expiration calculation
 	 * @return array
+	 *
+	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $origin argument is not null or an instance of the Iri class.
 	 */
-	public static function parse_from_headers(Headers $headers, Iri $origin = null, $time = null) {
+	public static function parse_from_headers(Headers $headers, $origin = null, $time = null) {
 		$cookie_headers = $headers->getValues('Set-Cookie');
 		if (empty($cookie_headers)) {
 			return [];
+		}
+
+		if ($origin !== null && !($origin instanceof Iri)) {
+			throw InvalidArgument::create(2, '$origin', Iri::class . ' or null', gettype($origin));
 		}
 
 		$cookies = [];

--- a/src/wp-includes/Requests/src/Cookie/Jar.php
+++ b/src/wp-includes/Requests/src/Cookie/Jar.php
@@ -49,7 +49,8 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Normalise cookie data into a \WpOrg\Requests\Cookie
 	 *
-	 * @param string|\WpOrg\Requests\Cookie $cookie
+	 * @param string|\WpOrg\Requests\Cookie $cookie Cookie header value, possibly pre-parsed (object).
+	 * @param string                        $key    Optional. The name for this cookie.
 	 * @return \WpOrg\Requests\Cookie
 	 */
 	public function normalize_cookie($cookie, $key = '') {
@@ -106,7 +107,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $offset
+	 * @param string $offset The key for the item to unset.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset($offset) {
@@ -171,7 +172,7 @@ class Jar implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Parse all cookies from a response and attach them to the response
 	 *
-	 * @param \WpOrg\Requests\Response $response
+	 * @param \WpOrg\Requests\Response $response Response as received.
 	 */
 	public function before_redirect_check(Response $response) {
 		$url = $response->url;

--- a/src/wp-includes/Requests/src/IdnaEncoder.php
+++ b/src/wp-includes/Requests/src/IdnaEncoder.php
@@ -137,7 +137,7 @@ class IdnaEncoder {
 	 *
 	 * @internal (Testing found regex was the fastest implementation)
 	 *
-	 * @param string $text
+	 * @param string $text Text to examine.
 	 * @return bool Is the text string ASCII-only?
 	 */
 	protected static function is_ascii($text) {
@@ -148,7 +148,7 @@ class IdnaEncoder {
 	 * Prepare a text string for use as an IDNA name
 	 *
 	 * @todo Implement this based on RFC 3491 and the newer 5891
-	 * @param string $text
+	 * @param string $text Text to prepare.
 	 * @return string Prepared string
 	 */
 	protected static function nameprep($text) {
@@ -160,7 +160,7 @@ class IdnaEncoder {
 	 *
 	 * Based on \WpOrg\Requests\Iri::replace_invalid_with_pct_encoding()
 	 *
-	 * @param string $input
+	 * @param string $input Text to convert.
 	 * @return array Unicode code points
 	 *
 	 * @throws \WpOrg\Requests\Exception Invalid UTF-8 codepoint (`idna.invalidcodepoint`)
@@ -329,10 +329,10 @@ class IdnaEncoder {
 						}
 
 						// output the code point for digit t + ((q - t) mod (base - t))
-						$digit   = $t + (($q - $t) % (self::BOOTSTRAP_BASE - $t));
+						$digit   = (int) ($t + (($q - $t) % (self::BOOTSTRAP_BASE - $t)));
 						$output .= self::digit_to_char($digit);
 						// let q = (q - t) div (base - t)
-						$q = floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
+						$q = (int) floor(($q - $t) / (self::BOOTSTRAP_BASE - $t));
 					} // end
 					// output the code point for digit q
 					$output .= self::digit_to_char($q);
@@ -381,7 +381,7 @@ class IdnaEncoder {
 	 * @param int $delta
 	 * @param int $numpoints
 	 * @param bool $firsttime
-	 * @return int New bias
+	 * @return int|float New bias
 	 *
 	 * function adapt(delta,numpoints,firsttime):
 	 */

--- a/src/wp-includes/Requests/src/Iri.php
+++ b/src/wp-includes/Requests/src/Iri.php
@@ -395,11 +395,11 @@ class Iri {
 			// preceding "/" (if any) from the output buffer; otherwise,
 			elseif (strpos($input, '/../') === 0) {
 				$input = substr($input, 3);
-				$output = substr_replace($output, '', strrpos($output, '/'));
+				$output = substr_replace($output, '', (strrpos($output, '/') ?: 0));
 			}
 			elseif ($input === '/..') {
 				$input = '/';
-				$output = substr_replace($output, '', strrpos($output, '/'));
+				$output = substr_replace($output, '', (strrpos($output, '/') ?: 0));
 			}
 			// D: if the input buffer consists only of "." or "..", then remove
 			// that from the input buffer; otherwise,
@@ -838,7 +838,8 @@ class Iri {
 		else {
 			$iuserinfo = null;
 		}
-		if (($port_start = strpos($remaining, ':', strpos($remaining, ']'))) !== false) {
+
+		if (($port_start = strpos($remaining, ':', (strpos($remaining, ']') ?: 0))) !== false) {
 			$port = substr($remaining, $port_start + 1);
 			if ($port === false || $port === '') {
 				$port = null;

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.9';
+	const VERSION = '2.0.11';
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.5';
+	const VERSION = '2.0.6';
 
 	/**
 	 * Selected transport name
@@ -642,12 +642,14 @@ class Requests {
 	/**
 	 * Set the default values
 	 *
+	 * The $options parameter is updated with the results.
+	 *
 	 * @param string $url URL to request
 	 * @param array $headers Extra headers to send with the request
 	 * @param array|null $data Data to send either as a query string for GET/HEAD requests, or in the body for POST requests
 	 * @param string $type HTTP request type
 	 * @param array $options Options for the request
-	 * @return void $options is updated with the results
+	 * @return void
 	 *
 	 * @throws \WpOrg\Requests\Exception When the $url is not an http(s) URL.
 	 */
@@ -824,9 +826,11 @@ class Requests {
 	 * Internal use only. Converts a raw HTTP response to a \WpOrg\Requests\Response
 	 * while still executing a multiple request.
 	 *
+	 * `$response` is either set to a \WpOrg\Requests\Response instance, or a \WpOrg\Requests\Exception object
+	 *
 	 * @param string $response Full response text including headers and body (will be overwritten with Response instance)
 	 * @param array $request Request data as passed into {@see \WpOrg\Requests\Requests::request_multiple()}
-	 * @return void `$response` is either set to a \WpOrg\Requests\Response instance, or a \WpOrg\Requests\Exception object
+	 * @return void
 	 */
 	public static function parse_multiple(&$response, $request) {
 		try {

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.6';
+	const VERSION = '2.0.8';
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Requests.php
+++ b/src/wp-includes/Requests/src/Requests.php
@@ -148,7 +148,7 @@ class Requests {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.0.8';
+	const VERSION = '2.0.9';
 
 	/**
 	 * Selected transport name

--- a/src/wp-includes/Requests/src/Response.php
+++ b/src/wp-includes/Requests/src/Response.php
@@ -137,16 +137,16 @@ class Response {
 	 *
 	 * @link https://php.net/json-decode
 	 *
-	 * @param ?bool $associative Optional. When `true`, JSON objects will be returned as associative arrays;
-	 *                           When `false`, JSON objects will be returned as objects.
-	 *                           When `null`, JSON objects will be returned as associative arrays
-	 *                           or objects depending on whether `JSON_OBJECT_AS_ARRAY` is set in the flags.
-	 *                           Defaults to `true` (in contrast to the PHP native default of `null`).
-	 * @param int   $depth       Optional. Maximum nesting depth of the structure being decoded.
-	 *                           Defaults to `512`.
-	 * @param int   $options     Optional. Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
-	 *                           JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR.
-	 *                           Defaults to `0` (no options set).
+	 * @param bool|null $associative Optional. When `true`, JSON objects will be returned as associative arrays;
+	 *                               When `false`, JSON objects will be returned as objects.
+	 *                               When `null`, JSON objects will be returned as associative arrays
+	 *                               or objects depending on whether `JSON_OBJECT_AS_ARRAY` is set in the flags.
+	 *                               Defaults to `true` (in contrast to the PHP native default of `null`).
+	 * @param int       $depth       Optional. Maximum nesting depth of the structure being decoded.
+	 *                               Defaults to `512`.
+	 * @param int       $options     Optional. Bitmask of JSON_BIGINT_AS_STRING, JSON_INVALID_UTF8_IGNORE,
+	 *                               JSON_INVALID_UTF8_SUBSTITUTE, JSON_OBJECT_AS_ARRAY, JSON_THROW_ON_ERROR.
+	 *                               Defaults to `0` (no options set).
 	 *
 	 * @return array
 	 *

--- a/src/wp-includes/Requests/src/Response/Headers.php
+++ b/src/wp-includes/Requests/src/Response/Headers.php
@@ -27,7 +27,7 @@ class Headers extends CaseInsensitiveDictionary {
 	 * Avoid using this where commas may be used unquoted in values, such as
 	 * Set-Cookie headers.
 	 *
-	 * @param string $offset
+	 * @param string $offset Name of the header to retrieve.
 	 * @return string|null Header value
 	 */
 	public function offsetGet($offset) {
@@ -69,7 +69,7 @@ class Headers extends CaseInsensitiveDictionary {
 	/**
 	 * Get all values for a given header
 	 *
-	 * @param string $offset
+	 * @param string $offset Name of the header to retrieve.
 	 * @return array|null Header values
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed argument is not valid as an array key.
@@ -79,7 +79,10 @@ class Headers extends CaseInsensitiveDictionary {
 			throw InvalidArgument::create(1, '$offset', 'string|int', gettype($offset));
 		}
 
-		$offset = strtolower($offset);
+		if (is_string($offset)) {
+			$offset = strtolower($offset);
+		}
+
 		if (!isset($this->data[$offset])) {
 			return null;
 		}

--- a/src/wp-includes/Requests/src/Transport/Curl.php
+++ b/src/wp-includes/Requests/src/Transport/Curl.php
@@ -25,6 +25,7 @@ use WpOrg\Requests\Utility\InputValidator;
 final class Curl implements Transport {
 	const CURL_7_10_5 = 0x070A05;
 	const CURL_7_16_2 = 0x071002;
+	const CURL_7_22_0 = 0x071600;
 
 	/**
 	 * Raw HTTP data
@@ -363,7 +364,7 @@ final class Curl implements Transport {
 		$options['hooks']->dispatch('curl.before_request', [&$this->handle]);
 
 		// Force closing the connection for old versions of cURL (<7.22).
-		if (!isset($headers['Connection'])) {
+		if ($this->version < self::CURL_7_22_0 && !isset($headers['Connection'])) {
 			$headers['Connection'] = 'close';
 		}
 

--- a/src/wp-includes/Requests/src/Transport/Curl.php
+++ b/src/wp-includes/Requests/src/Transport/Curl.php
@@ -465,7 +465,7 @@ final class Curl implements Transport {
 	 * @param string $response Response data from the body
 	 * @param array $options Request options
 	 * @return string|false HTTP response data including headers. False if non-blocking.
-	 * @throws \WpOrg\Requests\Exception
+	 * @throws \WpOrg\Requests\Exception If the request resulted in a cURL error.
 	 */
 	public function process_response($response, $options) {
 		if ($options['blocking'] === false) {
@@ -561,7 +561,7 @@ final class Curl implements Transport {
 	/**
 	 * Format a URL given GET data
 	 *
-	 * @param string $url
+	 * @param string       $url  Original URL.
 	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */

--- a/src/wp-includes/Requests/src/Transport/Curl.php
+++ b/src/wp-includes/Requests/src/Transport/Curl.php
@@ -25,7 +25,6 @@ use WpOrg\Requests\Utility\InputValidator;
 final class Curl implements Transport {
 	const CURL_7_10_5 = 0x070A05;
 	const CURL_7_16_2 = 0x071002;
-	const CURL_7_22_0 = 0x071600;
 
 	/**
 	 * Raw HTTP data
@@ -364,7 +363,7 @@ final class Curl implements Transport {
 		$options['hooks']->dispatch('curl.before_request', [&$this->handle]);
 
 		// Force closing the connection for old versions of cURL (<7.22).
-		if ($this->version < self::CURL_7_22_0 && !isset($headers['Connection'])) {
+		if (!isset($headers['Connection'])) {
 			$headers['Connection'] = 'close';
 		}
 

--- a/src/wp-includes/Requests/src/Transport/Fsockopen.php
+++ b/src/wp-includes/Requests/src/Transport/Fsockopen.php
@@ -51,6 +51,11 @@ final class Fsockopen implements Transport {
 	 */
 	private $max_bytes = false;
 
+	/**
+	 * Cache for received connection errors.
+	 *
+	 * @var string
+	 */
 	private $connect_error = '';
 
 	/**
@@ -405,7 +410,7 @@ final class Fsockopen implements Transport {
 	/**
 	 * Format a URL given GET data
 	 *
-	 * @param array $url_parts
+	 * @param array        $url_parts Array of URL parts as received from {@link https://www.php.net/parse_url}
 	 * @param array|object $data Data to build query using, see {@link https://www.php.net/http_build_query}
 	 * @return string URL with data
 	 */

--- a/src/wp-includes/Requests/src/Transport/Fsockopen.php
+++ b/src/wp-includes/Requests/src/Transport/Fsockopen.php
@@ -144,7 +144,15 @@ final class Fsockopen implements Transport {
 				$verifyname                          = false;
 			}
 
-			stream_context_set_option($context, ['ssl' => $context_options]);
+			// Handle the PHP 8.4 deprecation (PHP 9.0 removal) of the function signature we use for stream_context_set_option().
+			// Ref: https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures#stream_context_set_option
+			if (function_exists('stream_context_set_options')) {
+				// PHP 8.3+.
+				stream_context_set_options($context, ['ssl' => $context_options]);
+			} else {
+				// PHP < 8.3.
+				stream_context_set_option($context, ['ssl' => $context_options]);
+			}
 		} else {
 			$remote_socket = 'tcp://' . $host;
 		}

--- a/src/wp-includes/Requests/src/Utility/CaseInsensitiveDictionary.php
+++ b/src/wp-includes/Requests/src/Utility/CaseInsensitiveDictionary.php
@@ -95,7 +95,7 @@ class CaseInsensitiveDictionary implements ArrayAccess, IteratorAggregate {
 	/**
 	 * Unset the given header
 	 *
-	 * @param string $offset
+	 * @param string $offset The key for the item to unset.
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetUnset($offset) {

--- a/src/wp-includes/Requests/src/Utility/FilteredIterator.php
+++ b/src/wp-includes/Requests/src/Utility/FilteredIterator.php
@@ -28,7 +28,7 @@ final class FilteredIterator extends ArrayIterator {
 	/**
 	 * Create a new iterator
 	 *
-	 * @param array $data
+	 * @param array    $data     The array or object to be iterated on.
 	 * @param callable $callback Callback to be called on each value
 	 *
 	 * @throws \WpOrg\Requests\Exception\InvalidArgument When the passed $data argument is not iterable.
@@ -46,14 +46,25 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Prevent unserialization of the object for security reasons.
 	 *
 	 * @phpcs:disable PHPCompatibility.FunctionNameRestrictions.NewMagicMethods.__unserializeFound
+	 *
+	 * @param array $data Restored array of data originally serialized.
+	 *
+	 * @return void
 	 */
 	#[ReturnTypeWillChange]
 	public function __unserialize($data) {}
 	// phpcs:enable
 
+	/**
+	 * Perform reinitialization tasks.
+	 *
+	 * Prevents a callback from being injected during unserialization of an object.
+	 *
+	 * @return void
+	 */
 	public function __wakeup() {
 		unset($this->callback);
 	}
@@ -75,7 +86,11 @@ final class FilteredIterator extends ArrayIterator {
 	}
 
 	/**
-	 * @inheritdoc
+	 * Prevent creating a PHP value from a stored representation of the object for security reasons.
+	 *
+	 * @param string $data The serialized string.
+	 *
+	 * @return void
 	 */
 	#[ReturnTypeWillChange]
 	public function unserialize($data) {}

--- a/src/wp-includes/class-requests.php
+++ b/src/wp-includes/class-requests.php
@@ -17,7 +17,7 @@
 if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS') || REQUESTS_SILENCE_PSR0_DEPRECATIONS !== true) {
 	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 	trigger_error(
-		'The PSR-0 `Requests_...` class names in the Request library are deprecated.'
+		'The PSR-0 `Requests_...` class names in the Requests library are deprecated.'
 		. ' Switch to the PSR-4 `WpOrg\Requests\...` class names at your earliest convenience.',
 		E_USER_DEPRECATED
 	);

--- a/tests/phpunit/tests/http/includeOldRequestsClass.php
+++ b/tests/phpunit/tests/http/includeOldRequestsClass.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Tests that the old Requests class is included
+ * for plugins or themes that still use it.
+ *
+ * @group http
+ */
+class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 57341
+	 *
+	 * @coversNothing
+	 */
+	public function test_should_include_old_requests_class() {
+		$this->expectDeprecation();
+		$this->expectDeprecationMessage( 'The PSR-0 `Requests_...` class names in the Request library are deprecated.' );
+
+		new Requests();
+	}
+}

--- a/tests/phpunit/tests/http/includeOldRequestsClass.php
+++ b/tests/phpunit/tests/http/includeOldRequestsClass.php
@@ -15,7 +15,7 @@ class Tests_HTTP_IncludeOldRequestsClass extends WP_UnitTestCase {
 	 */
 	public function test_should_include_old_requests_class() {
 		$this->expectDeprecation();
-		$this->expectDeprecationMessage( 'The PSR-0 `Requests_...` class names in the Request library are deprecated.' );
+		$this->expectDeprecationMessage( 'The PSR-0 `Requests_...` class names in the Requests library are deprecated.' );
 
 		new Requests();
 	}


### PR DESCRIPTION
## Description
This PR replaced PR #1599 

The Requests library needs updating to at least 2.0.9 to avoid the cURL errors previously noted.

This PR includes incremental updates to move Requests to 2.0.11 and should also therefore fix a deprecation notice seen in PHP 8.4 testing

## Motivation and context
Fix cURL error and PHP 8.4 notice

## How has this been tested?
Local testing and awaiting unit tests.

## Screenshots
Note below the Deprecation notice is resolved.

### Before
![Screenshot 2024-10-29 at 16 45 09](https://github.com/user-attachments/assets/847c1495-65d5-4a4a-afd4-3862775cc708)

### After
![Screenshot 2024-10-29 at 16 53 57](https://github.com/user-attachments/assets/16357fd2-6a92-4ddc-bc4d-17bb96240649)

## Types of changes
- Bug fix
