### PR TITLE
Make images in gallery widget sortable via drag and drop

### DIFF
--- a/src/wp-admin/widgets-form.php
+++ b/src/wp-admin/widgets-form.php
@@ -22,6 +22,7 @@ if ( isset( $_GET['widgets-access'] ) ) {
 if ( 'on' === $widgets_access ) {
 	add_filter( 'admin_body_class', 'wp_widgets_access_body_class' );
 } else {
+	wp_enqueue_script( 'jquery-ui-sortable' );
 	wp_enqueue_script( 'admin-widgets' );
 
 	if ( wp_is_mobile() ) {


### PR DESCRIPTION
When I wrote the code to replace the jQueryUI Sortable module in core with the SortableJS library, it looks like I overlooked one place where the jQueryUI Sortable module is used. That is in the Gallery widget, where it is used to sort images via drag and drop.

At the moment, this results in it being impossible to sort images within the widget via drag and drop, though no errors appear in the browser console. It's just that nothing happens. Unfortunately, the code that performs the dragging and dropping is not in a file specific to the Gallery widget, but is instead buried deep inside the `media-views.js` file, so re-writing it to work with SortableJS is not really feasible.

I am planning to replace all the JavaScript for the media widgets (including the Gallery widget) in time (I hope) for CP v.2.5.0, so this issue will get resolved then. But we need a solution before then. Thankfully, it's quite simple, and just involves enqueuing the jQueryUI Sortable module in one specific place. That's what this PR does.

I have tested this, and so has the person who first reported this issue at https://forums.classicpress.net/t/classicpress-galleries-drag-drop-not-working/5801/