### PR TITLE
WP-r59674: Menus: call `get_privacy_policy_url()` once

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -202,14 +202,10 @@ class Walker_Nav_Menu extends Walker {
 		}
 
 		if ( ! empty( $menu_item->url ) ) {
-<<<<<<< HEAD
-			if ( get_privacy_policy_url() === $menu_item->url ) {
+			if ( $this->privacy_policy_url === $menu_item->url ) {
 				if ( ! empty( $menu_item->target && '_blank' === $menu_item->target && ! empty( $menu_item->xfn ) ) ) {
 					$atts['rel'] = 'nofollow privacy-policy';
 				} else {
-=======
-			if ( $this->privacy_policy_url === $menu_item->url ) {
->>>>>>> 396f6fbe43 (Menus: Improve performance by calling `get_privacy_policy_url()` once per `Walker_Nav_Menu` instance rather than for every nav menu item.)
 					$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
 				}
 			}

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -40,6 +40,23 @@ class Walker_Nav_Menu extends Walker {
 	);
 
 	/**
+	 * The URL to the privacy policy page.
+	 *
+	 * @since 6.8.0
+	 * @var string
+	 */
+	private $privacy_policy_url;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 6.8.0
+	 */
+	public function __construct() {
+		$this->privacy_policy_url = get_privacy_policy_url();
+	}
+
+	/**
 	 * Starts the list before the elements are added.
 	 *
 	 * @since 3.0.0
@@ -185,10 +202,14 @@ class Walker_Nav_Menu extends Walker {
 		}
 
 		if ( ! empty( $menu_item->url ) ) {
+<<<<<<< HEAD
 			if ( get_privacy_policy_url() === $menu_item->url ) {
 				if ( ! empty( $menu_item->target && '_blank' === $menu_item->target && ! empty( $menu_item->xfn ) ) ) {
 					$atts['rel'] = 'nofollow privacy-policy';
 				} else {
+=======
+			if ( $this->privacy_policy_url === $menu_item->url ) {
+>>>>>>> 396f6fbe43 (Menus: Improve performance by calling `get_privacy_policy_url()` once per `Walker_Nav_Menu` instance rather than for every nav menu item.)
 					$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
 				}
 			}

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -18,6 +18,13 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	private $orig_wp_nav_menu_max_depth;
 
 	/**
+	 * The ID of the privacy policy page.
+	 *
+	 * @var int
+	 */
+	private $privacy_policy_id;
+
+	/**
 	 * Setup.
 	 */
 	public function set_up() {
@@ -27,6 +34,19 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 
 		/** Walker_Nav_Menu class */
 		require_once ABSPATH . 'wp-includes/class-walker-nav-menu.php';
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Test Privacy Policy',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Set the privacy policy page.
+		update_option( 'wp_page_for_privacy_policy', $post_id );
+		$this->privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
+
 		$this->walker = new Walker_Nav_Menu();
 
 		$this->orig_wp_nav_menu_max_depth = $_wp_nav_menu_max_depth;
@@ -39,6 +59,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 		global $_wp_nav_menu_max_depth;
 
 		$_wp_nav_menu_max_depth = $this->orig_wp_nav_menu_max_depth;
+		delete_option( 'wp_page_for_privacy_policy' );
 		parent::tear_down();
 	}
 
@@ -167,23 +188,12 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @param string $target   Optional. The target value. Default empty string.
 	 */
 	public function test_walker_nav_menu_start_el_should_add_rel_privacy_policy_to_privacy_policy_url( $expected, $xfn = '', $target = '' ) {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
 		$output = '';
 
 		$item = array(
-			'ID'        => $privacy_policy_id,
-			'object_id' => $privacy_policy_id,
+			'ID'        => $this->privacy_policy_id,
+			'object_id' => $this->privacy_policy_id,
 			'title'     => 'Privacy Policy',
 			'target'    => $target,
 			'xfn'       => $xfn,
@@ -282,23 +292,12 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @covers Walker_Nav_Menu::start_el
 	 */
 	public function test_walker_nav_menu_start_el_should_not_add_rel_privacy_policy_when_no_url_is_passed() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
 		$output = '';
 
 		$item = array(
-			'ID'        => $privacy_policy_id,
-			'object_id' => $privacy_policy_id,
+			'ID'        => $this->privacy_policy_id,
+			'object_id' => $this->privacy_policy_id,
 			'title'     => 'Privacy Policy',
 			'target'    => '',
 			'xfn'       => '',
@@ -327,22 +326,11 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @covers Walker_Nav_Menu::start_el
 	 */
 	public function test_walker_nav_menu_start_el_should_add_rel_privacy_policy_when_id_does_not_match_but_url_does() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
 		$output = '';
 
 		// Ensure the ID does not match the privacy policy.
-		$not_privacy_policy_id = $privacy_policy_id - 1;
+		$not_privacy_policy_id = $this->privacy_policy_id - 1;
 
 		$item = array(
 			'ID'        => $not_privacy_policy_id,


### PR DESCRIPTION
**WP-r59674: Menus: Improve performance by calling `get_privacy_policy_url()` once per `Walker_Nav_Menu` instance rather than for every nav menu item.**

The `start_el()` method in `Walker_Nav_Menu` was calling `get_privacy_policy_url()` for every menu item when building menus. This resulted in redundant queries, particularly for menus with many items. This obtains the `get_privacy_policy_url()` value in the constructor for reuse in the `start_el()` method to improve performance.

Redundant code to construct the privacy policy page is also refactored into the `set_up()` method during tests.

WP:Props arzola, swissspidy, westonruter, mukesh27.
Fixes https://core.trac.wordpress.org/ticket/62818.

---

Merges https://core.trac.wordpress.org/changeset/59674 / https://github.com/WordPress/wordpress-develop/commit/396f6fbe43 to ClassicPress.

## Description
Improve performance of `Walker_Nav_Menu`.

## How has this been tested?
Local testing.

## Types of changes
- New feature

