### PR TITLE
Correct bulk author update of attachments

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3868,10 +3868,12 @@ function bulk_edit_attachments( $attachment_data = null ) {
 		}
 
 		// Update attachment author.
-		if ( isset( $attachment_data['post_author'] ) ) {
-			$attachment = get_post( $attachment_id );
-			$attachment->post_author = $attachment_data['post_author'];
-			wp_update_post( $attachment );
+		if ( isset( $attachment_data['post_author'] ) && $attachment_data['post_author'] !== '-1' ) {
+			$args = array(
+				'ID' => $attachment_id,
+				'post_author' => absint( $attachment_data['post_author'] ),
+			);
+			wp_update_post( $args, true );
 			update_post_meta( $attachment_id, '_edit_last', get_current_user_id() );
 			$update = true;
 		}


### PR DESCRIPTION
This PR address Issue #1710.

The problem that Issue identifies is that, when bulk editing attachments but leaving the author unchanged, the author instead becomes unset. This is because the value for an `unchanged` author is `-1`, which is interpreted as the value being set, and so triggers an author update. But no author has an ID of `-1`, so the author becomes unset.

This PR therefore adds a check to ensure that the value is not `-1`. It also slightly changes the way that the update is performed so that (a) there is no call to the database first to retrieve the attachment object (which is unnecessary as we already its ID), and (b) to return a `WP_Error` object on failure instead of the current `0` (in order to produce a more helpful error message).