### PR TITLE
Update media-grid.css to change selector from class to ID

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -326,6 +326,7 @@
 	display: inline;
 	padding: 0;
 	color: #d63638;
+	text-decoration: none;
 }
 #dialog-close-button {
 	top: 0;

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -320,9 +320,9 @@
 	line-height: 1.5;
 	color: #646970;
 }
-.media-modal .delete-attachment,
-.media-modal .trash-attachment,
-.media-modal .untrash-attachment {
+#media-modal .delete-attachment,
+#media-modal .trash-attachment,
+#media-modal .untrash-attachment {
 	display: inline;
 	padding: 0;
 	color: #d63638;


### PR DESCRIPTION
When selecting an item in the new Media Library grid view, the delete attachment button (yes, it's a button, though it looks like a link) in the bottom right has turned blue instead of red:

![Screenshot at 2024-10-29 22-03-43](https://github.com/user-attachments/assets/7ac18417-ad78-473e-a4bd-0c410deffa70)

This is caused by another CSS selector overriding the one for this button. This PR addresses that by increasing the specificity of the selector by changing the first part from a class to an ID, so that the button is now back to being red:

![Screenshot at 2024-10-29 22-03-17](https://github.com/user-attachments/assets/f00a757a-09ae-48bd-8fc8-f996eb044a48)


