### PR TITLE
Bugs when no media files have been uploaded

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -206,6 +206,7 @@ if ( 'grid' === $mode ) {
 		'paged'          => $paged,
 	);
 	$attachments = new WP_Query( $attachment_args );
+	$author = $author_link = '';
 
 	$total_pages = (int) $attachments->max_num_pages;
 	$prev_page   = ( $paged === 1 ) ? $paged : $paged - 1;


### PR DESCRIPTION
In the new Media Library grid view, there are some errors when no media files have been uploaded:

-    PHP warnings in wp-admin/upload.php line 544: Undefined variable `$author_link` and Undefined variable `$author`.
-    JavaScript error in media-grid.min.js: `Uncaught TypeError: dateFilter is null`. (This one occurs because the relevant dropdown only shows if there are are uploaded media files.)

This PR addresses these issues by (a) setting `$author_link` and `$author` to empty strings if they are not defined elsewhere, and by checking for the presence of the `dateFilter` dropdown before adding a listener to it.