### PR TITLE
Ensure LOGGED_IN_COOKIE is not validated when installing

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -560,7 +560,7 @@ function wp_validate_logged_in_cookie( $user_id ) {
 		return $user_id;
 	}
 
-	if ( is_blog_admin() || is_network_admin() || empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) ) {
+	if ( is_blog_admin() || is_network_admin() || empty( $_COOKIE[ LOGGED_IN_COOKIE ] ) || defined( 'WP_INSTALLING' ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
## Description
As described in an open Issue, under certain circumstances errors can be logged on servers if a users has a logged in cookie in a browser and the database tables have been dropped for a reinstall.

In testing it seems this needed a locally specified name for the logged in cookie in `wp-config.php`:
```
define( 'LOGGED_IN_COOKIE', 'session_' . AUTH_KEY );
```

## Motivation and context
Fixes #1675 

## How has this been tested?
Local testing with the above cookie named in current `develop` resulted in a `debug.log` error as reported in the open issue, with this applied fix, the error is no longer logged.

## Screenshots
N/A

## Types of changes
- Bug fix