### PR TITLE
Change wording for expected compatibility when updating

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -348,11 +348,7 @@ function list_plugin_updates() {
 
 		// Get plugin compat for running version of ClassicPress.
 		if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
-			$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: 100%%.' ), $cur_cp_version );
-			$compat .= ' <a href="https://link.classicpress.net/plugin-compatibility">' . __( 'More info.' ) . '</a>';
-		} elseif ( isset( $plugin_data->update->compatibility->{$cur_wp_version} ) ) {
-			$compat  = $plugin_data->update->compatibility->{$cur_wp_version};
-			$compat  = '<br>' . sprintf( __( 'Expected Compatibility with ClassicPress %1$s: %2$d%% (%3$d "works" votes out of %4$d total).' ), $cur_cp_version, $compat->percent, $compat->votes, $compat->total_votes );
+			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
 			$compat .= ' <a href="https://link.classicpress.net/plugin-compatibility">' . __( 'More info.' ) . '</a>';
 		} else {
 			$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $cur_cp_version );
@@ -361,12 +357,8 @@ function list_plugin_updates() {
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
 			if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $core_update_version, '>=' ) ) {
-				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: 100%%.' ), $core_update_version );
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s' ), $core_update_version );
 				$compat .= ' <a href="https://link.classicpress.net/plugin-compatibility">' . __( 'More info.' ) . '</a>';
-			} elseif ( isset( $plugin_data->update->compatibility->{$core_update_version} ) ) {
-				$update_compat = $plugin_data->update->compatibility->{$core_update_version};
-				$compat       .= '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: %2$d%% (%3$d "works" votes out of %4$d total).' ), $core_update_version, $update_compat->percent, $update_compat->votes, $update_compat->total_votes );
-				$compat       .= ' <a href="https://link.classicpress.net/plugin-compatibility">' . __( 'More info.' ) . '</a>';
 			} else {
 				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 				$compat .= ' <a href="https://link.classicpress.net/plugin-compatibility">' . __( 'More info.' ) . '</a>';


### PR DESCRIPTION
## Description
When a plugin update is available, change the wording from "Expected compatibility with ClassicPress 2.4.0: 100%." "Potentially compatible with ClassicPress 2.4.0.".

Also removes the "Expected Compatibility with ClassicPress 2.4.0: 70% (7 "works" votes out of 10 total).".

## Motivation and context
See [discussion on the forum](https://forums.classicpress.net/t/wp-plugins-do-not-work-on-cp-even-though-the-tag-is-100-compatible/).

The check is done comparing the `Requires at least:` header against `$wp_version` that in ClassicPress 2.3.0 is 6.2.6, but the plugin can still broke depending on the use of React, the "Compatibility mode" setting or using not polyfilled block functions.

## How has this been tested?
Local testing.

## Screenshots

### Before
![Ažuriranje](https://github.com/user-attachments/assets/0ad33dcc-5de7-44b1-8965-ff2e0c2e9853)
![c3e3443d5b48766403508e6b92f025fc9ad336df](https://github.com/user-attachments/assets/f67ff787-b5ea-470b-ab5d-08d1cbd1823a)

### After

![8c09da96cefcf170a6544c2be8b31d488cfee763-1](https://github.com/user-attachments/assets/0ad11761-cd67-4768-838c-e6d8e2cd4f10)

## Types of changes
- Bug fix

