### PR TITLE
Improve Error Handling for Password Reset Email

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3272,27 +3272,12 @@ function retrieve_password( $user_login = null ) {
 
 	$subject = wp_specialchars_decode( $subject );
 
-	/**
-	 * Filters the response after an attempt has been made to send the
-	 * reset password notification email to the user.
-	 *
-	 * @since CP-2.4.0
-	 *
-	 * @param bool   $failed  True if wp_mail() failed, false otherwise.
-	 * @param string $to      The intended recipient - user email address.
-	 * @param string $subject The subject of the email.
-	 * @param string $message The body of the email.
-	 * @param string $headers The headers of the email.
-	 */
 	if ( ! wp_mail( $to, $subject, $message, $headers ) ) {
-		$failed = apply_filters( 'cp_failed_password_mail', true, $to, $subject, $message, $headers );
-		if ( $failed ) {
-			$errors->add(
-				'retrieve_password_email_failure',
-				__( '<strong>Error:</strong> The email could not be sent. The site may not be correctly configured to send emails.' )
-			);
-			return $errors;
-		}
+		$errors->add(
+			'retrieve_password_email_failure',
+			__( '<strong>Error:</strong> The email could not be sent. The site may not be correctly configured to send emails.' )
+		);
+		return $errors;
 	}
 	return true;
 }


### PR DESCRIPTION
As is well known, CP's `wp_mail` function has significant limitations. These are usually overcome by installing a plugin that enables the use of SMTP. So far, so good.

If a site has a custom password reset form that uses the built-in password reset functionality (including the sending of a reset link by email), the use of an SMTP plugin does not prevent the user, who is attempting to reset their password, from seeing an error message. This warns: "The email could not be sent. The site may not be correctly configured to send emails." 


![Screenshot at 2025-01-17 12-35-56](https://github.com/user-attachments/assets/47fbe567-4d1f-4b2e-91ac-4b49f8c2ae95)


But if there is a functioning SMTP plugin active on the site, the email WILL have been sent, so that this message is wrong. 

## Description
This PR adds a filter so that the generation of the message can be intercepted. It also makes  two changes to the error message itself:

1. It changes "Your site" to "The site". The former is misleading, since in most cases the user will not be the owner of the site.
2. It removes from the error message the last part, which adds a link to a WP article explaining how to reset passwords. For most users, this is extremely unhelpful, since the advice there is only for site admins. And for CP, it is not a good look to be sending users to a WP site.

## How to Reproduce
Add an SMTP plugin to your site and configure it correctly. (I am using WP Offload SES to route emails via Amazon SES.)

Create a new page and add a password reset form to it that uses the default reset password functionality, like this:
```
<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( home_url( '/wp-login.php?action=lostpassword' ) ); ?>" method="post">		

		<fieldset>
			<div class="login-username">
				<label id="username-label" class="screen-reader-text">Email address</label>
				<input type="email" name="user_login" id="user_login" placeholder="Email address" class="input" value="" aria-labelledby="username-label" aria-describedby="reset-tip" required>
				<span role="tooltip" id="reset-tip" class="screen-reader-text">Please enter your law school email address.</span>
			</div>

			<div class="pwd-field-website">
				<input type='text' name='website' placeholder="Website" class="input" value="">
			</div>

			<div class="pwd-submit">
				<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary" value="Reset password">
				<input type="hidden" name="redirect_to" value="<?php echo esc_url_raw( home_url( '/lost-password/?authentication=success' ) ); ?>">
			</div>
		</fieldset>

	</form>
```

Now go the page while logged out and type in the email address of a user on the site. The error message noted above will be generated, although the email will be sent as intended.


### Changes made by this PR
A new filter is added, `cp_failed_password_mail` with a default of `true`. This reproduces the above behavior but with the amended error message. But the filter enables a site owner to change the value to `false`, which will then prevent the generation of the error message. A user can then generate their own message if they wish, which is facilitated by the passing of various variables.

## Types of changes
- Bug fix
