### PR TITLE
Ensure `pepper.php` plugin file is not included in builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,7 +144,10 @@ module.exports = function(grunt) {
 							// Exclude plugins unless specifically listed
 							'!wp-content/plugins/**',
 							'wp-content/plugins/index.php',
+							// ClassicPress Pepper plugin
 							'wp-content/plugins/cp-pepper/**',
+							// but not the ClassicPress pepper key file
+							'!wp-content/plugins/cp-pepper/pepper.php',
 							// Ignore unminified versions of external libs we don't ship:
 							'!wp-includes/js/backbone.js',
 							'!wp-includes/js/underscore.js',


### PR DESCRIPTION
## Description
During the release of `v2.3.0` there was a minor issue whereby the `pepper.php` file was copied over from testing in `src/` to `build/`. This file is created by the ClassicPress Pepper plugin and should not be copied into builds.

## Motivation and context
Ensure local pepper keys are not inadvertently revealed and make a smoother release process.

## How has this been tested?
Local build testing ensuring any `pepper.php` file in the plugin folder structure is not coped to `build/`.

## Screenshots
N/A

## Types of changes
- Bug fix