### PR TITLE
Modernise scss structure

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -1,7 +1,12 @@
 
 @use 'sass:color';
 @use 'sass:string';
-@forward 'variables' show $scheme-name, $base-color, $body-background, $highlight-color, $notification-color, $form-checked, $icon-color, $text-color, $dashboard-accent-1, $dashboard-accent-2, $dashboard-icon-background, $button-color, $menu-highlight-text, $menu-highlight-icon, $menu-highlight-background, $menu-submenu-background, $menu-submenu-focus-text, $menu-submenu-text, $menu-bubble-text, $menu-collapse-text, $menu-collapse-focus-icon, $link, $link-focus, $low-contrast-theme;
+@forward 'variables' show
+	$scheme-name, $base-color, $body-background, $highlight-color, $notification-color, $form-checked,
+	$icon-color, $text-color, $dashboard-accent-1, $dashboard-accent-2, $dashboard-icon-background,
+	$button-color, $menu-highlight-text, $menu-highlight-icon, $menu-highlight-background,
+	$menu-submenu-background, $menu-submenu-focus-text, $menu-submenu-text, $menu-bubble-text,
+	$menu-collapse-text, $menu-collapse-focus-icon, $link, $link-focus, $low-contrast-theme;
 @use 'variables';
 @use 'mixins';
 

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -1,4 +1,6 @@
 
+@use 'sass:color';
+@use 'sass:string';
 @import 'variables';
 @import 'mixins';
 
@@ -7,7 +9,7 @@
  * may use the function in their own admin CSS files. See #56811.
  */
 @function url-friendly-colour( $color ) {
-	@return '%23' + str-slice( '#{ $color }', 2, -1 );
+	@return '%23' + string.slice( '#{ $color }', 2, -1 );
 }
 
 body {

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -1,8 +1,9 @@
 
 @use 'sass:color';
 @use 'sass:string';
-@import 'variables';
-@import 'mixins';
+@forward 'variables' show $scheme-name, $base-color, $body-background, $highlight-color, $notification-color, $form-checked, $icon-color, $text-color, $dashboard-accent-1, $dashboard-accent-2, $dashboard-icon-background, $button-color, $menu-highlight-text, $menu-highlight-icon, $menu-highlight-background, $menu-submenu-background, $menu-submenu-focus-text, $menu-submenu-text, $menu-bubble-text, $menu-collapse-text, $menu-collapse-focus-icon, $link, $link-focus, $low-contrast-theme;
+@use 'variables';
+@use 'mixins';
 
 /**
  * This function name uses British English to maintain backward compatibility, as developers
@@ -13,19 +14,19 @@
 }
 
 body {
-	background: $body-background;
+	background: variables.$body-background;
 }
 
 
 /* Links */
 
 a {
-	color: $link;
+	color: variables.$link;
 
 	&:hover,
 	&:active,
 	&:focus {
-		color: $link-focus;
+		color: variables.$link-focus;
 	}
 }
 
@@ -38,12 +39,12 @@ span.wp-media-buttons-icon:before {
 }
 
 .wp-core-ui .button-link {
-	color: $link;
+	color: variables.$link;
 
 	&:hover,
 	&:active,
 	&:focus {
-		color: $link-focus;
+		color: variables.$link-focus;
 	}
 }
 
@@ -68,16 +69,16 @@ span.wp-media-buttons-icon:before {
 /* Forms */
 
 input[type=checkbox]:checked::before {
-	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($form-checked)}%27%2F%3E%3C%2Fsvg%3E");
+	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour(variables.$form-checked)}%27%2F%3E%3C%2Fsvg%3E");
 }
 
 input[type=radio]:checked::before {
-	background: $form-checked;
+	background: variables.$form-checked;
 }
 
 .wp-core-ui input[type="reset"]:hover,
 .wp-core-ui input[type="reset"]:active {
-	color: $link-focus;
+	color: variables.$link-focus;
 }
 
 input[type="text"]:focus,
@@ -99,8 +100,8 @@ input[type="checkbox"]:focus,
 input[type="radio"]:focus,
 select:focus,
 textarea:focus {
-	border-color: $highlight-color;
-	box-shadow: 0 0 0 1px $highlight-color;
+	border-color: variables.$highlight-color;
+	box-shadow: 0 0 0 1px variables.$highlight-color;
 }
 
 
@@ -137,35 +138,35 @@ textarea:focus {
 	.button.active,
 	.button.active:focus,
 	.button.active:hover {
-		border-color: $button-color;
+		border-color: variables.$button-color;
 		color: color.adjust( #32373c, $lightness: -5% );
-		box-shadow: inset 0 2px 5px -3px $button-color;
+		box-shadow: inset 0 2px 5px -3px variables.$button-color;
 	}
 
 	.button.active:focus {
 		box-shadow: 0 0 0 1px #32373c;
 	}
 
-	@if ( $low-contrast-theme != "true" ) {
+	@if ( variables.$low-contrast-theme != "true" ) {
 		.button,
 		.button-secondary {
-			color: $highlight-color;
-			border-color: $highlight-color;
+			color: variables.$highlight-color;
+			border-color: variables.$highlight-color;
 		}
 
 		.button.hover,
 		.button:hover,
 		.button-secondary:hover{
-			border-color: color.adjust($highlight-color, $lightness: -10%);
-			color: color.adjust($highlight-color, $lightness: -10%);
+			border-color: color.adjust(variables.$highlight-color, $lightness: -10%);
+			color: color.adjust(variables.$highlight-color, $lightness: -10%);
 		}
 
 		.button.focus,
 		.button:focus,
 		.button-secondary:focus {
-			border-color: color.adjust($highlight-color, $lightness: 10%);
-			color: color.adjust($highlight-color, $lightness: -20%);
-			box-shadow: 0 0 0 1px color.adjust($highlight-color, $lightness: 10%);
+			border-color: color.adjust(variables.$highlight-color, $lightness: 10%);
+			color: color.adjust(variables.$highlight-color, $lightness: -20%);
+			box-shadow: 0 0 0 1px color.adjust(variables.$highlight-color, $lightness: 10%);
 		}
 
 		.button-primary {
@@ -176,74 +177,74 @@ textarea:focus {
 	}
 
 	.button-primary {
-		@include button( $button-color );
+		@include mixins.button( variables.$button-color );
 	}
 
 	.button-group > .button.active {
-		border-color: $button-color;
+		border-color: variables.$button-color;
 	}
 
 	.wp-ui-primary {
-		color: $text-color;
-		background-color: $base-color;
+		color: variables.$text-color;
+		background-color: variables.$base-color;
 	}
 	.wp-ui-text-primary {
-		color: $base-color;
+		color: variables.$base-color;
 	}
 
 	.wp-ui-highlight {
-		color: $menu-highlight-text;
-		background-color: $menu-highlight-background;
+		color: variables.$menu-highlight-text;
+		background-color: variables.$menu-highlight-background;
 	}
 	.wp-ui-text-highlight {
-		color: $menu-highlight-background;
+		color: variables.$menu-highlight-background;
 	}
 
 	.wp-ui-notification {
-		color: $menu-bubble-text;
-		background-color: $menu-bubble-background;
+		color: variables.$menu-bubble-text;
+		background-color: variables.$menu-bubble-background;
 	}
 	.wp-ui-text-notification {
-		color: $menu-bubble-background;
+		color: variables.$menu-bubble-background;
 	}
 
 	.wp-ui-text-icon {
-		color: $menu-icon;
+		color: variables.$menu-icon;
 	}
 }
 
 
 /* List tables */
-@if $low-contrast-theme == "true" {
+@if variables.$low-contrast-theme == "true" {
 	.wrap .page-title-action:hover {
-		color: $menu-text;
-		background-color: $menu-background;
+		color: variables.$menu-text;
+		background-color: variables.$menu-background;
 	}
 } @else {
 	.wrap .page-title-action,
 	.wrap .page-title-action:active {
-		border: 1px solid $highlight-color;
-		color: $highlight-color;
+		border: 1px solid variables.$highlight-color;
+		color: variables.$highlight-color;
 	}
 
 	.wrap .page-title-action:hover {
-		color: color.adjust($highlight-color, $lightness: -10%);
-		border-color: color.adjust($highlight-color, $lightness: -10%);
+		color: color.adjust(variables.$highlight-color, $lightness: -10%);
+		border-color: color.adjust(variables.$highlight-color, $lightness: -10%);
 	}
 
 	.wrap .page-title-action:focus {
-		border-color: color.adjust($highlight-color, $lightness: 10%);
-		color: color.adjust($highlight-color, $lightness: -20%);
-		box-shadow: 0 0 0 1px color.adjust($highlight-color, $lightness: 10%);
+		border-color: color.adjust(variables.$highlight-color, $lightness: 10%);
+		color: color.adjust(variables.$highlight-color, $lightness: -20%);
+		box-shadow: 0 0 0 1px color.adjust(variables.$highlight-color, $lightness: 10%);
 	}
 }
 
 .view-switch a.current:before {
-	color: $menu-background;
+	color: variables.$menu-background;
 }
 
 .view-switch a:hover:before {
-	color: $menu-bubble-background;
+	color: variables.$menu-bubble-background;
 }
 
 
@@ -252,28 +253,28 @@ textarea:focus {
 #adminmenuback,
 #adminmenuwrap,
 #adminmenu {
-	background: $menu-background;
+	background: variables.$menu-background;
 }
 
 #adminmenu a {
-	color: $menu-text;
+	color: variables.$menu-text;
 }
 
 #adminmenu div.wp-menu-image:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 #adminmenu a:hover,
 #adminmenu li.menu-top:hover,
 #adminmenu li.opensub > a.menu-top,
 #adminmenu li > a.menu-top:focus {
-	color: $menu-highlight-text;
-	background-color: $menu-highlight-background;
+	color: variables.$menu-highlight-text;
+	background-color: variables.$menu-highlight-background;
 }
 
 #adminmenu li.menu-top:hover div.wp-menu-image:before,
 #adminmenu li.opensub > a.menu-top div.wp-menu-image:before {
-	color: $menu-highlight-icon;
+	color: variables.$menu-highlight-icon;
 }
 
 
@@ -282,8 +283,8 @@ textarea:focus {
 .about-wrap .nav-tab-active,
 .nav-tab-active,
 .nav-tab-active:hover {
-	background-color: $body-background;
-	border-bottom-color: $body-background;
+	background-color: variables.$body-background;
+	border-bottom-color: variables.$body-background;
 }
 
 
@@ -293,26 +294,26 @@ textarea:focus {
 #adminmenu .wp-has-current-submenu .wp-submenu,
 #adminmenu .wp-has-current-submenu.opensub .wp-submenu,
 #adminmenu a.wp-has-current-submenu:focus + .wp-submenu {
-	background: $menu-submenu-background;
+	background: variables.$menu-submenu-background;
 }
 
 #adminmenu li.wp-has-submenu.wp-not-current-submenu.opensub:hover:after,
 #adminmenu li.wp-has-submenu.wp-not-current-submenu:focus-within:after {
-	border-right-color: $menu-submenu-background;
+	border-right-color: variables.$menu-submenu-background;
 }
 
 #adminmenu .wp-submenu .wp-submenu-head {
-	color: $menu-submenu-text;
+	color: variables.$menu-submenu-text;
 }
 
 #adminmenu .wp-submenu a,
 #adminmenu .wp-has-current-submenu .wp-submenu a,
 #adminmenu a.wp-has-current-submenu:focus + .wp-submenu a,
 #adminmenu .wp-has-current-submenu.opensub .wp-submenu a {
-	color: $menu-submenu-text;
+	color: variables.$menu-submenu-text;
 
 	&:focus, &:hover {
-		color: $menu-submenu-focus-text;
+		color: variables.$menu-submenu-focus-text;
 	}
 }
 
@@ -322,24 +323,24 @@ textarea:focus {
 #adminmenu .wp-submenu li.current a,
 #adminmenu a.wp-has-current-submenu:focus + .wp-submenu li.current a,
 #adminmenu .wp-has-current-submenu.opensub .wp-submenu li.current a {
-	color: $menu-submenu-current-text;
+	color: variables.$menu-submenu-current-text;
 
 	&:hover, &:focus {
-		color: $menu-submenu-focus-text;
+		color: variables.$menu-submenu-focus-text;
 	}
 }
 
 ul#adminmenu a.wp-has-current-submenu:after,
 ul#adminmenu > li.current > a.current:after {
-    border-right-color: $body-background;
+	border-right-color: variables.$body-background;
 }
 
 #adminmenu li.current a.menu-top,
 #adminmenu li.wp-has-current-submenu a.wp-has-current-submenu,
 #adminmenu li.wp-has-current-submenu .wp-submenu .wp-submenu-head,
 .folded #adminmenu li.current.menu-top {
-	color: $menu-current-text;
-	background: $menu-current-background;
+	color: variables.$menu-current-text;
+	background: variables.$menu-current-background;
 }
 
 #adminmenu li.wp-has-current-submenu div.wp-menu-image:before,
@@ -350,7 +351,7 @@ ul#adminmenu > li.current > a.current:after {
 #adminmenu li:hover div.wp-menu-image:before,
 #adminmenu li a:focus div.wp-menu-image:before,
 #adminmenu li.opensub div.wp-menu-image:before {
-	color: $menu-current-icon;
+	color: variables.$menu-current-icon;
 }
 
 
@@ -359,49 +360,49 @@ ul#adminmenu > li.current > a.current:after {
 #adminmenu .menu-counter,
 #adminmenu .awaiting-mod,
 #adminmenu .update-plugins {
-	color: $menu-bubble-text;
-	background: $menu-bubble-background;
+	color: variables.$menu-bubble-text;
+	background: variables.$menu-bubble-background;
 }
 
 #adminmenu li.current a .awaiting-mod,
 #adminmenu li a.wp-has-current-submenu .update-plugins,
 #adminmenu li:hover a .awaiting-mod,
 #adminmenu li.menu-top:hover > a .update-plugins {
-	color: $menu-bubble-current-text;
-	background: $menu-bubble-current-background;
+	color: variables.$menu-bubble-current-text;
+	background: variables.$menu-bubble-current-background;
 }
 
 
 /* Admin Menu: collapse button */
 
 #collapse-button {
-    color: $menu-collapse-text;
+	color: variables.$menu-collapse-text;
 }
 
 #collapse-button:hover,
 #collapse-button:focus {
-    color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 /* Admin Bar */
 
 #wpadminbar {
-	color: $menu-text;
-	background: $menu-background;
+	color: variables.$menu-text;
+	background: variables.$menu-background;
 }
 
 #wpadminbar .ab-item,
 #wpadminbar a.ab-item,
 #wpadminbar > #wp-toolbar span.ab-label,
 #wpadminbar > #wp-toolbar span.noticon {
-	color: $menu-text;
+	color: variables.$menu-text;
 }
 
 #wpadminbar .ab-icon,
 #wpadminbar .ab-icon:before,
 #wpadminbar .ab-item:before,
 #wpadminbar .ab-item:after {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 #wpadminbar:not(.mobile) .ab-top-menu > li:hover > .ab-item,
@@ -409,45 +410,45 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar.nojq .quicklinks .ab-top-menu > li > .ab-item:focus,
 #wpadminbar.nojs .ab-top-menu > li.menupop:hover > .ab-item,
 #wpadminbar .ab-top-menu > li.menupop.hover > .ab-item {
-	color: $menu-submenu-focus-text;
-	background: $menu-submenu-background;
+	color: variables.$menu-submenu-focus-text;
+	background: variables.$menu-submenu-background;
 }
 
 #wpadminbar:not(.mobile) > #wp-toolbar li:hover span.ab-label,
 #wpadminbar:not(.mobile) > #wp-toolbar li.hover span.ab-label,
 #wpadminbar:not(.mobile) > #wp-toolbar a:focus span.ab-label {
-	color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 #wpadminbar:not(.mobile) li:hover .ab-icon:before,
 #wpadminbar:not(.mobile) li:hover .ab-item:before,
 #wpadminbar:not(.mobile) li:hover .ab-item:after,
 #wpadminbar:not(.mobile) li:hover #adminbarsearch:before {
-	color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 
 /* Admin Bar: submenu */
 
 #wpadminbar .menupop .ab-sub-wrapper {
-	background: $menu-submenu-background;
+	background: variables.$menu-submenu-background;
 }
 
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary,
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary .ab-submenu {
-	background: $menu-submenu-background-alt;
+	background: variables.$menu-submenu-background-alt;
 }
 
 #wpadminbar .ab-submenu .ab-item,
 #wpadminbar .quicklinks .menupop ul li a,
 #wpadminbar .quicklinks .menupop.hover ul li a,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li a {
-	color: $menu-submenu-text;
+	color: variables.$menu-submenu-text;
 }
 
 #wpadminbar .quicklinks li .blavatar,
 #wpadminbar .menupop .menupop > .ab-item:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 #wpadminbar .quicklinks .menupop ul li a:hover,
@@ -468,7 +469,7 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar li.hover .ab-item:before,
 #wpadminbar li:hover #adminbarsearch:before,
 #wpadminbar li #adminbarsearch.adminbar-focused:before {
-	color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 #wpadminbar .quicklinks li a:hover .blavatar,
@@ -477,82 +478,82 @@ ul#adminmenu > li.current > a.current:after {
 #wpadminbar .menupop .menupop > .ab-item:hover:before,
 #wpadminbar.mobile .quicklinks .ab-icon:before,
 #wpadminbar.mobile .quicklinks .ab-item:before {
-	color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 #wpadminbar.mobile .quicklinks .hover .ab-icon:before,
 #wpadminbar.mobile .quicklinks .hover .ab-item:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 
 /* Admin Bar: search */
 
 #wpadminbar #adminbarsearch:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 #wpadminbar > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus {
-	color: $menu-text;
-	background: $adminbar-input-background;
+	color: variables.$menu-text;
+	background: variables.$adminbar-input-background;
 }
 
 /* Admin Bar: recovery mode */
 
 #wpadminbar #wp-admin-bar-recovery-mode {
-	color: $adminbar-recovery-exit-text;
-	background-color: $adminbar-recovery-exit-background;
+	color: variables.$adminbar-recovery-exit-text;
+	background-color: variables.$adminbar-recovery-exit-background;
 }
 
 #wpadminbar #wp-admin-bar-recovery-mode .ab-item,
 #wpadminbar #wp-admin-bar-recovery-mode a.ab-item {
-	color: $adminbar-recovery-exit-text;
+	color: variables.$adminbar-recovery-exit-text;
 }
 
 #wpadminbar .ab-top-menu > #wp-admin-bar-recovery-mode.hover >.ab-item,
 #wpadminbar.nojq .quicklinks .ab-top-menu > #wp-admin-bar-recovery-mode > .ab-item:focus,
 #wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode:hover > .ab-item,
 #wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode > .ab-item:focus {
-	color: $adminbar-recovery-exit-text;
-	background-color: $adminbar-recovery-exit-background-alt;
+	color: variables.$adminbar-recovery-exit-text;
+	background-color: variables.$adminbar-recovery-exit-background-alt;
 }
 
 /* Admin Bar: my account */
 
 #wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
-	border-color: $adminbar-avatar-frame;
-	background-color: $adminbar-avatar-frame;
+	border-color: variables.$adminbar-avatar-frame;
+	background-color: variables.$adminbar-avatar-frame;
 }
 
 #wpadminbar #wp-admin-bar-user-info .display-name {
-	color: $menu-text;
+	color: variables.$menu-text;
 }
 
 #wpadminbar #wp-admin-bar-user-info a:hover .display-name {
-	color: $menu-submenu-focus-text;
+	color: variables.$menu-submenu-focus-text;
 }
 
 #wpadminbar #wp-admin-bar-user-info .username {
-	color: $menu-submenu-text;
+	color: variables.$menu-submenu-text;
 }
 
 
 /* Pointers */
 
 .wp-pointer .wp-pointer-content h3 {
-	background-color: $highlight-color;
-	border-color: color.adjust( $highlight-color, $lightness: -5% );
+	background-color: variables.$highlight-color;
+	border-color: color.adjust( variables.$highlight-color, $lightness: -5% );
 }
 
 .wp-pointer .wp-pointer-content h3:before {
-	color: $highlight-color;
+	color: variables.$highlight-color;
 }
 
 .wp-pointer.wp-pointer-top .wp-pointer-arrow,
 .wp-pointer.wp-pointer-top .wp-pointer-arrow-inner,
 .wp-pointer.wp-pointer-undefined .wp-pointer-arrow,
 .wp-pointer.wp-pointer-undefined .wp-pointer-arrow-inner {
-	border-bottom-color: $highlight-color;
+	border-bottom-color: variables.$highlight-color;
 }
 
 
@@ -560,22 +561,22 @@ ul#adminmenu > li.current > a.current:after {
 
 .media-item .bar,
 .media-progress-bar div {
-	background-color: $highlight-color;
+	background-color: variables.$highlight-color;
 }
 
 .details.attachment {
 	box-shadow:
 		inset 0 0 0 3px #fff,
-		inset 0 0 0 7px $highlight-color;
+		inset 0 0 0 7px variables.$highlight-color;
 }
 
 .attachment.details .check {
-	background-color: $highlight-color;
-	box-shadow: 0 0 0 1px #fff, 0 0 0 2px $highlight-color;
+	background-color: variables.$highlight-color;
+	box-shadow: 0 0 0 1px #fff, 0 0 0 2px variables.$highlight-color;
 }
 
 .media-selection .attachment.selection.details .thumbnail {
-	box-shadow: 0 0 0 1px #fff, 0 0 0 3px $highlight-color;
+	box-shadow: 0 0 0 1px #fff, 0 0 0 3px variables.$highlight-color;
 }
 
 
@@ -584,49 +585,49 @@ ul#adminmenu > li.current > a.current:after {
 .theme-browser .theme.active .theme-name,
 .theme-browser .theme.add-new-theme a:hover:after,
 .theme-browser .theme.add-new-theme a:focus:after {
-	background: $highlight-color;
+	background: variables.$highlight-color;
 }
 
 .theme-browser .theme.add-new-theme a:hover span:after,
 .theme-browser .theme.add-new-theme a:focus span:after {
-	color: $highlight-color;
+	color: variables.$highlight-color;
 }
 
 .theme-section.current,
 .theme-filter.current {
-	border-bottom-color: $menu-background;
+	border-bottom-color: variables.$menu-background;
 }
 
 body.more-filters-opened .more-filters {
-	color: $menu-text;
-	background-color: $menu-background;
+	color: variables.$menu-text;
+	background-color: variables.$menu-background;
 }
 
 body.more-filters-opened .more-filters:before {
-	color: $menu-text;
+	color: variables.$menu-text;
 }
 
 body.more-filters-opened .more-filters:hover,
 body.more-filters-opened .more-filters:focus {
-	background-color: $menu-highlight-background;
-	color: $menu-highlight-text;
+	background-color: variables.$menu-highlight-background;
+	color: variables.$menu-highlight-text;
 }
 
 body.more-filters-opened .more-filters:hover:before,
 body.more-filters-opened .more-filters:focus:before {
-	color: $menu-highlight-text;
+	color: variables.$menu-highlight-text;
 }
 
 /* Widgets */
 
 .widgets-chooser li.widgets-chooser-selected {
-	background-color: $menu-highlight-background;
-	color: $menu-highlight-text;
+	background-color: variables.$menu-highlight-background;
+	color: variables.$menu-highlight-text;
 }
 
 .widgets-chooser li.widgets-chooser-selected:before,
 .widgets-chooser li.widgets-chooser-selected:focus:before {
-	color: $menu-highlight-text;
+	color: variables.$menu-highlight-text;
 }
 
 
@@ -634,29 +635,29 @@ body.more-filters-opened .more-filters:focus:before {
 
 .nav-menus-php .item-edit:focus:before {
 	box-shadow:
-		0 0 0 1px color.adjust($button-color, $lightness: 10%),
-		0 0 2px 1px $button-color;
+		0 0 0 1px color.adjust(variables.$button-color, $lightness: 10%),
+		0 0 2px 1px variables.$button-color;
 }
 
 
 /* Responsive Component */
 
 div#wp-responsive-toggle a:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 .wp-responsive-open div#wp-responsive-toggle a {
 	// ToDo: make inset border
 	border-color: transparent;
-	background: $menu-highlight-background;
+	background: variables.$menu-highlight-background;
 }
 
 .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle a {
-	background: $menu-submenu-background;
+	background: variables.$menu-submenu-background;
 }
 
 .wp-responsive-open #wpadminbar #wp-admin-bar-menu-toggle .ab-icon:before {
-	color: $menu-icon;
+	color: variables.$menu-icon;
 }
 
 /* TinyMCE */
@@ -666,7 +667,7 @@ div#wp-responsive-toggle a:before {
 .mce-container.mce-menu .mce-menu-item:focus,
 .mce-container.mce-menu .mce-menu-item-normal.mce-active,
 .mce-container.mce-menu .mce-menu-item-preview.mce-active {
-	background: $highlight-color;
+	background: variables.$highlight-color;
 }
 
 /* Customizer */
@@ -675,24 +676,24 @@ div#wp-responsive-toggle a:before {
 	#customize-controls .control-section .accordion-section-title:hover,
 	#customize-controls .control-section.open .accordion-section-title,
 	#customize-controls .control-section .accordion-section-title:focus {
-		color: $link;
-		border-left-color: $button-color;
+		color: variables.$link;
+		border-left-color: variables.$button-color;
 	}
 
 	.customize-controls-close:focus,
 	.customize-controls-close:hover,
 	.customize-controls-preview-toggle:focus,
 	.customize-controls-preview-toggle:hover {
-		color: $link;
-		border-top-color: $button-color;
+		color: variables.$link;
+		border-top-color: variables.$button-color;
 	}
 
 	.customize-panel-back:hover,
 	.customize-panel-back:focus,
 	.customize-section-back:hover,
 	.customize-section-back:focus {
-		color: $link;
-		border-left-color: $button-color;
+		color: variables.$link;
+		border-left-color: variables.$button-color;
 	}
 
 	.customize-screen-options-toggle:hover,
@@ -702,7 +703,7 @@ div#wp-responsive-toggle a:before {
 	#customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:hover,
 	#customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:active,
 	#customize-controls .customize-info.open.active-menu-screen-options .customize-help-toggle:focus {
-		color: $link;
+		color: variables.$link;
 	}
 
 	.customize-screen-options-toggle:focus:before,
@@ -713,28 +714,28 @@ div#wp-responsive-toggle a:before {
 	#customize-save-button-wrapper .save:focus,
 	#publish-settings:focus {
 		box-shadow:
-			0 0 0 1px color.adjust($button-color, $lightness: 10%),
-			0 0 2px 1px $button-color;
+			0 0 0 1px color.adjust(variables.$button-color, $lightness: 10%),
+			0 0 2px 1px variables.$button-color;
 	}
 
 	#customize-controls .customize-info.open .customize-help-toggle,
 	#customize-controls .customize-info .customize-help-toggle:focus,
 	#customize-controls .customize-info .customize-help-toggle:hover {
-		color: $link;
+		color: variables.$link;
 	}
 
 	.control-panel-themes .customize-themes-section-title:focus,
 	.control-panel-themes .customize-themes-section-title:hover {
-		border-left-color: $button-color;
-		color: $link;
+		border-left-color: variables.$button-color;
+		color: variables.$link;
 	}
 
 	.control-panel-themes .theme-section .customize-themes-section-title.selected:after {
-		background: $button-color;
+		background: variables.$button-color;
 	}
 
 	.control-panel-themes .customize-themes-section-title.selected {
-		color: $link;
+		color: variables.$link;
 	}
 
 	#customize-theme-controls .control-section:hover > .accordion-section-title:after,
@@ -745,37 +746,37 @@ div#wp-responsive-toggle a:before {
 	#customize-outer-theme-controls .control-section .accordion-section-title:hover:after,
 	#customize-outer-theme-controls .control-section.open .accordion-section-title:after,
 	#customize-outer-theme-controls .control-section .accordion-section-title:focus:after {
-		color: $link;
+		color: variables.$link;
 	}
 
 	.customize-control .attachment-media-view .button-add-media:focus {
 		background-color: #fbfbfc;
-		border-color: $button-color;
+		border-color: variables.$button-color;
 		border-style: solid;
-		box-shadow: 0 0 0 1px $button-color;
+		box-shadow: 0 0 0 1px variables.$button-color;
 		outline: 2px solid transparent;
 	}
 
 	.wp-full-overlay-footer .devices button:focus,
 	.wp-full-overlay-footer .devices button.active:hover {
-		border-bottom-color: $button-color;
+		border-bottom-color: variables.$button-color;
 	}
 
 	.wp-full-overlay-footer .devices button:hover:before,
 	.wp-full-overlay-footer .devices button:focus:before {
-		color: $button-color;
+		color: variables.$button-color;
 	}
 
 	.wp-full-overlay .collapse-sidebar:hover,
 	.wp-full-overlay .collapse-sidebar:focus {
-		color: $button-color;
+		color: variables.$button-color;
 	}
 
 	.wp-full-overlay .collapse-sidebar:hover .collapse-sidebar-arrow,
 	.wp-full-overlay .collapse-sidebar:focus .collapse-sidebar-arrow {
 		box-shadow:
-			0 0 0 1px color.adjust($button-color, $lightness: 10%),
-			0 0 2px 1px $button-color;
+			0 0 0 1px color.adjust(variables.$button-color, $lightness: 10%),
+			0 0 2px 1px variables.$button-color;
 	}
 
 	&.wp-customizer .theme-overlay .theme-header .close:focus,
@@ -784,21 +785,21 @@ div#wp-responsive-toggle a:before {
 	&.wp-customizer .theme-overlay .theme-header .right:hover,
 	&.wp-customizer .theme-overlay .theme-header .left:focus,
 	&.wp-customizer .theme-overlay .theme-header .left:hover {
-		border-bottom-color: $button-color;
-		color: $link;
+		border-bottom-color: variables.$button-color;
+		color: variables.$link;
 	}
 }
 
 /* Welcome Panel */
 .welcome-panel {
-	background-color: $dashboard-accent-1;
+	background-color: variables.$dashboard-accent-1;
 }
 
 .welcome-panel-header-image circle {
-	stroke: $dashboard-accent-2;
-	fill: $dashboard-accent-1;
+	stroke: variables.$dashboard-accent-2;
+	fill: variables.$dashboard-accent-1;
 }
 
 [class*="welcome-panel-icon"] {
-	background-color: $dashboard-icon-background;
+	background-color: variables.$dashboard-icon-background;
 }

--- a/src/wp-admin/css/colors/_mixins.scss
+++ b/src/wp-admin/css/colors/_mixins.scss
@@ -1,3 +1,6 @@
+
+@use 'sass:color';
+
 /*
  * Button mixin- creates a button effect with correct
  * highlights/shadows, based on a base color.

--- a/src/wp-admin/css/colors/_variables.scss
+++ b/src/wp-admin/css/colors/_variables.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 // assign default value to all undefined variables
 
 $scheme-name: "default" !default;
@@ -37,7 +39,7 @@ $menu-current-text: $menu-highlight-text !default;
 $menu-current-icon: $menu-highlight-icon !default;
 $menu-current-background: $menu-highlight-background !default;
 
-$menu-submenu-text: mix( $base-color, $text-color, 30% ) !default;
+$menu-submenu-text: color.mix( $base-color, $text-color, 30% ) !default;
 $menu-submenu-background: color.adjust( $base-color, $lightness: -7% ) !default;
 $menu-submenu-background-alt: color.adjust( color.adjust( $menu-background, $lightness: 7% ), $saturation: -7% ) !default;
 
@@ -59,9 +61,9 @@ $adminbar-input-background: color.adjust( $menu-background, $lightness: 7% ) !de
 
 $adminbar-recovery-exit-text: $menu-bubble-text !default;
 $adminbar-recovery-exit-background: $menu-bubble-background !default;
-$adminbar-recovery-exit-background-alt: mix(black, $adminbar-recovery-exit-background, 10%) !default;
+$adminbar-recovery-exit-background-alt: color.mix(black, $adminbar-recovery-exit-background, 10%) !default;
 
-$menu-customizer-text: mix( $base-color, $text-color, 40% ) !default;
+$menu-customizer-text: color.mix( $base-color, $text-color, 40% ) !default;
 
 // Dashboard Colors
 

--- a/src/wp-admin/css/colors/blue/colors.scss
+++ b/src/wp-admin/css/colors/blue/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "blue";
 $base-color: #52accc;

--- a/src/wp-admin/css/colors/blue/colors.scss
+++ b/src/wp-admin/css/colors/blue/colors.scss
@@ -1,15 +1,15 @@
 
-$scheme-name: "blue";
-$base-color: #52accc;
-$icon-color: #e5f8ff;
 $highlight-color: #096484;
-$notification-color: #e1a948;
-$button-color: #e1a948;
 
-$menu-submenu-text: #e2ecf1;
-$menu-submenu-focus-text: #fff;
-$menu-submenu-background: #4796b3;
-
-$dashboard-icon-background: $highlight-color;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "blue",
+	$base-color: #52accc,
+	$icon-color: #e5f8ff,
+	$highlight-color: $highlight-color,
+	$notification-color: #e1a948,
+	$button-color: #e1a948,
+	$menu-submenu-text: #e2ecf1,
+	$menu-submenu-background: #4796b3,
+	$menu-submenu-focus-text: #fff,
+	$dashboard-icon-background: $highlight-color
+);

--- a/src/wp-admin/css/colors/coffee/colors.scss
+++ b/src/wp-admin/css/colors/coffee/colors.scss
@@ -1,10 +1,11 @@
 
-$scheme-name: "coffee";
 $base-color: #59524c;
-$highlight-color: #c7a589;
-$notification-color: #9ea476;
-$low-contrast-theme: "true";
 
-$form-checked: $base-color;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "coffee",
+	$base-color: $base-color,
+	$highlight-color: #c7a589,
+	$notification-color: #9ea476,
+	$form-checked: $base-color,
+	$low-contrast-theme: "true"
+);

--- a/src/wp-admin/css/colors/coffee/colors.scss
+++ b/src/wp-admin/css/colors/coffee/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "coffee";
 $base-color: #59524c;

--- a/src/wp-admin/css/colors/ectoplasm/colors.scss
+++ b/src/wp-admin/css/colors/ectoplasm/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "ectoplasm";
 $base-color: #523f6d;

--- a/src/wp-admin/css/colors/ectoplasm/colors.scss
+++ b/src/wp-admin/css/colors/ectoplasm/colors.scss
@@ -1,12 +1,12 @@
 
-$scheme-name: "ectoplasm";
 $base-color: #523f6d;
-$icon-color: #ece6f6;
-$highlight-color: #a3b745;
-$notification-color: #d46f15;
 
-$form-checked: $base-color;
-
-$dashboard-accent-1: $base-color;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "ectoplasm",
+	$base-color: $base-color,
+	$icon-color: #ece6f6,
+	$highlight-color: #a3b745,
+	$notification-color: #d46f15,
+	$form-checked: $base-color,
+	$dashboard-accent-1: $base-color
+);

--- a/src/wp-admin/css/colors/light/colors.scss
+++ b/src/wp-admin/css/colors/light/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "light";
 $base-color: #e5e5e5;

--- a/src/wp-admin/css/colors/light/colors.scss
+++ b/src/wp-admin/css/colors/light/colors.scss
@@ -1,30 +1,29 @@
 
-$scheme-name: "light";
-$base-color: #e5e5e5;
-$icon-color: #999;
 $text-color: #333;
-$highlight-color: #04a4cc;
-$notification-color: #d64e07;
-
-$body-background: #f5f5f5;
-
-$menu-highlight-text: #fff;
-$menu-highlight-icon: #ccc;
-$menu-highlight-background: #888;
-
-$menu-bubble-text: #fff;
 $menu-avatar-frame: #aaa;
-$menu-submenu-background: #fff;
 
-$menu-collapse-text: #777;
-$menu-collapse-focus-icon: #555;
+@use "../_admin.scss" with (
+	$scheme-name: "light",
+	$text-color: $text-color,
+	$base-color: #e5e5e5,
+	$icon-color: #999,
+	$highlight-color: #04a4cc,
+	$notification-color: #d64e07,
+	$body-background: #f5f5f5,
+	$menu-highlight-text: #fff,
+	$menu-highlight-icon: #ccc,
+	$menu-highlight-background: #888,
+	$menu-submenu-background: #fff,
+	$menu-bubble-text: #fff,
+	$menu-collapse-text: #777,
+	$menu-collapse-focus-icon: #555,
+	$dashboard-icon-background: $text-color
+);
 
-$dashboard-icon-background: $text-color;
-
-@import "../_admin.scss";
+@use "../variables";
 
 /* Override the theme filter highlight color for this scheme */
 .theme-section.current,
 .theme-filter.current {
-	border-bottom-color: $highlight-color;
+	border-bottom-color: variables.$highlight-color;
 }

--- a/src/wp-admin/css/colors/midnight/colors.scss
+++ b/src/wp-admin/css/colors/midnight/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "midnight";
 $base-color: #363b3f;

--- a/src/wp-admin/css/colors/midnight/colors.scss
+++ b/src/wp-admin/css/colors/midnight/colors.scss
@@ -1,10 +1,12 @@
 
-$scheme-name: "midnight";
-$base-color: #363b3f;
 $highlight-color: #e14d43;
 $notification-color: #69a8bb;
 
-$dashboard-accent-1: $notification-color;
-$dashboard-icon-background: $highlight-color;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "midnight",
+	$base-color: #363b3f,
+	$highlight-color: $highlight-color,
+	$notification-color: $notification-color,
+	$dashboard-accent-1: $notification-color,
+	$dashboard-icon-background: $highlight-color
+);

--- a/src/wp-admin/css/colors/modern/colors.scss
+++ b/src/wp-admin/css/colors/modern/colors.scss
@@ -1,16 +1,16 @@
 @use 'sass:color';
 
-$scheme-name: "modern";
-$base-color: #1e1e1e;
 $highlight-color: #3858e9;
-$menu-submenu-focus-text: #33f078;
-$notification-color: $highlight-color;
 
-$link: $highlight-color;
-$link-focus: color.adjust($highlight-color, $lightness: -10%);
-
-$dashboard-accent-1: #273fcc;
-$dashboard-accent-2: #627eff;
-$dashboard-icon-background: #1d2327;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "modern",
+	$base-color: #1e1e1e,
+	$highlight-color: $highlight-color,
+	$notification-color: $highlight-color,
+	$link: $highlight-color,
+	$link-focus: color.adjust($highlight-color, $lightness: -10%),
+	$menu-submenu-focus-text: #33f078,
+	$dashboard-accent-1: #273fcc,
+	$dashboard-accent-2: #627eff,
+	$dashboard-icon-background: #1d2327
+);

--- a/src/wp-admin/css/colors/ocean/colors.scss
+++ b/src/wp-admin/css/colors/ocean/colors.scss
@@ -1,11 +1,12 @@
 
-$scheme-name: "ocean";
 $base-color: #738e96;
-$icon-color: #f2fcff;
-$highlight-color: #9ebaa0;
-$notification-color: #aa9d88;
-$low-contrast-theme: "true";
 
-$form-checked: $base-color;
-
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "ocean",
+	$base-color: $base-color,
+	$icon-color: #f2fcff,
+	$highlight-color: #9ebaa0,
+	$notification-color: #aa9d88,
+	$form-checked: $base-color,
+	$low-contrast-theme: "true"
+);

--- a/src/wp-admin/css/colors/ocean/colors.scss
+++ b/src/wp-admin/css/colors/ocean/colors.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 
 $scheme-name: "ocean";
 $base-color: #738e96;

--- a/src/wp-admin/css/colors/sunrise/colors.scss
+++ b/src/wp-admin/css/colors/sunrise/colors.scss
@@ -1,9 +1,11 @@
 @use 'sass:color';
 
-$scheme-name: "sunrise";
-$base-color: #cf4944;
 $highlight-color: #dd823b;
-$notification-color: #ccaf0b;
-$menu-submenu-focus-text: color.adjust( $highlight-color, $lightness: 35% );
 
-@import "../_admin.scss";
+@use "../_admin.scss" with (
+	$scheme-name: "sunrise",
+	$base-color: #cf4944,
+	$highlight-color: $highlight-color,
+	$notification-color: #ccaf0b,
+	$menu-submenu-focus-text: color.adjust($highlight-color, $lightness: 35%)
+);


### PR DESCRIPTION
## Description
Recent updates to the SASS dependency (see #1597 and #1594) have started to display deprecation notices durung the `grunt sass:colors` build step.

This PR aims to address these notices by modernising and updating the scss files, rather than simply silence the warnings.

## Motivation and context
Cleaner build output.

## How has this been tested?
Local testing and comparison of built files.

To compare before and after, on `develop` run `grunt sass:colors` and note the deprecation notices. Repeat that on this PR and see clean output.

To compare the built CSS before and after, use the following series of commands to build the current CSS, rename the folder in `build/`, build the CSS from the new file and then compare them. The final command should report nothing:
```
git checkout develop 
grunt sass:colors
mv build/wp-admin/css/colors build/wp-admin/css/current-colors/
git checkout update/modernise-scss
grunt sass:colors
diff -ur build/wp-admin/css/colors build/wp-admin/css/current-colors/
```

## Screenshots
### Before
![Screenshot 2024-10-30 at 08 44 47](https://github.com/user-attachments/assets/3a071447-78c0-4cee-8b3a-70b616578443)

### After
![Screenshot 2024-10-30 at 08 44 33](https://github.com/user-attachments/assets/0bfe40c8-c101-4557-9559-a310209b9b02)

## Types of changes
- Bug fix
