### PR TITLE
Restore Comment_Walker::comment function

### DIFF
--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -284,6 +284,22 @@ class Walker_Comment extends Walker {
 	}
 
 	/**
+	 * Outputs a single comment.
+	 *
+	 * @since 3.6.0
+	 * @since CP-2.3.0 - restored function and converted to wrapper of `html5_comment()`
+	 *
+	 * @see wp_list_comments()
+	 *
+	 * @param WP_Comment $comment Comment to display.
+	 * @param int        $depth   Depth of the current comment.
+	 * @param array      $args    An array of arguments.
+	 */
+	protected function comment( $comment, $depth, $args ) {
+		$this->html5_comment( $comment, $depth, $args );
+	}
+
+	/**
 	 * Outputs a comment in the HTML5 format.
 	 *
 	 * @since 3.6.0

--- a/src/wp-includes/class-walker-comment.php
+++ b/src/wp-includes/class-walker-comment.php
@@ -287,7 +287,7 @@ class Walker_Comment extends Walker {
 	 * Outputs a single comment.
 	 *
 	 * @since 3.6.0
-	 * @since CP-2.3.0 - restored function and converted to wrapper of `html5_comment()`
+	 * @since CP-2.4.0 - restored function and converted to wrapper of `html5_comment()`
 	 *
 	 * @see wp_list_comments()
 	 *

--- a/tests/phpunit/tests/comment/cpWalker.php
+++ b/tests/phpunit/tests/comment/cpWalker.php
@@ -24,7 +24,7 @@ class Tests_Comment_Walker_Functions extends WP_UnitTestCase {
 	 * @see https://github.com/ClassicPress/ClassicPress/issues/1645
 	 */
 	public function test_comment_wrapper_of_html5_comment() {
-		$comment = self::factory()->comment->create_and_get(
+		$comment_1 = self::factory()->comment->create_and_get(
 			array(
 				'comment_post_ID'  => $this->post_id,
 				'comment_author'   => 'A ClassicPress Commenter',
@@ -33,8 +33,20 @@ class Tests_Comment_Walker_Functions extends WP_UnitTestCase {
 			)
 		);
 
+		$comment_2 = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_author'   => 'A Different ClassicPress Commenter',
+				'comment_content'  => 'Hi, this is another comment used for testing!',
+				'comment_approved' => 1,
+			)
+		);
+
 		$comment_walker = new Walker_Comment();
 		$test_comment = new Walker_Comment_Helper();
+
+		$this->assertTrue( method_exists( 'Walker_Comment', 'comment' ) );
+		$this->assertTrue( method_exists( 'Walker_Comment', 'html5_comment' ) );
 
 		$args = array(
 			'style'       => 'div',
@@ -42,7 +54,15 @@ class Tests_Comment_Walker_Functions extends WP_UnitTestCase {
 			'max_depth'   => 1,
 		);
 
-		$this->assertSame( $test_comment->exposed_comment( $comment, 1, $args ), $test_comment->exposed_html5_comment( $comment, 1, $args ) );
+		// Render 2 comments using HTML5 function
+		$html5_comment  = $test_comment->exposed_html5_comment( $comment_1, 1, $args );
+		$html5_comment .= $test_comment->exposed_html5_comment( $comment_2, 1, $args );
+
+		// Render 2 comments using wrapper on the original function name
+		$original_comment  = $test_comment->exposed_comment( $comment_1, 1, $args );
+		$original_comment .= $test_comment->exposed_comment( $comment_2, 1, $args );
+
+		$this->assertSame( $original_comment, $html5_comment );
 	}
 }
 
@@ -52,9 +72,8 @@ class Walker_Comment_Helper extends Walker_Comment {
 	 * Expose parent protected `comment()` function for testing
 	 */
 	public function exposed_comment( $comment, $args, $depth ) {
-		// use output buffer to capture rendered comment, render twice to account for odd/even rendering
+		// use output buffer to capture rendered comment.
 		ob_start();
-		$this->comment( $comment, $args, $depth );
 		$this->comment( $comment, $args, $depth );
 		return ob_get_clean();
 	}
@@ -63,9 +82,8 @@ class Walker_Comment_Helper extends Walker_Comment {
 	 * Expose parent protected `html5_comment()` function for testing
 	 */
 	public function exposed_html5_comment( $comment, $args, $depth ) {
-		// use output buffer to capture rendered comment, render twice to account for odd/even rendering
+		// use output buffer to capture rendered comment.
 		ob_start();
-		$this->html5_comment( $comment, $args, $depth );
 		$this->html5_comment( $comment, $args, $depth );
 		return ob_get_clean();
 	}

--- a/tests/phpunit/tests/comment/cpWalker.php
+++ b/tests/phpunit/tests/comment/cpWalker.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @group comment
+ *
+ * @covers ::wp_list_comments
+ */
+class Tests_Comment_Walker_Functions extends WP_UnitTestCase {
+
+	/**
+	 * Comment post ID.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->post_id = self::factory()->post->create();
+	}
+
+	/**
+	 * @see https://github.com/ClassicPress/ClassicPress/issues/1645
+	 */
+	public function test_comment_wrapper_of_html5_comment() {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_author'   => 'A ClassicPress Commenter',
+				'comment_content'  => 'Hi, this is a comment used for testing!',
+				'comment_approved' => 1,
+			)
+		);
+
+		$comment_walker = new Walker_Comment();
+		$test_comment = new Walker_Comment_Helper();
+
+		$args = array(
+			'style'       => 'div',
+			'avatar_size' => 0,
+			'max_depth'   => 1,
+		);
+
+		$this->assertSame( $test_comment->exposed_comment( $comment, 1, $args ), $test_comment->exposed_html5_comment( $comment, 1, $args ) );
+	}
+}
+
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile
+class Walker_Comment_Helper extends Walker_Comment {
+	/**
+	 * Expose parent protected `comment()` function for testing
+	 */
+	public function exposed_comment( $comment, $args, $depth ) {
+		// use output buffer to capture rendered comment, render twice to account for odd/even rendering
+		ob_start();
+		$this->comment( $comment, $args, $depth );
+		$this->comment( $comment, $args, $depth );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Expose parent protected `html5_comment()` function for testing
+	 */
+	public function exposed_html5_comment( $comment, $args, $depth ) {
+		// use output buffer to capture rendered comment, render twice to account for odd/even rendering
+		ob_start();
+		$this->html5_comment( $comment, $args, $depth );
+		$this->html5_comment( $comment, $args, $depth );
+		return ob_get_clean();
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes #1645 
It reintrodyced the `comment` function to the `Comment_Walker` class as a wrapper for the `html5_comment` function.

## Motivation and context
Backwards compatibility
Fixes #1645

## How has this been tested?
Includes a new unit test
OP offered to test also so that would be very useful.

## Screenshots
N/A

## Types of changes
- Bug fix
