### PR TITLE
Remove default Sortable outline on page load

### DIFF
--- a/src/wp-admin/js/postbox.js
+++ b/src/wp-admin/js/postbox.js
@@ -153,7 +153,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		if ( column.id !== 'advanced-sortables' && column.querySelector( '.postbox' ) == null ) {
 			column.classList.add( 'empty-container' );
-			column.style.outline = 'none'; // By default, Sortable targets should not be visible on page load
 			column.setAttribute( 'data-emptystring', emptySortableText );
 		}
 	} );

--- a/src/wp-admin/js/postbox.js
+++ b/src/wp-admin/js/postbox.js
@@ -153,7 +153,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		if ( column.id !== 'advanced-sortables' && column.querySelector( '.postbox' ) == null ) {
 			column.classList.add( 'empty-container' );
-			column.style.outline = '3px dashed #c3c4c7';
+			column.style.outline = 'none'; // By default, Sortable targets should not be visible on page load
 			column.setAttribute( 'data-emptystring', emptySortableText );
 		}
 	} );


### PR DESCRIPTION
## Description

Since the addition of the new vanilla SortableJS library, a rogue outline appeared on the Dashboard and on the post editor page **on page load**. The same outline does not appear on WordPress.

The outline should appear **on drag init**.

If I start dragging an element then let it go, the outline disappears, which is correct behaviour.

## Motivation and context

This is a visual bug. A rogue outline that disappears after dragging ended.

## How has this been tested?

I have tested this with both CP 2.2.x and the newly released 2.3.0.
I have tested it on a fresh installation, and also using FX Builder and SCF/ACF.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/87d400d2-568c-456e-be5e-ff3a299220a8)

![image](https://github.com/user-attachments/assets/efda6fb5-3c37-470c-98c0-4e650bcc8b00)

![image](https://github.com/user-attachments/assets/eae42b27-93e9-4813-828f-ccad3ad73419)

### After

![image](https://github.com/user-attachments/assets/63f0c570-3e19-48b6-a04d-1265cf106a84)

![image](https://github.com/user-attachments/assets/06a7faea-648e-4b63-a7d0-2278bcedf821)

![image](https://github.com/user-attachments/assets/b8557548-6fb0-4ec0-8b63-7d1f60837ac4)

## Types of changes

- Visual bug fix
