### PR TITLE
Fix "Show Details" button in admin Updates page

### DIFF
--- a/src/wp-admin/js/common.js
+++ b/src/wp-admin/js/common.js
@@ -838,8 +838,7 @@ $( function() {
 			menu: $adminMenuWrap.height()
 		},
 		$headerEnd = $( '.wp-header-end' ),
-		topMenuItems = document.body.className.includes( 'wp-admin' ) ? $adminmenu[0].querySelectorAll( 'li.wp-has-submenu' ) : [];
-
+		topMenuItems = document.body.className.includes( 'wp-admin' ) && $adminmenu[0] ? $adminmenu[0].querySelectorAll( 'li.wp-has-submenu' ) : [];
 	/**
 	 * Makes the fly-out submenu header clickable, when the menu is folded.
 	 *


### PR DESCRIPTION
In PR #1590, we fixed an error message that indicated that the admin menu was undefined on the front-end. At the time, adding a conditional to check we're on an admin page seemed sufficient. But a related error message also appears after clicking on View Details for any plugin on the `plugins.php` page.

That's a minor thing. Unfortunately, Issue #1654 seems to be caused by the same problem. That issue is that, on the `update-core.php` page, clicking `Show Details` has no effect. In my own testing, it seems that that's because this bug occurs before the JavaScript for the `Show Details` link. Since JS is single-threaded, it means that the relevant code never runs.

This PR fixes the bug by adding a second thing to check for, namely `$adminmenu[0]`. (I tried just `$adminmenu`, but that didn't work.)