### PR TITLE
Fix jQuery object being used as an element, resulting in `Uncaught TypeError`

### DIFF
--- a/src/wp-admin/js/common.js
+++ b/src/wp-admin/js/common.js
@@ -1080,7 +1080,7 @@ $( function() {
 			 * @return {void}
 			 */
 		}).find( 'li.wp-has-submenu.wp-not-current-submenu' ).on( 'focusin.adminmenu', function() {
-			adjustSubmenu( $( this ) );
+			adjustSubmenu( $( this )[0] );
 		});
 	}
 


### PR DESCRIPTION
## Description

In `common.js`, at line 1082, this code:

```
find( 'li.wp-has-submenu.wp-not-current-submenu' ).on( 'focusin.adminmenu', function() {
	adjustSubmenu( $( this ) );
});

```

sends `$( this )` as an object.

At line 922, this object is called as:

`submenu = menuItem.querySelector( '.wp-submenu' );`

This results in a fatal error when focusing an admin menu item, as the `querySelector()` function requires another selector (a DOM element), not an object.

The fix is to add the first (and only) element inside the `$( this )` object.

```
find( 'li.wp-has-submenu.wp-not-current-submenu' ).on( 'focusin.adminmenu', function() {
	adjustSubmenu( $( this )[0] );
});

```

## Motivation and context

If the user focuses (clicks) on an admin menu element, and then changes their mind, and stay on the Appearance -> Menus page, they won't be able to drag/re-arrange menu items, as a fatal error has occurred, blocking any further script execution.

## How has this been tested?

Tested with CP 2.2.0+nightly.20241204 and CP 2.3.0. Tested with the default theme and a custom theme.

## Screenshots

### BEFORE

![2](https://github.com/user-attachments/assets/5951bb9b-5c74-4d2e-8055-d162fa3ecd0c)

### AFTER

The console error does not appear any more, as a DOM element is now passed correctly to the `adjustSubmenu()` function.

## Types of changes

- Bug fix
