### PR TITLE
Add an option to enable Link Manager

### DIFF
--- a/src/wp-admin/includes/bookmark.php
+++ b/src/wp-admin/includes/bookmark.php
@@ -344,17 +344,12 @@ function wp_link_manager_disabled_message() {
 		$plugins = get_plugins();
 
 		if ( empty( $plugins['link-manager/link-manager.php'] ) ) {
-			if ( current_user_can( 'install_plugins' ) ) {
-				$install_url = wp_nonce_url(
-					self_admin_url( 'update.php?action=install-plugin&plugin=link-manager' ),
-					'install-plugin_link-manager'
-				);
-
+			if ( current_user_can( 'manage_options' ) ) {
 				wp_die(
 					sprintf(
 						/* translators: %s: A link to install the Link Manager plugin. */
-						__( 'If you are looking to use the link manager, please install the <a href="%s">Link Manager plugin</a>.' ),
-						esc_url( $install_url )
+						__( 'If you are looking to use the link manager, please enable it in the <a href="%s">General Settings</a>.' ),
+						esc_url( self_admin_url( 'options-general.php' ) )
 					)
 				);
 			}

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -3510,7 +3510,7 @@ function maybe_disable_automattic_widgets() {
 function maybe_disable_link_manager() {
 	global $wp_current_db_version, $wpdb;
 
-	if ( $wp_current_db_version >= 22006 && get_option( 'link_manager_enabled' ) && ! $wpdb->get_var( "SELECT link_id FROM $wpdb->links LIMIT 1" ) ) {
+	if ( $wp_current_db_version >= 22006 && get_option( 'link_manager_enabled' ) !== '1' && ! $wpdb->get_var( "SELECT link_id FROM $wpdb->links LIMIT 1" ) ) {
 		update_option( 'link_manager_enabled', 0 );
 	}
 }

--- a/src/wp-admin/js/link.js
+++ b/src/wp-admin/js/link.js
@@ -9,8 +9,6 @@ jQuery( function($) {
 	var newCat, noSyncChecks = false, syncChecks, catAddAfter;
 
 	$('#link_name').trigger( 'focus' );
-	// Postboxes.
-	postboxes.add_postbox_toggles('link');
 
 	/**
 	 * Adds event that opens a particular category tab.
@@ -41,7 +39,7 @@ jQuery( function($) {
 	 *
 	 * @return {void}
 	 */
-	$('#link-category-add-submit').on( 'click', function() { newCat.focus(); } );
+	$('#link-category-add-submit').on( 'click', function() { newCat.trigger( 'focus' ); } );
 
 	/**
 	 * Synchronize category checkboxes.

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -669,6 +669,18 @@ for ( $index = 0; $index <= 2; $index++ ) {
 	<?php _e( 'XML-RPC server disabled' ); ?></label>
 </fieldset></td>
 </tr>
+<tr>
+<th scope="row"><?php _e( 'Enable Link Manager' ); ?></th>
+<td> <fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Enable Link Manager' );
+	?>
+</span></legend><label for="link_manager_enabled">
+<input name="link_manager_enabled" type="checkbox" id="link_manager_enabled" value="1" <?php checked( '1', get_option( 'link_manager_enabled' ) ); ?>>
+	<?php _e( 'Link Manager enabled' ); ?></label>
+</fieldset></td>
+</tr>
 
 <?php do_settings_fields( 'general', 'default' ); ?>
 </table>

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -103,6 +103,7 @@ $allowed_options            = array(
 		'new_admin_email',
 		'disable_emojis',
 		'disable_xml_rpc',
+		'link_manager_enabled',
 	),
 	'discussion' => array(
 		'default_pingback_flag',


### PR DESCRIPTION
## Description
This PR adds a checkbox under General Settings to enable Link Manager

## Motivation and context
Link Manager was disabled in WP-3.5 but still present at code level.
If someone find it useful it can be re-enabled by using a plugin (that is just one line: `add_filter( 'pre_option_link_manager_enabled', '__return_true' );`) or setting `link_manager_enabled` option to 1.

## How has this been tested?
Local testing.

## Screenshots
### After
<img width="439" alt="Schermata 2024-12-30 alle 11 49 54" src="https://github.com/user-attachments/assets/c40db52d-ca18-4d3a-aa34-c09c546126c8" />
<img width="1373" alt="Schermata 2024-12-30 alle 11 51 30" src="https://github.com/user-attachments/assets/572ae914-a098-442a-97fa-8100644b284d" />


## Types of changes
- New feature (really ? :-)

