### PR TITLE
Minify filepond JS and CSS during build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -320,7 +320,8 @@ module.exports = function(grunt) {
 					'wp-admin/css/*.css',
 					'!wp-admin/css/wp-admin*.css',
 					'wp-includes/css/*.css',
-					'wp-includes/js/mediaelement/wp-mediaelement.css'
+					'wp-includes/js/mediaelement/wp-mediaelement.css',
+					'wp-includes/js/filepond/*.css'
 				]
 			},
 			rtl: {
@@ -699,6 +700,7 @@ module.exports = function(grunt) {
 					'wp-includes/js/mediaelement/mediaelement-migrate.js',
 					'wp-includes/js/tinymce/plugins/wordpress/plugin.js',
 					'wp-includes/js/tinymce/plugins/wp*/plugin.js',
+					'wp-includes/js/filepond/*.js',
 
 					// Exceptions
 					'!wp-admin/js/custom-header.js', // Why? We should minify this.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -825,11 +825,11 @@ function wp_default_scripts( $scripts ) {
 	did_action( 'init' ) && $scripts->localize( 'wp-plupload', 'pluploadL10n', $uploader_l10n );
 
 	// FilePond uploader
-	$scripts->add( 'cp-filepond-file-validate-size', '/wp-includes/js/filepond/filepond-plugin-file-validate-size$suffix.js', array(), '2.2.8' );
-	$scripts->add( 'cp-filepond-file-validate-type', '/wp-includes/js/filepond/filepond-plugin-file-validate-type$suffix.js', array(), '1.2.9' );
-	$scripts->add( 'cp-filepond-file-rename', '/wp-includes/js/filepond/filepond-plugin-file-rename$suffix.js', array(), '1.1.8' );
-	$scripts->add( 'cp-filepond-plugin-image-preview', '/wp-includes/js/filepond/filepond-plugin-image-preview$suffix.js', array(), '4.6.12' );
-	$scripts->add( 'cp-filepond', '/wp-includes/js/filepond/cp-filepond$suffix.js', array(), '4.31.2' );
+	$scripts->add( 'cp-filepond-file-validate-size', "/wp-includes/js/filepond/filepond-plugin-file-validate-size$suffix.js", array(), '2.2.8' );
+	$scripts->add( 'cp-filepond-file-validate-type', "/wp-includes/js/filepond/filepond-plugin-file-validate-type$suffix.js", array(), '1.2.9' );
+	$scripts->add( 'cp-filepond-file-rename', "/wp-includes/js/filepond/filepond-plugin-file-rename$suffix.js", array(), '1.1.8' );
+	$scripts->add( 'cp-filepond-plugin-image-preview', "/wp-includes/js/filepond/filepond-plugin-image-preview$suffix.js", array(), '4.6.12' );
+	$scripts->add( 'cp-filepond', "/wp-includes/js/filepond/cp-filepond$suffix.js", array(), '4.31.2' );
 
 	$scripts->add( 'comment-reply', "/wp-includes/js/comment-reply$suffix.js", array(), false, 1 );
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -825,11 +825,11 @@ function wp_default_scripts( $scripts ) {
 	did_action( 'init' ) && $scripts->localize( 'wp-plupload', 'pluploadL10n', $uploader_l10n );
 
 	// FilePond uploader
-	$scripts->add( 'cp-filepond-file-validate-size', '/wp-includes/js/filepond/filepond-plugin-file-validate-size.js', array(), '2.2.8' );
-	$scripts->add( 'cp-filepond-file-validate-type', '/wp-includes/js/filepond/filepond-plugin-file-validate-type.js', array(), '1.2.9' );
-	$scripts->add( 'cp-filepond-file-rename', '/wp-includes/js/filepond/filepond-plugin-file-rename.js', array(), '1.1.8' );
-	$scripts->add( 'cp-filepond-plugin-image-preview', '/wp-includes/js/filepond/filepond-plugin-image-preview.js', array(), '4.6.12' );
-	$scripts->add( 'cp-filepond', '/wp-includes/js/filepond/cp-filepond.js', array(), '4.31.2' );
+	$scripts->add( 'cp-filepond-file-validate-size', '/wp-includes/js/filepond/filepond-plugin-file-validate-size$suffix.js', array(), '2.2.8' );
+	$scripts->add( 'cp-filepond-file-validate-type', '/wp-includes/js/filepond/filepond-plugin-file-validate-type$suffix.js', array(), '1.2.9' );
+	$scripts->add( 'cp-filepond-file-rename', '/wp-includes/js/filepond/filepond-plugin-file-rename$suffix.js', array(), '1.1.8' );
+	$scripts->add( 'cp-filepond-plugin-image-preview', '/wp-includes/js/filepond/filepond-plugin-image-preview$suffix.js', array(), '4.6.12' );
+	$scripts->add( 'cp-filepond', '/wp-includes/js/filepond/cp-filepond$suffix.js', array(), '4.31.2' );
 
 	$scripts->add( 'comment-reply', "/wp-includes/js/comment-reply$suffix.js", array(), false, 1 );
 


### PR DESCRIPTION
## Description
Fixes #1618 

This change minified the FilePond JS and CSS files during the build process and amends loading in `script-loader.php` to use the minified files on production installations.

## Motivation and context
Fixes open issue and should reduce file load size.
Looking at current `script-loader.php` file it seems minified CSS files are expected so this may also fix a 404 error in the file uploader.

## How has this been tested?
Would benefit from manual testing. Minifoed file creation confirmed on local check.

## Screenshots
### Before
![Screenshot 2024-10-30 at 09 48 10](https://github.com/user-attachments/assets/4151ce03-e3d7-443b-8900-45b0ec7e24d8)

### After
![Screenshot 2024-10-30 at 15 01 41](https://github.com/user-attachments/assets/fe63782e-5911-4fc9-955b-a1fb58abbc78)

## Types of changes
- Bug fix