### PR TITLE
Bugfix: ensure widget title input instantiated before attempting to sort

### DIFF
--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -266,6 +266,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			if ( input ) {
 				title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+			}
+			if ( title ) {
 				title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 				widget.querySelector( '.in-widget-title' ).innerHTML = title;
 			}

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -265,7 +265,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				input = widget.querySelector( 'input[id*="-title"]' );
 
 			if ( input ) {
-				title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+				title = input.value || '';
 			}
 			if ( title ) {
 				title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -266,8 +266,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			if ( input ) {
 				title = widget.querySelector( 'input[id*="-title"]' ).value || '';
-			}
-			if ( title ) {
 				title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 				widget.querySelector( '.in-widget-title' ).innerHTML = title;
 			}

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -261,11 +261,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 
 		sortable.querySelectorAll( '.widget' ).forEach( function( widget ) {
-			var title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+			var title,
+				input = widget.querySelector( 'input[id*="-title"]' );
+
+			if ( input ) {
+				title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+			}
 			if ( title ) {
 				title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+				widget.querySelector( '.in-widget-title' ).innerHTML = title;
 			}
-			widget.querySelector( '.in-widget-title' ).innerHTML = title;
 
 			if ( widget.querySelector( 'p.widget-error' ) != null ) {
 				widget.querySelector( 'details' ).setAttribute( 'open', 'open' );


### PR DESCRIPTION
After the commits for the Custom HTML and Text widgets were merged, @xxsimoxx and I have seen instances where adding and sorting of widgets became impossible. That's because the title input of each widget input was not always instantiated first, which is required for the sorting functionality. This PR simply adds a check to ensure that the title input exists before attempting to sort.