### PR TITLE
Update media.css to address a regression

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -679,11 +679,6 @@ border color while dragging a file over the uploader drop area */
 	right: 51px;
 }
 
-.edit-attachment-frame .media-frame-title {
-	left: 0;
-	right: 150px; /* leave space for prev/next/close */
-}
-
 .edit-attachment-frame .edit-media-header .right:before,
 .edit-attachment-frame .edit-media-header .left:before {
 	font: normal 20px/50px dashicons !important;
@@ -732,15 +727,12 @@ border color while dragging a file over the uploader drop area */
 	cursor: default;
 }
 
-.edit-attachment-frame .media-frame-content,
 .edit-attachment-frame .media-frame-router {
 	left: 0;
 }
 
 .edit-attachment-frame .media-frame-content {
 	border-bottom: none;
-	bottom: 0;
-	top: 50px;
 }
 
 .edit-attachment-frame .attachment-details {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -744,7 +744,6 @@ border color while dragging a file over the uploader drop area */
 }
 
 .edit-attachment-frame .attachment-details {
-	position: absolute;
 	overflow: auto;
 	top: 0;
 	bottom: 0;


### PR DESCRIPTION
When going to the media grid view and selecting a file, a modal dialog box opens, but it's missing the controls on the right. (This also causes the image and the details in the right-hand column to be pushed up too high.)

It's hard to show what's missing, but this PR simply deletes one line of CSS, so that the controls are back again, as below:

![Screenshot at 2024-11-02 19-33-04](https://github.com/user-attachments/assets/17a7b76d-02a4-4989-a12b-2d5d52fdeded)

EDIT: Now also taken the opportunity to remove several more lines of CSS that are made obsolete by the original commit.