### PR TITLE
The ClassicPress Theme - apply styling to main menu only

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -2085,7 +2085,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		margin-left: 2px;
 		font-size: 0.85em;
 	}
-	.menu {
+	#primary-menu.menu {
 		display: flex;
 		flex-grow: 1;
 		justify-content: space-between;
@@ -2094,16 +2094,16 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		margin: 0;
 		line-height: 3.5em;
 	}
-	.menu li a {
+	#primary-menu.menu li a {
 		display: flex;
 		flex-grow: 1;
 		padding: 0.4em 0.5em;
 	}
-	nav .menu .sub-menu li a {
+	#primary-menu.menu .sub-menu li a {
 		line-height: 1.4em;
 		padding: 0.55em .85em;
 	}
-	.menu ul li {
+	#primary-menu.menu ul li {
 		padding: 0;
 		flex-direction: column;
 	}


### PR DESCRIPTION
When adding the default navigation widget, the styling from main menu is applied. Results in wrong alignment of the menu items in the navigation widget. Adding a prefix will fix this.