### PR TITLE
Automatically add `fetchpriority="high"` to hero image to improve load time performance

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -437,9 +437,11 @@ add_action( 'delete_term', '_wp_delete_tax_menu_item', 10, 3 );
 add_action( 'transition_post_status', '_wp_auto_add_pages_to_menu', 10, 3 );
 add_action( 'delete_post', '_wp_delete_customize_changeset_dependent_auto_drafts' );
 
-// Post Thumbnail CSS class filtering.
+// Post Thumbnail specific image filtering.
 add_action( 'begin_fetch_post_thumbnail_html', '_wp_post_thumbnail_class_filter_add' );
 add_action( 'end_fetch_post_thumbnail_html', '_wp_post_thumbnail_class_filter_remove' );
+add_action( 'begin_fetch_post_thumbnail_html', '_wp_post_thumbnail_context_filter_add' );
+add_action( 'end_fetch_post_thumbnail_html', '_wp_post_thumbnail_context_filter_remove' );
 
 // Redirect old slugs.
 add_action( 'template_redirect', 'wp_old_slug_redirect' );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4515,7 +4515,7 @@ function wp_get_loading_attr_default( $context ) {
 	 * Do not lazy-load images in the header block template part, as they are likely above the fold.
 	 * For classic themes, this is handled in the condition below using the 'get_header' action.
 	 */
-	$header_area = WP_TEMPLATE_PART_AREA_HEADER;
+	$header_area = 'header';
 	if ( "template_part_{$header_area}" === $context ) {
 		return false;
 	}

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -4476,3 +4476,149 @@ function wp_queue_comments_for_comment_meta_lazyload( $comments ) {
 
 	wp_lazyload_comment_meta( $comment_ids );
 }
+
+/**
+ * Gets the default value to use for a `loading` attribute on an element.
+ *
+ * This function should only be called for a tag and context if lazy-loading is generally enabled.
+ *
+ * The function usually returns 'lazy', but uses certain heuristics to guess whether the current element is likely to
+ * appear above the fold, in which case it returns a boolean `false`, which will lead to the `loading` attribute being
+ * omitted on the element. The purpose of this refinement is to avoid lazy-loading elements that are within the initial
+ * viewport, which can have a negative performance impact.
+ *
+ * Under the hood, the function uses {@see wp_increase_content_media_count()} every time it is called for an element
+ * within the main content. If the element is the very first content element, the `loading` attribute will be omitted.
+ * This default threshold of 3 content elements to omit the `loading` attribute for can be customized using the
+ * {@see 'wp_omit_loading_attr_threshold'} filter.
+ *
+ * @since 5.9.0
+ * @deprecated 6.3.0 Use wp_get_loading_optimization_attributes() instead.
+ * @see wp_get_loading_optimization_attributes()
+ *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
+ * @param string $context Context for the element for which the `loading` attribute value is requested.
+ * @return string|bool The default `loading` attribute value. Either 'lazy', 'eager', or a boolean `false`, to indicate
+ *                     that the `loading` attribute should be skipped.
+ */
+function wp_get_loading_attr_default( $context ) {
+	_deprecated_function( __FUNCTION__, '6.3.0', 'wp_get_loading_optimization_attributes' );
+	global $wp_query;
+
+	// Skip lazy-loading for the overall block template, as it is handled more granularly.
+	if ( 'template' === $context ) {
+		return false;
+	}
+
+	/*
+	 * Do not lazy-load images in the header block template part, as they are likely above the fold.
+	 * For classic themes, this is handled in the condition below using the 'get_header' action.
+	 */
+	$header_area = WP_TEMPLATE_PART_AREA_HEADER;
+	if ( "template_part_{$header_area}" === $context ) {
+		return false;
+	}
+
+	// Special handling for programmatically created image tags.
+	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) {
+		/*
+		 * Skip programmatically created images within post content as they need to be handled together with the other
+		 * images within the post content.
+		 * Without this clause, they would already be counted below which skews the number and can result in the first
+		 * post content image being lazy-loaded only because there are images elsewhere in the post content.
+		 */
+		if ( doing_filter( 'the_content' ) ) {
+			return false;
+		}
+
+		// Conditionally skip lazy-loading on images before the loop.
+		if (
+			// Only apply for main query but before the loop.
+			$wp_query->before_loop && $wp_query->is_main_query()
+			/*
+			 * Any image before the loop, but after the header has started should not be lazy-loaded,
+			 * except when the footer has already started which can happen when the current template
+			 * does not include any loop.
+			 */
+			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
+		) {
+			return false;
+		}
+	}
+
+	/*
+	 * The first elements in 'the_content' or 'the_post_thumbnail' should not be lazy-loaded,
+	 * as they are likely above the fold.
+	 */
+	if ( 'the_content' === $context || 'the_post_thumbnail' === $context ) {
+		// Only elements within the main query loop have special handling.
+		if ( is_admin() || ! in_the_loop() || ! is_main_query() ) {
+			return 'lazy';
+		}
+
+		// Increase the counter since this is a main query content element.
+		$content_media_count = wp_increase_content_media_count();
+
+		// If the count so far is below the threshold, return `false` so that the `loading` attribute is omitted.
+		if ( $content_media_count <= wp_omit_loading_attr_threshold() ) {
+			return false;
+		}
+
+		// For elements after the threshold, lazy-load them as usual.
+		return 'lazy';
+	}
+
+	// Lazy-load by default for any unknown context.
+	return 'lazy';
+}
+
+/**
+ * Adds `loading` attribute to an `img` HTML tag.
+ *
+ * @since 5.5.0
+ * @deprecated 6.3.0 Use wp_img_tag_add_loading_optimization_attrs() instead.
+ * @see wp_img_tag_add_loading_optimization_attrs()
+ *
+ * @param string $image   The HTML `img` tag where the attribute should be added.
+ * @param string $context Additional context to pass to the filters.
+ * @return string Converted `img` tag with `loading` attribute added.
+ */
+function wp_img_tag_add_loading_attr( $image, $context ) {
+	_deprecated_function( __FUNCTION__, '6.3.0', 'wp_img_tag_add_loading_optimization_attrs' );
+	/*
+	 * Get loading attribute value to use. This must occur before the conditional check below so that even images that
+	 * are ineligible for being lazy-loaded are considered.
+	 */
+	$value = wp_get_loading_attr_default( $context );
+
+	// Images should have source and dimension attributes for the `loading` attribute to be added.
+	if ( ! str_contains( $image, ' src="' ) || ! str_contains( $image, ' width="' ) || ! str_contains( $image, ' height="' ) ) {
+		return $image;
+	}
+
+	/**
+	 * Filters the `loading` attribute value to add to an image. Default `lazy`.
+	 *
+	 * Returning `false` or an empty string will not add the attribute.
+	 * Returning `true` will add the default value.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @param string|bool $value   The `loading` attribute value. Returning a falsey value will result in
+	 *                             the attribute being omitted for the image.
+	 * @param string      $image   The HTML `img` tag to be filtered.
+	 * @param string      $context Additional context about how the function was called or where the img tag is.
+	 */
+	$value = apply_filters( 'wp_img_tag_add_loading_attr', $value, $image, $context );
+
+	if ( $value ) {
+		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {
+			$value = 'lazy';
+		}
+
+		return str_replace( '<img', '<img loading="' . esc_attr( $value ) . '"', $image );
+	}
+
+	return $image;
+}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1050,9 +1050,18 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 			'decoding' => 'async',
 		);
 
+		/**
+		 * Filters the context in which wp_get_attachment_image() is used.
+		 *
+		 * @since 6.3.0
+		 *
+		 * @param string $context The context. Default 'wp_get_attachment_image'.
+		 */
+		$context = apply_filters( 'wp_get_attachment_image_context', 'wp_get_attachment_image' );
+
 		// Add `loading` attribute.
-		if ( wp_lazy_loading_enabled( 'img', 'wp_get_attachment_image' ) ) {
-			$default_attr['loading'] = wp_get_loading_attr_default( 'wp_get_attachment_image' );
+		if ( wp_lazy_loading_enabled( 'img', $context ) ) {
+			$default_attr['loading'] = wp_get_loading_attr_default( $context );
 		}
 
 		$attr = wp_parse_args( $attr, $default_attr );
@@ -2168,6 +2177,47 @@ function _wp_post_thumbnail_class_filter_add( $attr ) {
  */
 function _wp_post_thumbnail_class_filter_remove( $attr ) {
 	remove_filter( 'wp_get_attachment_image_attributes', '_wp_post_thumbnail_class_filter' );
+}
+
+/**
+ * Overrides the context used in {@see wp_get_attachment_image()}. Internal use only.
+ *
+ * Uses the {@see 'begin_fetch_post_thumbnail_html'} and {@see 'end_fetch_post_thumbnail_html'}
+ * action hooks to dynamically add/remove itself so as to only filter post thumbnails.
+ *
+ * @ignore
+ * @since 6.3.0
+ * @access private
+ *
+ * @param string $context The context for rendering an attachment image.
+ * @return string Modified context set to 'the_post_thumbnail'.
+ */
+function _wp_post_thumbnail_context_filter( $context ) {
+	return 'the_post_thumbnail';
+}
+
+/**
+ * Adds the '_wp_post_thumbnail_context_filter' callback to the 'wp_get_attachment_image_context'
+ * filter hook. Internal use only.
+ *
+ * @ignore
+ * @since 6.3.0
+ * @access private
+ */
+function _wp_post_thumbnail_context_filter_add() {
+	add_filter( 'wp_get_attachment_image_context', '_wp_post_thumbnail_context_filter' );
+}
+
+/**
+ * Removes the '_wp_post_thumbnail_context_filter' callback from the 'wp_get_attachment_image_context'
+ * filter hook. Internal use only.
+ *
+ * @ignore
+ * @since 6.3.0
+ * @access private
+ */
+function _wp_post_thumbnail_context_filter_remove() {
+	remove_filter( 'wp_get_attachment_image_context', '_wp_post_thumbnail_context_filter' );
 }
 
 add_shortcode( 'wp_caption', 'img_caption_shortcode' );

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5638,6 +5638,7 @@ function wp_get_webp_info( $filename ) {
 function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	global $wp_query;
 
+<<<<<<< HEAD
 	/*
 	 * Closure for postprocessing logic.
 	 * It is here to avoid duplicate logic in many places below, without having
@@ -5664,6 +5665,8 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		}
 	};
 
+=======
+>>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
 	$loading_attrs = array();
 
 	/*
@@ -5684,6 +5687,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		return $loading_attrs;
 	}
 
+<<<<<<< HEAD
 	if ( isset( $attr['loading'] ) ) {
 		/*
 		 * While any `loading` value could be set in `$loading_attrs`, for
@@ -5729,18 +5733,116 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 
 	// Special handling for programmatically created image tags.
 	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context || 'widget_media_image' === $context ) {
+=======
+>>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
 		/*
 		 * Skip programmatically created images within post content as they need to be handled together with the other
 		 * images within the post content.
-		 * Without this clause, they would already be considered below which skews the image count and can result in
-		 * the first post content image being lazy-loaded or an image further down the page being marked as a high
-		 * priority.
+	 * Without this clause, they would already be considered within their own context which skews the image count and
+	 * can result in the first post content image being lazy-loaded or an image further down the page being marked as a
+	 * high priority.
 		 */
+	switch ( $context ) {
+		case 'the_post_thumbnail':
+		case 'wp_get_attachment_image':
+		case 'widget_media_image':
 		if ( doing_filter( 'the_content' ) ) {
 			return $loading_attrs;
 		}
+	}
 
-		// Conditionally skip lazy-loading on images before the loop.
+	/*
+	 * The key function logic starts here.
+	 */
+	$maybe_in_viewport    = null;
+	$increase_count       = false;
+	$maybe_increase_count = false;
+
+	// Logic to handle a `loading` attribute that is already provided.
+	if ( isset( $attr['loading'] ) ) {
+		/*
+		 * Interpret "lazy" as not in viewport. Any other value can be
+		 * interpreted as in viewport (realistically only "eager" or `false`
+		 * to force-omit the attribute are other potential values).
+		 */
+		if ( 'lazy' === $attr['loading'] ) {
+			$maybe_in_viewport = false;
+		} else {
+			$maybe_in_viewport = true;
+		}
+	}
+
+	// Logic to handle a `fetchpriority` attribute that is already provided.
+	if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
+		/*
+		 * If the image was already determined to not be in the viewport (e.g.
+		 * from an already provided `loading` attribute), trigger a warning.
+		 * Otherwise, the value can be interpreted as in viewport, since only
+		 * the most important in-viewport image should have `fetchpriority` set
+		 * to "high".
+		 */
+		if ( false === $maybe_in_viewport ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				__( 'An image should not be lazy-loaded and marked as high priority at the same time.' ),
+				'6.3.0'
+			);
+			/*
+			 * Set `fetchpriority` here for backward-compatibility as we should
+			 * not override what a developer decided, even though it seems
+			 * incorrect.
+			 */
+			$loading_attrs['fetchpriority'] = 'high';
+		} else {
+			$maybe_in_viewport = true;
+		}
+	}
+
+	if ( null === $maybe_in_viewport ) {
+		switch ( $context ) {
+			// Consider elements with these header-specific contexts to be in viewport.
+			case 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER:
+			case 'get_header_image_tag':
+				$maybe_in_viewport    = true;
+				$maybe_increase_count = true;
+				break;
+			// Count main content elements and detect whether in viewport.
+			case 'the_content':
+			case 'the_post_thumbnail':
+			case 'do_shortcode':
+				// Only elements within the main query loop have special handling.
+				if ( ! is_admin() && in_the_loop() && is_main_query() ) {
+					/*
+					 * Get the content media count, since this is a main query
+					 * content element. This is accomplished by "increasing"
+					 * the count by zero, as the only way to get the count is
+					 * to call this function.
+					 * The actual count increase happens further below, based
+					 * on the `$increase_count` flag set here.
+					 */
+					$content_media_count = wp_increase_content_media_count( 0 );
+					$increase_count      = true;
+
+					// If the count so far is below the threshold, `loading` attribute is omitted.
+					if ( $content_media_count < wp_omit_loading_attr_threshold() ) {
+						$maybe_in_viewport = true;
+					} else {
+						$maybe_in_viewport = false;
+					}
+				}
+				/*
+				 * For the 'the_post_thumbnail' context, the following case
+				 * clause needs to be considered as well, therefore skip the
+				 * break statement here if the viewport has not been
+				 * determined.
+				 */
+				if ( 'the_post_thumbnail' !== $context || null !== $maybe_in_viewport ) {
+					break;
+				}
+			// phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect
+			// Consider elements before the loop as being in viewport.
+			case 'wp_get_attachment_image':
+			case 'widget_media_image':
 		if (
 			// Only apply for main query but before the loop.
 			$wp_query->before_loop && $wp_query->is_main_query()
@@ -5751,13 +5853,15 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 			 */
 			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
 		) {
-			// Increase media count if there are images in header above a certian minimum size threshold.
-			$maybe_increase_content_media_count();
-			return $postprocess( $loading_attrs, true );
+					$maybe_in_viewport    = true;
+					$maybe_increase_count = true;
+				}
+				break;
 		}
 	}
 
 	/*
+<<<<<<< HEAD
 	 * Skip programmatically created images within post content as they need to be handled together with the other
 	 * images within the post content.
 	 * Without this clause, they would already be counted below which skews the number and can result in the first
@@ -5771,27 +5875,39 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	 * The first elements in 'the_content' or 'the_post_thumbnail' should not be lazy-loaded,
 	 * as they are likely above the fold. Shortcodes are processed after content images, so if
 	 * thresholds haven't already been met, apply the same logic to those as well.
+=======
+	 * If the element is in the viewport (`true`), potentially add
+	 * `fetchpriority` with a value of "high". Otherwise, i.e. if the element
+	 * is not not in the viewport (`false`) or it is unknown (`null`), add
+	 * `loading` with a value of "lazy".
+>>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
 	 */
-	if ( 'the_content' === $context || 'the_post_thumbnail' === $context || 'do_shortcode' === $context ) {
-		// Only elements within the main query loop have special handling.
-		if ( is_admin() || ! in_the_loop() || ! is_main_query() ) {
+	if ( $maybe_in_viewport ) {
+		$loading_attrs = wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr );
+	} else {
+		// Only add `loading="lazy"` if the feature is enabled.
+		if ( wp_lazy_loading_enabled( $tag_name, $context ) ) {
 			$loading_attrs['loading'] = 'lazy';
-			return $postprocess( $loading_attrs, false );
+		}
 		}
 
-		// Increase the counter since this is a main query content element.
-		$content_media_count = wp_increase_content_media_count();
+	/*
+	 * If flag was set based on contextual logic above, increase the content
+	 * media count, either unconditionally, or based on whether the image size
+	 * is larger than the threshold.
+	 */
+	if ( $increase_count ) {
+		wp_increase_content_media_count();
+	} elseif ( $maybe_increase_count ) {
+		/** This filter is documented in wp-admin/includes/media.php */
+		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
 
-		// If the count so far is below the threshold, `loading` attribute is omitted.
-		if ( $content_media_count <= wp_omit_loading_attr_threshold() ) {
-			// The first largest image will still get `fetchpriority='high'`.
-			return $postprocess( $loading_attrs, true );
+		if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
+			wp_increase_content_media_count();
 		}
 	}
 
-	// Lazy-load by default for any unknown context.
-	$loading_attrs['loading'] = 'lazy';
-	return $postprocess( $loading_attrs, false );
+	return $loading_attrs;
 }
 
 /**

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5728,7 +5728,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	}
 
 	// Special handling for programmatically created image tags.
-	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) {
+	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context || 'widget_media_image' === $context ) {
 		/*
 		 * Skip programmatically created images within post content as they need to be handled together with the other
 		 * images within the post content.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1058,13 +1058,19 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 		 * @param string $context The context. Default 'wp_get_attachment_image'.
 		 */
 		$context = apply_filters( 'wp_get_attachment_image_context', 'wp_get_attachment_image' );
-
-		// Add `loading` attribute.
-		if ( wp_lazy_loading_enabled( 'img', $context ) ) {
-			$default_attr['loading'] = wp_get_loading_attr_default( $context );
-		}
-
 		$attr = wp_parse_args( $attr, $default_attr );
+
+		$loading_attr              = $attr;
+		$loading_attr['width']     = $width;
+		$loading_attr['height']    = $height;
+		$loading_optimization_attr = wp_get_loading_optimization_attributes(
+			'img',
+			$loading_attr,
+			$context
+		);
+
+		// Add loading optimization attributes if not available.
+		$attr = array_merge( $attr, $loading_optimization_attr );
 
 		// Omit the `decoding` attribute if the value is invalid according to the spec.
 		if ( empty( $attr['decoding'] ) || ! in_array( $attr['decoding'], array( 'async', 'sync', 'auto' ), true ) ) {
@@ -1073,8 +1079,13 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 
 		// If the default value of `lazy` for the `loading` attribute is overridden
 		// to omit the attribute for this image, ensure it is not included.
-		if ( array_key_exists( 'loading', $attr ) && ! $attr['loading'] ) {
+		if ( isset( $attr['loading'] ) && ! $attr['loading'] ) {
 			unset( $attr['loading'] );
+		}
+
+		// If the `fetchpriority` attribute is overridden and set to false or an empty string.
+		if ( isset( $attr['fetchpriority'] ) && ! $attr['fetchpriority'] ) {
+			unset( $attr['fetchpriority'] );
 		}
 
 		// Generate 'srcset' and 'sizes' if not already present.
@@ -1780,7 +1791,7 @@ function wp_lazy_loading_enabled( $tag_name, $context ) {
  *
  * @see wp_img_tag_add_width_and_height_attr()
  * @see wp_img_tag_add_srcset_and_sizes_attr()
- * @see wp_img_tag_add_loading_attr()
+ * @see wp_img_tag_add_loading_optimization_attrs()
  * @see wp_iframe_tag_add_loading_attr()
  *
  * @param string $content The HTML content to be filtered.
@@ -1793,7 +1804,6 @@ function wp_filter_content_tags( $content, $context = null ) {
 		$context = current_filter();
 	}
 
-	$add_img_loading_attr    = wp_lazy_loading_enabled( 'img', $context );
 	$add_iframe_loading_attr = wp_lazy_loading_enabled( 'iframe', $context );
 
 	if ( ! preg_match_all( '/<(img|iframe)\s[^>]+>/', $content, $matches, PREG_SET_ORDER ) ) {
@@ -1857,10 +1867,8 @@ function wp_filter_content_tags( $content, $context = null ) {
 				$filtered_image = wp_img_tag_add_srcset_and_sizes_attr( $filtered_image, $context, $attachment_id );
 			}
 
-			// Add 'loading' attribute if applicable.
-			if ( $add_img_loading_attr && ! str_contains( $filtered_image, ' loading=' ) ) {
-				$filtered_image = wp_img_tag_add_loading_attr( $filtered_image, $context );
-			}
+			// Add loading optimization attributes if applicable.
+			$filtered_image = wp_img_tag_add_loading_optimization_attrs( $filtered_image, $context );
 
 			// Add 'decoding=async' attribute unless a 'decoding' attribute is already present.
 			if ( ! str_contains( $filtered_image, ' decoding=' ) ) {
@@ -1914,45 +1922,101 @@ function wp_filter_content_tags( $content, $context = null ) {
 }
 
 /**
- * Adds `loading` attribute to an `img` HTML tag.
+ * Adds optimization attributes to an `img` HTML tag.
  *
- * @since 5.5.0
+ * @since 6.3.0
  *
  * @param string $image   The HTML `img` tag where the attribute should be added.
  * @param string $context Additional context to pass to the filters.
- * @return string Converted `img` tag with `loading` attribute added.
+ * @return string Converted `img` tag with optimization attributes added.
  */
-function wp_img_tag_add_loading_attr( $image, $context ) {
-	// Get loading attribute value to use. This must occur before the conditional check below so that even images that
-	// are ineligible for being lazy-loaded are considered.
-	$value = wp_get_loading_attr_default( $context );
+function wp_img_tag_add_loading_optimization_attrs( $image, $context ) {
+	$width             = preg_match( '/ width=["\']([0-9]+)["\']/', $image, $match_width ) ? (int) $match_width[1] : null;
+	$height            = preg_match( '/ height=["\']([0-9]+)["\']/', $image, $match_height ) ? (int) $match_height[1] : null;
+	$loading_val       = preg_match( '/ loading=["\']([A-Za-z]+)["\']/', $image, $match_loading ) ? $match_loading[1] : null;
+	$fetchpriority_val = preg_match( '/ fetchpriority=["\']([A-Za-z]+)["\']/', $image, $match_fetchpriority ) ? $match_fetchpriority[1] : null;
 
-	// Images should have source and dimension attributes for the `loading` attribute to be added.
+	/*
+	 * Get loading optimization attributes to use.
+	 * This must occur before the conditional check below so that even images
+	 * that are ineligible for being lazy-loaded are considered.
+	 */
+	$optimization_attrs = wp_get_loading_optimization_attributes(
+		'img',
+		array(
+			'width'         => $width,
+			'height'        => $height,
+			'loading'       => $loading_val,
+			'fetchpriority' => $fetchpriority_val,
+		),
+		$context
+	);
+
+	// Images should have source and dimension attributes for the loading optimization attributes to be added.
 	if ( ! str_contains( $image, ' src="' ) || ! str_contains( $image, ' width="' ) || ! str_contains( $image, ' height="' ) ) {
 		return $image;
 	}
 
+	// Retained for backward compatibility.
+	$loading_attrs_enabled = wp_lazy_loading_enabled( 'img', $context );
+
+	if ( empty( $loading_val ) && $loading_attrs_enabled ) {
 	/**
 	 * Filters the `loading` attribute value to add to an image. Default `lazy`.
+		 * This filter is added in for backward compatibility.
 	 *
 	 * Returning `false` or an empty string will not add the attribute.
 	 * Returning `true` will add the default value.
+		 * `true` and `false` usage supported for backward compatibility.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @param string|bool $value   The `loading` attribute value. Returning a falsey value will result in
-	 *                             the attribute being omitted for the image.
+		 * @param string|bool $loading Current value for `loading` attribute for the image.
 	 * @param string      $image   The HTML `img` tag to be filtered.
 	 * @param string      $context Additional context about how the function was called or where the img tag is.
 	 */
-	$value = apply_filters( 'wp_img_tag_add_loading_attr', $value, $image, $context );
+		$filtered_loading_attr = apply_filters(
+			'wp_img_tag_add_loading_attr',
+			isset( $optimization_attrs['loading'] ) ? $optimization_attrs['loading'] : false,
+			$image,
+			$context
+		);
 
-	if ( $value ) {
-		if ( ! in_array( $value, array( 'lazy', 'eager' ), true ) ) {
-			$value = 'lazy';
+		// Validate the values after filtering.
+		if ( isset( $optimization_attrs['loading'] ) && ! $filtered_loading_attr ) {
+			// Unset `loading` attributes if `$filtered_loading_attr` is set to `false`.
+			unset( $optimization_attrs['loading'] );
+		} elseif ( in_array( $filtered_loading_attr, array( 'lazy', 'eager' ), true ) ) {
+			/*
+			 * If the filter changed the loading attribute to "lazy" when a fetchpriority attribute
+			 * with value "high" is already present, trigger a warning since those two attribute
+			 * values should be mutually exclusive.
+			 *
+			 * The same warning is present in `wp_get_loading_optimization_attributes()`, and here it
+			 * is only intended for the specific scenario where the above filtered caused the problem.
+			 */
+			if ( isset( $optimization_attrs['fetchpriority'] ) && 'high' === $optimization_attrs['fetchpriority'] &&
+				( isset( $optimization_attrs['loading'] ) ? $optimization_attrs['loading'] : false ) !== $filtered_loading_attr &&
+				'lazy' === $filtered_loading_attr
+			) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					__( 'An image should not be lazy-loaded and marked as high priority at the same time.' ),
+					'6.3.0'
+				);
 		}
 
-		return str_replace( '<img', '<img loading="' . esc_attr( $value ) . '"', $image );
+			// The filtered value will still be respected.
+			$optimization_attrs['loading'] = $filtered_loading_attr;
+		}
+
+		if ( ! empty( $optimization_attrs['loading'] ) ) {
+			$image = str_replace( '<img', '<img loading="' . esc_attr( $optimization_attrs['loading'] ) . '"', $image );
+		}
+	}
+
+	if ( empty( $fetchpriority_val ) && ! empty( $optimization_attrs['fetchpriority'] ) ) {
+		$image = str_replace( '<img', '<img fetchpriority="' . esc_attr( $optimization_attrs['fetchpriority'] ) . '"', $image );
 	}
 
 	return $image;
@@ -2103,12 +2167,29 @@ function wp_iframe_tag_add_loading_attr( $iframe, $context ) {
 
 	// Get loading attribute value to use. This must occur before the conditional check below so that even iframes that
 	// are ineligible for being lazy-loaded are considered.
-	$value = wp_get_loading_attr_default( $context );
+	$optimization_attrs = wp_get_loading_optimization_attributes(
+		'iframe',
+		array(
+			/*
+			 * The concrete values for width and height are not important here for now
+			 * since fetchpriority is not yet supported for iframes.
+			 * TODO: Use WP_HTML_Tag_Processor to extract actual values once support is
+			 * added.
+			 */
+			'width'   => str_contains( $iframe, ' width="' ) ? 100 : null,
+			'height'  => str_contains( $iframe, ' height="' ) ? 100 : null,
+			// This function is never called when a 'loading' attribute is already present.
+			'loading' => null,
+		),
+		$context
+	);
 
 	// Iframes should have source and dimension attributes for the `loading` attribute to be added.
 	if ( ! str_contains( $iframe, ' src="' ) || ! str_contains( $iframe, ' width="' ) || ! str_contains( $iframe, ' height="' ) ) {
 		return $iframe;
 	}
+
+	$value = isset( $optimization_attrs['loading'] ) ? $optimization_attrs['loading'] : false;
 
 	/**
 	 * Filters the `loading` attribute value to add to an iframe. Default `lazy`.
@@ -5534,44 +5615,107 @@ function wp_get_webp_info( $filename ) {
 }
 
 /**
- * Gets the default value to use for a `loading` attribute on an element.
+ * Gets loading optimization attributes.
  *
- * This function should only be called for a tag and context if lazy-loading is generally enabled.
+ * This function returns an array of attributes that should be merged into the given attributes array to optimize
+ * loading performance. Potential attributes returned by this function are:
+ * - `loading` attribute with a value of "lazy"
+ * - `fetchpriority` attribute with a value of "high"
  *
- * The function usually returns 'lazy', but uses certain heuristics to guess whether the current element is likely to
- * appear above the fold, in which case it returns a boolean `false`, which will lead to the `loading` attribute being
- * omitted on the element. The purpose of this refinement is to avoid lazy-loading elements that are within the initial
- * viewport, which can have a negative performance impact.
+ * If any of these attributes are already present in the given attributes, they will not be modified. Note that no
+ * element should have both `loading="lazy"` and `fetchpriority="high"`, so the function will trigger a warning in case
+ * both attributes are present with those values.
  *
- * Under the hood, the function uses {@see wp_increase_content_media_count()} every time it is called for an element
- * within the main content. If the element is the very first content element, the `loading` attribute will be omitted.
- * This default threshold of 3 content elements to omit the `loading` attribute for can be customized using the
- * {@see 'wp_omit_loading_attr_threshold'} filter.
- *
- * @since 5.9.0
+ * @since 6.3.0
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
- * @param string $context Context for the element for which the `loading` attribute value is requested.
- * @return string|bool The default `loading` attribute value. Either 'lazy', 'eager', or a boolean `false`, to indicate
- *                     that the `loading` attribute should be skipped.
+ * @param string $tag_name The tag name.
+ * @param array  $attr     Array of the attributes for the tag.
+ * @param string $context  Context for the element for which the loading optimization attribute is requested.
+ * @return array Loading optimization attributes.
  */
-function wp_get_loading_attr_default( $context ) {
+function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	global $wp_query;
 
-	// Skip lazy-loading for the overall block template, as it is handled more granularly.
+	/*
+	 * Closure for postprocessing logic.
+	 * It is here to avoid duplicate logic in many places below, without having
+	 * to introduce a very specific private global function.
+	 */
+	$postprocess = static function( $loading_attributes, $with_fetchpriority = false ) use ( $tag_name, $attr, $context ) {
+		// Potentially add `fetchpriority="high"`.
+		if ( $with_fetchpriority ) {
+			$loading_attributes = wp_maybe_add_fetchpriority_high_attr( $loading_attributes, $tag_name, $attr );
+		}
+		// Potentially strip `loading="lazy"` if the feature is disabled.
+		if ( isset( $loading_attributes['loading'] ) && ! wp_lazy_loading_enabled( $tag_name, $context ) ) {
+			unset( $loading_attributes['loading'] );
+		}
+		return $loading_attributes;
+	};
+
+	$loading_attrs = array();
+
+	/*
+	 * Skip lazy-loading for the overall block template, as it is handled more granularly.
+	 * The skip is also applicable for `fetchpriority`.
+	 */
 	if ( 'template' === $context ) {
-		return false;
+		return $loading_attrs;
 	}
 
+<<<<<<< HEAD
 	// Do not lazy-load images in the header block template part, as they are likely above the fold.
 	$header_area = 'header';
+=======
+	// For now this function only supports images and iframes.
+	if ( 'img' !== $tag_name && 'iframe' !== $tag_name ) {
+		return $loading_attrs;
+	}
+
+	// For any resources, width and height must be provided, to avoid layout shifts.
+	if ( ! isset( $attr['width'], $attr['height'] ) ) {
+		return $loading_attrs;
+	}
+
+	if ( isset( $attr['loading'] ) ) {
+		/*
+		 * While any `loading` value could be set in `$loading_attrs`, for
+		 * consistency we only do it for `loading="lazy"` since that is the
+		 * only possible value that WordPress core would apply on its own.
+		 */
+		if ( 'lazy' === $attr['loading'] ) {
+			$loading_attrs['loading'] = 'lazy';
+			if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					__( 'An image should not be lazy-loaded and marked as high priority at the same time.' ),
+					'6.3.0'
+				);
+			}
+		}
+
+		return $postprocess( $loading_attrs, true );
+	}
+
+	// An image with `fetchpriority="high"` cannot be assigned `loading="lazy"` at the same time.
+	if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
+		return $postprocess( $loading_attrs, true );
+	}
+
+	/*
+	 * Do not lazy-load images in the header block template part, as they are likely above the fold.
+	 * For classic themes, this is handled in the condition below using the 'get_header' action.
+	 */
+	$header_area = WP_TEMPLATE_PART_AREA_HEADER;
+>>>>>>> b6fde03ef7 (Media: Automatically add `fetchpriority="high"` to hero image to improve load time performance.)
 	if ( "template_part_{$header_area}" === $context ) {
-		return false;
+		return $postprocess( $loading_attrs, true );
 	}
 
 	// Special handling for programmatically created image tags.
-	if ( ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) ) {
+	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) {
 		/*
 		 * Skip programmatically created images within post content as they need to be handled together with the other
 		 * images within the post content.
@@ -5579,7 +5723,7 @@ function wp_get_loading_attr_default( $context ) {
 		 * post content image being lazy-loaded only because there are images elsewhere in the post content.
 		 */
 		if ( doing_filter( 'the_content' ) ) {
-			return false;
+			return $postprocess( $loading_attrs, true );
 		}
 
 		// Conditionally skip lazy-loading on images before the loop.
@@ -5593,7 +5737,7 @@ function wp_get_loading_attr_default( $context ) {
 			 */
 			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
 		) {
-			return false;
+			return $postprocess( $loading_attrs, true );
 		}
 	}
 
@@ -5614,23 +5758,23 @@ function wp_get_loading_attr_default( $context ) {
 	if ( 'the_content' === $context || 'the_post_thumbnail' === $context ) {
 		// Only elements within the main query loop have special handling.
 		if ( is_admin() || ! in_the_loop() || ! is_main_query() ) {
-			return 'lazy';
+			$loading_attrs['loading'] = 'lazy';
+			return $postprocess( $loading_attrs, false );
 		}
 
 		// Increase the counter since this is a main query content element.
 		$content_media_count = wp_increase_content_media_count();
 
-		// If the count so far is below the threshold, return `false` so that the `loading` attribute is omitted.
+		// If the count so far is below the threshold, `loading` attribute is omitted.
 		if ( $content_media_count <= wp_omit_loading_attr_threshold() ) {
-			return false;
+			// The first largest image will still get `fetchpriority='high'`.
+			return $postprocess( $loading_attrs, true );
 		}
-
-		// For elements after the threshold, lazy-load them as usual.
-		return 'lazy';
 	}
 
 	// Lazy-load by default for any unknown context.
-	return 'lazy';
+	$loading_attrs['loading'] = 'lazy';
+	return $postprocess( $loading_attrs, false );
 }
 
 /**
@@ -5682,4 +5826,77 @@ function wp_increase_content_media_count( $amount = 1 ) {
 	$content_media_count += $amount;
 
 	return $content_media_count;
+}
+
+/**
+ * Determines whether to add `fetchpriority='high'` to loading attributes.
+ *
+ * @since 6.3.0
+ * @access private
+ *
+ * @param array  $loading_attrs Array of the loading optimization attributes for the element.
+ * @param string $tag_name      The tag name.
+ * @param array  $attr          Array of the attributes for the element.
+ * @return array Updated loading optimization attributes for the element.
+ */
+function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr ) {
+	// For now, adding `fetchpriority="high"` is only supported for images.
+	if ( 'img' !== $tag_name ) {
+		return $loading_attrs;
+	}
+
+	if ( isset( $attr['fetchpriority'] ) ) {
+		/*
+		 * While any `fetchpriority` value could be set in `$loading_attrs`,
+		 * for consistency we only do it for `fetchpriority="high"` since that
+		 * is the only possible value that WordPress core would apply on its
+		 * own.
+		 */
+		if ( 'high' === $attr['fetchpriority'] ) {
+			$loading_attrs['fetchpriority'] = 'high';
+			wp_high_priority_element_flag( false );
+		}
+		return $loading_attrs;
+	}
+
+	// Lazy-loading and `fetchpriority="high"` are mutually exclusive.
+	if ( isset( $loading_attrs['loading'] ) && 'lazy' === $loading_attrs['loading'] ) {
+		return $loading_attrs;
+	}
+
+	if ( ! wp_high_priority_element_flag() ) {
+		return $loading_attrs;
+	}
+
+	/**
+	 * Filters the minimum square-pixels threshold for an image to be eligible as the high-priority image.
+	 *
+	 * @since 6.3.0
+	 *
+	 * @param int $threshold Minimum square-pixels threshold. Default 50000.
+	 */
+	$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
+	if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
+		$loading_attrs['fetchpriority'] = 'high';
+		wp_high_priority_element_flag( false );
+	}
+	return $loading_attrs;
+}
+
+/**
+ * Accesses a flag that indicates if an element is a possible candidate for `fetchpriority='high'`.
+ *
+ * @since 6.3.0
+ * @access private
+ *
+ * @param bool $value Optional. Used to change the static variable. Default null.
+ * @return bool Returns true if high-priority element was marked already, otherwise false.
+ */
+function wp_high_priority_element_flag( $value = null ) {
+	static $high_priority_element = true;
+
+	if ( is_bool( $value ) ) {
+		$high_priority_element = $value;
+	}
+	return $high_priority_element;
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5709,6 +5709,11 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		return $postprocess( $loading_attrs, true );
 	}
 
+	// The custom header image is always expected to be in the header.
+	if ( 'get_header_image_tag' === $context ) {
+		return $postprocess( $loading_attrs, true );
+	}
+
 	// Special handling for programmatically created image tags.
 	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) {
 		/*

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1961,20 +1961,20 @@ function wp_img_tag_add_loading_optimization_attrs( $image, $context ) {
 	$loading_attrs_enabled = wp_lazy_loading_enabled( 'img', $context );
 
 	if ( empty( $loading_val ) && $loading_attrs_enabled ) {
-	/**
-	 * Filters the `loading` attribute value to add to an image. Default `lazy`.
+		/**
+		 * Filters the `loading` attribute value to add to an image. Default `lazy`.
 		 * This filter is added in for backward compatibility.
-	 *
-	 * Returning `false` or an empty string will not add the attribute.
-	 * Returning `true` will add the default value.
+		 *
+		 * Returning `false` or an empty string will not add the attribute.
+		 * Returning `true` will add the default value.
 		 * `true` and `false` usage supported for backward compatibility.
-	 *
-	 * @since 5.5.0
-	 *
+		 *
+		 * @since 5.5.0
+		 *
 		 * @param string|bool $loading Current value for `loading` attribute for the image.
-	 * @param string      $image   The HTML `img` tag to be filtered.
-	 * @param string      $context Additional context about how the function was called or where the img tag is.
-	 */
+		 * @param string      $image   The HTML `img` tag to be filtered.
+		 * @param string      $context Additional context about how the function was called or where the img tag is.
+		 */
 		$filtered_loading_attr = apply_filters(
 			'wp_img_tag_add_loading_attr',
 			isset( $optimization_attrs['loading'] ) ? $optimization_attrs['loading'] : false,
@@ -2004,7 +2004,7 @@ function wp_img_tag_add_loading_optimization_attrs( $image, $context ) {
 					__( 'An image should not be lazy-loaded and marked as high priority at the same time.' ),
 					'6.3.0'
 				);
-		}
+			}
 
 			// The filtered value will still be respected.
 			$optimization_attrs['loading'] = $filtered_loading_attr;
@@ -5643,7 +5643,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	 * It is here to avoid duplicate logic in many places below, without having
 	 * to introduce a very specific private global function.
 	 */
-	$postprocess = static function( $loading_attributes, $with_fetchpriority = false ) use ( $tag_name, $attr, $context ) {
+	$postprocess = static function ( $loading_attributes, $with_fetchpriority = false ) use ( $tag_name, $attr, $context ) {
 		// Potentially add `fetchpriority="high"`.
 		if ( $with_fetchpriority ) {
 			$loading_attributes = wp_maybe_add_fetchpriority_high_attr( $loading_attributes, $tag_name, $attr );
@@ -5665,10 +5665,6 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		return $loading_attrs;
 	}
 
-<<<<<<< HEAD
-	// Do not lazy-load images in the header block template part, as they are likely above the fold.
-	$header_area = 'header';
-=======
 	// For now this function only supports images and iframes.
 	if ( 'img' !== $tag_name && 'iframe' !== $tag_name ) {
 		return $loading_attrs;
@@ -5708,8 +5704,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	 * Do not lazy-load images in the header block template part, as they are likely above the fold.
 	 * For classic themes, this is handled in the condition below using the 'get_header' action.
 	 */
-	$header_area = WP_TEMPLATE_PART_AREA_HEADER;
->>>>>>> b6fde03ef7 (Media: Automatically add `fetchpriority="high"` to hero image to improve load time performance.)
+	$header_area = 'header';
 	if ( "template_part_{$header_area}" === $context ) {
 		return $postprocess( $loading_attrs, true );
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5732,11 +5732,12 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		/*
 		 * Skip programmatically created images within post content as they need to be handled together with the other
 		 * images within the post content.
-		 * Without this clause, they would already be counted below which skews the number and can result in the first
-		 * post content image being lazy-loaded only because there are images elsewhere in the post content.
+		 * Without this clause, they would already be considered below which skews the image count and can result in
+		 * the first post content image being lazy-loaded or an image further down the page being marked as a high
+		 * priority.
 		 */
 		if ( doing_filter( 'the_content' ) ) {
-			return $postprocess( $loading_attrs, true );
+			return $loading_attrs;
 		}
 
 		// Conditionally skip lazy-loading on images before the loop.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5655,7 +5655,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		return $loading_attributes;
 	};
 	// Closure to increase media count for images with certain minimum threshold, mostly used for header images.
-	$maybe_increase_content_media_count = static function() use ( $attr ) {
+	$maybe_increase_content_media_count = static function () use ( $attr ) {
 		/** This filter is documented in wp-admin/includes/media.php */
 		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
 		// Images with a certain minimum size in the header of the page are also counted towards the threshold.

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5638,35 +5638,6 @@ function wp_get_webp_info( $filename ) {
 function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	global $wp_query;
 
-<<<<<<< HEAD
-	/*
-	 * Closure for postprocessing logic.
-	 * It is here to avoid duplicate logic in many places below, without having
-	 * to introduce a very specific private global function.
-	 */
-	$postprocess = static function ( $loading_attributes, $with_fetchpriority = false ) use ( $tag_name, $attr, $context ) {
-		// Potentially add `fetchpriority="high"`.
-		if ( $with_fetchpriority ) {
-			$loading_attributes = wp_maybe_add_fetchpriority_high_attr( $loading_attributes, $tag_name, $attr );
-		}
-		// Potentially strip `loading="lazy"` if the feature is disabled.
-		if ( isset( $loading_attributes['loading'] ) && ! wp_lazy_loading_enabled( $tag_name, $context ) ) {
-			unset( $loading_attributes['loading'] );
-		}
-		return $loading_attributes;
-	};
-	// Closure to increase media count for images with certain minimum threshold, mostly used for header images.
-	$maybe_increase_content_media_count = static function () use ( $attr ) {
-		/** This filter is documented in wp-admin/includes/media.php */
-		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
-		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
-		if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
-			wp_increase_content_media_count();
-		}
-	};
-
-=======
->>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
 	$loading_attrs = array();
 
 	/*
@@ -5687,68 +5658,20 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		return $loading_attrs;
 	}
 
-<<<<<<< HEAD
-	if ( isset( $attr['loading'] ) ) {
-		/*
-		 * While any `loading` value could be set in `$loading_attrs`, for
-		 * consistency we only do it for `loading="lazy"` since that is the
-		 * only possible value that WordPress core would apply on its own.
-		 */
-		if ( 'lazy' === $attr['loading'] ) {
-			$loading_attrs['loading'] = 'lazy';
-			if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
-				_doing_it_wrong(
-					__FUNCTION__,
-					__( 'An image should not be lazy-loaded and marked as high priority at the same time.' ),
-					'6.3.0'
-				);
-			}
-		}
-
-		return $postprocess( $loading_attrs, true );
-	}
-
-	// An image with `fetchpriority="high"` cannot be assigned `loading="lazy"` at the same time.
-	if ( isset( $attr['fetchpriority'] ) && 'high' === $attr['fetchpriority'] ) {
-		return $postprocess( $loading_attrs, true );
-	}
-
 	/*
-	 * Do not lazy-load images in the header block template part, as they are likely above the fold.
-	 * For classic themes, this is handled in the condition below using the 'get_header' action.
-	 */
-	$header_area = 'header';
-	if ( "template_part_{$header_area}" === $context ) {
-		// Increase media count if there are images in header above a certian minimum size threshold.
-		$maybe_increase_content_media_count();
-		return $postprocess( $loading_attrs, true );
-	}
-
-	// The custom header image is always expected to be in the header.
-	if ( 'get_header_image_tag' === $context ) {
-		// Increase media count if there are images in header above a certian minimum size threshold.
-		$maybe_increase_content_media_count();
-		return $postprocess( $loading_attrs, true );
-	}
-
-	// Special handling for programmatically created image tags.
-	if ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context || 'widget_media_image' === $context ) {
-=======
->>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
-		/*
-		 * Skip programmatically created images within post content as they need to be handled together with the other
-		 * images within the post content.
+	 * Skip programmatically created images within post content as they need to be handled together with the other
+	 * images within the post content.
 	 * Without this clause, they would already be considered within their own context which skews the image count and
 	 * can result in the first post content image being lazy-loaded or an image further down the page being marked as a
 	 * high priority.
-		 */
+	 */
 	switch ( $context ) {
 		case 'the_post_thumbnail':
 		case 'wp_get_attachment_image':
 		case 'widget_media_image':
-		if ( doing_filter( 'the_content' ) ) {
-			return $loading_attrs;
-		}
+			if ( doing_filter( 'the_content' ) ) {
+				return $loading_attrs;
+			}
 	}
 
 	/*
@@ -5801,7 +5724,6 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	if ( null === $maybe_in_viewport ) {
 		switch ( $context ) {
 			// Consider elements with these header-specific contexts to be in viewport.
-			case 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER:
 			case 'get_header_image_tag':
 				$maybe_in_viewport    = true;
 				$maybe_increase_count = true;
@@ -5843,16 +5765,16 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 			// Consider elements before the loop as being in viewport.
 			case 'wp_get_attachment_image':
 			case 'widget_media_image':
-		if (
-			// Only apply for main query but before the loop.
-			$wp_query->before_loop && $wp_query->is_main_query()
-			/*
-			 * Any image before the loop, but after the header has started should not be lazy-loaded,
-			 * except when the footer has already started which can happen when the current template
-			 * does not include any loop.
-			 */
-			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
-		) {
+				if (
+					// Only apply for main query but before the loop.
+					$wp_query->before_loop && $wp_query->is_main_query()
+					/*
+					 * Any image before the loop, but after the header has started should not be lazy-loaded,
+					 * except when the footer has already started which can happen when the current template
+					 * does not include any loop.
+					 */
+					&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
+				) {
 					$maybe_in_viewport    = true;
 					$maybe_increase_count = true;
 				}
@@ -5861,26 +5783,10 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	}
 
 	/*
-<<<<<<< HEAD
-	 * Skip programmatically created images within post content as they need to be handled together with the other
-	 * images within the post content.
-	 * Without this clause, they would already be counted below which skews the number and can result in the first
-	 * post content image being lazy-loaded only because there are images elsewhere in the post content.
-	 */
-	if ( ( 'the_post_thumbnail' === $context || 'wp_get_attachment_image' === $context ) && doing_filter( 'the_content' ) ) {
-		return false;
-	}
-
-	/*
-	 * The first elements in 'the_content' or 'the_post_thumbnail' should not be lazy-loaded,
-	 * as they are likely above the fold. Shortcodes are processed after content images, so if
-	 * thresholds haven't already been met, apply the same logic to those as well.
-=======
 	 * If the element is in the viewport (`true`), potentially add
 	 * `fetchpriority` with a value of "high". Otherwise, i.e. if the element
 	 * is not not in the viewport (`false`) or it is unknown (`null`), add
 	 * `loading` with a value of "lazy".
->>>>>>> 02f9f1ea95 (Media: Simplify logic in `wp_get_loading_optimization_attributes()`.)
 	 */
 	if ( $maybe_in_viewport ) {
 		$loading_attrs = wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr );
@@ -5889,7 +5795,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		if ( wp_lazy_loading_enabled( $tag_name, $context ) ) {
 			$loading_attrs['loading'] = 'lazy';
 		}
-		}
+	}
 
 	/*
 	 * If flag was set based on contextual logic above, increase the content

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5805,7 +5805,7 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	if ( $increase_count ) {
 		wp_increase_content_media_count();
 	} elseif ( $maybe_increase_count ) {
-		/** This filter is documented in wp-admin/includes/media.php */
+		/** This filter is documented in wp-includes/media.php */
 		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
 
 		if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
@@ -5895,6 +5895,7 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 			$loading_attrs['fetchpriority'] = 'high';
 			wp_high_priority_element_flag( false );
 		}
+
 		return $loading_attrs;
 	}
 
@@ -5915,10 +5916,12 @@ function wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr 
 	 * @param int $threshold Minimum square-pixels threshold. Default 50000.
 	 */
 	$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
+
 	if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
 		$loading_attrs['fetchpriority'] = 'high';
 		wp_high_priority_element_flag( false );
 	}
+
 	return $loading_attrs;
 }
 
@@ -5937,5 +5940,6 @@ function wp_high_priority_element_flag( $value = null ) {
 	if ( is_bool( $value ) ) {
 		$high_priority_element = $value;
 	}
+
 	return $high_priority_element;
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5654,6 +5654,15 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 		}
 		return $loading_attributes;
 	};
+	// Closure to increase media count for images with certain minimum threshold, mostly used for header images.
+	$maybe_increase_content_media_count = static function() use ( $attr ) {
+		/** This filter is documented in wp-admin/includes/media.php */
+		$wp_min_priority_img_pixels = apply_filters( 'wp_min_priority_img_pixels', 50000 );
+		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
+		if ( $wp_min_priority_img_pixels <= $attr['width'] * $attr['height'] ) {
+			wp_increase_content_media_count();
+		}
+	};
 
 	$loading_attrs = array();
 
@@ -5706,11 +5715,15 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 	 */
 	$header_area = 'header';
 	if ( "template_part_{$header_area}" === $context ) {
+		// Increase media count if there are images in header above a certian minimum size threshold.
+		$maybe_increase_content_media_count();
 		return $postprocess( $loading_attrs, true );
 	}
 
 	// The custom header image is always expected to be in the header.
 	if ( 'get_header_image_tag' === $context ) {
+		// Increase media count if there are images in header above a certian minimum size threshold.
+		$maybe_increase_content_media_count();
 		return $postprocess( $loading_attrs, true );
 	}
 
@@ -5737,6 +5750,8 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 			 */
 			&& did_action( 'get_header' ) && ! did_action( 'get_footer' )
 		) {
+			// Increase media count if there are images in header above a certian minimum size threshold.
+			$maybe_increase_content_media_count();
 			return $postprocess( $loading_attrs, true );
 		}
 	}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5769,9 +5769,10 @@ function wp_get_loading_optimization_attributes( $tag_name, $attr, $context ) {
 
 	/*
 	 * The first elements in 'the_content' or 'the_post_thumbnail' should not be lazy-loaded,
-	 * as they are likely above the fold.
+	 * as they are likely above the fold. Shortcodes are processed after content images, so if
+	 * thresholds haven't already been met, apply the same logic to those as well.
 	 */
-	if ( 'the_content' === $context || 'the_post_thumbnail' === $context ) {
+	if ( 'the_content' === $context || 'the_post_thumbnail' === $context || 'do_shortcode' === $context ) {
 		// Only elements within the main query loop have special handling.
 		if ( is_admin() || ! in_the_loop() || ! is_main_query() ) {
 			$loading_attrs['loading'] = 'lazy';

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2924,13 +2924,10 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			'class'         => null,
 			'force_display' => false,
 			'loading'       => null,
+			'fetchpriority' => null,
 			'extra_attr'    => '',
 			'decoding'      => 'async',
 		);
-
-		if ( wp_lazy_loading_enabled( 'img', 'get_avatar' ) ) {
-			$defaults['loading'] = wp_get_loading_attr_default( 'get_avatar' );
-		}
 
 		if ( empty( $args ) ) {
 			$args = array();
@@ -2948,6 +2945,11 @@ if ( ! function_exists( 'get_avatar' ) ) :
 		if ( empty( $args['width'] ) ) {
 			$args['width'] = $args['size'];
 		}
+
+		// Update args with loading optimized attributes.
+		$loading_optimization_attr = wp_get_loading_optimization_attributes( 'img', $args, 'get_avatar' );
+
+		$args = array_merge( $args, $loading_optimization_attr );
 
 		if ( is_object( $id_or_email ) && isset( $id_or_email->comment_ID ) ) {
 			$id_or_email = get_comment( $id_or_email );
@@ -3001,7 +3003,7 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			}
 		}
 
-		// Add `loading` and `decoding` attributes.
+		// Add `loading`, `fetchpriority` and `decoding` attributes.
 		$extra_attr = $args['extra_attr'];
 
 		if ( in_array( $args['loading'], array( 'lazy', 'eager' ), true )
@@ -3022,6 +3024,17 @@ if ( ! function_exists( 'get_avatar' ) ) :
 			}
 
 			$extra_attr .= "decoding='{$args['decoding']}'";
+		}
+
+		// Add support for `fetchpriority`.
+		if ( in_array( $args['fetchpriority'], array( 'high', 'low', 'auto' ), true )
+			&& ! preg_match( '/\bfetchpriority\s*=/', $extra_attr )
+		) {
+			if ( ! empty( $extra_attr ) ) {
+				$extra_attr .= ' ';
+			}
+
+			$extra_attr .= "fetchpriority='{$args['fetchpriority']}'";
 		}
 
 		$avatar = sprintf(

--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -186,22 +186,6 @@ function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr =
 			update_post_thumbnail_cache();
 		}
 
-		// Add `loading` attribute.
-		if ( wp_lazy_loading_enabled( 'img', 'the_post_thumbnail' ) ) {
-			// Get the 'loading' attribute value to use as default, taking precedence over the default from
-			// `wp_get_attachment_image()`.
-			$loading = wp_get_loading_attr_default( 'the_post_thumbnail' );
-
-			// Add the default to the given attributes unless they already include a 'loading' directive.
-			if ( empty( $attr ) ) {
-				$attr = array( 'loading' => $loading );
-			} elseif ( is_array( $attr ) && ! array_key_exists( 'loading', $attr ) ) {
-				$attr['loading'] = $loading;
-			} elseif ( is_string( $attr ) && ! preg_match( '/(^|&)loading=/', $attr ) ) {
-				$attr .= '&loading=' . $loading;
-			}
-		}
-
 		$html = wp_get_attachment_image( $post_thumbnail_id, $size, false, $attr );
 
 		/**

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -259,6 +259,14 @@ function do_shortcode( $content, $ignore_html = false ) {
 		return $content;
 	}
 
+	// Ensure this context is only added once if shortcodes are nested.
+	$has_filter = has_filter( 'wp_get_attachment_image_context', '_filter_do_shortcode_context' );
+	$filter_added = false;
+
+	if ( ! $has_filter ) {
+		$filter_added = add_filter( 'wp_get_attachment_image_context', '_filter_do_shortcode_context' );
+	}
+
 	$content = do_shortcodes_in_html_tags( $content, $ignore_html, $tagnames );
 
 	$pattern = get_shortcode_regex( $tagnames );
@@ -267,7 +275,27 @@ function do_shortcode( $content, $ignore_html = false ) {
 	// Always restore square braces so we don't break things like <!--[if IE ]>.
 	$content = unescape_invalid_shortcodes( $content );
 
+	// Only remove the filter if it was added in this scope.
+	if ( $filter_added ) {
+		remove_filter( 'wp_get_attachment_image_context', '_filter_do_shortcode_context' );
+	}
+
 	return $content;
+}
+
+/**
+ * Filter the `wp_get_attachment_image_context` hook during shortcode rendering.
+ *
+ * When wp_get_attachment_image() is called during shortcode rendering, we need to make clear
+ * that the context is a shortcode and not part of the theme's template rendering logic.
+ *
+ * @since 6.3.0
+ * @access private
+ *
+ * @return string The filtered context value for wp_get_attachment_images when doing shortcodes.
+ */
+function _filter_do_shortcode_context() {
+	return 'do_shortcode';
 }
 
 /**

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1226,6 +1226,7 @@ function get_header_image_tag( $attr = array() ) {
 			'width'  => $width,
 			'height' => $height,
 			'alt'    => $alt,
+			'decoding' => 'async',
 		)
 	);
 
@@ -1248,6 +1249,29 @@ function get_header_image_tag( $attr = array() ) {
 				$attr['sizes']  = $sizes;
 			}
 		}
+	}
+
+	$attr = array_merge(
+		$attr,
+		wp_get_loading_optimization_attributes( 'img', $attr, 'get_header_image_tag' )
+	);
+
+	/*
+	 * If the default value of `lazy` for the `loading` attribute is overridden
+	 * to omit the attribute for this image, ensure it is not included.
+	 */
+	if ( isset( $attr['loading'] ) && ! $attr['loading'] ) {
+		unset( $attr['loading'] );
+	}
+
+	// If the `fetchpriority` attribute is overridden and set to false or an empty string.
+	if ( isset( $attr['fetchpriority'] ) && ! $attr['fetchpriority'] ) {
+		unset( $attr['fetchpriority'] );
+	}
+
+	// If the `decoding` attribute is overridden and set to false or an empty string.
+	if ( isset( $attr['decoding'] ) && ! $attr['decoding'] ) {
+		unset( $attr['decoding'] );
 	}
 
 	/**

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -239,15 +239,6 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				$instance['height'] = '';
 			}
 
-<<<<<<< HEAD
-			$image = sprintf(
-				'<img class="%1$s" src="%2$s" alt="%3$s" width="%4$s" height="%5$s">',
-				esc_attr( $classes ),
-				esc_url( $instance['url'] ),
-				esc_attr( $instance['alt'] ),
-				esc_attr( $instance['width'] ),
-				esc_attr( $instance['height'] )
-=======
 			$attr = array(
 				'class'    => $classes,
 				'src'      => $instance['url'],
@@ -255,7 +246,6 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				'width'    => $instance['width'],
 				'height'   => $instance['height'],
 				'decoding' => 'async',
->>>>>>> 21490c6ba4 (Media: Ensure that the image widget supports loading optimization attributes.)
 			);
 
 			$loading_optimization_attr = wp_get_loading_optimization_attributes(
@@ -273,7 +263,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				$image .= ' ' . $name . '="' . $value . '"';
 			}
 
-			$image .= ' />';
+			$image .= '>';
 		} // End if().
 
 		$url = '';

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -239,6 +239,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				$instance['height'] = '';
 			}
 
+<<<<<<< HEAD
 			$image = sprintf(
 				'<img class="%1$s" src="%2$s" alt="%3$s" width="%4$s" height="%5$s">',
 				esc_attr( $classes ),
@@ -246,7 +247,33 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				esc_attr( $instance['alt'] ),
 				esc_attr( $instance['width'] ),
 				esc_attr( $instance['height'] )
+=======
+			$attr = array(
+				'class'    => $classes,
+				'src'      => $instance['url'],
+				'alt'      => $instance['alt'],
+				'width'    => $instance['width'],
+				'height'   => $instance['height'],
+				'decoding' => 'async',
+>>>>>>> 21490c6ba4 (Media: Ensure that the image widget supports loading optimization attributes.)
 			);
+
+			$loading_optimization_attr = wp_get_loading_optimization_attributes(
+				'img',
+				$attr,
+				'widget_media_image'
+			);
+
+			$attr = array_merge( $attr, $loading_optimization_attr );
+
+			$attr  = array_map( 'esc_attr', $attr );
+			$image = '<img';
+
+			foreach ( $attr as $name => $value ) {
+				$image .= ' ' . $name . '="' . $value . '"';
+			}
+
+			$image .= ' />';
 		} // End if().
 
 		$url = '';

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -76,13 +76,14 @@ CAP;
 	}
 
 	/**
-	 * Ensures that the static content media count and related filter are reset between tests.
+	 * Ensures that the static content media count, fetchpriority element flag and related filter are reset between tests.
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		$this->reset_content_media_count();
 		$this->reset_omit_loading_attr_filter();
+		$this->reset_high_priority_element_flag();
 	}
 
 	public function test_img_caption_shortcode_added() {
@@ -2080,7 +2081,7 @@ EOF;
 	 */
 	public function test_wp_filter_content_tags_srcset_sizes_wrong() {
 		$img = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$img = wp_img_tag_add_loading_attr( $img, 'test' );
+		$img = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
 		$img = wp_img_tag_add_decoding_attr( $img, 'the_content' );
 
 		// Replace the src URL.
@@ -2095,7 +2096,7 @@ EOF;
 	public function test_wp_filter_content_tags_srcset_sizes_with_preexisting_srcset() {
 		// Generate HTML and add a dummy srcset attribute.
 		$img = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$img = wp_img_tag_add_loading_attr( $img, 'test' );
+		$img = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
 		$img = wp_img_tag_add_decoding_attr( $img, 'the_content' );
 		$img = preg_replace( '|<img ([^>]+)>|', '<img $1 ' . 'srcset="image2x.jpg 2x">', $img );
 
@@ -2240,7 +2241,7 @@ EOF;
 
 		// Build HTML for the editor.
 		$img          = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$img          = wp_img_tag_add_loading_attr( $img, 'test' );
+		$img          = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
 		$img_https    = str_replace( 'http://', 'https://', $img );
 		$img_relative = str_replace( 'http://', '//', $img );
 
@@ -2781,6 +2782,7 @@ EOF;
 	 * @ticket 44427
 	 * @ticket 50367
 	 * @ticket 50756
+	 * @ticket 58235
 	 * @requires function imagejpeg
 	 */
 	public function test_wp_filter_content_tags_loading_lazy() {
@@ -2795,13 +2797,17 @@ EOF;
 		$iframe                 = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
 		$iframe_no_width_height = '<iframe src="https://www.example.com"></iframe>';
 
-		$lazy_img       = wp_img_tag_add_loading_attr( $img, 'test' );
-		$lazy_img_xhtml = wp_img_tag_add_loading_attr( $img_xhtml, 'test' );
-		$lazy_img_html5 = wp_img_tag_add_loading_attr( $img_html5, 'test' );
+		$lazy_img       = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
+		$lazy_img_xhtml = wp_img_tag_add_loading_optimization_attrs( $img_xhtml, 'test' );
+		$lazy_img_html5 = wp_img_tag_add_loading_optimization_attrs( $img_html5, 'test' );
 		$lazy_iframe    = wp_iframe_tag_add_loading_attr( $iframe, 'test' );
 
 		// The following should not be modified because there already is a 'loading' attribute.
+<<<<<<< HEAD
 		$img_eager    = str_replace( '">', '" loading="eager">', $img );
+=======
+		$img_eager    = str_replace( ' />', ' loading="eager" fetchpriority="high" />', $img );
+>>>>>>> b6fde03ef7 (Media: Automatically add `fetchpriority="high"` to hero image to improve load time performance.)
 		$iframe_eager = str_replace( '">', '" loading="eager">', $iframe );
 
 		$content = '
@@ -2860,10 +2866,11 @@ EOF;
 	/**
 	 * @ticket 44427
 	 * @ticket 50756
+	 * @ticket 58235
 	 */
 	public function test_wp_filter_content_tags_loading_lazy_opted_in() {
 		$img         = get_image_tag( self::$large_id, '', '', '', 'medium' );
-		$lazy_img    = wp_img_tag_add_loading_attr( $img, 'test' );
+		$lazy_img    = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
 		$lazy_img    = wp_img_tag_add_decoding_attr( $lazy_img, 'the_content' );
 		$iframe      = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
 		$lazy_iframe = wp_iframe_tag_add_loading_attr( $iframe, 'test' );
@@ -2918,6 +2925,9 @@ EOF;
 	/**
 	 * @ticket 44427
 	 * @ticket 50367
+	 *
+	 * @expectedDeprecated wp_img_tag_add_loading_attr
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 */
 	public function test_wp_img_tag_add_loading_attr() {
 		$img = '<img src="example.png" alt=" width="300" height="225">';
@@ -2929,6 +2939,9 @@ EOF;
 	/**
 	 * @ticket 44427
 	 * @ticket 50367
+	 *
+	 * @expectedDeprecated wp_img_tag_add_loading_attr
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 */
 	public function test_wp_img_tag_add_loading_attr_without_src() {
 		$img = '<img alt=" width="300" height="225">';
@@ -2940,6 +2953,9 @@ EOF;
 	/**
 	 * @ticket 44427
 	 * @ticket 50367
+	 *
+	 * @expectedDeprecated wp_img_tag_add_loading_attr
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 */
 	public function test_wp_img_tag_add_loading_attr_with_single_quotes() {
 		$img = "<img src='example.png' alt=' width='300' height='225'>";
@@ -3077,6 +3093,93 @@ EOF;
 
 		// There should not be any loading attribute in this case.
 		$this->assertStringNotContainsString( ' loading=', $img );
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_attachment_image
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_attachment_image_fetchpriority_not_present_by_default() {
+		$img = wp_get_attachment_image( self::$large_id );
+
+		$this->assertStringNotContainsString( ' fetchpriority="high"', $img );
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_attachment_image
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_attachment_image_fetchpriority_high_when_not_lazy_loaded() {
+		$img = wp_get_attachment_image( self::$large_id, 'large', false, array( 'loading' => false ) );
+
+		$this->assertStringContainsString( ' fetchpriority="high"', $img );
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @dataProvider data_provider_fetchpriority_values
+	 *
+	 * @covers ::wp_get_attachment_image
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_attachment_image_fetchpriority_original_value_respected( $value ) {
+		$img = wp_get_attachment_image(
+			self::$large_id,
+			'large',
+			false,
+			array(
+				'loading'       => false,
+				'fetchpriority' => $value,
+			)
+		);
+
+		$this->assertStringContainsString( ' fetchpriority="' . $value . '"', $img );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_provider_fetchpriority_values() {
+		return self::text_array_to_dataprovider( array( 'high', 'low', 'auto' ) );
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_attachment_image
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_attachment_image_fetchpriority_stripped_when_false() {
+		$img = wp_get_attachment_image(
+			self::$large_id,
+			'large',
+			false,
+			array(
+				'loading'       => false,
+				'fetchpriority' => false,
+			)
+		);
+
+		$this->assertStringNotContainsString( ' fetchpriority=', $img );
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_attachment_image
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_attachment_image_fetchpriority_high_prevents_lazy_loading() {
+		$img = wp_get_attachment_image( self::$large_id, 'large', false, array( 'fetchpriority' => 'high' ) );
+
+		$this->assertStringNotContainsString( ' loading="lazy"', $img );
 	}
 
 	/**
@@ -3354,6 +3457,8 @@ EOF;
 	 *
 	 * @covers ::wp_get_loading_attr_default
 	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
+	 *
 	 * @dataProvider data_wp_get_loading_attr_default
 	 *
 	 * @param string $context
@@ -3377,8 +3482,10 @@ EOF;
 			// Set as main query.
 			$this->set_main_query( $query );
 
-			// For contexts other than for the main content, still return 'lazy' even in the loop
-			// and in the main query, and do not increase the content media count.
+			/*
+			 * For contexts other than for the main content, still return 'lazy' even in the loop
+			 * and in the main query, and do not increase the content media count.
+			 */
 			$this->assertSame( 'lazy', wp_get_loading_attr_default( 'wp_get_attachment_image' ) );
 
 			// Return `false` in the main query for first three element.
@@ -3403,8 +3510,15 @@ EOF;
 
 	/**
 	 * @ticket 53675
+	 * @ticket 58235
 	 */
 	public function test_wp_omit_loading_attr_threshold_filter() {
+		// Using a smaller image here.
+		$attr = array(
+			'width'  => 100,
+			'height' => 100,
+		);
+
 		$query = $this->get_new_wp_query_for_published_post();
 		$this->set_main_query( $query );
 
@@ -3416,25 +3530,37 @@ EOF;
 
 			// Due to the filter, now the first five elements should not be lazy-loaded, i.e. return `false`.
 			for ( $i = 0; $i < 5; $i++ ) {
-				$this->assertFalse( wp_get_loading_attr_default( 'the_content' ) );
+				$this->assertEmpty(
+					wp_get_loading_optimization_attributes( 'img', $attr, 'the_content' ),
+					'Expected second image to not be lazy-loaded.'
+				);
 			}
 
 			// For following elements, lazy-load them again.
-			$this->assertSame( 'lazy', wp_get_loading_attr_default( 'the_content' ) );
+			$this->assertSame(
+				array( 'loading' => 'lazy' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, 'the_content' )
+			);
 		}
 	}
 
 	/**
 	 * @ticket 53675
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_filter_content_tags
+	 * @covers ::wp_img_tag_add_loading_optimization_attrs
+	 * @covers ::wp_get_loading_optimization_attributes
 	 */
-	public function test_wp_filter_content_tags_with_wp_get_loading_attr_default() {
+	public function test_wp_filter_content_tags_with_loading_optimization_attrs() {
 		$img1         = get_image_tag( self::$large_id, '', '', '', 'large' );
 		$iframe1      = '<iframe src="https://www.example.com" width="640" height="360"></iframe>';
 		$img2         = get_image_tag( self::$large_id, '', '', '', 'medium' );
 		$img3         = get_image_tag( self::$large_id, '', '', '', 'thumbnail' );
 		$iframe2      = '<iframe src="https://wordpress.org" width="640" height="360"></iframe>';
-		$lazy_img2    = wp_img_tag_add_loading_attr( $img2, 'the_content' );
-		$lazy_img3    = wp_img_tag_add_loading_attr( $img3, 'the_content' );
+		$prio_img1    = str_replace( ' src=', ' fetchpriority="high" src=', $img1 );
+		$lazy_img2    = wp_img_tag_add_loading_optimization_attrs( $img2, 'the_content' );
+		$lazy_img3    = wp_img_tag_add_loading_optimization_attrs( $img3, 'the_content' );
 		$lazy_iframe2 = wp_iframe_tag_add_loading_attr( $iframe2, 'the_content' );
 
 		// Use a threshold of 2.
@@ -3442,7 +3568,7 @@ EOF;
 
 		// Following the threshold of 2, the first two content media elements should not be lazy-loaded.
 		$content_unfiltered = $img1 . $iframe1 . $img2 . $img3 . $iframe2;
-		$content_expected   = $img1 . $iframe1 . $lazy_img2 . $lazy_img3 . $lazy_iframe2;
+		$content_expected   = $prio_img1 . $iframe1 . $lazy_img2 . $lazy_img3 . $lazy_iframe2;
 		$content_expected   = wp_img_tag_add_decoding_attr( $content_expected, 'the_content' );
 
 		$query = $this->get_new_wp_query_for_published_post();
@@ -3491,6 +3617,8 @@ EOF;
 	 *
 	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
 	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
+	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
 	public function test_wp_get_loading_attr_default_before_loop_if_not_main_query( $context ) {
@@ -3513,6 +3641,8 @@ EOF;
 	 *
 	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
 	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
+	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
 	public function test_wp_get_loading_attr_default_before_loop_in_main_query_but_header_not_called( $context ) {
@@ -3534,6 +3664,8 @@ EOF;
 	 *
 	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
 	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
+	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
 	public function test_wp_get_loading_attr_default_before_loop_if_main_query( $context ) {
@@ -3554,6 +3686,8 @@ EOF;
 	 * @covers ::wp_get_loading_attr_default
 	 *
 	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
@@ -3579,6 +3713,8 @@ EOF;
 	 * @covers ::wp_get_loading_attr_default
 	 *
 	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
@@ -3609,16 +3745,205 @@ EOF;
 	}
 
 	/**
-	 * @ticket 58089
+<<<<<<< HEAD
+=======
+	 * Tests that wp_filter_content_tags() does not add loading="lazy" to the first
+	 * image in the loop when using a block theme.
+	 *
+	 * @ticket 56930
+	 * @ticket 58548
+	 * @ticket 58235
 	 *
 	 * @covers ::wp_filter_content_tags
-	 * @covers ::wp_get_loading_attr_default
+	 * @covers ::wp_img_tag_add_loading_optimization_attrs
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_filter_content_tags_does_not_lazy_load_first_image_in_block_theme() {
+		global $_wp_current_template_content, $wp_query, $wp_the_query, $post;
+
+		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_decoding_attr', '__return_false' );
+		$this->force_omit_loading_attr_threshold( 1 );
+
+		$img1      = get_image_tag( self::$large_id, '', '', '', 'large' );
+		$img2      = get_image_tag( self::$large_id, '', '', '', 'medium' );
+		$prio_img1 = str_replace( ' src=', ' fetchpriority="high" src=', $img1 );
+		$lazy_img2 = wp_img_tag_add_loading_optimization_attrs( $img2, 'the_content' );
+
+		// Only the second image should be lazy-loaded.
+		$post_content     = $img1 . $img2;
+		$expected_content = wpautop( $prio_img1 . $lazy_img2 );
+
+		// Update the post to test with so that it has the above post content.
+		wp_update_post(
+			array(
+				'ID'                    => self::$post_ids['publish'],
+				'post_content'          => $post_content,
+				'post_content_filtered' => $post_content,
+			)
+		);
+
+		$wp_query     = new WP_Query( array( 'p' => self::$post_ids['publish'] ) );
+		$wp_the_query = $wp_query;
+		$post         = get_post( self::$post_ids['publish'] );
+
+		$_wp_current_template_content = '<!-- wp:post-content /-->';
+
+		$html = get_the_block_template_html();
+		$this->assertSame( '<div class="wp-site-blocks"><div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow">' . $expected_content . '</div></div>', $html );
+	}
+
+	/**
+	 * Tests that wp_filter_content_tags() does not add loading="lazy"
+	 * to the featured image when using a block theme.
+	 *
+	 * @ticket 56930
+	 * @ticket 58548
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_filter_content_tags
+	 * @covers ::wp_img_tag_add_loading_optimization_attrs
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_filter_content_tags_does_not_lazy_load_first_featured_image_in_block_theme() {
+		global $_wp_current_template_content, $wp_query, $wp_the_query, $post;
+
+		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_decoding_attr', '__return_false' );
+		add_filter(
+			'wp_get_attachment_image_attributes',
+			static function( $attr ) {
+				unset( $attr['srcset'], $attr['sizes'], $attr['decoding'] );
+				return $attr;
+			}
+		);
+		$this->force_omit_loading_attr_threshold( 1 );
+
+		$content_img      = get_image_tag( self::$large_id, '', '', '', 'large' );
+		$lazy_content_img = wp_img_tag_add_loading_optimization_attrs( $content_img, 'the_content' );
+
+		// The featured image should not be lazy-loaded as it is the first image.
+		$featured_image_id = self::$large_id;
+		update_post_meta( self::$post_ids['publish'], '_thumbnail_id', $featured_image_id );
+		$expected_featured_image = '<figure class="wp-block-post-featured-image">' . get_the_post_thumbnail(
+			self::$post_ids['publish'],
+			'post-thumbnail',
+			array(
+				'loading'       => false,
+				'fetchpriority' => 'high',
+			)
+		) . '</figure>';
+
+		// Reset high priority flag as the forced `fetchpriority="high"` above already modified it.
+		$this->reset_high_priority_element_flag();
+
+		// The post content image should be lazy-loaded since the featured image appears above.
+		$post_content     = $content_img;
+		$expected_content = wpautop( $lazy_content_img );
+
+		// Update the post to test with so that it has the above post content.
+		wp_update_post(
+			array(
+				'ID'                    => self::$post_ids['publish'],
+				'post_content'          => $post_content,
+				'post_content_filtered' => $post_content,
+			)
+		);
+		$wp_query     = new WP_Query( array( 'p' => self::$post_ids['publish'] ) );
+		$wp_the_query = $wp_query;
+		$post         = get_post( self::$post_ids['publish'] );
+
+		$_wp_current_template_content = '<!-- wp:post-featured-image /--> <!-- wp:post-content /-->';
+
+		$html = get_the_block_template_html();
+		$this->assertSame( '<div class="wp-site-blocks">' . $expected_featured_image . ' <div class="entry-content wp-block-post-content is-layout-flow wp-block-post-content-is-layout-flow">' . $expected_content . '</div></div>', $html );
+	}
+
+	/**
+	 * Tests that wp_filter_content_tags() does not add loading="lazy" to images
+	 * in a "Header" template part.
+	 *
+	 * @ticket 56930
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_filter_content_tags
+	 * @covers ::wp_img_tag_add_loading_optimization_attrs
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_filter_content_tags_does_not_lazy_load_images_in_header() {
+		global $_wp_current_template_content;
+
+		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
+		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
+		add_filter( 'wp_img_tag_add_decoding_attr', '__return_false' );
+
+		// Use a single image for each header and footer template parts.
+		$header_img = get_image_tag( self::$large_id, '', '', '', 'large' );
+		// Since header_img is qualified candidate for LCP, fetchpriority high is applied to it.
+		$header_img = str_replace( '<img', '<img fetchpriority="high"', $header_img );
+
+		$footer_img = get_image_tag( self::$large_id, '', '', '', 'medium' );
+
+		// Create header and footer template parts.
+		$header_post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_name'    => 'header',
+				'post_content' => $header_img,
+			)
+		);
+		wp_set_post_terms( $header_post_id, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
+		wp_set_post_terms( $header_post_id, get_stylesheet(), 'wp_theme' );
+		$footer_post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'wp_template_part',
+				'post_status'  => 'publish',
+				'post_name'    => 'footer',
+				'post_content' => $footer_img,
+			)
+		);
+		wp_set_post_terms( $footer_post_id, WP_TEMPLATE_PART_AREA_FOOTER, 'wp_template_part_area' );
+		wp_set_post_terms( $footer_post_id, get_stylesheet(), 'wp_theme' );
+
+		$_wp_current_template_content = '<!-- wp:template-part {"slug":"header","theme":"' . get_stylesheet() . '","tagName":"header"} /--><!-- wp:template-part {"slug":"footer","theme":"' . get_stylesheet() . '","tagName":"footer"} /-->';
+
+		// Header image should not be lazy-loaded, footer image should be lazy-loaded.
+		$expected_template_content  = '<header class="wp-block-template-part">' . $header_img . '</header>';
+		$expected_template_content .= '<footer class="wp-block-template-part">' . wp_img_tag_add_loading_optimization_attrs( $footer_img, 'force-lazy' ) . '</footer>';
+
+		$html = get_the_block_template_html();
+		$this->assertSame( '<div class="wp-site-blocks">' . $expected_template_content . '</div>', $html );
+	}
+
+	/**
+>>>>>>> b6fde03ef7 (Media: Automatically add `fetchpriority="high"` to hero image to improve load time performance.)
+	 * @ticket 58089
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_filter_content_tags
+	 * @covers ::wp_get_loading_optimization_attributes
 	 */
 	public function test_wp_filter_content_tags_does_not_lazy_load_special_images_within_the_content() {
 		global $wp_query, $wp_the_query;
 
 		// Force no lazy-loading on the image tag expected in the content.
-		$expected_content = wpautop( wp_get_attachment_image( self::$large_id, 'large', false, array( 'loading' => false ) ) );
+		$expected_content = wpautop(
+			wp_get_attachment_image(
+				self::$large_id,
+				'large',
+				false,
+				array(
+					'loading'       => false,
+					'fetchpriority' => 'high',
+				)
+			)
+		);
+
+		// Reset high priority flag as the forced `fetchpriority="high"` above already modified it.
+		$this->reset_high_priority_element_flag();
 
 		// Overwrite post content with an image.
 		add_filter(
@@ -3656,6 +3981,8 @@ EOF;
 	 *
 	 * @covers ::wp_get_loading_attr_default
 	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
+	 *
 	 * @dataProvider data_special_contexts_for_the_content
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
@@ -3670,6 +3997,8 @@ EOF;
 	 * @ticket 58089
 	 *
 	 * @covers ::wp_get_loading_attr_default
+	 *
+	 * @expectedDeprecated wp_get_loading_attr_default
 	 *
 	 * @dataProvider data_special_contexts_for_the_content
 	 *
@@ -3700,6 +4029,313 @@ EOF;
 			'the_post_thumbnail'      => array( 'context' => 'the_post_thumbnail' ),
 			'wp_get_attachment_image' => array( 'context' => 'wp_get_attachment_image' ),
 		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_attr_default() returns the expected loading attribute value.
+	 *
+	 * @ticket 53675
+	 * @ticket 56930
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default
+	 *
+	 * @param string $context
+	 */
+	public function test_wp_get_loading_optimization_attributes( $context ) {
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Return 'lazy' by default.
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'test' )
+		);
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'wp_get_attachment_image' )
+		);
+
+		// Return 'lazy' if not in the loop or the main query.
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+
+		$query = $this->get_new_wp_query_for_published_post();
+
+		while ( have_posts() ) {
+			the_post();
+
+			// Return 'lazy' if in the loop but not in the main query.
+			$this->assertSame(
+				array( 'loading' => 'lazy' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+
+			// Set as main query.
+			$this->set_main_query( $query );
+
+			/*
+			 * For contexts other than for the main content, still return 'lazy' even in the loop
+			 * and in the main query, and do not increase the content media count.
+			 */
+			$this->assertSame(
+				array( 'loading' => 'lazy' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, 'wp_get_attachment_image' )
+			);
+
+			// First three element are not lazy loaded. However, first image is loaded with fetchpriority high.
+			$this->assertSame(
+				array( 'fetchpriority' => 'high' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+				"Expected first image to not be lazy-loaded. First large image get's high fetchpriority."
+			);
+			$this->assertEmpty(
+				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+				'Expected second image to not be lazy-loaded.'
+			);
+			$this->assertEmpty(
+				wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+				'Expected third image to not be lazy-loaded.'
+			);
+
+			// Return 'lazy' if in the loop and in the main query for any subsequent elements.
+			$this->assertSame(
+				array( 'loading' => 'lazy' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+
+			// Yes, for all subsequent elements.
+			$this->assertSame(
+				array( 'loading' => 'lazy' ),
+				wp_get_loading_optimization_attributes( 'img', $attr, $context )
+			);
+		}
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value before loop but after get_header if not main query.
+	 *
+	 * @ticket 58211
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_before_loop_if_not_main_query( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+
+		do_action( 'get_header' );
+
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Lazy if not main query.
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value before loop but after get_header in main query but header was not called.
+	 *
+	 * @ticket 58211
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_before_loop_in_main_query_but_header_not_called( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+		$this->set_main_query( $wp_query );
+
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Lazy if header not called.
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value before loop but after get_header for main query.
+	 *
+	 * @ticket 58211
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_before_loop_if_main_query( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+		$this->set_main_query( $wp_query );
+		do_action( 'get_header' );
+
+		$attr = $this->get_width_height_for_high_priority();
+
+		// First image is loaded with high fetchpriority.
+		$this->assertSame(
+			array( 'fetchpriority' => 'high' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context ),
+			'Expected first image to not be lazy-loaded. First large image is loaded with high fetchpriority.'
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute value after get_header and after loop.
+	 *
+	 * @ticket 58211
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_after_loop( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+		$this->set_main_query( $wp_query );
+
+		do_action( 'get_header' );
+
+		while ( have_posts() ) {
+			the_post();
+		}
+
+		$attr = $this->get_width_height_for_high_priority();
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns the expected loading attribute if no loop.
+	 *
+	 * @ticket 58211
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_no_loop( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+		$this->set_main_query( $wp_query );
+
+		// Ensure header and footer is called.
+		do_action( 'get_header' );
+		do_action( 'get_footer' );
+
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Load lazy if the there is no loop and footer was called.
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns 'lazy' for special contexts when they're used outside of 'the_content' filter.
+	 *
+	 * @ticket 58089
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_special_contexts_for_the_content
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_should_return_lazy_for_special_contexts_outside_of_the_content( $context ) {
+		$attr = $this->get_width_height_for_high_priority();
+		$this->assertSame(
+			array( 'loading' => 'lazy' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, $context )
+		);
+	}
+
+	/**
+	 * Tests that wp_get_loading_optimization_attributes() returns false for special contexts when they're used within 'the_content' filter.
+	 *
+	 * @ticket 58089
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_special_contexts_for_the_content
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_should_return_false_for_special_contexts_within_the_content( $context ) {
+		remove_all_filters( 'the_content' );
+
+		$result = null;
+		add_filter(
+			'the_content',
+			function( $content ) use ( &$result, $context ) {
+				$attr   = $this->get_width_height_for_high_priority();
+				$result = wp_get_loading_optimization_attributes( 'img', $attr, $context );
+				return $content;
+			}
+		);
+		apply_filters( 'the_content', '' );
+
+		$this->assertSame(
+			array( 'fetchpriority' => 'high' ),
+			$result,
+			'First large image is loaded with high fetchpriority.'
+		);
+	}
+
+	/**
+	 * @ticket 44427
+	 * @ticket 50367
+	 * @ticket 58235
+	 */
+	public function test_wp_img_tag_add_loading_optimization_attrs() {
+		$img = '<img src="example.png" alt=" width="300" height="225" />';
+		$img = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
+
+		$this->assertStringContainsString( ' loading="lazy"', $img );
+	}
+
+	/**
+	 * @ticket 44427
+	 * @ticket 50367
+	 * @ticket 58235
+	 */
+	public function test_wp_img_tag_add_loading_optimization_attrs_without_src() {
+		$img = '<img alt="" width="300" height="225" />';
+		$img = wp_img_tag_add_loading_optimization_attrs( $img, 'test' );
+
+		$this->assertStringNotContainsString( ' loading=', $img );
 	}
 
 	/**
@@ -3753,6 +4389,7 @@ EOF;
 	 * that featured image not being lazy-loaded, since the images in the post content aren't displayed in the excerpt.
 	 *
 	 * @ticket 56588
+	 * @ticket 58235
 	 *
 	 * @covers ::wp_trim_excerpt
 	 */
@@ -3764,6 +4401,7 @@ EOF;
 		 * then use a post that contains exactly 2 images.
 		 */
 		$this->force_omit_loading_attr_threshold( 2 );
+
 		$post_content  = '<img src="example.jpg" width="800" height="600">';
 		$post_content .= '<p>Some text.</p>';
 		$post_content .= '<img src="example2.jpg" width="800" height="600">';
@@ -3777,7 +4415,17 @@ EOF;
 		$featured_image_id = self::$large_id;
 		update_post_meta( $post_id, '_thumbnail_id', $featured_image_id );
 
-		$expected_image_tag = get_the_post_thumbnail( $post_id, 'post-thumbnail', array( 'loading' => false ) );
+		$expected_image_tag = get_the_post_thumbnail(
+			$post_id,
+			'post-thumbnail',
+			array(
+				'loading'       => false,
+				'fetchpriority' => 'high',
+			)
+		);
+
+		// Reset high priority flag as the forced `fetchpriority="high"` above already modified it.
+		$this->reset_high_priority_element_flag();
 
 		$wp_query     = new WP_Query( array( 'post__in' => array( $post_id ) ) );
 		$wp_the_query = $wp_query;
@@ -3811,6 +4459,10 @@ EOF;
 
 		// Clean up the above filter.
 		remove_filter( 'wp_omit_loading_attr_threshold', '__return_null', 100 );
+	}
+
+	private function reset_high_priority_element_flag() {
+		wp_high_priority_element_flag( true );
 	}
 
 	/**
@@ -3909,7 +4561,7 @@ EOF;
 	 *
 	 * @ticket 58212
 	 *
-	 * @covers ::wp_get_attachment_image()
+	 * @covers ::wp_get_attachment_image
 	 */
 	public function test_wp_get_attachment_image_context_filter_default() {
 		$last_context = '';
@@ -3924,7 +4576,7 @@ EOF;
 	 *
 	 * @ticket 58212
 	 *
-	 * @covers ::wp_get_attachment_image()
+	 * @covers ::wp_get_attachment_image
 	 */
 	public function test_wp_get_attachment_image_context_filter_value_is_passed_correctly() {
 		$last_context = '';
@@ -3940,6 +4592,298 @@ EOF;
 
 		wp_get_attachment_image( self::$large_id );
 		$this->assertSame( 'my_custom_context', $last_context );
+	}
+
+	/**
+	 * Tests tag restriction for `wp_get_loading_optimization_attributes()`.
+	 *
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_optimization_attributes_min_required_attrs
+	 *
+	 * @param string $tag_name The tag name.
+	 * @param string $attr Element attributes.
+	 * @param array  $expected Expected return value.
+	 * @param string $message Message to display if the test fails.
+	 */
+	public function test_wp_get_loading_optimization_attributes_min_required_attrs( $tag_name, $attr, $expected, $message ) {
+		$context = 'the_post_thumbnail';
+		$this->assertSame( wp_get_loading_optimization_attributes( $tag_name, $attr, $context ), $expected, $message );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_get_loading_optimization_attributes_min_required_attrs() {
+		return array(
+			'img_with_min_attrs' => array(
+				'img',
+				array(
+					'width'  => 100,
+					'height' => 100,
+				),
+				array( 'loading' => 'lazy' ),
+				'Expected default `loading="lazy"`.',
+			),
+			'img_without_height' => array(
+				'img',
+				array( 'width' => 100 ),
+				array(),
+				'Expected blank array as height is required.',
+			),
+			'img_without_width'  => array(
+				'img',
+				array( 'height' => 100 ),
+				array(),
+				'Expected blank array as width is required.',
+			),
+		);
+	}
+
+	/**
+	 * Tests tag restriction for `wp_get_loading_optimization_attributes()`.
+	 *
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_optimization_attributes_check_allowed_tags
+	 *
+	 * @param string $tag_name The tag name.
+	 * @param array  $expected Expected return value.
+	 * @param string $message Message to display if the test fails.
+	 */
+	public function test_wp_get_loading_optimization_attributes_check_allowed_tags( $tag_name, $expected, $message ) {
+		$attr    = $this->get_width_height_for_high_priority();
+		$context = 'the_post_thumbnail';
+		$this->assertSame( wp_get_loading_optimization_attributes( $tag_name, $attr, $context ), $expected, $message );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_get_loading_optimization_attributes_check_allowed_tags() {
+		return array(
+			'img'    => array(
+				'img',
+				array( 'loading' => 'lazy' ),
+				'Expected `loading="lazy"` for the img.',
+			),
+			'iframe' => array(
+				'iframe',
+				array(
+					'loading' => 'lazy',
+				),
+				'Expected `loading="lazy"` for the iframe.',
+			),
+			'video'  =>
+			array(
+				'video',
+				array(),
+				'Function should return empty array as video tag is not supported.',
+			),
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_skip_for_block_template() {
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Skip logic if context is `template`.
+		$this->assertSame(
+			array(),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'template' ),
+			'Skip logic and return blank array for block template.'
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_header_block_template() {
+		$attr = $this->get_width_height_for_high_priority();
+
+		// Skip logic if context is `template`.
+		$this->assertSame(
+			array( 'fetchpriority' => 'high' ),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER ),
+			'Images in the header block template part should not be lazy-loaded and first large image is set high fetchpriority.'
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 * @expectedIncorrectUsage wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_incorrect_loading_attrs() {
+		$attr                  = $this->get_width_height_for_high_priority();
+		$attr['loading']       = 'lazy';
+		$attr['fetchpriority'] = 'high';
+
+		$this->assertSame(
+			array(
+				'loading'       => 'lazy',
+				'fetchpriority' => 'high',
+			),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'test' ),
+			'This should return both lazy-loading and high fetchpriority, but with doing_it_wrong message.'
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_if_loading_attr_present() {
+		$attr            = $this->get_width_height_for_high_priority();
+		$attr['loading'] = 'eager';
+
+		// Check fetchpriority high logic if loading attribute is present.
+		$this->assertSame(
+			array(
+				'fetchpriority' => 'high',
+			),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'test' ),
+			'fetchpriority should be set to high.'
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_low_res_image() {
+		$attr = array(
+			'width'   => 100,
+			'height'  => 100,
+			'loading' => 'eager',
+		);
+
+		// fetchpriority not set as image is of lower resolution.
+		$this->assertSame(
+			array(),
+			wp_get_loading_optimization_attributes( 'img', $attr, 'test' ),
+			'loading optimization attr array should be empty.'
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_maybe_add_fetchpriority_high_attr
+	 *
+	 * @dataProvider data_wp_maybe_add_fetchpriority_high_attr
+	 */
+	public function test_wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr, $expected_fetchpriority ) {
+		$loading_attrs = wp_maybe_add_fetchpriority_high_attr( $loading_attrs, $tag_name, $attr );
+
+		if ( $expected_fetchpriority ) {
+			$this->assertArrayHasKey( 'fetchpriority', $loading_attrs, 'fetchpriority attribute should be present' );
+			$this->assertSame( $expected_fetchpriority, $loading_attrs['fetchpriority'], 'fetchpriority attribute has incorrect value' );
+		} else {
+			$this->assertArrayNotHasKey( 'fetchpriority', $loading_attrs, 'fetchpriority attribute should not be present' );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_maybe_add_fetchpriority_high_attr() {
+		return array(
+			'small image'                   => array(
+				array(),
+				'img',
+				$this->get_insufficient_width_height_for_high_priority(),
+				false,
+			),
+			'large image'                   => array(
+				array(),
+				'img',
+				$this->get_width_height_for_high_priority(),
+				'high',
+			),
+			'image with loading=lazy'       => array(
+				array( 'loading' => 'lazy' ),
+				'img',
+				$this->get_width_height_for_high_priority(),
+				false,
+			),
+			'image with loading=eager'      => array(
+				array( 'loading' => 'eager' ),
+				'img',
+				$this->get_width_height_for_high_priority(),
+				'high',
+			),
+			'image with fetchpriority=high' => array(
+				array(),
+				'img',
+				array_merge(
+					$this->get_insufficient_width_height_for_high_priority(),
+					array( 'fetchpriority' => 'high' )
+				),
+				'high',
+			),
+			'image with fetchpriority=low'  => array(
+				array(),
+				'img',
+				array_merge(
+					$this->get_insufficient_width_height_for_high_priority(),
+					array( 'fetchpriority' => 'low' )
+				),
+				false,
+			),
+			'non-image element'             => array(
+				array(),
+				'video',
+				$this->get_width_height_for_high_priority(),
+				false,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 58235
+	 *
+	 * @covers ::wp_maybe_add_fetchpriority_high_attr
+	 */
+	public function test_wp_maybe_add_fetchpriority_high_attr_min_priority_filter() {
+		$attr = array(
+			'width'  => 50,
+			'height' => 50,
+		);
+
+		add_filter(
+			'wp_min_priority_img_pixels',
+			static function( $res ) {
+				return 2500; // 50*50=2500
+			}
+		);
+
+		// fetchpriority set to high as resolution is equal to (or greater than) 2500.
+		$this->assertSame(
+			array(
+				'fetchpriority' => 'high',
+			),
+			wp_maybe_add_fetchpriority_high_attr( array(), 'img', $attr )
+		);
 	}
 
 	/**
@@ -4039,6 +4983,38 @@ EOF;
 	public function set_main_query( $query ) {
 		global $wp_the_query;
 		$wp_the_query = $query;
+	}
+
+	/**
+	 * Returns an array with dimension attribute values eligible for a high priority image.
+	 *
+	 * @return array Associative array with 'width' and 'height' keys.
+	 */
+	private function get_width_height_for_high_priority() {
+		/*
+		 * The product of width * height must be >50000 to qualify for high priority image.
+		 * 300 * 200 = 60000
+		 */
+		return array(
+			'width'  => 300,
+			'height' => 200,
+		);
+	}
+
+	/**
+	 * Returns an array with dimension attribute values ineligible for a high priority image.
+	 *
+	 * @return array Associative array with 'width' and 'height' keys.
+	 */
+	private function get_insufficient_width_height_for_high_priority() {
+		/*
+		 * The product of width * height must be >50000 to qualify for high priority image.
+		 * 200 * 100 = 20000
+		 */
+		return array(
+			'width'  => 200,
+			'height' => 100,
+		);
 	}
 }
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3747,31 +3747,36 @@ EOF;
 	 * @covers ::wp_filter_content_tags
 	 * @covers ::wp_get_loading_optimization_attributes
 	 */
-	public function test_wp_filter_content_tags_does_not_lazy_load_special_images_within_the_content() {
+	public function test_wp_filter_content_tags_does_not_apply_loading_optimization_to_special_images_within_the_content() {
 		global $wp_query, $wp_the_query;
 
-		// Force no lazy-loading on the image tag expected in the content.
-		$expected_content = wpautop(
-			wp_get_attachment_image(
+		// Force no lazy-loading or fetchpriority on the image tag expected in the content.
+		$expected_image = wp_get_attachment_image(
 				self::$large_id,
 				'large',
 				false,
 				array(
 					'loading'       => false,
-					'fetchpriority' => 'high',
-				)
+				'fetchpriority' => false,
 			)
 		);
 
 		// Reset high priority flag as the forced `fetchpriority="high"` above already modified it.
 		$this->reset_high_priority_element_flag();
 
+		$image_within_content = '';
+
 		// Overwrite post content with an image.
 		add_filter(
 			'the_content',
+<<<<<<< HEAD
 			static function () {
+=======
+			static function() use ( &$image_within_content ) {
+>>>>>>> 96c64cd42d (Media: Avoid programmatically created images within post content from incorrectly receiving `fetchpriority="high"`.)
 				// Replace content with an image tag, i.e. the 'wp_get_attachment_image' context is used while running 'the_content' filter.
-				return wp_get_attachment_image( self::$large_id, 'large', false );
+				$image_within_content = wp_get_attachment_image( self::$large_id, 'large', false );
+				return $image_within_content;
 			},
 			9 // Run before wp_filter_content_tags().
 		);
@@ -3791,8 +3796,12 @@ EOF;
 			$content = get_echo( 'the_content' );
 		}
 
-		// Ensure that parsed content has the image without lazy-loading.
-		$this->assertSame( $expected_content, $content );
+		// Ensure that parsed image within content does not receive any loading optimization attributes.
+		$this->assertSame( $expected_image, $image_within_content, 'Image with wp_get_attachment_image context within post content should not receive loading optimization attributes' );
+
+		// Ensure that parsed content has the image with fetchpriority as it is the first large image.
+		$expected_content = wpautop( str_replace( '<img ', '<img fetchpriority="high" ', $expected_image ) );
+		$this->assertSame( $expected_content, $content, 'Post content with programmatically injected image is missing loading optimization attributes' );
 	}
 
 	/**
@@ -4116,7 +4125,7 @@ EOF;
 	}
 
 	/**
-	 * Tests that wp_get_loading_optimization_attributes() returns false for special contexts when they're used within 'the_content' filter.
+	 * Tests that wp_get_loading_optimization_attributes() does not modify any attributes for special contexts when they're used within 'the_content' filter.
 	 *
 	 * @ticket 58089
 	 * @ticket 58235
@@ -4127,7 +4136,7 @@ EOF;
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
-	public function test_wp_get_loading_optimization_attributes_should_return_false_for_special_contexts_within_the_content( $context ) {
+	public function test_wp_get_loading_optimization_attributes_should_not_modify_images_for_special_contexts_within_the_content( $context ) {
 		remove_all_filters( 'the_content' );
 
 		$result = null;
@@ -4141,11 +4150,7 @@ EOF;
 		);
 		apply_filters( 'the_content', '' );
 
-		$this->assertSame(
-			array( 'fetchpriority' => 'high' ),
-			$result,
-			'First large image is loaded with high fetchpriority.'
-		);
+		$this->assertSame( array(), $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3804,7 +3804,7 @@ EOF;
 	 *
 	 * @expectedDeprecated wp_get_loading_attr_default
 	 *
-	 * @dataProvider data_special_contexts_for_the_content
+	 * @dataProvider data_special_contexts_for_the_content_wp_get_loading_attr_default
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
@@ -3821,7 +3821,7 @@ EOF;
 	 *
 	 * @expectedDeprecated wp_get_loading_attr_default
 	 *
-	 * @dataProvider data_special_contexts_for_the_content
+	 * @dataProvider data_special_contexts_for_the_content_wp_get_loading_attr_default
 	 *
 	 * @param string $context Context for the element for which the `loading` attribute value is requested.
 	 */
@@ -3846,6 +3846,19 @@ EOF;
 	 * @return array[]
 	 */
 	public function data_special_contexts_for_the_content() {
+		return array(
+			'widget_media_image'      => array( 'context' => 'widget_media_image' ),
+			'the_post_thumbnail'      => array( 'context' => 'the_post_thumbnail' ),
+			'wp_get_attachment_image' => array( 'context' => 'wp_get_attachment_image' ),
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_special_contexts_for_the_content_wp_get_loading_attr_default() {
 		return array(
 			'the_post_thumbnail'      => array( 'context' => 'the_post_thumbnail' ),
 			'wp_get_attachment_image' => array( 'context' => 'wp_get_attachment_image' ),

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4693,19 +4693,6 @@ EOF;
 	 *
 	 * @covers ::wp_get_loading_optimization_attributes
 	 */
-	public function test_wp_get_loading_optimization_attributes_header_block_template_increase_media_count() {
-		$attr = $this->get_width_height_for_high_priority();
-		wp_get_loading_optimization_attributes( 'img', $attr, 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER );
-
-		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
-		$this->assertSame( 1, wp_increase_content_media_count( 0 ) );
-	}
-
-	/**
-	 * @ticket 58635
-	 *
-	 * @covers ::wp_get_loading_optimization_attributes
-	 */
 	public function test_wp_get_loading_optimization_attributes_header_image_tag_increase_media_count() {
 		$attr = $this->get_width_height_for_high_priority();
 		wp_get_loading_optimization_attributes( 'img', $attr, 'get_header_image_tag' );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4537,7 +4537,7 @@ EOF;
 		$attr['loading']       = 'lazy';
 		$attr['fetchpriority'] = 'high';
 
-		$this->assertSame(
+		$this->assertEqualSetsWithIndex(
 			array(
 				'loading'       => 'lazy',
 				'fetchpriority' => 'high',

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3905,6 +3905,62 @@ EOF;
 	}
 
 	/**
+	 * Tests that `wp_get_attachment_image()` uses the correct default context.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::wp_get_attachment_image()
+	 */
+	public function test_wp_get_attachment_image_context_filter_default() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		wp_get_attachment_image( self::$large_id );
+		$this->assertSame( 'wp_get_attachment_image', $last_context );
+	}
+
+	/**
+	 * Tests that `wp_get_attachment_image()` allows overriding the context via filter.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::wp_get_attachment_image()
+	 */
+	public function test_wp_get_attachment_image_context_filter_value_is_passed_correctly() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		// Add a filter that modifies the context.
+		add_filter(
+			'wp_get_attachment_image_context',
+			static function() {
+				return 'my_custom_context';
+			}
+		);
+
+		wp_get_attachment_image( self::$large_id );
+		$this->assertSame( 'my_custom_context', $last_context );
+	}
+
+	/**
+	 * Helper method to keep track of the last context returned by the 'wp_get_attachment_image_context' filter.
+	 *
+	 * The method parameter is passed by reference and therefore will always contain the last context value.
+	 *
+	 * @param mixed $last_context Variable to track last context. Passed by reference.
+	 */
+	private function track_last_attachment_image_context( &$last_context ) {
+		add_filter(
+			'wp_get_attachment_image_context',
+			static function( $context ) use ( &$last_context ) {
+				$last_context = $context;
+				return $context;
+			},
+			11
+		);
+	}
+
+	/**
 	 * Add threshold to create a `-scaled` output image for testing.
 	 */
 	public function add_big_image_size_threshold() {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -78,8 +78,8 @@ CAP;
 	/**
 	 * Ensures that the static content media count, fetchpriority element flag and related filter are reset between tests.
 	 */
-	public function set_up() {
-		parent::set_up();
+	public function tear_down() {
+		parent::tear_down();
 
 		$this->reset_content_media_count();
 		$this->reset_omit_loading_attr_filter();
@@ -4583,6 +4583,122 @@ EOF;
 			array(),
 			wp_get_loading_optimization_attributes( 'img', $attr, 'test' ),
 			'loading optimization attr array should be empty.'
+		);
+	}
+
+	/**
+	 * @ticket 58681
+	 *
+	 * @dataProvider data_wp_get_loading_optimization_attributes_in_shortcodes
+	 */
+	public function test_wp_get_loading_optimization_attributes_in_shortcodes( $setup, $expected, $message ) {
+		$attr = $this->get_width_height_for_high_priority();
+		$setup();
+
+		// The first image processed in a shortcode should have fetchpriority set to high.
+		$this->assertSame(
+			$expected,
+			wp_get_loading_optimization_attributes( 'img', $attr, 'do_shortcode' ),
+			$message
+		);
+	}
+
+	public function data_wp_get_loading_optimization_attributes_in_shortcodes() {
+		return array(
+			'main_shortcode_image_should_have_fetchpriority_high'  => array(
+				'setup'    => function () {
+					global $wp_query;
+
+					// Set WP_Query to be in the loop and the main query.
+					$wp_query->in_the_loop = true;
+					$this->set_main_query( $wp_query );
+				},
+				'expected' => array(
+					'fetchpriority' => 'high',
+				),
+				'message'  => 'Fetch priority not applied to during shortcode rendering.',
+			),
+			'main_shortcode_image_after_threshold_is_loading_lazy' => array(
+				'setup'    => function () {
+					global $wp_query;
+
+					// Set WP_Query to be in the loop and the main query.
+					$wp_query->in_the_loop = true;
+					$this->set_main_query( $wp_query );
+
+					// Set internal flags so lazy should be applied.
+					wp_high_priority_element_flag( false );
+					wp_increase_content_media_count( 3 );
+				},
+				'expected' => array(
+					'loading' => 'lazy',
+				),
+				'message'  => 'Lazy-loading not applied to during shortcode rendering.',
+			),
+			'shortcode_image_outside_of_the_loop_are_loaded_lazy'  => array(
+				'setup'    => function () {
+					// Avoid setting up the WP_Query object for the loop.
+					return;
+				},
+				'expected' => array(
+					'loading' => 'lazy',
+				),
+				'message'  => 'Lazy-loading not applied to shortcodes outside the loop.',
+			),
+		);
+	}
+
+	/**
+	 * @ticket 58681
+	 */
+	public function test_content_rendering_with_shortcodes() {
+		// The gallery shortcode will dynamically create image markup that should be optimized.
+		$content = "[gallery ids='" . self::$large_id . "' size='large']";
+		$actual  = apply_filters( 'the_content', $content );
+
+		$this->assertStringContainsString(
+			// Since the main query and loop isn't set, this should be lazily loaded.
+			'loading="lazy"',
+			$actual,
+			'Could not confirm shortcodes get optimizations applied.'
+		);
+	}
+
+	/**
+	 * @ticket 58681
+	 */
+	public function test_content_rendering_with_shortcodes_nested() {
+		global $wp_query;
+
+		// Set WP_Query to be in the loop and the main query.
+		$wp_query->in_the_loop = true;
+		$this->set_main_query( $wp_query );
+
+		add_shortcode(
+			'div',
+			function ( $atts, $content = null ) {
+				$parsed_atts = shortcode_atts(
+					array(
+						'class' => '',
+					),
+					$atts
+				);
+
+				$class = ! empty( $parsed_atts['class'] ) ? sprintf( ' class="%s"', $parsed_atts['class'] ) : null;
+
+				return sprintf( '<div %s>%s</div>', $class, do_shortcode( $content ) );
+			}
+		);
+
+		// The gallery shortcode will dynamically create image markup that should be optimized.
+		$content = "[div][gallery ids='" . self::$large_id . "' size='large'][div]";
+		$actual  = apply_filters( 'the_content', $content );
+
+		$this->assertStringContainsString(
+			// Since this is in the loop, it should have a high fetchpriority.
+			'fetchpriority="high"',
+			$actual,
+			'Could not confirm shortcodes get optimizations applied.'
 		);
 	}
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3752,11 +3752,11 @@ EOF;
 
 		// Force no lazy-loading or fetchpriority on the image tag expected in the content.
 		$expected_image = wp_get_attachment_image(
-				self::$large_id,
-				'large',
-				false,
-				array(
-					'loading'       => false,
+			self::$large_id,
+			'large',
+			false,
+			array(
+				'loading'       => false,
 				'fetchpriority' => false,
 			)
 		);
@@ -3769,11 +3769,7 @@ EOF;
 		// Overwrite post content with an image.
 		add_filter(
 			'the_content',
-<<<<<<< HEAD
-			static function () {
-=======
-			static function() use ( &$image_within_content ) {
->>>>>>> 96c64cd42d (Media: Avoid programmatically created images within post content from incorrectly receiving `fetchpriority="high"`.)
+			static function () use ( &$image_within_content ) {
 				// Replace content with an image tag, i.e. the 'wp_get_attachment_image' context is used while running 'the_content' filter.
 				$image_within_content = wp_get_attachment_image( self::$large_id, 'large', false );
 				return $image_within_content;

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -4676,6 +4676,55 @@ EOF;
 	}
 
 	/**
+	 * @ticket 58635
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_header_block_template_increase_media_count() {
+		$attr = $this->get_width_height_for_high_priority();
+		wp_get_loading_optimization_attributes( 'img', $attr, 'template_part_' . WP_TEMPLATE_PART_AREA_HEADER );
+
+		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
+		$this->assertSame( 1, wp_increase_content_media_count( 0 ) );
+	}
+
+	/**
+	 * @ticket 58635
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 */
+	public function test_wp_get_loading_optimization_attributes_header_image_tag_increase_media_count() {
+		$attr = $this->get_width_height_for_high_priority();
+		wp_get_loading_optimization_attributes( 'img', $attr, 'get_header_image_tag' );
+
+		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
+		$this->assertSame( 1, wp_increase_content_media_count( 0 ) );
+	}
+
+	/**
+	 * @ticket 58635
+	 *
+	 * @covers ::wp_get_loading_optimization_attributes
+	 *
+	 * @dataProvider data_wp_get_loading_attr_default_before_and_no_loop
+	 *
+	 * @param string $context Context for the element for which the `loading` attribute value is requested.
+	 */
+	public function test_wp_get_loading_optimization_attributes_image_before_loop_increase_media_count( $context ) {
+		global $wp_query;
+
+		$wp_query = $this->get_new_wp_query_for_published_post();
+		$this->set_main_query( $wp_query );
+		do_action( 'get_header' );
+
+		$attr = $this->get_width_height_for_high_priority();
+		wp_get_loading_optimization_attributes( 'img', $attr, $context );
+
+		// Images with a certain minimum size in the header of the page are also counted towards the threshold.
+		$this->assertSame( 1, wp_increase_content_media_count( 0 ) );
+	}
+
+	/**
 	 * Helper method to keep track of the last context returned by the 'wp_get_attachment_image_context' filter.
 	 *
 	 * The method parameter is passed by reference and therefore will always contain the last context value.

--- a/tests/phpunit/tests/post/thumbnails.php
+++ b/tests/phpunit/tests/post/thumbnails.php
@@ -558,7 +558,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	private function track_last_attachment_image_context( &$last_context ) {
 		add_filter(
 			'wp_get_attachment_image_context',
-			static function( $context ) use ( &$last_context ) {
+			static function ( $context ) use ( &$last_context ) {
 				$last_context = $context;
 				return $context;
 			},

--- a/tests/phpunit/tests/post/thumbnails.php
+++ b/tests/phpunit/tests/post/thumbnails.php
@@ -437,6 +437,135 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Tests that `_wp_post_thumbnail_context_filter()` returns 'the_post_thumbnail'.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers::_wp_post_thumbnail_context_filter
+	 */
+	public function test_wp_post_thumbnail_context_filter_should_return_the_post_thumbnail() {
+		$this->assertSame( 'the_post_thumbnail', _wp_post_thumbnail_context_filter( 'wp_get_attachment_image' ) );
+	}
+
+	/**
+	 * Tests that `::_wp_post_thumbnail_context_filter_add` adds a filter to override the context
+	 * used in `wp_get_attachment_image()`.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::_wp_post_thumbnail_context_filter_add
+	 */
+	public function test_wp_post_thumbnail_context_filter_add_should_add_the_filter() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		_wp_post_thumbnail_context_filter_add();
+		wp_get_attachment_image( self::$attachment_id );
+
+		$this->assertSame( 'the_post_thumbnail', $last_context );
+	}
+
+	/**
+	 * Tests that `_wp_post_thumbnail_context_filter_remove()` removes a filter to override the context
+	 * used in `wp_get_attachment_image()`.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::_wp_post_thumbnail_context_filter_remove
+	 */
+	public function test_wp_post_thumbnail_context_filter_remove_should_remove_the_filter() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		_wp_post_thumbnail_context_filter_add();
+		wp_get_attachment_image( self::$attachment_id );
+
+		// Verify that the filter has been added before testing that it has been removed.
+		$this->assertSame(
+			'the_post_thumbnail',
+			$last_context,
+			'The filter was not added.'
+		);
+
+		_wp_post_thumbnail_context_filter_remove();
+
+		// The context should no longer be modified by the filter.
+		wp_get_attachment_image( self::$attachment_id );
+
+		$this->assertSame(
+			'wp_get_attachment_image',
+			$last_context,
+			'The filter was not removed.'
+		);
+	}
+
+	/**
+	 * Tests that `get_the_post_thumbnail()` uses the 'the_post_thumbnail' context.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::get_the_post_thumbnail
+	 */
+	public function test_get_the_post_thumbnail_should_use_the_post_thumbnail_context() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		set_post_thumbnail( self::$post, self::$attachment_id );
+		get_the_post_thumbnail( self::$post );
+
+		$this->assertSame( 'the_post_thumbnail', $last_context );
+	}
+
+	/**
+	 * Tests that `get_the_post_thumbnail()` restores the context afterwards.
+	 *
+	 * @ticket 58212
+	 *
+	 * @covers ::get_the_post_thumbnail
+	 */
+	public function test_get_the_post_thumbnail_should_remove_the_post_thumbnail_context_afterwards() {
+		$last_context = '';
+		$this->track_last_attachment_image_context( $last_context );
+
+		set_post_thumbnail( self::$post, self::$attachment_id );
+		get_the_post_thumbnail( self::$post );
+
+		// Verify that the context was overridden before testing that it has been restored.
+		$this->assertSame(
+			'the_post_thumbnail',
+			$last_context,
+			'The context was not overridden.'
+		);
+
+		// The context should no longer be overridden.
+		wp_get_attachment_image( self::$attachment_id );
+
+		$this->assertSame(
+			'wp_get_attachment_image',
+			$last_context,
+			'The context was not restored.'
+		);
+	}
+
+	/**
+	 * Helper method to keep track of the last context returned by the 'wp_get_attachment_image_context' filter.
+	 *
+	 * The method parameter is passed by reference and therefore will always contain the last context value.
+	 *
+	 * @param mixed $last_context Variable to track last context. Passed by reference.
+	 */
+	private function track_last_attachment_image_context( &$last_context ) {
+		add_filter(
+			'wp_get_attachment_image_context',
+			static function( $context ) use ( &$last_context ) {
+				$last_context = $context;
+				return $context;
+			},
+			11
+		);
+	}
+
 	public function filter_post_thumbnail_size( $size, $post_id ) {
 		if ( is_array( $this->current_size_filter_data ) && isset( $this->current_size_filter_data[ $post_id ] ) ) {
 			return $this->current_size_filter_data[ $post_id ];

--- a/tests/phpunit/tests/theme/customHeader.php
+++ b/tests/phpunit/tests/theme/customHeader.php
@@ -174,6 +174,82 @@ class Tests_Theme_CustomHeader extends WP_UnitTestCase {
 		$this->assertStringContainsString( sprintf( 'src="%s"', $custom ), $html );
 	}
 
+	/**
+	 * Tests default values of performance attributes for "get_header_image_tag".
+	 *
+	 * @ticket 58680
+	 */
+	public function test_get_header_image_tag_with_default_performance_attributes() {
+		$this->add_theme_support(
+			array(
+				'default-image' => 'http://localhost/default-header.jpg',
+				'width'         => 60,
+				'height'        => 60,
+			)
+		);
+
+		add_filter(
+			'wp_min_priority_img_pixels',
+			static function() {
+				return 2500; // 50*50=2500
+			}
+		);
+
+		wp_high_priority_element_flag( true );
+
+		$html = get_header_image_tag();
+		$this->assertStringNotContainsString( ' loading="lazy"', $html );
+		$this->assertStringContainsString( ' fetchpriority="high"', $html );
+		$this->assertStringContainsString( ' decoding="async"', $html );
+	}
+
+	/**
+	 * Tests custom values of performance attributes for "get_header_image_tag".
+	 *
+	 * @ticket 58680
+	 */
+	public function test_get_header_image_tag_with_custom_performance_attributes() {
+		$this->add_theme_support(
+			array(
+				'default-image' => 'http://localhost/default-header.jpg',
+				'width'         => 500,
+				'height'        => 500,
+			)
+		);
+
+		$html = get_header_image_tag(
+			array(
+				'fetchpriority' => '',
+				'decoding'      => '',
+			)
+		);
+		$this->assertStringNotContainsString( ' fetchpriority="high"', $html );
+		$this->assertStringNotContainsString( ' decoding="async"', $html );
+	}
+
+	/**
+	 * Tests custom lazy loading for "get_header_image_tag".
+	 *
+	 * @ticket 58680
+	 */
+	public function test_get_header_image_tag_with_custom_lazy_loading() {
+		$this->add_theme_support(
+			array(
+				'default-image' => 'http://localhost/default-header.jpg',
+				'width'         => 500,
+				'height'        => 500,
+			)
+		);
+
+		$html = get_header_image_tag(
+			array(
+				'loading' => 'lazy',
+			)
+		);
+		$this->assertStringNotContainsString( ' fetchpriority="high"', $html );
+		$this->assertStringContainsString( ' loading="lazy"', $html );
+	}
+
 	public function test_get_custom_header_markup_without_registered_default_image() {
 		$this->add_theme_support();
 

--- a/tests/phpunit/tests/theme/customHeader.php
+++ b/tests/phpunit/tests/theme/customHeader.php
@@ -190,7 +190,7 @@ class Tests_Theme_CustomHeader extends WP_UnitTestCase {
 
 		add_filter(
 			'wp_min_priority_img_pixels',
-			static function() {
+			static function () {
 				return 2500; // 50*50=2500
 			}
 		);

--- a/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
@@ -494,6 +494,8 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 
 		// Custom image class.
 		$this->assertStringContainsString( 'src="http://example.org/url/to/image.jpg"', $output );
+		$this->assertStringContainsString( 'decoding="async"', $output );
+		$this->assertStringContainsString( 'loading="lazy"', $output );
 
 		// Link settings.
 		ob_start();


### PR DESCRIPTION
## Description
WP-r56037

 Media: Automatically add fetchpriority="high" to hero image to improve load time performance.

This changeset adds support for the fetchpriority attribute, which is typically added to a single image in each HTML response with a value of "high". This enhances load time performance (also Largest Contentful Paint, or LCP) by telling the browser to prioritize this image for downloading even before the layout of the page has been computed. In lab tests, this has shown to improve LCP performance by ~10% on average.

Specifically, fetchpriority="high" is added to the first image that satisfies all of the following conditions:

    The image is not lazy-loaded, i.e. does not have loading="lazy".
    The image does not already have a (conflicting) fetchpriority attribute.
    The size of of the image (i.e. width * height) is greater than 50,000 squarepixels. 

While these heuristics are based on several field analyses, there will always be room for optimization. Sites can customize the squarepixel threshold using a new filter wp_min_priority_img_pixels which should return an integer for the value.

Since the logic for adding fetchpriority="high" is heavily intertwined with the logic for adding loading="lazy", yet the features should work decoupled from each other, the majority of code changes in this changeset is refactoring of the existing lazy-loading logic to be reusable. For this purpose, a new function wp_get_loading_optimization_attributes() has been introduced which returns an associative array of performance-relevant attributes for a given HTML element. This function replaces wp_get_loading_attr_default(), which has been deprecated. As another result of that change, a new function wp_img_tag_add_loading_optimization_attrs() replaces the more specific wp_img_tag_add_loading_attr(), which has been deprecated as well.

See https://make.wordpress.org/core/2023/05/02/proposal-for-enhancing-lcp-image-performance-with-fetchpriority/ for the original proposal and additional context.

Props thekt12, joemcgill, spacedmonkey, mukesh27, costdev, 10upsimon.

## Motivation and context
Partially fixes #1608 
Includes multiple backports to address performance enhancements and bugfixes of this feature, above and beyound the listed changes in the Issue as reported to ensure cleaner backporting.

## How has this been tested?
Local testing during backporting including removal of tests linked to Block themes
New unit tests have been included.

## Screenshots
N/A

## Types of changes
- New feature