### PR TITLE
Ensure images are displayed in Media List View

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -370,6 +370,7 @@ table.media .column-title .media-icon {
 }
 
 table.media .column-title .media-icon img {
+	width: 100%;
 	max-width: 60px;
 	height: auto;
 	vertical-align: top; /* Remove descender white-space. */


### PR DESCRIPTION
In some circumstances, the width of an uploaded image may be too small to show up in the Media View list. This PR sets the width of the image at 100% to ensure that it does show. (The height is already set to auto, and a max-width is also already set, so this change will not cause the image to expand beyond the space allotted for it.)