### PR TITLE
Empty "Update Services" list in writing options for new installations

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -469,7 +469,7 @@ function populate_options( array $options = array() ) {
 		'moderation_keys'                 => '',
 		'active_plugins'                  => array(),
 		'category_base'                   => '',
-		'ping_sites'                      => 'http://rpc.pingomatic.com/',
+		'ping_sites'                      => '',
 		'comment_max_links'               => 2,
 		'gmt_offset'                      => $gmt_offset,
 


### PR DESCRIPTION
## Description
Change schema to default to an empty string for the option `ping_sites`, resulting in an empty "Update Services" list in "writing options" for new installations.

## Motivation and context
Discussion on the forum thread "[Removal of Ping-o-Matic?](https://forums.classicpress.net/t/removal-of-ping-o-matic/5604)"

## How has this been tested?
New install.

## Screenshots


<img width="802" alt="image" src="https://github.com/user-attachments/assets/c874d74f-4be7-4e2b-b736-75c8af9c5577">

