### PR TITLE
Update the 4 freedoms in freedoms.php

### DIFF
--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -73,10 +73,11 @@ if ( $is_privacy_notice ) {
 	<p class="about-description"><?php printf( __( 'ClassicPress is Free and open source software, built by a distributed community of volunteer developers from around the world. ClassicPress comes with some awesome, worldview-changing rights courtesy of its <a href="%s">license</a>, the GPL.' ), 'https://opensource.org/licenses/gpl-license' ); ?></p>
 
 	<ul class="about-freedoms">
-		<li><?php _e( 'You have the freedom to run the program, for any purpose. (freedom 0)' ); ?></li>
-		<li><?php _e( 'You have access to the source code, the freedom to study how the program works, and the freedom to change it to make it do what you wish. (freedom 1)' ); ?></li>
-		<li><?php _e( 'You have the freedom to redistribute copies of the original program so you can help your neighbor. (freedom 2)' ); ?></li>
-		<li><?php _e( 'You have the freedom to distribute copies of your modified versions to others. By doing this you can give the whole community a chance to benefit from your changes. (freedom 3)' ); ?></li>
+		<h3><?php _e( 'The Four Freedoms' ); ?></h3>
+		<li><h4><?php _e( 'The 1st Freedom' ); ?></h4><?php _e( 'To run the program for any purpose.' ); ?></li>
+		<li><h4><?php _e( 'The 2nd Freedom' ); ?></h4><?php _e( 'To study how the program works and change it to make it do what you wish.' ); ?></li>
+		<li><h4><?php _e( 'The 3rd Freedom' ); ?></h4><?php _e( 'To redistribute.' ); ?></li>
+		<li><h4><?php _e( 'The 4th Freedom' ); ?></h4><?php _e( 'To distribute copies of your modified versions to others.' ); ?></li>
 	</ul>
 
 	<p>


### PR DESCRIPTION
Update the 4 freedoms at page wp-admin/freedoms.php, to match the ones from WP. Are similar but much shorter. 
Did not find the current ones at the CP site, so I think they are not marked as the official CP freedoms.  
Matching freedoms is better for translators as well.
