### PR TITLE
Use WP_Query internally in get_pages

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5807,23 +5807,6 @@ function get_pages( $args = array() ) {
 		'no_found_rows'          => true,
 	);
 
-<<<<<<< HEAD
-	$cache_key = "get_pages:$key:$last_changed";
-	$cache     = wp_cache_get( $cache_key, 'posts' );
-	if ( false !== $cache ) {
-		_prime_post_caches( $cache, false, false );
-
-		// Convert to WP_Post instances.
-		$pages = array_map( 'get_post', $cache );
-		/** This filter is documented in wp-includes/post.php */
-		$pages = apply_filters( 'get_pages', $pages, $parsed_args );
-
-		return $pages;
-	}
-
-	$inclusions = '';
-=======
->>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 	if ( ! empty( $parsed_args['include'] ) ) {
 		$child_of     = 0; // Ignore child_of, parent, exclude, meta_key, and meta_value params if using include.
 		$parent       = -1;
@@ -5850,8 +5833,8 @@ function get_pages( $args = array() ) {
 					$post_author = $post_author->ID;
 				}
 				$query_args['author__in'][] = $post_author;
-				}
 			}
+		}
 	}
 
 	if ( is_array( $parent ) ) {
@@ -5869,92 +5852,17 @@ function get_pages( $args = array() ) {
 		$query_args['orderby'] = array_fill_keys( $orderby, $parsed_args['sort_order'] );
 	}
 
-<<<<<<< HEAD
-	$orderby_array = array();
-	$allowed_keys  = array(
-		'author',
-		'post_author',
-		'date',
-		'post_date',
-		'title',
-		'post_title',
-		'name',
-		'post_name',
-		'modified',
-		'post_modified',
-		'modified_gmt',
-		'post_modified_gmt',
-		'menu_order',
-		'parent',
-		'post_parent',
-		'ID',
-		'rand',
-		'comment_count',
-	);
-
-	foreach ( explode( ',', $parsed_args['sort_column'] ) as $orderby ) {
-		$orderby = trim( $orderby );
-		if ( ! in_array( $orderby, $allowed_keys, true ) ) {
-			continue;
-		}
-
-		switch ( $orderby ) {
-			case 'menu_order':
-				break;
-			case 'ID':
-				$orderby = "$wpdb->posts.ID";
-				break;
-			case 'rand':
-				$orderby = 'RAND()';
-				break;
-			case 'comment_count':
-				$orderby = "$wpdb->posts.comment_count";
-				break;
-			default:
-				if ( str_starts_with( $orderby, 'post_' ) ) {
-					$orderby = "$wpdb->posts." . $orderby;
-				} else {
-					$orderby = "$wpdb->posts.post_" . $orderby;
-				}
-		}
-
-		$orderby_array[] = $orderby;
-
-=======
 	$order = $parsed_args['sort_order'];
 	if ( $order ) {
 		$query_args['order'] = $order;
->>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 	}
 
 	if ( ! empty( $number ) ) {
 		$query_args['posts_per_page'] = $number;
 	}
 
-<<<<<<< HEAD
-	$pages = $wpdb->get_results( $query );
-
-	if ( empty( $pages ) ) {
-		wp_cache_set( $cache_key, array(), 'posts' );
-
-		/** This filter is documented in wp-includes/post.php */
-		$pages = apply_filters( 'get_pages', array(), $parsed_args );
-
-		return $pages;
-	}
-
-	// Sanitize before caching so it'll only get done once.
-	$num_pages = count( $pages );
-	for ( $i = 0; $i < $num_pages; $i++ ) {
-		$pages[ $i ] = sanitize_post( $pages[ $i ], 'raw' );
-	}
-
-	// Update cache.
-	update_post_cache( $pages );
-=======
 	$query = new WP_Query( $query_args );
 	$pages = $query->get_posts();
->>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 
 	if ( $child_of || $hierarchical ) {
 		$pages = get_page_children( $child_of, $pages );
@@ -5977,19 +5885,6 @@ function get_pages( $args = array() ) {
 		}
 	}
 
-<<<<<<< HEAD
-	$page_structure = array();
-	foreach ( $pages as $page ) {
-		$page_structure[] = $page->ID;
-	}
-
-	wp_cache_set( $cache_key, $page_structure, 'posts' );
-
-	// Convert to WP_Post instances.
-	$pages = array_map( 'get_post', $pages );
-
-=======
->>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 	/**
 	 * Filters the retrieved list of pages.
 	 *

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5832,7 +5832,7 @@ function get_pages( $args = array() ) {
 					}
 					$post_author = $post_author->ID;
 				}
-				$query_args['author__in'][] = $post_author;
+				$query_args['author__in'][] = (int) $post_author;
 			}
 		}
 	}
@@ -5860,6 +5860,16 @@ function get_pages( $args = array() ) {
 	if ( ! empty( $number ) ) {
 		$query_args['posts_per_page'] = $number;
 	}
+
+	/**
+	 * Filters query arguments passed to WP_Query in get_pages.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param array $query_args  Array of arguments passed to WP_Query.
+	 * @param array $parsed_args Array of get_pages() arguments.
+	 */
+	$query_args = apply_filters( 'get_pages_query_args', $query_args, $parsed_args );
 
 	$query = new WP_Query( $query_args );
 	$pages = $query->get_posts();

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -65,7 +65,11 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		clean_post_cache( $pages[0]->ID );
 		$this->assertNotEquals( $time1, $time2 = wp_cache_get( 'last_changed', 'posts' ) );
 		get_post( $pages[0]->ID );
+<<<<<<< HEAD
 		$num_queries = get_num_queries();
+=======
+		$num_queries = $wpdb->num_queries;
+>>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 
 		// last_changed bumped so num_queries should increment.
 		$pages = get_pages( array( 'number' => 2 ) );
@@ -168,6 +172,60 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 
 		$found_ids = wp_list_pluck( $found, 'ID' );
 		$this->assertSameSets( array( $posts[0] ), $found_ids );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_include_ignore_meta_key() {
+		$posts = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'include'    => $posts,
+				'meta_key'   => 'foo',
+				'meta_value' => 'bar',
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+		$this->assertSameSets( $posts, $page_ids );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_include_ignore_exclude() {
+		$includes = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$excludes = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'include' => $includes,
+				'exclude' => $excludes,
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+		$this->assertSameSets( $includes, $page_ids );
 	}
 
 	/**
@@ -715,5 +773,254 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$pages = get_pages(); // Database should not get queried.
 
 		$this->assertSame( $num_queries, $wpdb->num_queries );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_post_type() {
+		register_post_type( 'wptests_pt', array( 'hierarchical' => true ) );
+		$posts = self::factory()->post->create_many( 2, array( 'post_type' => 'wptests_pt' ) );
+		$pages = get_pages(
+			array(
+				'post_type' => 'wptests_pt',
+			)
+		);
+		$this->assertSameSets( $posts, wp_list_pluck( $pages, 'ID' ) );
+	}
+
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_author() {
+		$author_1 = self::factory()->user->create(
+			array(
+				'user_login' => 'author1',
+				'role'       => 'author',
+			)
+		);
+		$posts    = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type'   => 'page',
+				'post_author' => $author_1,
+			)
+		);
+		$pages    = get_pages(
+			array(
+				'authors' => $author_1,
+			)
+		);
+
+		$this->assertSameSets( $posts, wp_list_pluck( $pages, 'ID' ) );
+	}
+
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_post_status() {
+		register_post_status(
+			'foo',
+			array(
+				'public' => true,
+			)
+		);
+
+		$posts = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'foo',
+			)
+		);
+		$pages = get_pages(
+			array(
+				'post_status' => 'foo',
+			)
+		);
+
+		$this->assertSameSets( $posts, wp_list_pluck( $pages, 'ID' ) );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_offset() {
+		$posts = self::factory()->post->create_many( 4, array( 'post_type' => 'page' ) );
+		$pages = get_pages(
+			array(
+				'offset' => 2,
+				'number' => 2,
+			)
+		);
+
+		$this->assertSameSets( array( $posts[2], $posts[3] ), wp_list_pluck( $pages, 'ID' ) );
+	}
+
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_authors() {
+		$author_1 = self::factory()->user->create(
+			array(
+				'user_login' => 'author1',
+				'role'       => 'author',
+			)
+		);
+		$post_1   = self::factory()->post->create(
+			array(
+				'post_title'  => 'Page 1',
+				'post_type'   => 'page',
+				'post_author' => $author_1,
+				'post_date'   => '2007-01-01 00:00:00',
+			)
+		);
+
+		$author_2 = self::factory()->user->create(
+			array(
+				'user_login' => 'author2',
+				'role'       => 'author',
+			)
+		);
+		$post_2   = self::factory()->post->create(
+			array(
+				'post_title'  => 'Page 2',
+				'post_type'   => 'page',
+				'post_author' => $author_2,
+				'post_date'   => '2007-01-01 00:00:00',
+			)
+		);
+		$pages    = get_pages(
+			array(
+				'authors' => "{$author_1}, {$author_2}",
+			)
+		);
+
+		$this->assertSameSets( array( $post_1, $post_2 ), wp_list_pluck( $pages, 'ID' ) );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_authors_names() {
+		$author_1 = self::factory()->user->create(
+			array(
+				'user_login' => 'author1',
+				'role'       => 'author',
+			)
+		);
+		$post_1   = self::factory()->post->create(
+			array(
+				'post_title'  => 'Page 1',
+				'post_type'   => 'page',
+				'post_author' => $author_1,
+				'post_date'   => '2007-01-01 00:00:00',
+			)
+		);
+
+		$author_2 = self::factory()->user->create(
+			array(
+				'user_login' => 'author2',
+				'role'       => 'author',
+			)
+		);
+		$post_2   = self::factory()->post->create(
+			array(
+				'post_title'  => 'Page 2',
+				'post_type'   => 'page',
+				'post_author' => $author_2,
+				'post_date'   => '2007-01-01 00:00:00',
+			)
+		);
+		$pages    = get_pages(
+			array(
+				'authors' => 'author1, author2',
+			)
+		);
+
+		$this->assertSameSets( array( $post_1, $post_2 ), wp_list_pluck( $pages, 'ID' ) );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_orderby() {
+		global $wpdb;
+		// 'rand' is a valid value.
+		get_pages( array( 'sort_column' => 'rand' ) );
+		$this->assertStringContainsString( 'ORDER BY RAND()', $wpdb->last_query, 'Check order is random' );
+
+		// This isn't allowed.
+		get_pages( array( 'sort_order' => 'rand' ) );
+		$this->assertStringContainsString( 'ORDER BY', $wpdb->last_query, 'Check orderby is present' );
+		$this->assertStringNotContainsString( 'RAND()', $wpdb->last_query, 'Check order is random is not present' );
+		$this->assertStringContainsString( 'DESC', $wpdb->last_query, 'Check DESC is random is not present' );
+
+		// 'none' is a valid value.
+		get_pages( array( 'sort_column' => 'none' ) );
+		$this->assertStringNotContainsString( 'ORDER BY', $wpdb->last_query, 'Check orderby is not present' );
+		$this->assertStringNotContainsString( 'DESC', $wpdb->last_query, 'Check DESC is not present' );
+		$this->assertStringNotContainsString( 'ASC', $wpdb->last_query, 'Check ASC is not present' );
+
+		// False is a valid value.
+		get_pages( array( 'sort_column' => false ) );
+		$this->assertStringContainsString( 'ORDER BY', $wpdb->last_query, 'Check orderby is present if sort_column equal false is passed.' );
+
+		// Empty array() is a valid value.
+		get_pages( array( 'sort_column' => array() ) );
+		$this->assertStringContainsString( 'ORDER BY', $wpdb->last_query, 'Check orderby is present  if sort_column equals an empty array is passed.' );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_order() {
+		global $wpdb;
+
+		get_pages(
+			array(
+				'sort_column' => 'post_type',
+			)
+		);
+		$this->assertStringContainsString(
+			"ORDER BY $wpdb->posts.post_type ASC",
+			$wpdb->last_query,
+			'Check order is post type'
+		);
+
+		get_pages(
+			array(
+				'sort_column' => 'title',
+				'sort_order'  => 'foo',
+			)
+		);
+		$this->assertStringContainsString(
+			"ORDER BY $wpdb->posts.post_title DESC",
+			$wpdb->last_query,
+			'Check order is default'
+		);
+
+		get_pages(
+			array(
+				'sort_order'  => 'asc',
+				'sort_column' => 'date',
+			)
+		);
+		$this->assertStringContainsString(
+			"ORDER BY $wpdb->posts.post_date ASC",
+			$wpdb->last_query,
+			'Check order is post date'
+		);
 	}
 }

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -359,6 +359,291 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	}
 
 	/**
+<<<<<<< HEAD
+=======
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 */
+	public function test_get_pages_test_filter() {
+		register_post_type( 'wptests_pt', array( 'hierarchical' => true ) );
+
+		$posts              = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'wptests_pt',
+			)
+		);
+		$query_args_values  = array();
+		$parsed_args_values = array();
+
+		// Filter the query to return the wptests_pt post type.
+		add_filter(
+			'get_pages_query_args',
+			static function( $query_args, $parsed_args ) use ( &$query_args_values, &$parsed_args_values ) {
+				$query_args['post_type'] = 'wptests_pt';
+				$query_args_values       = $query_args;
+				$parsed_args_values      = $parsed_args;
+				return $query_args;
+			},
+			10,
+			2
+		);
+
+		$pages    = get_pages();
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+		$this->assertSameSets( $posts, $page_ids, 'The return post ids should match the post type wptests_pt.' );
+
+		$query_args = array(
+			'orderby'                => array( 'post_title' => 'ASC' ),
+			'order'                  => 'ASC',
+			'post__not_in'           => array(),
+			'meta_key'               => '',
+			'meta_value'             => '',
+			'posts_per_page'         => -1,
+			'offset'                 => 0,
+			'post_type'              => 'wptests_pt',
+			'post_status'            => array( 'publish' ),
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'ignore_sticky_posts'    => true,
+			'no_found_rows'          => true,
+		);
+
+		$this->assertSameSets( $query_args, $query_args_values, 'Query arguments should match expected values' );
+
+		$parsed_args = array(
+			'child_of'     => 0,
+			'sort_order'   => 'ASC',
+			'sort_column'  => 'post_title',
+			'hierarchical' => 1,
+			'exclude'      => array(),
+			'include'      => array(),
+			'meta_key'     => '',
+			'meta_value'   => '',
+			'authors'      => '',
+			'parent'       => -1,
+			'exclude_tree' => array(),
+			'number'       => '',
+			'offset'       => 0,
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+		);
+
+		$this->assertSameSets( $parsed_args, $parsed_args_values, 'Parsed arguments should match expected values' );
+	}
+
+	/**
+	 * @ticket 12821
+	 * @covers ::get_pages
+	 * @dataProvider data_get_pages_args
+	 */
+	public function test_get_pages_args_test_filter( $args, $expected_query_args ) {
+		$filter = new MockAction();
+		add_filter( 'get_pages_query_args', array( $filter, 'filter' ), 10, 2 );
+
+		$results = get_pages( $args );
+
+		$this->assertIsArray( $results, 'get_pages should result an array' );
+
+		$filter_args = $filter->get_args();
+
+		$default_args = array(
+			'orderby'                => array( 'post_title' => 'ASC' ),
+			'order'                  => 'ASC',
+			'post__not_in'           => array(),
+			'meta_key'               => '',
+			'meta_value'             => '',
+			'posts_per_page'         => -1,
+			'offset'                 => 0,
+			'post_type'              => 'page',
+			'post_status'            => array( 'publish' ),
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'ignore_sticky_posts'    => true,
+			'no_found_rows'          => true,
+		);
+
+		$query_args = wp_parse_args( $expected_query_args, $default_args );
+
+		$this->assertSameSets( $query_args, $filter_args[0][0], 'Unexpected $query_args for get_pages_query_args filter' );
+
+		$defaults = array(
+			'child_of'     => 0,
+			'sort_order'   => 'ASC',
+			'sort_column'  => 'post_title',
+			'hierarchical' => 1,
+			'exclude'      => array(),
+			'include'      => array(),
+			'meta_key'     => '',
+			'meta_value'   => '',
+			'authors'      => '',
+			'parent'       => -1,
+			'exclude_tree' => array(),
+			'number'       => '',
+			'offset'       => 0,
+			'post_type'    => 'page',
+			'post_status'  => 'publish',
+		);
+
+		$parsed_args = wp_parse_args( $args, $defaults );
+		$this->assertSameSets( $parsed_args, $filter_args[0][1], 'Unexpected $parsed_args for get_pages_query_args filter' );
+	}
+
+	public function data_get_pages_args() {
+		return array(
+			'default'            => array(
+				'args'                => array(),
+				'expected_query_args' => array(),
+			),
+			'exclude'            => array(
+				'args'                => array( 'exclude' => array( 1, 2, 4 ) ),
+				'expected_query_args' => array( 'post__not_in' => array( 1, 2, 4 ) ),
+			),
+			'post status'        => array(
+				'args'                => array( 'post_status' => 'draft' ),
+				'expected_query_args' => array( 'post_status' => array( 'draft' ) ),
+			),
+			'number'             => array(
+				'args'                => array( 'number' => 99 ),
+				'expected_query_args' => array( 'posts_per_page' => 99 ),
+			),
+			'meta query'         => array(
+				'args'                => array(
+					'meta_key'   => 'foo',
+					'meta_value' => 'bar',
+				),
+				'expected_query_args' => array(
+					'meta_key'   => 'foo',
+					'meta_value' => 'bar',
+				),
+			),
+			'post parent number' => array(
+				'args'                => array( 'parent' => 5 ),
+				'expected_query_args' => array( 'post_parent' => 5 ),
+			),
+			'post parent array'  => array(
+				'args'                => array( 'parent' => array( 5 ) ),
+				'expected_query_args' => array( 'post_parent__in' => array( 5 ) ),
+			),
+			'offset'             => array(
+				'args'                => array( 'offset' => 2 ),
+				'expected_query_args' => array( 'offset' => 2 ),
+			),
+			'authors'            => array(
+				'args'                => array( 'authors' => 2 ),
+				'expected_query_args' => array( 'author__in' => array( 2 ) ),
+			),
+			'sort order'         => array(
+				'args'                => array( 'sort_order' => 'DESC' ),
+				'expected_query_args' => array(
+					'order'   => 'DESC',
+					'orderby' => array( 'post_title' => 'DESC' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @ticket 12821
+	 */
+	public function test_get_pages_include_ignores_meta_key() {
+		$posts = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'include'    => $posts,
+				'meta_key'   => 'foo',
+				'meta_value' => 'bar',
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+		$this->assertSameSets( $posts, $page_ids );
+	}
+
+	/**
+	 * @ticket 12821
+	 */
+	public function test_get_pages_include_ignores_exclude() {
+		$includes = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$excludes = self::factory()->post->create_many(
+			2,
+			array(
+				'post_type' => 'page',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'include' => $includes,
+				'exclude' => $excludes,
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+		$this->assertSameSets( $includes, $page_ids );
+	}
+
+	public function test_get_pages_exclude_tree() {
+		$post_id1 = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$post_id2 = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $post_id1,
+			)
+		);
+		$post_id3 = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$post_id4 = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $post_id3,
+			)
+		);
+
+		$all = get_pages();
+
+		$this->assertCount( 4, $all );
+
+		$exclude1 = get_pages( "exclude_tree=$post_id1" );
+		$this->assertCount( 2, $exclude1 );
+
+		$exclude2 = get_pages( array( 'exclude_tree' => $post_id1 ) );
+		$this->assertCount( 2, $exclude2 );
+
+		$exclude3 = get_pages( array( 'exclude_tree' => array( $post_id1 ) ) );
+		$this->assertCount( 2, $exclude3 );
+
+		$exclude4 = get_pages( array( 'exclude_tree' => array( $post_id1, $post_id2 ) ) );
+		$this->assertCount( 2, $exclude4 );
+
+		$exclude5 = get_pages( array( 'exclude_tree' => array( $post_id1, $post_id3 ) ) );
+		$this->assertCount( 0, $exclude5 );
+
+		$post_id5 = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$post_id6 = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $post_id5,
+			)
+		);
+
+		$exclude6 = get_pages( array( 'exclude_tree' => array( $post_id1, $post_id3 ) ) );
+		$this->assertCount( 2, $exclude6 );
+	}
+
+	/**
+>>>>>>> 1825c75f88 (Posts, Post Types: Add a new filter for query arguments in `get_pages`.)
 	 * @ticket 9470
 	 */
 	public function test_get_pages_parent() {

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -65,11 +65,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		clean_post_cache( $pages[0]->ID );
 		$this->assertNotEquals( $time1, $time2 = wp_cache_get( 'last_changed', 'posts' ) );
 		get_post( $pages[0]->ID );
-<<<<<<< HEAD
 		$num_queries = get_num_queries();
-=======
-		$num_queries = $wpdb->num_queries;
->>>>>>> eb6bf15bc7 (Posts, Post Types: Use WP_Query internally in get_pages. )
 
 		// last_changed bumped so num_queries should increment.
 		$pages = get_pages( array( 'number' => 2 ) );

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -359,8 +359,6 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	}
 
 	/**
-<<<<<<< HEAD
-=======
 	 * @ticket 12821
 	 * @covers ::get_pages
 	 */
@@ -379,7 +377,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		// Filter the query to return the wptests_pt post type.
 		add_filter(
 			'get_pages_query_args',
-			static function( $query_args, $parsed_args ) use ( &$query_args_values, &$parsed_args_values ) {
+			static function ( $query_args, $parsed_args ) use ( &$query_args_values, &$parsed_args_values ) {
 				$query_args['post_type'] = 'wptests_pt';
 				$query_args_values       = $query_args;
 				$parsed_args_values      = $parsed_args;
@@ -643,7 +641,6 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 	}
 
 	/**
->>>>>>> 1825c75f88 (Posts, Post Types: Add a new filter for query arguments in `get_pages`.)
 	 * @ticket 9470
 	 */
 	public function test_get_pages_parent() {


### PR DESCRIPTION
## Description

WP-r55569: Posts, Post Types: Use WP_Query internally in get_pages.

Convert get_pages to use WP_Query internally. Using WP_Query means that a lot of code has been removed however existing parameters supported by get_pages are transformed in to query arguments. The custom caching solution found in the old version of this function is replaced with the caching found in WP_Query (added in [[53941]](https://core.trac.wordpress.org/changeset/53941)). This change adds consistency to the codebase, as improvements and changes to WP_Query will filter down to the get_pages function.

WP:Props mikeschinkel, spacedmonkey, nacin, scribu, filosofo, jane, garyc40, markoheijnen, grandslambert, kevinB, wlindley, dbernar1, atimmer, mdawaffe, helen, benjibee, johnbillion, peterwilsoncc, costdev, flixos90, joemcgill.

WP-r55845: Posts, Post Types: Add a new filter for query arguments in get_pages

In WP-r55569 get_pages was converted to use WP_Query internally. But for plugins that were extending the get_pages filters and filter WP_Query query arguments, this could result in a conflict. Add a filter get_pages_query_args to allow developers to change arguments passed to WP_Query but also have the context of the original arguments passed to the get_pages function.

This change also expands test coverage of get_pages to ensure no breakages in the future.

WP:Props spacedmonkey, westonruter, costdev, flixos90, kenwins, marianne38.

## Motivation and context
Partially fixes #1608

## How has this been tested?
Backport, loacl tests pass

## Screenshots
N/A

## Types of changes
- Performance enhancement
