### PR TITLE
Correct a data attribute in the media grid view

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -398,7 +398,7 @@ if ( 'grid' === $mode ) {
 					$url          = $meta['url'];
 					$width        = ! empty( $meta['width'] ) ? $meta['width'] : '';
 					$height       = ! empty( $meta['height'] ) ? $meta['height'] : '';
-					$file_name    = $meta['name'];
+					$file_name    = $meta['filename'];
 					$file_type    = $meta['type'];
 					$subtype      = $meta['subtype'];
 					$mime_type    = $meta['mime'];


### PR DESCRIPTION
The current media grid view data attribute for filename incorrectly uses `name` instead of `filename`. I suspect this is a regression introduced by accident. This produces weirdly long strings. This PR corrects that by using `filename`.