### PR TITLE
Add polyfill for get_block_theme_folders()

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -423,6 +423,20 @@ class WP_Compat {
 			}
 		}
 
+		if ( ! function_exists( 'get_block_theme_folders' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.4.0
+			 *
+			 * @return string ''.
+			 */
+			function get_block_theme_folders( ...$args ) {
+				WP_Compat::using_block_function();
+				return '';
+			}
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -427,7 +427,7 @@ class WP_Compat {
 			/**
 			 * Polyfill for block functions.
 			 *
-			 * @since CP-2.4.0
+			 * @since CP-2.3.0
 			 *
 			 * @return string ''.
 			 */

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -43,6 +43,7 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'wp_is_block_theme' ) );
 		$this->assertTrue( function_exists( 'parse_blocks' ) );
 		$this->assertTrue( function_exists( 'get_dynamic_block_names' ) );
+		$this->assertTrue( function_exists( 'get_block_theme_folders' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add polyfill for `get_block_theme_folders()` function and the relative check in PHPUnit.

## Motivation and context
Starting from version 3.17.0 [Query Monitor](https://wordpress.org/plugins/query-monitor/) uses the function and is unusable in the frontend.



## How has this been tested?
Local testing and unit tests.

## Screenshots
### Before
<img width="441" alt="image" src="https://github.com/user-attachments/assets/ec944cf7-f3b2-4a28-ae2b-54e31488a940">

### After
<img width="215" alt="image" src="https://github.com/user-attachments/assets/52914926-27e5-4000-b38a-365250af3500">


## Types of changes
- New feature

