### PR TITLE
Enable the saving of posts and pages by keyboard shortcuts

### DIFF
--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -1728,6 +1728,19 @@ final class _WP_Editors {
 			self::wp_link_dialog();
 		}
 
+		/* Enables the saving and updating of posts and pages using Ctrl (or Cmd) + s on keyboard */
+		?>
+		<script>
+		document.addEventListener( 'keydown', function( e ) {
+			var updateButton = document.getElementById( 'save-post' ) ? document.getElementById( 'save-post' ) : document.getElementById( 'publish' );
+			if ( ( e.ctrlKey || e.metaKey ) && e.key === 's' ) {
+				e.preventDefault();
+				updateButton.click();
+			}
+		} );
+		</script>
+		<?php
+
 		/**
 		 * Fires after any core TinyMCE editor instances are created.
 		 *


### PR DESCRIPTION
This PR arises from the forum thread at https://forums.classicpress.net/t/useful-improvements-to-the-user-interface/5790. It enables posts and pages to be saved or updated by using the keyboard shortcut `Ctrl + s` (or `Cmd + s`) on a Mac.

This code enables saving and updating to occur regardless of whether the user is in the Visual or Text tab. (Other code suggested works only in the Visual tab.)