### PR TITLE
Declare ClassicPress theme as a default theme

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -53,16 +53,17 @@ final class WP_Theme implements ArrayAccess {
 	 * @var array
 	 */
 	private static $default_themes = array(
-		'classic'         => 'ClassicPress Classic',
-		'default'         => 'ClassicPress Default',
-		'twentyten'       => 'Twenty Ten',
-		'twentyeleven'    => 'Twenty Eleven',
-		'twentytwelve'    => 'Twenty Twelve',
-		'twentythirteen'  => 'Twenty Thirteen',
-		'twentyfourteen'  => 'Twenty Fourteen',
-		'twentyfifteen'   => 'Twenty Fifteen',
-		'twentysixteen'   => 'Twenty Sixteen',
-		'twentyseventeen' => 'Twenty Seventeen',
+		'classic'                => 'ClassicPress Classic',
+		'default'                => 'ClassicPress Default',
+		'the-classicpress-theme' => 'The ClassicPress Theme',
+		'twentyten'              => 'Twenty Ten',
+		'twentyeleven'           => 'Twenty Eleven',
+		'twentytwelve'           => 'Twenty Twelve',
+		'twentythirteen'         => 'Twenty Thirteen',
+		'twentyfourteen'         => 'Twenty Fourteen',
+		'twentyfifteen'          => 'Twenty Fifteen',
+		'twentysixteen'          => 'Twenty Sixteen',
+		'twentyseventeen'        => 'Twenty Seventeen',
 	);
 
 	/**

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -416,6 +416,6 @@ function wp_templating_constants() {
 	 * @see WP_Theme::get_core_default_theme()
 	 */
 	if ( ! defined( 'WP_DEFAULT_THEME' ) ) {
-		define( 'WP_DEFAULT_THEME', 'twentytwentythree' );
+		define( 'WP_DEFAULT_THEME', 'the-classicpress-theme' );
 	}
 }


### PR DESCRIPTION
## Description
The current core code uses `twentytwentthree` as the default theme, a theme ClassicPress has never bundled. It also does not list `the-classicpress-theme` as a core default theme.

This in turn creates warning messages in Site Health about inactive and non-core themes.

## Motivation and context
This PR updates core code to reflect that `the-classicpress-theme` is considered the ClassicPress core theme.

## How has this been tested?
Local automated and manual testing.

## Screenshots
### Before
![Screenshot 2024-12-27 at 12 01 10](https://github.com/user-attachments/assets/75de5536-9a71-4bed-94c5-d78e42abab07)
And:

![Screenshot 2024-12-27 at 12 01 23](https://github.com/user-attachments/assets/62fb288d-730f-4205-8634-5f3128a7b166)

### After
![Screenshot 2024-12-27 at 11 53 31](https://github.com/user-attachments/assets/6a8f4f1a-011f-41b8-af26-b4f9d19beeda)

## Types of changes
- Bug fix