### PR TITLE
Arrow navigation within modal on media grid

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,6 +43,7 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
+	height: -moz-fit-content;
 	height: fit-content;	
 	padding: 16px 16px 0;
 	position: absolute;
@@ -53,6 +54,7 @@
 	overflow: hidden;
 }
 .imgedit-settings {
+	height: -moz-fit-content;
 	height: fit-content;
 	overflow: hidden;  
 	background: #f6f7f7;

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,18 +43,18 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
-	height: 100vh;	
+	height: fit-content;	
 	padding: 16px 16px 0;
 	position: absolute;
 	top: 0;
 	right: 282px;
 	bottom: 0;
 	left: 0;
-	overflow: auto;
+	overflow: hidden;
 }
 .imgedit-settings {
-	height: 100vh;
-	overflow: auto;  
+	height: fit-content;
+	overflow: hidden;  
 	background: #f6f7f7;
 	border-left: 1px solid #dcdcde;
 	padding: 20px 16px 0;

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -544,7 +544,7 @@ if ( 'grid' === $mode ) {
 					<div class="attachment-details save-ready">
 						<div class="attachment-media-view">
 							<h3 class="screen-reader-text"><?php esc_html_e( 'Attachment Preview' ); ?></h3>
-							<div class="media-navigation" role="navigation" aria-label="<?php esc_html_e( 'Media Navigation' ); ?>">
+							<div class="media-navigation" aria-label="<?php esc_html_e( 'Media Navigation' ); ?>">
 								<button type="button" id="left-dashicon-mobile" class="left dashicons">
 									<span class="screen-reader-text"><?php esc_html_e( 'Edit previous media item' ); ?></span>
 								</button>

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -411,7 +411,7 @@ if ( 'grid' === $mode ) {
 			<ul class="media-grid-view">
 
 				<?php
-				foreach ( $attachments->posts as $attachment ) {
+				foreach ( $attachments->posts as $key => $attachment ) {
 					$meta = wp_prepare_attachment_for_js( $attachment->ID );
 					$date         = $meta['dateFormatted'];
 					$author       = $meta['authorName'];
@@ -472,6 +472,7 @@ if ( 'grid' === $mode ) {
 						data-menu-order="<?php echo esc_attr( $menu_order ); ?>"
 						data-taxes="<?php echo esc_attr( $media_cats ); ?>"
 						data-tags="<?php echo esc_attr( $media_tags ); ?>"
+						data-order="<?php echo esc_attr( $key + 1 ); ?>"
 						data-update-nonce="<?php echo $update_nonce; ?>"
 						data-delete-nonce="<?php echo $delete_nonce; ?>"
 						data-edit-nonce="<?php echo $edit_nonce; ?>"

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -331,16 +331,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			leftIcon.setAttribute( 'aria-disabled', true );
 			leftIconMobile.setAttribute( 'aria-disabled', true );
 		} else {
-			leftIcon.setAttribute( 'aria-disabled',false );
-			leftIconMobile.setAttribute( 'aria-disabled',false );
+			leftIcon.setAttribute( 'aria-disabled', false );
+			leftIconMobile.setAttribute( 'aria-disabled', false );
 		}
 
 		if ( next === '' ) {
 			rightIcon.setAttribute( 'aria-disabled', true );
 			rightIconMobile.setAttribute( 'aria-disabled', true );
 		} else {
-			rightIcon.setAttribute( 'aria-disabled',false );
-			rightIconMobile.setAttribute( 'aria-disabled',false );
+			rightIcon.setAttribute( 'aria-disabled', false );
+			rightIconMobile.setAttribute( 'aria-disabled', false );
 		}
 
 		items.forEach( function( i ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -222,7 +222,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function resetDataOrdering() {
 		var items = document.querySelectorAll( '.media-item' ),
 			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
-			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' );
+			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' ),
+			count5;
 
 		items.forEach( function( item, index ) {
 			item.setAttribute( 'data-order', parseInt( index + 1 ) );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -890,8 +890,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				var div = document.createElement( 'div' );
 				div.id = 'edit-image-navigation';
 				div.className = 'attachment-media-view landscape';
-				document.querySelector( '.media-frame-content' ).before( div );
 				div.append( mediaNavigationMobile );
+				document.querySelector( '.media-frame-content' ).before( div );
 			}
 
 			document.querySelector( '.attachment-details' ).setAttribute( 'hidden', true );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -885,17 +885,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( result ) {
-			// Avoid duplicate navigation buttons
-			if ( dialog.querySelector( '#edit-image-navigation') != null ) {
-				dialog.querySelector( '#edit-image-navigation').remove();
-			}
-
 			// Add navigation buttons
-			var div = document.createElement( 'div' );
-			div.id = 'edit-image-navigation';
-			div.className = 'attachment-media-view landscape';
-			document.querySelector( '.media-frame-content' ).before( div );
-			div.append( mediaNavigationMobile );
+			if ( dialog.querySelector( '#edit-image-navigation') == null ) {
+				var div = document.createElement( 'div' );
+				div.id = 'edit-image-navigation';
+				div.className = 'attachment-media-view landscape';
+				document.querySelector( '.media-frame-content' ).before( div );
+				div.append( mediaNavigationMobile );
+			}
 
 			document.querySelector( '.attachment-details' ).setAttribute( 'hidden', true );
 			document.querySelector( '.attachment-details' ).setAttribute( 'inert', true );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -255,7 +255,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			menuOrder = item.dataset.menuOrder,
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
-			items = document.querySelectorAll('.media-item'),
+			items = document.querySelectorAll( '.media-item' ),
 			order = 1;
 
 		// Modify current URL

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -255,7 +255,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
 			order = item.dataset.order,
-			total = document.querySelectorAll( '.media-item' ).length,
+			total = document.querySelectorAll( '.media-item' ).length;
 
 		// Modify current URL
 		queryParams.set( 'item', id );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -255,6 +255,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	window.addEventListener( 'resize', toggleMediaNavigation );
 
+	// Delete media item
+	dialog.querySelector( '.delete-attachment' ).addEventListener( 'click', function() {
+		var id = location.search.replace( '?item=', '' );
+		if ( confirm( _wpMediaGridSettings.confirm_delete ) ) {
+			deleteItem( id );
+			resetDataOrdering();
+		}
+	} );
+
 	// Open modal
 	function openModalDialog( item ) {
 		var id = item.id.replace( 'media-', '' ),
@@ -382,14 +391,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		setTimeout( function() {
 			dialog.showModal();
 		}, 1 );
-
-		// Delete media item
-		dialog.querySelector( '.delete-attachment' ).addEventListener( 'click', function() {
-			if ( confirm( _wpMediaGridSettings.confirm_delete ) ) {
-				deleteItem( id );
-				resetDataOrdering();
-			}
-		} );
 
 		// Update media categories and tags
 		dialog.querySelectorAll( '.compat-item input' ).forEach( function( input ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -254,8 +254,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			menuOrder = item.dataset.menuOrder,
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
-			items = document.querySelectorAll( '.media-item' ),
-			order = 1;
+			order = item.dataset.order,
+			total = document.querySelectorAll( '.media-item' ).length,
 
 		// Modify current URL
 		queryParams.set( 'item', id );
@@ -342,15 +342,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			rightIconMobile.setAttribute( 'aria-disabled', false );
 		}
 
-		items.forEach( function( i ) {
-			if ( i.id === item.id ) {
-				dialog.querySelector( '#current-media-item' ).textContent = order;
-				dialog.querySelector( '#total-media-items' ).textContent = items.length;
-				dialog.querySelector( '#current-media-item-mobile' ).textContent = order;
-				dialog.querySelector( '#total-media-items-mobile' ).textContent = items.length;
-			}
-			order++;
-		} );
+		// Set order of media item and total
+		dialog.querySelector( '#current-media-item' ).textContent = order;
+		dialog.querySelector( '#total-media-items' ).textContent = total;
+		dialog.querySelector( '#current-media-item-mobile' ).textContent = order;
+		dialog.querySelector( '#total-media-items-mobile' ).textContent = total;
 
 		toggleMediaNavigation();
 

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -255,7 +255,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
 			order = item.dataset.order,
-			total = document.querySelectorAll( '.media-item' ).length;
+			total = parseInt( document.querySelector( '.displaying-num' ).textContent );
 
 		// Modify current URL
 		queryParams.set( 'item', id );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -8,7 +8,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		uploadCatSelect = document.getElementById( 'upload-category' ),
 		inputElement = document.getElementById( 'filepond' ),
 		ajaxurl = document.getElementById( 'ajax-url' ).value,
-		body = document.body,
 		dialog = document.getElementById( 'media-modal' ),
 		leftIcon = document.getElementById( 'left-dashicon' ),
 		rightIcon = document.getElementById( 'right-dashicon' ),

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -961,12 +961,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			toolbar.classList.add( 'media-toolbar-mode-select' );
 
 			deleteButton.addEventListener( 'click', function() {
-				if ( confirm( _wpMediaGridSettings.confirm_multiple ) ) {
-					document.querySelectorAll( '.media-item.selected' ).forEach( function( deleteSelect ) {
-						deleteItem( deleteSelect.id.replace( 'media-', '' ) );
-					} );
+				var selectedItems = document.querySelectorAll( '.media-item.selected' );
+				if ( selectedItems.length !== 0 ) {
+					if ( confirm( _wpMediaGridSettings.confirm_multiple ) ) {
+						selectedItems.forEach( function( deleteSelect ) {
+							deleteItem( deleteSelect.id.replace( 'media-', '' ) );
+						} );
+					}
+					document.querySelector( '.select-mode-toggle-button' ).click();
 				}
-				document.querySelector( '.select-mode-toggle-button' ).click();
 			} );
 		}
 	} );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -208,6 +208,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				}
 				mediaItem.remove();
 				closeButton.click();
+				resetDataOrdering();
 			} else {
 				console.log( _wpMediaGridSettings.delete_failed );
 			}
@@ -215,6 +216,23 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		.catch( function( error ) {
 			console.error( _wpMediaGridSettings.error, error );
 		} );
+	}
+
+	// Reset ordering of remaining media items after deletion
+	function resetDataOrdering() {
+		var items = document.querySelectorAll( '.media-item' ),
+			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
+			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' );
+
+		items.forEach( function( item, index ) {
+			item.setAttribute( 'data-order', parseInt( index + 1 ) );
+		} );
+
+		// Reset totals
+		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
+		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + ' ' + count[5];
+		dialog.querySelector( '#total-media-items' ).textContent = items.length;
+		dialog.querySelector( '#total-media-items-mobile' ).textContent = items.length;
 	}
 
 	// Toggle media button navigation wrappers according to viewport width
@@ -364,6 +382,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				deleteItem( id );
 			}
 		} );
+		resetDataOrdering();
 
 		// Update media categories and tags
 		dialog.querySelectorAll( '.compat-item input' ).forEach( function( input ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -380,9 +380,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		dialog.querySelector( '.delete-attachment' ).addEventListener( 'click', function() {
 			if ( confirm( _wpMediaGridSettings.confirm_delete ) ) {
 				deleteItem( id );
+				resetDataOrdering();
 			}
 		} );
-		resetDataOrdering();
 
 		// Update media categories and tags
 		dialog.querySelectorAll( '.compat-item input' ).forEach( function( input ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -230,11 +230,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		// Reset totals
 		if ( 5 in count ) { // allow for different languages
-			count5 = count[5];
+			count5 = ' ' + count[5];
 		} else {
 			count5 = '';
 		}
-		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + ' ' + count5;
+		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + count5;
 
 		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
 		dialog.querySelector( '#total-media-items' ).textContent = items.length;

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -328,19 +328,19 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		rightIcon.setAttribute( 'data-next', next );
 
 		if ( prev === '' ) {
-			leftIcon.disabled = true;
-			leftIconMobile.disabled = true;
+			leftIcon.setAttribute( 'aria-disabled', true );
+			leftIconMobile.setAttribute( 'aria-disabled', true );
 		} else {
-			leftIcon.disabled = false;
-			leftIconMobile.disabled = false;
+			leftIcon.setAttribute( 'aria-disabled',false );
+			leftIconMobile.setAttribute( 'aria-disabled',false );
 		}
 
 		if ( next === '' ) {
-			rightIcon.disabled = true;
-			rightIconMobile.disabled = true;
+			rightIcon.setAttribute( 'aria-disabled', true );
+			rightIconMobile.setAttribute( 'aria-disabled', true );
 		} else {
-			rightIcon.disabled = false;
-			rightIconMobile.disabled = false;
+			rightIcon.setAttribute( 'aria-disabled',false );
+			rightIconMobile.setAttribute( 'aria-disabled',false );
 		}
 
 		items.forEach( function( i ) {
@@ -855,7 +855,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 		}
 	}
-	mediaNavigation.addEventListener( 'keydown', keydownHandler );
+	document.querySelector( '.edit-media-header' ).addEventListener( 'keydown', keydownHandler );
 	mediaNavigationMobile.addEventListener( 'keydown', keydownHandler );
 
 	// Edit image
@@ -890,6 +890,18 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( result ) {
+			// Avoid duplicate navigation buttons
+			if ( dialog.querySelector( '#edit-image-navigation') != null ) {
+				dialog.querySelector( '#edit-image-navigation').remove();
+			}
+
+			// Add navigation buttons
+			var div = document.createElement( 'div' );
+			div.id = 'edit-image-navigation';
+			div.className = 'attachment-media-view landscape';
+			document.querySelector( '.media-frame-content' ).before( div );
+			div.append( mediaNavigationMobile );
+
 			document.querySelector( '.attachment-details' ).setAttribute( 'hidden', true );
 			document.querySelector( '.attachment-details' ).setAttribute( 'inert', true );
 			document.querySelector( '.media-frame-content' ).insertAdjacentHTML( 'beforeend', result.data.html );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -229,8 +229,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 
 		// Reset totals
+		if ( 5 in count ) { // allow for different languages
+			count5 = count[5];
+		} else {
+			count5 = '';
+		}
+		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + ' ' + count5;
+
 		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
-		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + ' ' + count[5];
 		dialog.querySelector( '#total-media-items' ).textContent = items.length;
 		dialog.querySelector( '#total-media-items-mobile' ).textContent = items.length;
 	}


### PR DESCRIPTION
When PR #1756 was merged, it had just had a new commit added at the last minute to add arrow navigation within the modal. This PR addresses the issues that that commit has raised.

First, it removes a `role="navigation"` attribute from a `div` containing buttons. That role is for a menu; buttons are not a menu, so it is wrong and bad for accessibility.

Second, that PR creates an inconsistent UX when a user clicks an Edit Image button from within the modal while on mobile. A user using the arrow keys may navigate to a new file, but the buttons to provide the same experience do not appear on screen. This PR ensures that those buttons are now shown by adding a new `div` with the ID of `edit-image-navigation` to contain the relevant buttons.

Third, for the arrow keys to work, the cursor needs to be within a specific area. This PR enlarges that area on screens above 480px in width to ensure that it includes the Close button (by listening to `document.querySelector( '.edit-media-header'`  to add the `keydownHandler` function). This is important because, when the modal is opened, focus is automatically placed on that button. In other words, this ensures that the arrow keys will work immediately when the modal is opened.

Finally, as noted above, the arrow keys work only if the cursor is within a specific area. This means that the original behavior of disabling a navigation button once it had reached the first file (in the case of the left button) or last file (in the case of the right button) caused the arrow keys to stop working as a means of navigation because a disabled button cannot trap focus.

This PR addresses that by using the `aria-disabled` attribute instead. This means that the correct information is still passed to screenreaders, but the buttons can continue to trap focus and so allow the arrows to keep working. This does mean that there is no longer a visual indicator that the button is disabled, but that is no longer essential because we now have a numeric indicator to say which file the modal is currently on.