### PR TITLE
Remove usage of mysql2date in generate_postdata method

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4721,8 +4721,19 @@ class WP_Query {
 
 		$authordata = get_userdata( $post->post_author );
 
-		$currentday   = mysql2date( 'd.m.y', $post->post_date, false );
-		$currentmonth = mysql2date( 'm', $post->post_date, false );
+		$currentday   = false;
+		$currentmonth = false;
+
+		$post_date = $post->post_date;
+		if ( ! empty( $post_date ) && '0000-00-00 00:00:00' !== $post_date ) {
+			// Avoid using mysql2date for performance reasons.
+			$currentmonth = substr( $post_date, 5, 2 );
+			$day          = substr( $post_date, 8, 2 );
+			$year         = substr( $post_date, 2, 2 );
+
+			$currentday = sprintf( '%s.%s.%s', $day, $currentmonth, $year );
+		}
+
 		$numpages     = 1;
 		$multipage    = 0;
 		$page         = $this->get( 'page' );


### PR DESCRIPTION
## Description
WP-r55558: Date / Time: Remove usage of mysql2date in generate_postdata method.

Remove usage of `mysql2date` in `generate_postdata`. `mysql2date` has a performance overhead, as it creates a `DateTimeZone` object each time it is called. Use a simple sub string function to generate the values needed for the `currentmonth` and `currentday` global variables.

WP:Props spacedmonkey, Rarst, SergeyBiryukov, flixos90. Fixes https://core.trac.wordpress.org/ticket/57683.

---

Merges https://core.trac.wordpress.org/changeset/55558 / WordPress/wordpress-develop@1eba58d5a6 to ClassicPress.

## Motivation and context
Partially fixes #1608 

## How has this been tested?
Backport

## Screenshots
N/A

## Types of changes
- Performance enhancement