### PR TITLE
Update copyright year in license.txt

### DIFF
--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018-2024 ClassicPress and contributors
+Copyright © 2018-2025 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2024 by the WordPress contributors
+  Copyright 2003-2025 by the WordPress contributors
 
   WordPress is released under the GPL
 


### PR DESCRIPTION
## Description
PHPUnit tests will fail until the copyright year is updated in `src/license.txt`

## Motivation and context
Fix for Unit Testing

## How has this been tested?
Local testing with`composer run phpunit -- --group=basic`, this PR should pass on GitHub.

## Screenshots
### Before
![Screenshot 2025-01-01 at 10 21 37](https://github.com/user-attachments/assets/362a7b69-6322-454c-a378-b3ac5aceb2c0)

### After
![Screenshot 2025-01-01 at 10 21 48](https://github.com/user-attachments/assets/32b37499-50d7-478e-8206-81ba5713f022)

## Types of changes
- Bug fix