### PR TITLE
Add "plugins" in admin bar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -988,7 +988,7 @@ function wp_admin_bar_appearance_menu( $wp_admin_bar ) {
 	if ( current_user_can( 'activate_plugins' ) ) {
 		$wp_admin_bar->add_node(
 			array(
-				'parent' => 'site-name',
+				'parent' => 'appearance',
 				'id'     => 'plugins',
 				'title'  => __( 'Plugins' ),
 				'href'   => admin_url( 'plugins.php' ),

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -985,6 +985,17 @@ function wp_admin_bar_appearance_menu( $wp_admin_bar ) {
 		)
 	);
 
+	if ( current_user_can( 'activate_plugins' ) ) {
+		$wp_admin_bar->add_node(
+			array(
+				'parent' => 'site-name',
+				'id'     => 'plugins',
+				'title'  => __( 'Plugins' ),
+				'href'   => admin_url( 'plugins.php' ),
+			)
+		);
+	}
+
 	if ( current_user_can( 'switch_themes' ) ) {
 		$wp_admin_bar->add_node(
 			array(


### PR DESCRIPTION
As proposed by @citrika in #1721  this PR adds a shortcut for plugins menu in the admin bar.
There are already already shortcuts for themes and for plugins (only in MS admin bar).

## How has this been tested?
Local testing.

## Screenshots
### After
<img width="154" alt="Schermata 2025-01-13 alle 09 02 16" src="https://github.com/user-attachments/assets/2362e4cf-c4ad-4702-8aa1-be50b20000d6" />


## Types of changes
- New feature
