### PR TITLE
Add `d.m.Y` to date format presets on General Settings screen

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -517,11 +517,12 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 	 * Filters the default date formats.
 	 *
 	 * @since 2.7.0
-	 * @since 4.0.0 Added ISO date standard YYYY-MM-DD format.
+	 * @since 4.0.0 Replaced the `Y/m/d` format with `Y-m-d` (ISO date standard YYYY-MM-DD).
+	 * @since 6.8.0 Added the `d.m.Y` format.
 	 *
 	 * @param string[] $default_date_formats Array of default date formats.
 	 */
-	$date_formats = array_unique( apply_filters( 'date_formats', array( __( 'F j, Y' ), 'Y-m-d', 'm/d/Y', 'd/m/Y' ) ) );
+	$date_formats = array_unique( apply_filters( 'date_formats', array( __( 'F j, Y' ), 'Y-m-d', 'm/d/Y', 'd/m/Y', 'd.m.Y' ) ) );
 
 	$custom = true;
 


### PR DESCRIPTION
## Description

Backport of https://core.trac.wordpress.org/changeset/59475.

This gives users another option when selecting how dates are displayed on their site. This change is relevant for better localization, providing more date format choices for users in regions where this format is common.

The `array_unique()` call ensures that if this format was already added by a plugin or theme, it won't be duplicated.

Follow-up to https://core.trac.wordpress.org/changeset/9131, https://core.trac.wordpress.org/changeset/22299, https://core.trac.wordpress.org/changeset/28820, https://core.trac.wordpress.org/changeset/28848.

WP:Props Daedalon, pbearne, fierevere, im3dabasia1, SergeyBiryukov. 
Fixes https://core.trac.wordpress.org/ticket/55685.

---

Merges https://core.trac.wordpress.org/changeset/59475 / WordPress/wordpress-develop@cc5c5b85af to ClassicPress.

## How has this been tested?
Local testing.

## Screenshots
### Before
<img width="477" alt="image" src="https://github.com/user-attachments/assets/189b8af5-1277-450c-86c4-b25932a4ea0b">

### After
<img width="475" alt="image" src="https://github.com/user-attachments/assets/e65500ee-c9c7-447d-8c3c-76fd76f7f803">

## Types of changes
- New feature
