### PR TITLE
Add "Copy" button to "All Settings" screen 

### DIFF
--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -394,14 +394,11 @@ foreach ( (array) $options as $option ) :
 			$class               = 'all-options';
 			$clipboard_text      = $value;
 		} else {
-			$value    = 'SERIALIZED DATA';
-			$disabled = true;
-			$class    = 'all-options disabled';
-			ob_start();
+			$value              = 'SERIALIZED DATA';
+			$disabled           = true;
+			$class              = 'all-options disabled';
 			$unserialized_value = unserialize( $option->option_value );
-			var_dump( $unserialized_value );
-			$clipboard_text     = ob_get_contents();
-			ob_end_clean();
+			$clipboard_text     = print_r( $unserialized_value, true );
 		}
 	} else {
 		$value               = $option->option_value;

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -377,6 +377,8 @@ require_once ABSPATH . 'wp-admin/admin-header.php'; ?>
 <?php
 $options = $wpdb->get_results( "SELECT * FROM $wpdb->options ORDER BY option_name" );
 
+$can_copy = wp_is_using_https() || in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ) );
+
 foreach ( (array) $options as $option ) :
 	$disabled = false;
 
@@ -418,8 +420,10 @@ foreach ( (array) $options as $option ) :
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?>>
 	<?php endif; ?>
-	<button type="button" class="button" data-clipboard-text="<?php echo esc_attr( $clipboard_text ); ?>" onClick="navigator.clipboard.writeText( this.getAttribute( 'data-clipboard-text' ) ); document.getElementById( 'success-<?php echo $name; ?>' ).classList.remove( 'hidden' ); setTimeout(function() { document.getElementById( 'success-<?php echo $name; ?>' ).classList.add( 'hidden' ); }, 2000);"><?php _e( 'Copy' ); ?></button>
-	<span id="success-<?php echo $name; ?>" class="success hidden" aria-hidden="true"><?php _e( 'Copied!' ); ?></span></td>
+	<?php if ( $can_copy ) : ?>
+		<button type="button" class="button" data-clipboard-text="<?php echo esc_attr( $clipboard_text ); ?>" onClick="navigator.clipboard.writeText( this.getAttribute( 'data-clipboard-text' ) ); document.getElementById( 'success-<?php echo $name; ?>' ).classList.remove( 'hidden' ); setTimeout(function() { document.getElementById( 'success-<?php echo $name; ?>' ).classList.add( 'hidden' ); }, 2000);"><?php _e( 'Copy' ); ?></button>
+		<span id="success-<?php echo $name; ?>" class="success hidden" aria-hidden="true"><?php _e( 'Copied!' ); ?></span></td>
+	<?php endif; ?>
 </tr>
 <?php endforeach; ?>
 </table>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -390,15 +390,22 @@ foreach ( (array) $options as $option ) :
 			$value               = maybe_unserialize( $option->option_value );
 			$options_to_update[] = $option->option_name;
 			$class               = 'all-options';
+			$clipboard_text      = $value;
 		} else {
 			$value    = 'SERIALIZED DATA';
 			$disabled = true;
 			$class    = 'all-options disabled';
+			ob_start();
+			$unserialized_value = unserialize( $option->option_value );
+			var_dump( $unserialized_value );
+			$clipboard_text     = ob_get_contents();
+			ob_end_clean();
 		}
 	} else {
 		$value               = $option->option_value;
 		$options_to_update[] = $option->option_name;
 		$class               = 'all-options';
+		$clipboard_text      = $value;
 	}
 
 	$name = esc_attr( $option->option_name );
@@ -410,7 +417,8 @@ foreach ( (array) $options as $option ) :
 		<textarea class="<?php echo $class; ?>" name="<?php echo $name; ?>" id="<?php echo $name; ?>" cols="30" rows="5"><?php echo esc_textarea( $value ); ?></textarea>
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?>>
-	<?php endif; ?></td>
+	<?php endif; ?>
+	<button type="button" class="button" data-clipboard-text="<?php echo esc_attr( $clipboard_text ); ?>" onClick="navigator.clipboard.writeText( this.getAttribute('data-clipboard-text' ) );"><?php _e( 'Copy' ); ?></button></td>
 </tr>
 <?php endforeach; ?>
 </table>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -418,7 +418,8 @@ foreach ( (array) $options as $option ) :
 	<?php else : ?>
 		<input class="regular-text <?php echo $class; ?>" type="text" name="<?php echo $name; ?>" id="<?php echo $name; ?>" value="<?php echo esc_attr( $value ); ?>"<?php disabled( $disabled, true ); ?>>
 	<?php endif; ?>
-	<button type="button" class="button" data-clipboard-text="<?php echo esc_attr( $clipboard_text ); ?>" onClick="navigator.clipboard.writeText( this.getAttribute('data-clipboard-text' ) );"><?php _e( 'Copy' ); ?></button></td>
+	<button type="button" class="button" data-clipboard-text="<?php echo esc_attr( $clipboard_text ); ?>" onClick="navigator.clipboard.writeText( this.getAttribute( 'data-clipboard-text' ) ); document.getElementById( 'success-<?php echo $name; ?>' ).classList.remove( 'hidden' ); setTimeout(function() { document.getElementById( 'success-<?php echo $name; ?>' ).classList.add( 'hidden' ); }, 2000);"><?php _e( 'Copy' ); ?></button>
+	<span id="success-<?php echo $name; ?>" class="success hidden" aria-hidden="true"><?php _e( 'Copied!' ); ?></span></td>
 </tr>
 <?php endforeach; ?>
 </table>


### PR DESCRIPTION
## Description
Add "Copy" button to "All Settings" screen (`wp-admin/options.php`) to copy the content of the option.
If the option is serialized a `var_dump` of the option will be copied.

<img width="946" alt="image" src="https://github.com/user-attachments/assets/6a898a19-2297-40a0-828c-a97dc0f3ec43">

## Motivation and context
While allowing the user to modify serialized options is risky, allowing them to copy their contents offers the possibility of extracting data from these options.

Without the ability to see serialized options this screen loses some of its usefulness.

## How has this been tested?
Local testing.

## Types of changes
- New feature
