### PR TITLE
WP-r59736: Add invalid password message for post passwords

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1773,7 +1773,7 @@ function get_the_password_form( $post = 0 ) {
 		 * @since 6.8.0
 		 *
 		 * @param string  $text The message shown to users when entering an invalid password.
-		 * @param WP_Post $post   Post object.
+		 * @param WP_Post $post Post object.
 		 */
 		$invalid_password      = apply_filters( 'the_password_form_incorrect_password', __( 'Invalid password.' ), $post );
 		$invalid_password_html = '<div class="post-password-form-invalid-password" role="alert"><p id="error-' . $field_id . '">' . $invalid_password . '</p></div>';

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1772,7 +1772,7 @@ function get_the_password_form( $post = 0 ) {
 		 *
 		 * @since 6.8.0
 		 *
-		 * @param string The message shown to users when entering an invalid password.
+		 * @param string  $text The message shown to users when entering an invalid password.
 		 * @param WP_Post $post   Post object.
 		 */
 		$invalid_password      = apply_filters( 'the_password_form_incorrect_password', __( 'Invalid password.' ), $post );

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1757,7 +1757,7 @@ function prepend_attachment( $content ) {
  * @return string HTML content for password form for password protected post.
  */
 function get_the_password_form( $post = 0 ) {
-	$post   = get_post( $post );
+	$post                  = get_post( $post );
 	$field_id              = 'pwbox-' . ( empty( $post->ID ) ? wp_rand() : $post->ID );
 	$invalid_password      = '';
 	$invalid_password_html = '';
@@ -1783,11 +1783,7 @@ function get_the_password_form( $post = 0 ) {
 
 	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $invalid_password_html . '
 	<p>' . __( 'This content is password protected. To view it please enter your password below:' ) . '</p>
-<<<<<<< HEAD
-	<p><label for="' . $label . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $label . '" type="password" spellcheck="false" size="20"></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '"></p></form>
-=======
-	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . ' /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
->>>>>>> 23a215a4d0 (Accessibility: Add invalid password message for post passwords.)
+	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . '></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '"></p></form>
 	';
 
 	/**

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1758,10 +1758,36 @@ function prepend_attachment( $content ) {
  */
 function get_the_password_form( $post = 0 ) {
 	$post   = get_post( $post );
-	$label  = 'pwbox-' . ( empty( $post->ID ) ? rand() : $post->ID );
-	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form" method="post">
+	$field_id              = 'pwbox-' . ( empty( $post->ID ) ? wp_rand() : $post->ID );
+	$invalid_password      = '';
+	$invalid_password_html = '';
+	$aria                  = '';
+	$class                 = '';
+
+	// If the referrer is the same as the current request, the user has entered an invalid password.
+	if ( ! empty( $post->ID ) && wp_get_raw_referer() === get_permalink( $post->ID ) && isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
+		/**
+		 * Filters the invalid password message shown on password-protected posts.
+		 * The filter is only applied if the post is password protected.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param string The message shown to users when entering an invalid password.
+		 * @param WP_Post $post   Post object.
+		 */
+		$invalid_password      = apply_filters( 'the_password_form_incorrect_password', __( 'Invalid password.' ), $post );
+		$invalid_password_html = '<div class="post-password-form-invalid-password" role="alert"><p id="error-' . $field_id . '">' . $invalid_password . '</p></div>';
+		$aria                  = ' aria-describedby="error-' . $field_id . '"';
+		$class                 = ' password-form-error';
+	}
+
+	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $invalid_password_html . '
 	<p>' . __( 'This content is password protected. To view it please enter your password below:' ) . '</p>
+<<<<<<< HEAD
 	<p><label for="' . $label . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $label . '" type="password" spellcheck="false" size="20"></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '"></p></form>
+=======
+	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . ' /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
+>>>>>>> 23a215a4d0 (Accessibility: Add invalid password message for post passwords.)
 	';
 
 	/**
@@ -1773,11 +1799,13 @@ function get_the_password_form( $post = 0 ) {
 	 *
 	 * @since 2.7.0
 	 * @since 5.8.0 Added the `$post` parameter.
+	 * @since 6.8.0 Added the `$invalid_password` parameter.
 	 *
 	 * @param string  $output The password form HTML output.
 	 * @param WP_Post $post   Post object.
+	 * @param string  $invalid_password The invalid password message.
 	 */
-	return apply_filters( 'the_password_form', $output, $post );
+	return apply_filters( 'the_password_form', $output, $post, $invalid_password );
 }
 
 /**

--- a/tests/phpunit/tests/post/postPasswordRequired.php
+++ b/tests/phpunit/tests/post/postPasswordRequired.php
@@ -9,6 +9,7 @@ class Tests_Post_PostPasswordRequired extends WP_UnitTestCase {
 	 * @var PasswordHash
 	 */
 	protected static $wp_hasher;
+	const INVALID_MESSAGE = 'Password errata.';
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		require_once ABSPATH . WPINC . '/class-phpass.php';
@@ -77,5 +78,61 @@ class Tests_Post_PostPasswordRequired extends WP_UnitTestCase {
 
 		// Password is not required as it remains valid when hashed with phpass:
 		$this->assertFalse( $required );
+	}
+
+	public function test_post_password_invalid_message() {
+		// Create a post with a password:
+		$post_id = self::factory()->post->create(
+			array(
+				'post_password' => 'password',
+			)
+		);
+
+		// Set the cookie with the wrong phpass hash:
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = self::$wp_hasher->HashPassword( 'wrong-password' );
+
+		// Set the referer to the same page:
+		$_SERVER['HTTP_REFERER'] = get_permalink( $post_id );
+
+		// Go to the page:
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertStringContainsString( 'Invalid password.', get_the_content() );
+
+		// Clear the cookie:
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+	}
+
+	public function filter_post_password_invalid_message_filter() {
+		return self::INVALID_MESSAGE;
+	}
+
+	public function test_post_password_invalid_message_filter() {
+		// Create a post with a password:
+		$post_id = self::factory()->post->create(
+			array(
+				'post_password' => 'password',
+			)
+		);
+
+		// Set the cookie with the wrong phpass hash:
+		$_COOKIE[ 'wp-postpass_' . COOKIEHASH ] = self::$wp_hasher->HashPassword( 'wrong-password' );
+
+		// Set the referer to the same page:
+		$_SERVER['HTTP_REFERER'] = get_permalink( $post_id );
+
+		// Add the filter:
+		add_filter( 'the_password_form_incorrect_password', array( $this, 'filter_post_password_invalid_message_filter' ) );
+
+		// Go to the page:
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertStringContainsString( self::INVALID_MESSAGE, get_the_content() );
+
+		// Clear the cookie:
+		unset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] );
+
+		// Remove the filter:
+		add_filter( 'the_password_form_incorrect_password', array( $this, 'filter_post_password_invalid_message_filter' ) );
 	}
 }


### PR DESCRIPTION
**WP-r59736: Accessibility: Add invalid password message for post passwords.**

Display a message notifying the user of an incorrect password when submitting the post password form. Improve the accessibility of the form by adding a required attribute for consistent identification.

WP:Props henry.wright, jonnyauk, kreppar, tommusrhodus, joedolson, audrasjb, jdahir0789, parthvataliya, dhruvang21.
Fixes https://core.trac.wordpress.org/ticket/37332.

Merges https://core.trac.wordpress.org/changeset/59736 / https://github.com/WordPress/wordpress-develop/commit/23a215a4d0 to ClassicPress.

**WP-r59737: Docs: Add missing $text filter argument.**
Fix omitted filter argument variable name for `the_password_form_incorrect_password`. Follow up to https://core.trac.wordpress.org/changeset/59736.

WP:Props mukesh27, joedolson.
See https://core.trac.wordpress.org/ticket/37332.

CP Props: KTS915.

## Description
This backport display an error message if the password supplied for a protected post is wrong.
Using the new `the_password_form_incorrect_password` the message can be configured.

## Motivation and context
Accessibility.

## How has this been tested?
Local testing on a password protected page.
The filter works.
New unit tests (not from upstream).


## Screenshots
### Before
After submitting a wrong password.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/ab4758ce-c5f4-4751-bd2d-ff1c1269f33c" />

### After

<img width="571" alt="image" src="https://github.com/user-attachments/assets/de8566b2-bb91-47f2-9e70-0cbe00da0609" />

With filter:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/e07e839d-2972-426b-b03b-999cfe616fe7" />


## Types of changes
- New feature

