### PR TITLE
Eliminate erroneous restore backup notice

### DIFF
--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -228,7 +228,7 @@ switch ( $action ) {
 				'path' => ADMIN_COOKIE_PATH,
 				'domain' => COOKIE_DOMAIN,
 				'secure' => is_ssl(),
-				'httponly' => true,
+				'httponly' => false,
 				'samesite' => 'Strict',
 			);
 			setcookie( 'wp-saving-post', $post_id . '-saved', $cookie_options );


### PR DESCRIPTION
We have had several reports of users being told that the backup version of their post or page is different from the current post or page:

![6759d519cd052dc82efb0b92473ce2b06ee9b51d_2_1035x210](https://github.com/user-attachments/assets/6342eb8b-dd18-4390-b5d4-789c0c9bab87)

We addressed some of this in PR #1575 . But apparently not all. There have been more reports in the forums at https://forums.classicpress.net/t/question-about-restore-backup-notice-in-classicpress-theme/5639, though these have been harder to explain. However, a new user of CP has found what appears to be the problem. It is a change to a cookie that we made in PR #1372.

This caused a change to the `httponly` property from `false` to `true`. This change prevents the cookie from being accessed by JavaScript and so the version of a post or page stored in the browser does not use the same cookie as CP, which causes the versions to differ.

This PR restores that `httponly` property to `false`.

I have asked the user who found the cause to keep a lookout in case other cookies also need to be modified.
