### PR TITLE
Align headings in Link Manager correctly

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -650,6 +650,15 @@ form#tags-filter {
 	line-height: 1.4;
 }
 
+#poststuff h3.hndle, /* Back-compat for pre-4.4 */
+#poststuff .stuffbox > h3, /* Back-compat for pre-4.4 */
+#poststuff h2 {
+	font-size: 14px;
+	padding: 8px 12px;
+	margin: 0;
+	line-height: 1.4;
+}
+
 #poststuff .stuffbox h2 {
 	padding: 8px 10px;
 }


### PR DESCRIPTION
This PR adds back a few lines of CSS previously removed so that, if enabled, the headings in the Links Manager are correctly aligned.

## Description
To get the Link Manager to disp[lay on the admin menu, install and activate the Link Manager plugin: https://wordpress.org/plugins/link-manager/

Now go to Add New. The headings are misaligned:

![Screenshot at 2024-12-13 09-41-13](https://github.com/user-attachments/assets/2f039cae-f07d-4b48-a840-ef4d320b18b9)

With these lines restored, the headings are aligned correctly:

![Screenshot at 2024-12-13 09-42-09](https://github.com/user-attachments/assets/f9ba14de-3480-4d33-9318-23276b066e73)

I have actually never used the Link Manager and didn't realize it still existed. But it does. The above plugin contains just one line of code to turn it on. The issue was initially reported — and fix provided — on the forums at https://forums.classicpress.net/t/default-link-manager-layout-issue/5705
