### PR TITLE
Preserve metabox classes when defining open attribute

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1272,9 +1272,10 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 					 *
 					 * @since CP-2.0.0
 					 */
+					$classes = postbox_classes( $box['id'], $page );
 					$hidden_class   = ( in_array( $box['id'], $hidden, true ) ) ? ' hide-if-js' : '';
-					$open_attribute = postbox_classes( $box['id'], $page ) ? '' : ' open';
-					echo '<details id="' . $box['id'] . '" class="postbox' . $hidden_class . '"' . $open_attribute . '>' . "\n";
+					$open_attribute = $classes ? '' : ' open';
+					echo '<details id="' . $box['id'] . '" class="postbox' . $classes . $hidden_class . '"' . $open_attribute . '>' . "\n";
 
 					echo '<summary>';
 					echo '<div>';

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1272,9 +1272,9 @@ function do_meta_boxes( $screen, $context, $data_object ) {
 					 *
 					 * @since CP-2.0.0
 					 */
-					$classes = postbox_classes( $box['id'], $page );
+					$classes        = ' ' . postbox_classes( $box['id'], $page );
 					$hidden_class   = ( in_array( $box['id'], $hidden, true ) ) ? ' hide-if-js' : '';
-					$open_attribute = $classes ? '' : ' open';
+					$open_attribute = str_contains( $classes, 'closed' ) ? '' : ' open';
 					echo '<details id="' . $box['id'] . '" class="postbox' . $classes . $hidden_class . '"' . $open_attribute . '>' . "\n";
 
 					echo '<summary>';


### PR DESCRIPTION
## Description
As described in #1694, custom classes applied using the core filter `"postbox_classes_{$screen_id}_{$box_id}"` in `wp-admin/includes/template.php` on `edit` pages are not applied and the open attribute is removed if the core filter is used.

## Motivation and context
Fixes open issue and restore functionality of a core filter, and open attribute when the core filter is used.

## How has this been tested?
Local testing

## Screenshots
Steps for testing are described in the open Issue.

## Types of changes
- Bug fix