### PR TITLE
Grouped backport of PHPStan fixes

### DIFF
--- a/src/wp-admin/includes/class-wp-privacy-requests-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-requests-table.php
@@ -424,7 +424,8 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 	 * @since 4.9.6
 	 *
 	 * @param WP_User_Request $item Item being shown.
-	 * @return string Status column markup.
+	 * @return string|void Status column markup. Returns a string if no status is found,
+	 *                     otherwise it displays the markup.
 	 */
 	public function column_status( $item ) {
 		$status        = get_post_status( $item->ID );

--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -66,7 +66,8 @@ class WP_Site_Health_Auto_Updates {
 	 * @param string $constant         The name of the constant to check.
 	 * @param bool|string|array $value The value that the constant should be, if set,
 	 *                                 or an array of acceptable values.
-	 * @return array The test results.
+	 * @return array|null The test results if there are any constants set incorrectly,
+	 *                    or null if the test passed.
 	 */
 	public function test_constants( $constant, $value ) {
 		$acceptable_values = (array) $value;
@@ -82,6 +83,8 @@ class WP_Site_Health_Auto_Updates {
 				'severity'    => 'fail',
 			);
 		}
+
+		return null;
 	}
 
 	/**
@@ -89,7 +92,8 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return array The test results.
+	 * @return array|null The test results if wp_version_check() is disabled,
+	 *                    or null if the test passed.
 	 */
 	public function test_wp_version_check_attached() {
 		if ( ( ! is_multisite() || is_main_site() && is_network_admin() )
@@ -104,6 +108,8 @@ class WP_Site_Health_Auto_Updates {
 				'severity'    => 'fail',
 			);
 		}
+
+		return null;
 	}
 
 	/**
@@ -111,7 +117,8 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return array The test results.
+	 * @return array|null The test results if the {@see 'automatic_updater_disabled'} filter is set,
+	 *                    or null if the test passed.
 	 */
 	public function test_filters_automatic_updater_disabled() {
 		/** This filter is documented in wp-admin/includes/class-wp-automatic-updater.php */
@@ -125,6 +132,8 @@ class WP_Site_Health_Auto_Updates {
 				'severity'    => 'fail',
 			);
 		}
+
+		return null;
 	}
 
 	/**
@@ -132,7 +141,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.3.0
 	 *
-	 * @return array|false The test results. False if auto-updates are enabled.
+	 * @return array|false The test results if auto-updates are disabled, false otherwise.
 	 */
 	public function test_wp_automatic_updates_disabled() {
 		if ( ! class_exists( 'WP_Automatic_Updater' ) ) {
@@ -156,7 +165,7 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return array|false The test results. False if the auto-updates failed.
+	 * @return array|false The test results if auto-updates previously failed, false otherwise.
 	 */
 	public function test_if_failed_update() {
 		$failed = get_site_option( 'auto_core_update_failed' );
@@ -306,7 +315,9 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
 	 *
-	 * @return array|false The test results. False if they're not writeable.
+	 * @return array|false The test results if at least some of WordPress core files are writeable,
+	 *                     or if a list of the checksums could not be retrieved from WordPress.org.
+	 *                     False if the core files are not writeable.
 	 */
 	public function test_all_files_writable() {
 		global $wp_filesystem;
@@ -387,7 +398,8 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return array|false The test results. False if it isn't a development version.
+	 * @return array|false|null The test results if development updates are blocked.
+	 *                          False if it isn't a development version. Null if the test passed.
 	 */
 	public function test_accepts_dev_updates() {
 		require ABSPATH . WPINC . '/version.php'; // $wp_version; // x.y.z
@@ -418,6 +430,8 @@ class WP_Site_Health_Auto_Updates {
 				'severity'    => 'fail',
 			);
 		}
+
+		return null;
 	}
 
 	/**
@@ -425,7 +439,8 @@ class WP_Site_Health_Auto_Updates {
 	 *
 	 * @since 5.2.0
 	 *
-	 * @return array The test results.
+	 * @return array|null The test results if minor updates are blocked,
+	 *                    or null if the test passed.
 	 */
 	public function test_accepts_minor_updates() {
 		if ( defined( 'WP_AUTO_UPDATE_CORE' ) && false === WP_AUTO_UPDATE_CORE ) {
@@ -450,5 +465,7 @@ class WP_Site_Health_Auto_Updates {
 				'severity'    => 'fail',
 			);
 		}
+
+		return null;
 	}
 }

--- a/src/wp-includes/class-wp-comment.php
+++ b/src/wp-includes/class-wp-comment.php
@@ -351,14 +351,16 @@ final class WP_Comment {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @param string $name Property name.
-	 * @return bool
+	 * @param string $name Property to check if set.
+	 * @return bool Whether the property is set.
 	 */
 	public function __isset( $name ) {
 		if ( in_array( $name, $this->post_fields, true ) && 0 !== (int) $this->comment_post_ID ) {
 			$post = get_post( $this->comment_post_ID );
 			return property_exists( $post, $name );
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3953,6 +3953,8 @@ class WP_Query {
 		if ( in_array( $name, $this->compat_fields, true ) ) {
 			return isset( $this->$name );
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -161,7 +161,7 @@ class WP_Recovery_Mode {
 	 * @since 5.2.0
 	 *
 	 * @param array $error Error details from `error_get_last()`.
-	 * @return true|WP_Error True if the error was handled and headers have already been sent.
+	 * @return true|WP_Error|void True if the error was handled and headers have already been sent.
 	 *                       Or the request will exit to try and catch multiple errors at once.
 	 *                       WP_Error if an error occurred preventing it from being handled.
 	 */

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -137,8 +137,13 @@ class WP_Widget {
 	 *
 	 * @since 2.8.0
 	 *
+<<<<<<< HEAD
 	 * @param array $instance Current settings.
 	 * @return string Default return is 'noform'.
+=======
+	 * @param array $instance The settings for the particular instance of the widget.
+	 * @return string|void Default return is 'noform'.
+>>>>>>> 0a45a6ce0d (Docs: Add missing `void` to DocBlock `@return` types.)
 	 */
 	public function form( $instance ) {
 		echo '<p class="no-options-widget">' . __( 'There are no options for this widget.' ) . '</p>';

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -137,13 +137,8 @@ class WP_Widget {
 	 *
 	 * @since 2.8.0
 	 *
-<<<<<<< HEAD
-	 * @param array $instance Current settings.
-	 * @return string Default return is 'noform'.
-=======
 	 * @param array $instance The settings for the particular instance of the widget.
 	 * @return string|void Default return is 'noform'.
->>>>>>> 0a45a6ce0d (Docs: Add missing `void` to DocBlock `@return` types.)
 	 */
 	public function form( $instance ) {
 		echo '<p class="no-options-widget">' . __( 'There are no options for this widget.' ) . '</p>';

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2802,7 +2802,7 @@ function trailingslashit( $value ) {
  *
  * @since 2.2.0
  *
- * @param string $text Value from which trailing slashes will be removed.
+ * @param string $value Value from which trailing slashes will be removed.
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $value ) {

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2269,7 +2269,7 @@ function add_new_user_to_blog( $user_id, $password, $meta ) {
  *
  * @since MU (3.0.0)
  *
- * @param PHPMailer $phpmailer The PHPMailer instance (passed by reference).
+ * @param PHPMailer\PHPMailer\PHPMailer $phpmailer The PHPMailer instance (passed by reference).
  */
 function fix_phpmailer_messageid( $phpmailer ) {
 	$phpmailer->Hostname = get_network()->domain;

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1150,7 +1150,11 @@ function wp_user_settings() {
 		}
 
 		$last_saved = (int) get_user_option( 'user-settings-time', $user_id );
-		$current    = isset( $_COOKIE[ 'wp-settings-time-' . $user_id ] ) ? preg_replace( '/[^0-9]/', '', $_COOKIE[ 'wp-settings-time-' . $user_id ] ) : 0;
+		$current    = 0;
+
+		if ( isset( $_COOKIE[ 'wp-settings-time-' . $user_id ] ) ) {
+			$current = (int) preg_replace( '/[^0-9]/', '', $_COOKIE[ 'wp-settings-time-' . $user_id ] );
+		}
 
 		// The cookie is newer than the saved value. Update the user_option and leave the cookie as-is.
 		if ( $current > $last_saved ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -339,7 +339,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$users = array();
 
-		foreach ( $query->results as $user ) {
+		foreach ( $query->get_results() as $user ) {
 			$data    = $this->prepare_item_for_response( $user, $request );
 			$users[] = $this->prepare_response_for_collection( $data );
 		}

--- a/src/xmlrpc.php
+++ b/src/xmlrpc.php
@@ -22,9 +22,7 @@ if ( ! isset( $HTTP_RAW_POST_DATA ) ) {
 }
 
 // Fix for mozBlog and other cases where '<?xml' isn't on the very first line.
-if ( isset( $HTTP_RAW_POST_DATA ) ) {
-	$HTTP_RAW_POST_DATA = trim( $HTTP_RAW_POST_DATA );
-}
+$HTTP_RAW_POST_DATA = trim( $HTTP_RAW_POST_DATA );
 // phpcs:enable
 
 /** Include the bootstrap for setting up ClassicPress environment */


### PR DESCRIPTION
## Description
This is a grouped set of backports that correct issues found and patched upstream by the static code analysis tool - [PHPStan](https://phpstan.org).

## Motivation and context
More efficient code base.

Some of the commits listed on the Ticket are either not required or will required deeper changes backporting other changes first.
https://core.trac.wordpress.org/ticket/52217

## How has this been tested?
These are backports of upstream commits.
Local tests passing on completed PR.

## Screenshots
N/A

## Types of changes
- Code enhancement
