### PR TITLE
Improve `_load_textdomain_just_in_time()` logic when there are no translation files

### DIFF
--- a/src/wp-includes/class-wp-textdomain-registry.php
+++ b/src/wp-includes/class-wp-textdomain-registry.php
@@ -97,7 +97,7 @@ class WP_Textdomain_Registry {
 	 */
 	public function has( $domain ) {
 		return (
-			! empty( $this->current[ $domain ] ) ||
+			isset( $this->current[ $domain ] ) ||
 			empty( $this->all[ $domain ] ) ||
 			in_array( $domain, $this->domains_with_translations, true )
 		);

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -838,6 +838,12 @@ function unload_textdomain( $domain, $reloadable = false ) {
 	do_action( 'unload_textdomain', $domain, $reloadable );
 
 	if ( isset( $l10n[ $domain ] ) ) {
+		if ( $l10n[ $domain ] instanceof NOOP_Translations ) {
+			unset( $l10n[ $domain ] );
+
+			return false;
+		}
+
 		unset( $l10n[ $domain ] );
 
 		if ( ! $reloadable ) {
@@ -1311,6 +1317,8 @@ function get_translations_for_domain( $domain ) {
 		$noop_translations = new NOOP_Translations();
 	}
 
+	$l10n[ $domain ] = &$noop_translations;
+
 	return $noop_translations;
 }
 
@@ -1326,7 +1334,7 @@ function get_translations_for_domain( $domain ) {
  */
 function is_textdomain_loaded( $domain ) {
 	global $l10n;
-	return isset( $l10n[ $domain ] );
+	return isset( $l10n[ $domain ] ) && ! $l10n[ $domain ] instanceof NOOP_Translations;
 }
 
 /**

--- a/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
+++ b/tests/phpunit/tests/l10n/loadTextdomainJustInTime.php
@@ -122,6 +122,27 @@ class Tests_L10n_LoadTextdomainJustInTime extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 58321
+	 *
+	 * @covers ::get_translations_for_domain
+	 */
+	public function test_get_translations_for_domain_get_locale_is_called_only_once() {
+		$filter_locale = new MockAction();
+		add_filter( 'locale', array( $filter_locale, 'filter' ) );
+
+		get_translations_for_domain( 'internationalized-plugin' );
+		get_translations_for_domain( 'internationalized-plugin' );
+		get_translations_for_domain( 'internationalized-plugin' );
+		$translations = get_translations_for_domain( 'internationalized-plugin' );
+
+		remove_filter( 'locale', array( $filter_locale, 'filter' ) );
+
+		$this->assertSame( 1, $filter_locale->get_call_count() );
+		$this->assertInstanceOf( 'NOOP_Translations', $translations );
+		$this->assertFalse( is_textdomain_loaded( 'internationalized-plugin' ) );
+	}
+
+	/**
 	 * @ticket 37113
 	 *
 	 * @covers ::is_textdomain_loaded

--- a/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
+++ b/tests/phpunit/tests/l10n/wpLocaleSwitcher.php
@@ -384,7 +384,7 @@ class Tests_L10n_wpLocaleSwitcher extends WP_UnitTestCase {
 		$locale_switched_user_locale  = switch_to_locale( $user_locale ); // False.
 		$locale_switched_site_locale  = switch_to_locale( $site_locale ); // True.
 		$site_locale_after_switch     = get_locale();
-		$language_header_after_switch = isset( $l10n['default'] ); // en_US
+		$language_header_after_switch = is_textdomain_loaded( 'default' ); // en_US
 
 		restore_current_locale();
 


### PR DESCRIPTION
## Description
WP-r55865: I18N: Improve `_load_textdomain_just_in_time()` logic when there are no translation files.

Fixes a performance issue where the JIT logic is invoked for every translation call if the there are no translations in the current locale. With this change, the information is cached by adding `Noop_Translations` instances to the global `$l10n` array. This way, `get_translations_for_domain()` returns earlier, thus avoiding subsequent `_load_textdomain_just_in_time()` calls.

WP:Props swissspidy, johnbillion, ocean90.
Fixes https://core.trac.wordpress.org/ticket/58321.

---

Merges https://core.trac.wordpress.org/changeset/55865 / WordPress/wordpress-develop@bf38bd326c to ClassicPress.

## Motivation and context
Partially fixes #1608 

## How has this been tested?
Backport and added additional tests
Tests passing locally

## Screenshots
N/A

## Types of changes
- Performance enhancement
