### PR TITLE
Replace jQuery with vanilla JavaScript in wp-medialement.js

### DIFF
--- a/src/wp-includes/js/mediaelement/wp-mediaelement.js
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.js
@@ -1,4 +1,4 @@
-/* global _wpmejsSettings, mejsL10n */
+/* global _wpmejsSettings, mejsL10n, MediaElementPlayer */
 (function(window) {
 	window.wp = window.wp || {};
 

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.js
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.js
@@ -71,8 +71,7 @@
 			// Only initialize new media elements.
 			var mediaElements = document.querySelectorAll( '.wp-audio-shortcode, .wp-video-shortcode' );
 			mediaElements.forEach( function( element ) {
-				if ( !element.classList.contains( 'mejs-container' ) && 
-					( !element.parentNode || !element.parentNode.classList.contains( 'mejs-mediaelement' ) ) ) {
+				if ( !element.classList.contains( 'mejs-container' ) && ( !element.parentNode || !element.parentNode.classList.contains( 'mejs-mediaelement' ) ) ) {
 					new MediaElementPlayer( element, settings );
 				}
 			});

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.js
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.js
@@ -1,6 +1,5 @@
 /* global _wpmejsSettings, mejsL10n */
-(function( window, $ ) {
-
+(function(window) {
 	window.wp = window.wp || {};
 
 	function wpMediaElement() {
@@ -16,19 +15,22 @@
 		 *
 		 * @since 4.4.0
 		 *
+		 * Rewritten in vanilla JavaScript
+		 * @since CP-2.4.0
+		 *
 		 * @return {void}
 		 */
 		function initialize() {
 			if ( typeof _wpmejsSettings !== 'undefined' ) {
-				settings = $.extend( true, {}, _wpmejsSettings );
+				settings = Object.assign( {}, _wpmejsSettings );
 			}
 			settings.classPrefix = 'mejs-';
-			settings.success = settings.success || function ( mejs ) {
+			settings.success = settings.success || function( mejs ) {
 				var autoplay, loop;
 
-				if ( mejs.rendererName && -1 !== mejs.rendererName.indexOf( 'flash' ) ) {
-					autoplay = mejs.attributes.autoplay && 'false' !== mejs.attributes.autoplay;
-					loop = mejs.attributes.loop && 'false' !== mejs.attributes.loop;
+				if ( mejs.rendererName && mejs.rendererName.indexOf( 'flash' ) !== -1 ) {
+					autoplay = mejs.attributes.autoplay && mejs.attributes.autoplay !== 'false';
+					loop = mejs.attributes.loop && mejs.attributes.loop !== 'false';
 
 					if ( autoplay ) {
 						mejs.addEventListener( 'canplay', function() {
@@ -52,24 +54,28 @@
 			 *
 			 * @since 4.9.3
 			 *
+			 * Rewritten in vanilla JavaScript
+			 * @since CP-2.4.0
+			 *
 			 * @param {object} media The wrapper that mimics all the native events/properties/methods for all renderers.
 			 * @param {object} node  The original HTML video, audio, or iframe tag where the media was loaded.
 			 * @return {string}
 			 */
-			settings.customError = function ( media, node ) {
+			settings.customError = function( media, node ) {
 				// Make sure we only fall back to a download link for flash files.
-				if ( -1 !== media.rendererName.indexOf( 'flash' ) || -1 !== media.rendererName.indexOf( 'flv' ) ) {
+				if ( media.rendererName.indexOf( 'flash' ) !== -1 || media.rendererName.indexOf( 'flv' ) !== -1 ) {
 					return '<a href="' + node.src + '">' + mejsL10n.strings['mejs.download-file'] + '</a>';
 				}
 			};
 
 			// Only initialize new media elements.
-			$( '.wp-audio-shortcode, .wp-video-shortcode' )
-				.not( '.mejs-container' )
-				.filter(function () {
-					return ! $( this ).parent().hasClass( 'mejs-mediaelement' );
-				})
-				.mediaelementplayer( settings );
+			var mediaElements = document.querySelectorAll( '.wp-audio-shortcode, .wp-video-shortcode' );
+			mediaElements.forEach( function( element ) {
+				if ( !element.classList.contains( 'mejs-container' ) && 
+					( !element.parentNode || !element.parentNode.classList.contains( 'mejs-mediaelement' ) ) ) {
+					new MediaElementPlayer( element, settings );
+				}
+			});
 		}
 
 		return {
@@ -83,6 +89,6 @@
 	 */
 	window.wp.mediaelement = new wpMediaElement();
 
-	$( window.wp.mediaelement.initialize );
+	window.addEventListener( 'load', window.wp.mediaelement.initialize );
 
-})( window, jQuery );
+} )( window );


### PR DESCRIPTION
Adding a video to the TinyMCE editor on a post or page causes an error to show in the browser console:
```
Uncaught ReferenceError: jQuery is not defined
```
This PR resolves that by re-writing the `~/wp-includes/js/mediaelement/wp-mediaelement.js` file so as to replace the previous jQuery with vanilla JavaScript.