### PR TITLE
Change a few instances of WordPress to ClassicPress

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1945,7 +1945,7 @@ class WP_Site_Health {
 			$result['status'] = 'critical';
 			$result['label']  = sprintf(
 				/* translators: %s: wp-content */
-				__( 'Unable to locate WordPress content directory (%s)' ),
+				__( 'Unable to locate ClassicPress content directory (%s)' ),
 				'<code>wp-content</code>'
 			);
 			$result['description'] = sprintf(

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1648,7 +1648,7 @@ function wp_dashboard_php_nag() {
 		if ( $response['is_lower_than_future_minimum'] ) {
 			$message = sprintf(
 				/* translators: %s: The server PHP version. */
-				__( 'Your site is running on an outdated version of PHP (%s), which does not receive security updates and soon will not be supported by ClassicPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress.' ),
+				__( 'Your site is running on an outdated version of PHP (%s), which does not receive security updates and soon will not be supported by ClassicPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade ClassicPress.' ),
 				PHP_VERSION
 			);
 		} else {
@@ -1661,7 +1661,7 @@ function wp_dashboard_php_nag() {
 	} elseif ( $response['is_lower_than_future_minimum'] ) {
 		$message = sprintf(
 			/* translators: %s: The server PHP version. */
-			__( 'Your site is running on an outdated version of PHP (%s), which soon will not be supported by ClassicPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade WordPress.' ),
+			__( 'Your site is running on an outdated version of PHP (%s), which soon will not be supported by ClassicPress. Ensure that PHP is updated on your server as soon as possible. Otherwise you will not be able to upgrade ClassicPress.' ),
 			PHP_VERSION
 		);
 	} else {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1058,7 +1058,7 @@ function _wp_delete_all_temp_backups() {
 	}
 
 	if ( ! $wp_filesystem->wp_content_dir() ) {
-		return new WP_Error( 'fs_no_content_dir', __( 'Unable to locate WordPress content directory (wp-content).' ) );
+		return new WP_Error( 'fs_no_content_dir', __( 'Unable to locate ClassicPress content directory (wp-content).' ) );
 	}
 
 	$temp_backup_dir = $wp_filesystem->wp_content_dir() . 'upgrade-temp-backup/';


### PR DESCRIPTION
## Description
While updating the `en_GB` translation files in readiness for ClassicPress `2.4.0` I found a few instances in core of `WordPress` that should be changes to `ClassicPress`.

## Motivation and context
Branding.

## How has this been tested?
In translation files only.

## Screenshots
N/A

## Types of changes
- Bug fix