### PR TITLE
Upgrade PHPMailer to version 6.9.3.

### DIFF
--- a/src/wp-includes/PHPMailer/PHPMailer.php
+++ b/src/wp-includes/PHPMailer/PHPMailer.php
@@ -253,7 +253,7 @@ class PHPMailer
      * You can set your own, but it must be in the format "<id@domain>",
      * as defined in RFC5322 section 3.6.4 or it will be ignored.
      *
-     * @see https://tools.ietf.org/html/rfc5322#section-3.6.4
+     * @see https://www.rfc-editor.org/rfc/rfc5322#section-3.6.4
      *
      * @var string
      */
@@ -387,7 +387,7 @@ class PHPMailer
      * 'DELAY'   will notify you if there is an unusual delay in delivery, but the actual
      *           delivery's outcome (success or failure) is not yet decided.
      *
-     * @see https://tools.ietf.org/html/rfc3461 See section 4.1 for more information about NOTIFY
+     * @see https://www.rfc-editor.org/rfc/rfc3461.html#section-4.1 for more information about NOTIFY
      */
     public $dsn = '';
 
@@ -756,7 +756,7 @@ class PHPMailer
      *
      * @var string
      */
-    const VERSION = '6.9.2';
+    const VERSION = '6.9.3';
 
     /**
      * Error severity: message only, continue processing.
@@ -1873,7 +1873,7 @@ class PHPMailer
      */
     protected static function isPermittedPath($path)
     {
-        //Matches scheme definition from https://tools.ietf.org/html/rfc3986#section-3.1
+        //Matches scheme definition from https://www.rfc-editor.org/rfc/rfc3986#section-3.1
         return !preg_match('#^[a-z][a-z\d+.-]*://#i', $path);
     }
 
@@ -2714,7 +2714,7 @@ class PHPMailer
         }
 
         //Only allow a custom message ID if it conforms to RFC 5322 section 3.6.4
-        //https://tools.ietf.org/html/rfc5322#section-3.6.4
+        //https://www.rfc-editor.org/rfc/rfc5322#section-3.6.4
         if (
             '' !== $this->MessageID &&
             preg_match(
@@ -4919,7 +4919,7 @@ class PHPMailer
      * Uses the 'relaxed' algorithm from RFC6376 section 3.4.2.
      * Canonicalized headers should *always* use CRLF, regardless of mailer setting.
      *
-     * @see https://tools.ietf.org/html/rfc6376#section-3.4.2
+     * @see https://www.rfc-editor.org/rfc/rfc6376#section-3.4.2
      *
      * @param string $signHeader Header
      *
@@ -4931,7 +4931,7 @@ class PHPMailer
         $signHeader = static::normalizeBreaks($signHeader, self::CRLF);
         //Unfold header lines
         //Note PCRE \s is too broad a definition of whitespace; RFC5322 defines it as `[ \t]`
-        //@see https://tools.ietf.org/html/rfc5322#section-2.2
+        //@see https://www.rfc-editor.org/rfc/rfc5322#section-2.2
         //That means this may break if you do something daft like put vertical tabs in your headers.
         $signHeader = preg_replace('/\r\n[ \t]+/', ' ', $signHeader);
         //Break headers out into an array
@@ -4963,7 +4963,7 @@ class PHPMailer
      * Uses the 'simple' algorithm from RFC6376 section 3.4.3.
      * Canonicalized bodies should *always* use CRLF, regardless of mailer setting.
      *
-     * @see https://tools.ietf.org/html/rfc6376#section-3.4.3
+     * @see https://www.rfc-editor.org/rfc/rfc6376#section-3.4.3
      *
      * @param string $body Message Body
      *
@@ -4999,7 +4999,7 @@ class PHPMailer
         $DKIMquery = 'dns/txt'; //Query method
         $DKIMtime = time();
         //Always sign these headers without being asked
-        //Recommended list from https://tools.ietf.org/html/rfc6376#section-5.4.1
+        //Recommended list from https://www.rfc-editor.org/rfc/rfc6376#section-5.4.1
         $autoSignHeaders = [
             'from',
             'to',
@@ -5105,7 +5105,7 @@ class PHPMailer
         }
         //The DKIM-Signature header is included in the signature *except for* the value of the `b` tag
         //which is appended after calculating the signature
-        //https://tools.ietf.org/html/rfc6376#section-3.5
+        //https://www.rfc-editor.org/rfc/rfc6376#section-3.5
         $dkimSignatureHeader = 'DKIM-Signature: v=1;' .
             ' d=' . $this->DKIM_domain . ';' .
             ' s=' . $this->DKIM_selector . ';' . static::$LE .

--- a/src/wp-includes/PHPMailer/SMTP.php
+++ b/src/wp-includes/PHPMailer/SMTP.php
@@ -35,7 +35,7 @@ class SMTP
      *
      * @var string
      */
-    const VERSION = '6.9.2';
+    const VERSION = '6.9.3';
 
     /**
      * SMTP line break constant.
@@ -62,7 +62,7 @@ class SMTP
      * The maximum line length allowed by RFC 5321 section 4.5.3.1.6,
      * *excluding* a trailing CRLF break.
      *
-     * @see https://tools.ietf.org/html/rfc5321#section-4.5.3.1.6
+     * @see https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1.6
      *
      * @var int
      */
@@ -72,7 +72,7 @@ class SMTP
      * The maximum line length allowed for replies in RFC 5321 section 4.5.3.1.5,
      * *including* a trailing CRLF line break.
      *
-     * @see https://tools.ietf.org/html/rfc5321#section-4.5.3.1.5
+     * @see https://www.rfc-editor.org/rfc/rfc5321#section-4.5.3.1.5
      *
      * @var int
      */
@@ -373,7 +373,7 @@ class SMTP
         }
         //Anything other than a 220 response means something went wrong
         //RFC 5321 says the server will wait for us to send a QUIT in response to a 554 error
-        //https://tools.ietf.org/html/rfc5321#section-3.1
+        //https://www.rfc-editor.org/rfc/rfc5321#section-3.1
         if ($responseCode === 554) {
             $this->quit();
         }
@@ -582,7 +582,7 @@ class SMTP
                 }
                 //Send encoded username and password
                 if (
-                    //Format from https://tools.ietf.org/html/rfc4616#section-2
+                    //Format from https://www.rfc-editor.org/rfc/rfc4616#section-2
                     //We skip the first field (it's forgery), so the string starts with a null byte
                     !$this->sendCommand(
                         'User & Password',
@@ -795,7 +795,7 @@ class SMTP
             //Send the lines to the server
             foreach ($lines_out as $line_out) {
                 //Dot-stuffing as per RFC5321 section 4.5.2
-                //https://tools.ietf.org/html/rfc5321#section-4.5.2
+                //https://www.rfc-editor.org/rfc/rfc5321#section-4.5.2
                 if (!empty($line_out) && $line_out[0] === '.') {
                     $line_out = '.' . $line_out;
                 }


### PR DESCRIPTION
This is a maintenance release, adding support for the release version of PHP 8.4, and experimental support for PHP 8.5.

References:
* [https://github.com/PHPMailer/PHPMailer/releases/tag/v6.9.3 PHPMailer 6.9.3 release notes]
* [https://github.com/PHPMailer/PHPMailer/compare/v6.9.2...v6.9.3 Full list of changes in PHPMailer 6.9.3]

Follow-up to https://core.trac.wordpress.org/changeset/50628, https://core.trac.wordpress.org/changeset/50799, https://core.trac.wordpress.org/changeset/51169, https://core.trac.wordpress.org/changeset/51634, https://core.trac.wordpress.org/changeset/51635, https://core.trac.wordpress.org/changeset/52252, https://core.trac.wordpress.org/changeset/52749, https://core.trac.wordpress.org/changeset/52811, https://core.trac.wordpress.org/changeset/53500, https://core.trac.wordpress.org/changeset/53535, https://core.trac.wordpress.org/changeset/53917, https://core.trac.wordpress.org/changeset/54427, https://core.trac.wordpress.org/changeset/54937, https://core.trac.wordpress.org/changeset/55557, https://core.trac.wordpress.org/changeset/56484, https://core.trac.wordpress.org/changeset/57137, https://core.trac.wordpress.org/changeset/59246.

WP:Props desrosj, yogeshbhutkar, ayeshrajans.
Fixes https://core.trac.wordpress.org/ticket/62632.

---

Merges https://core.trac.wordpress.org/changeset/59481 / WordPress/wordpress-develop@8eb8d63409 to ClassicPress.

## Description
No changes in code in this PR.
Just a version bump and changes in comments.

## Motivation and context
Update the library to a version that claim support with PHP 8.4.

## How has this been tested?
Unit tests, `tests/phpunit/tests/pluggable/wpMail.php` confirms that our change is not reverted.

