### PR TITLE
Media dialog fix and styling improvements

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,7 +43,6 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
-	height: -moz-fit-content;
 	height: fit-content;
 	padding: 16px 16px 0;
 	position: absolute;
@@ -54,7 +53,6 @@
 	overflow: hidden;
 }
 .imgedit-settings {
-	height: -moz-fit-content;
 	height: fit-content;
 	overflow: hidden;
 	background: #f6f7f7;

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,18 +43,18 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
-	height: 100vh;	
+	height: fit-content;
 	padding: 16px 16px 0;
 	position: absolute;
 	top: 0;
 	right: 282px;
 	bottom: 0;
 	left: 0;
-	overflow: auto;
+	overflow: hidden;
 }
 .imgedit-settings {
-	height: 100vh;
-	overflow: auto;  
+	height: fit-content;
+	overflow: hidden;
 	background: #f6f7f7;
 	border-left: 1px solid #dcdcde;
 	padding: 20px 16px 0;
@@ -66,9 +66,6 @@
 }
 .imgedit-group-top h2 {
 	display: inline-block;
-}
-.imgedit-wrap {
-	box-shadow: inset 0 4px 4px -4px rgba(0, 0, 0, 0.1);
 }
 .imgedit-settings .imgedit-help-toggle {
 	margin: 13px 0 0;
@@ -362,4 +359,10 @@ dialog::backdrop {
 	outline-offset: 0.125rem;
 	outline-style: solid;
 	outline-width: 0.125rem;
+}
+/* Caret next to "Restore original image" */
+.button-link .imgedit-help-toggle {
+	margin: 0;
+	border: 0;
+	text-decoration: none;
 }

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -364,5 +364,7 @@ dialog::backdrop {
 .button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
+	-webkit-text-decoration: none;
+	-moz-text-decoration: none;
 	text-decoration: none;
 }

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -360,9 +360,8 @@ dialog::backdrop {
 	outline-style: solid;
 	outline-width: 0.125rem;
 }
-/* Caret next to "Restore original image" */
-/*.button-link .imgedit-help-toggle {
+.button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
 	text-decoration: none;
-}*/
+}

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -363,5 +363,7 @@ dialog::backdrop {
 .button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
+	-webkit-text-decoration: none;
+	-moz-text-decoration: none;
 	text-decoration: none;
 }

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -364,7 +364,5 @@ dialog::backdrop {
 .button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
-	-webkit-text-decoration: none;
-	-moz-text-decoration: none;
 	text-decoration: none;
 }

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -361,8 +361,8 @@ dialog::backdrop {
 	outline-width: 0.125rem;
 }
 /* Caret next to "Restore original image" */
-.button-link .imgedit-help-toggle {
+/*.button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
 	text-decoration: none;
-}
+}*/

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,7 +43,7 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
-	height: fit-content;
+	height: 100vh;
 	padding: 16px 16px 0;
 	position: absolute;
 	top: 0;
@@ -53,7 +53,7 @@
 	overflow: hidden;
 }
 .imgedit-settings {
-	height: fit-content;
+	height: 100vh;
 	overflow: hidden;
 	background: #f6f7f7;
 	border-left: 1px solid #dcdcde;
@@ -363,7 +363,5 @@ dialog::backdrop {
 .button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;
-	-webkit-text-decoration: none;
-	-moz-text-decoration: none;
 	text-decoration: none;
 }

--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -43,7 +43,8 @@
 	margin-right: 0;
 }
 .imgedit-panel-content {
-	height: 100vh;
+	height: -moz-fit-content;
+	height: fit-content;
 	padding: 16px 16px 0;
 	position: absolute;
 	top: 0;
@@ -53,7 +54,8 @@
 	overflow: hidden;
 }
 .imgedit-settings {
-	height: 100vh;
+	height: -moz-fit-content;
+	height: fit-content;
 	overflow: hidden;
 	background: #f6f7f7;
 	border-left: 1px solid #dcdcde;
@@ -360,6 +362,7 @@ dialog::backdrop {
 	outline-style: solid;
 	outline-width: 0.125rem;
 }
+/* Caret next to "Restore original image" */
 .button-link .imgedit-help-toggle {
 	margin: 0;
 	border: 0;

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -643,6 +643,12 @@ border color while dragging a file over the uploader drop area */
 
 .edit-attachment-frame .edit-media-header {
 	overflow: hidden;
+	height: 50px;
+	position: sticky;
+	top: 0;
+	background: #fff;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+	z-index: 1;
 }
 
 .upload-php .media-modal-close .media-modal-icon:before {
@@ -682,13 +688,10 @@ border color while dragging a file over the uploader drop area */
 	right: 51px;
 }
 
-.edit-attachment-frame .edit-media-header .media-navigation,
-.attachment-media-view .media-navigation {
+.edit-attachment-frame .edit-media-header .media-navigation {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	border-top: 1px solid #dcdcde;
-	border-bottom: 1px solid #dcdcde;
 	font-size: 17px;
 	font-variant-numeric: tabular-nums;
 	-webkit-font-smoothing: subpixel-antialiased;
@@ -775,6 +778,15 @@ border color while dragging a file over the uploader drop area */
 }
 
 .edit-attachment-frame .media-frame-content {
+	position: absolute;
+	top: 50px;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	height: auto;
+	width: auto;
+	margin: 0;
+	overflow: auto;
 	border-bottom: none;
 }
 
@@ -876,7 +888,7 @@ border color while dragging a file over the uploader drop area */
 	clear: both;
 }
 
-.copy-to-clipboard-container .copy-attachment-url {
+.copy-to-clipboard-container button.copy-attachment-url {
 	white-space: normal;
 }
 
@@ -916,8 +928,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 .imgedit-wrap {
-	position: relative;
-	padding-top: 10px;
+	padding-bottom: 10px;
 }
 
 .imgedit-settings p,
@@ -1282,7 +1293,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;
@@ -1366,10 +1377,58 @@ audio, video {
 	}
 }
 
+@media only screen and (max-width: 900px) {
+	.media-sidebar .setting .copy-to-clipboard-container,
+	.attachment-details .attachment-info .copy-to-clipboard-container {
+		margin-left: 0;
+		padding-top: 0;
+	}
+
+	.media-sidebar .setting input,
+	.media-sidebar .setting textarea,
+	.media-sidebar .setting .name,
+	.attachment-details .setting input,
+	.attachment-details .setting textarea,
+	.attachment-details .setting .name,
+	.compat-item label span {
+		float: none;
+	}
+
+	.media-sidebar .setting input[type="text"],
+	.media-sidebar .setting input[type="password"],
+	.media-sidebar .setting input[type="email"],
+	.media-sidebar .setting input[type="number"],
+	.media-sidebar .setting input[type="search"],
+	.media-sidebar .setting input[type="tel"],
+	.media-sidebar .setting input[type="url"],
+	.media-sidebar .setting textarea,
+	.media-sidebar .setting select,
+	.attachment-details .setting input[type="text"],
+	.attachment-details .setting input[type="password"],
+	.attachment-details .setting input[type="email"],
+	.attachment-details .setting input[type="number"],
+	.attachment-details .setting input[type="search"],
+	.attachment-details .setting input[type="tel"],
+	.attachment-details .setting input[type="url"],
+	.attachment-details .setting textarea,
+	.attachment-details .setting select,
+	.attachment-details .setting + .description {
+		float: none;
+		width: 98%;
+		max-width: none;
+		height: auto;
+	}
+}
+
 @media only screen and (max-width: 782px) {
 	.media-frame.mode-select .attachments-browser.fixed .media-toolbar {
 		top: 46px;
 		right: 10px;
+	}
+
+	.media-modal .media-frame-title h2 {
+		line-height: 2.5;
+		font-size: 20px;
 	}
 }
 
@@ -1380,19 +1439,6 @@ audio, video {
 }
 
 @media only screen and (max-width: 480px) {
-	.edit-attachment-frame .media-frame-title {
-		right: 110px;
-	}
-
-	.upload-php .media-modal-close {
-		width: 40px;
-		height: 40px;
-	}
-
-	.edit-attachment-frame .media-frame-content {
-		top: 40px;
-	}
-
 	.edit-attachment-frame .attachment-media-view {
 		float: none;
 		height: auto;
@@ -1404,8 +1450,52 @@ audio, video {
 		width: 100%;
 	}
 
-	.edit-attachment-frame .attachment-media-view .thumbnail {
-		padding: 0 16px 16px;
+	.imgedit-settings .imgedit-scale-button-wrapper {
+		display: block;
+	}
+
+	.edit-attachment-frame .edit-media-header {
+		height: 80px;
+	}
+
+	.edit-attachment-frame .media-frame-title {
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 40px;
+	}
+
+	.edit-attachment-frame .edit-media-header .media-navigation {
+		top: 40px;
+		left: 0;
+		right: 0;
+	}
+
+	.upload-php .media-modal-close,
+	.edit-attachment-frame .edit-media-header #dialog-close-button,
+	.edit-attachment-frame .edit-media-header .left,
+	.edit-attachment-frame .edit-media-header .right {
+		width: 40px;
+		height: 40px;
+	}
+
+	.edit-attachment-frame .edit-media-header .right:before,
+	.edit-attachment-frame .edit-media-header .left:before {
+		line-height: 40px !important;
+	}
+
+	.edit-attachment-frame .media-frame-content {
+		top: 80px;
+	}
+
+	.edit-attachment-frame .edit-media-header .media-navigation {
+		border-top: 1px solid #dcdcde;
+		border-bottom: 1px solid #dcdcde;
+	}
+
+	.media-modal .media-frame-title h2 {
+		line-height: 2.22222222;
+		font-size: 18px;
 	}
 }
 

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1378,45 +1378,27 @@ audio, video {
 }
 
 @media only screen and (max-width: 900px) {
-	.media-sidebar .setting .copy-to-clipboard-container,
 	.attachment-details .attachment-info .copy-to-clipboard-container {
-		margin-left: 0;
+		margin: 10px 0 0 0;
 		padding-top: 0;
 	}
 
-	.media-sidebar .setting input,
-	.media-sidebar .setting textarea,
-	.media-sidebar .setting .name,
-	.attachment-details .setting input,
-	.attachment-details .setting textarea,
+	.attachment-details .compat-item label span,
 	.attachment-details .setting .name,
-	.compat-item label span {
-		float: none;
-	}
-
-	.media-sidebar .setting input[type="text"],
-	.media-sidebar .setting input[type="password"],
-	.media-sidebar .setting input[type="email"],
-	.media-sidebar .setting input[type="number"],
-	.media-sidebar .setting input[type="search"],
-	.media-sidebar .setting input[type="tel"],
-	.media-sidebar .setting input[type="url"],
-	.media-sidebar .setting textarea,
-	.media-sidebar .setting select,
 	.attachment-details .setting input[type="text"],
-	.attachment-details .setting input[type="password"],
-	.attachment-details .setting input[type="email"],
-	.attachment-details .setting input[type="number"],
-	.attachment-details .setting input[type="search"],
-	.attachment-details .setting input[type="tel"],
-	.attachment-details .setting input[type="url"],
 	.attachment-details .setting textarea,
-	.attachment-details .setting select,
 	.attachment-details .setting + .description {
 		float: none;
 		width: 98%;
 		max-width: none;
 		height: auto;
+	}
+
+	.attachment-details .setting + .description {
+		clear: both;
+		font-size: 12px;
+		font-style: normal;
+		margin-bottom: 10px;
 	}
 }
 
@@ -1450,10 +1432,6 @@ audio, video {
 		width: 100%;
 	}
 
-	.imgedit-settings .imgedit-scale-button-wrapper {
-		display: block;
-	}
-
 	.edit-attachment-frame .edit-media-header {
 		height: 80px;
 	}
@@ -1469,6 +1447,8 @@ audio, video {
 		top: 40px;
 		left: 0;
 		right: 0;
+		border-top: 1px solid #dcdcde;
+		border-bottom: 1px solid #dcdcde;
 	}
 
 	.upload-php .media-modal-close,
@@ -1488,14 +1468,13 @@ audio, video {
 		top: 80px;
 	}
 
-	.edit-attachment-frame .edit-media-header .media-navigation {
-		border-top: 1px solid #dcdcde;
-		border-bottom: 1px solid #dcdcde;
-	}
-
 	.media-modal .media-frame-title h2 {
 		line-height: 2.22222222;
 		font-size: 18px;
+	}
+
+	.imgedit-settings .imgedit-scale-button-wrapper {
+		display: block;
 	}
 }
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -524,6 +524,9 @@ if ( 'grid' === $mode ) {
 
 			<div class="edit-attachment-frame mode-select hide-menu hide-router">
 				<div class="edit-media-header">
+					<div class="media-frame-title">
+						<h2><?php esc_html_e( 'Attachment details' ); ?></h2>
+					</div>
 					<div class="media-navigation">
 						<button type="button" id="left-dashicon" class="left dashicons">
 							<span class="screen-reader-text"><?php esc_html_e( 'Edit previous media item' ); ?></span>
@@ -537,22 +540,10 @@ if ( 'grid' === $mode ) {
 						<span class="screen-reader-text"><?php esc_html_e( 'Close dialog' ); ?></span>
 					</button>
 				</div>
-				<div class="media-frame-title">
-					<h2><?php esc_html_e( 'Attachment details' ); ?></h2>
-				</div>
 				<div class="media-frame-content">
 					<div class="attachment-details save-ready">
 						<div class="attachment-media-view">
 							<h3 class="screen-reader-text"><?php esc_html_e( 'Attachment Preview' ); ?></h3>
-							<div class="media-navigation" role="navigation" aria-label="<?php esc_html_e( 'Media Navigation' ); ?>">
-								<button type="button" id="left-dashicon-mobile" class="left dashicons">
-									<span class="screen-reader-text"><?php esc_html_e( 'Edit previous media item' ); ?></span>
-								</button>
-								<div class="media-contextual-pagination"><span id="current-media-item-mobile" aria-hidden="true"></span>&nbsp;/&nbsp;<span id="total-media-items-mobile"></span></div>
-								<button type="button" id="right-dashicon-mobile" class="right dashicons">
-									<span class="screen-reader-text"><?php esc_html_e( 'Edit next media item' ); ?></span>
-								</button>
-							</div>
 							<div id="media-image" class="thumbnail thumbnail-image">
 								<img class="details-image" src="" draggable="false" alt="">
 								<div class="attachment-actions">

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -312,15 +312,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		rightIcon.setAttribute( 'data-next', next );
 
 		if ( prev === '' ) {
-			leftIcon.disabled = true;
+			leftIcon.setAttribute( 'aria-disabled', true );
 		} else {
-			leftIcon.disabled = false;
+			leftIcon.setAttribute( 'aria-disabled', false );
 		}
 
 		if ( next === '' ) {
-			rightIcon.disabled = true;
+			rightIcon.setAttribute( 'aria-disabled', true );
 		} else {
-			rightIcon.disabled = false;
+			rightIcon.setAttribute( 'aria-disabled', false );
 		}
 
 		items.forEach( function( i ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -334,6 +334,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		// Show modal
 		dialog.classList.add( 'modal-loading' );
 
+		body.style.overflow = 'hidden';
+
 		// Fix wrong image flash
 		setTimeout( function() {
 			dialog.showModal();
@@ -786,6 +788,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		queryParams.delete( 'mode' );
 		history.replaceState( null, null, location.href.split('?')[0] ); // reset URL params
 		dialog.classList.remove( 'modal-loading' );
+		body.style.overflow = '';
 		dialog.close();
 		if ( focusID != null ) { // set focus correctly
 			document.getElementById( focusID ).focus();

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -13,10 +13,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		leftIcon = document.getElementById( 'left-dashicon' ),
 		rightIcon = document.getElementById( 'right-dashicon' ),
 		closeButton = document.getElementById( 'dialog-close-button' ),
-		leftIconMobile = document.getElementById( 'left-dashicon-mobile' ),
-		rightIconMobile = document.getElementById( 'right-dashicon-mobile' ),
 		mediaNavigation = document.querySelector( '.edit-media-header .media-navigation' ),
-		mediaNavigationMobile = document.querySelector( '.attachment-media-view .media-navigation' ),
 		paged = '1',
 		dateFilter = document.getElementById( 'filter-by-date' ) ? document.getElementById( 'filter-by-date' ) : '',
 		typeFilter = document.getElementById( 'filter-by-type' ) ? document.getElementById( 'filter-by-type' ) : '',
@@ -218,19 +215,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 	}
 
-	// Toggle media button navigation wrappers according to viewport width
-	function toggleMediaNavigation() {
-		if ( window.innerWidth > 480 ) {
-			mediaNavigation.style.display = '';
-			mediaNavigationMobile.style.display = 'none';
-		} else {
-			mediaNavigation.style.display = 'none';
-			mediaNavigationMobile.style.display = '';
-		}
-	}
-
-	window.addEventListener( 'resize', toggleMediaNavigation );
-
 	// Open modal
 	function openModalDialog( item ) {
 		var id = item.id.replace( 'media-', '' ),
@@ -329,31 +313,23 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		if ( prev === '' ) {
 			leftIcon.disabled = true;
-			leftIconMobile.disabled = true;
 		} else {
 			leftIcon.disabled = false;
-			leftIconMobile.disabled = false;
 		}
 
 		if ( next === '' ) {
 			rightIcon.disabled = true;
-			rightIconMobile.disabled = true;
 		} else {
 			rightIcon.disabled = false;
-			rightIconMobile.disabled = false;
 		}
 
 		items.forEach( function( i ) {
 			if ( i.id === item.id ) {
 				dialog.querySelector( '#current-media-item' ).textContent = order;
 				dialog.querySelector( '#total-media-items' ).textContent = items.length;
-				dialog.querySelector( '#current-media-item-mobile' ).textContent = order;
-				dialog.querySelector( '#total-media-items-mobile' ).textContent = items.length;
 			}
 			order++;
 		} );
-
-		toggleMediaNavigation();
 
 		// Show modal
 		dialog.classList.add( 'modal-loading' );
@@ -824,24 +800,22 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		if ( id ) {
 			focusID = id; // set focusID for when modal is closed
 			document.getElementById( id ).click();
-			mediaNavigation.style.display === '' ? leftIcon.focus() : leftIconMobile.focus();
+			leftIcon.focus();
 		}
 		removeImageEditWrap();
 	}
 	leftIcon.addEventListener( 'click', prevModalDialog );
-	leftIconMobile.addEventListener( 'click', prevModalDialog );
 
 	function nextModalDialog() {
 		var id = rightIcon.dataset.next;
 		if ( id ) {
 			focusID = id; // set focusID for when modal is closed
 			document.getElementById( id ).click();
-			mediaNavigation.style.display === '' ? rightIcon.focus() : rightIconMobile.focus();
+			rightIcon.focus();
 		}
 		removeImageEditWrap();
 	}
 	rightIcon.addEventListener( 'click', nextModalDialog );
-	rightIconMobile.addEventListener( 'click', nextModalDialog );
 
 	// Handle keyboard navigation
 	function keydownHandler( e ) {
@@ -856,7 +830,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		}
 	}
 	mediaNavigation.addEventListener( 'keydown', keydownHandler );
-	mediaNavigationMobile.addEventListener( 'keydown', keydownHandler );
 
 	// Edit image
 	document.querySelector( '.edit-attachment' ).addEventListener( 'click', function( e ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -832,7 +832,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 		}
 	}
-	mediaNavigation.addEventListener( 'keydown', keydownHandler );
+	document.querySelector( '.edit-media-header' ).addEventListener( 'keydown', keydownHandler );
 
 	// Edit image
 	document.querySelector( '.edit-attachment' ).addEventListener( 'click', function( e ) {


### PR DESCRIPTION
## Description
The merged PR [#1756 "Media dialog contextual pagination with button navigation repositioning"](https://github.com/ClassicPress/ClassicPress/pull/1756) introduced an alternative button navigation positioning for smaller viewports which was missing in image edit screen. This PR not only fixes that, it also simplifies the markup and adds styling improvements like a sticky header for better UX when scrolling in mobile.

Edit:
For the sake of completeness, I've updated this PR to show a simplified markup version of the media button navigation with CSS improvements for better UX in mobile including a sticky header. I plan to create another PR to apply some of this CSS to the PR #1768.

### Before

https://github.com/user-attachments/assets/a8c0b41f-1e0a-4e29-abf5-5c23f6e1c307

### After

https://github.com/user-attachments/assets/2055c8e8-4519-4b73-9ed4-eecc89303ce0


## Types of changes
- Bug fix
- New feature

