### PR TITLE
Restore skipped test resizing avif image

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,7 @@ jobs:
   # - Run PHPUnit Tests.
   test-php:
     name: "PHP ${{ matrix.php }} on MySQL ${{matrix.mysql}}${{ matrix.memcached && ' with memcached' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false

--- a/tests/phpunit/tests/image/resize.php
+++ b/tests/phpunit/tests/image/resize.php
@@ -97,8 +97,6 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		$file   = DIR_TESTDATA . '/images/avif-lossy.avif';
 		$editor = wp_get_image_editor( $file );
 
-		$this->markTestSkipped( 'Skip test while investigating failing GitHub Actions.' );
-
 		// Check if the editor supports the avif mime type.
 		if ( is_wp_error( $editor ) || ! $editor->supports_mime_type( 'image/avif' ) ) {
 			$this->markTestSkipped( sprintf( 'No AVIF support in the editor engine %s on this system.', $this->editor_engine ) );


### PR DESCRIPTION
## Description
Recently a unit test on resizing an avif image with Imagick was failing so the test was skipped.

This PR restores the test to allow monitoring and investigation as needed. Local tests using Imagick are orking as expected.

## Motivation and context
Restore a unit test and allow investigation into why it is failing on GitHub.

## How has this been tested?
Local run of the test with Imagick available is working.
To run just the single test use `composer run phpunit -- --filter=test_resize_avif `

## Screenshots
### Before
![Screenshot 2025-01-16 at 09 34 10](https://github.com/user-attachments/assets/944edef5-5ff1-4971-badb-36140c52da77)

### After
![Screenshot 2025-01-16 at 09 34 34](https://github.com/user-attachments/assets/ec4801ce-5159-44ee-86c1-1d5aef8bcf31)

## Types of changes
- Bug fix