### PR TITLE
Add Docker Login step to Actions

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -20,6 +20,7 @@ jobs:
   # - Read .nvmrc.
   # - Installs NodeJS.
   # - Sets up caching for NPM.
+  # - Login at Docker Hub to increase access limits
   # - Setup, wait for and initialise MySQL.
   # - Installs NPM dependencies using install-changed to hash the `package.json` file.
   # - Configure PHP.
@@ -103,6 +104,12 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1


### PR DESCRIPTION
## Description
Occasionally, GitHub Actions fail, especially PHPUnit tests. This issue presents are one failure in the list of PHP Unit tests and a Docker error is reported.

For an example see action history (may require login):
https://github.com/ClassicPress/ClassicPress/actions/runs/12696759892/job/35391515623

## Motivation and context
On investigating this, a potential solution suggested by Copilot it to add a Docker login step to the Workflow to increase pull limits.

## How has this been tested?
Tests on this PR will ensure login succeeds and continued use after this is merged should eliminate these occasional errors

## Screenshots
![Screenshot 2025-01-11 at 09 56 07](https://github.com/user-attachments/assets/fc693725-15e3-4af3-8189-b39b3e9d09a2)

## Types of changes
- Bug fix
- New feature
