### PR TITLE
Additional confirmation clicks are needed in subsequent deletions through the media dialog

### DIFF
--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -231,6 +231,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	window.addEventListener( 'resize', toggleMediaNavigation );
 
+	// Delete media item
+	dialog.querySelector( '.delete-attachment' ).addEventListener( 'click', function() {
+		var id = location.search.replace( '?item=', '' );
+		if ( confirm( _wpMediaGridSettings.confirm_delete ) ) {
+			deleteItem( id );
+		}
+	} );
+
 	// Open modal
 	function openModalDialog( item ) {
 		var id = item.id.replace( 'media-', '' ),
@@ -362,13 +370,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		setTimeout( function() {
 			dialog.showModal();
 		}, 1 );
-
-		// Delete media item
-		dialog.querySelector( '.delete-attachment' ).addEventListener( 'click', function() {
-			if ( confirm( _wpMediaGridSettings.confirm_delete ) ) {
-				deleteItem( id );
-			}
-		} );
 
 		// Update media categories and tags
 		dialog.querySelectorAll( '.compat-item input' ).forEach( function( input ) {


### PR DESCRIPTION
## Description
The number of clicks needed to confirm the subsequent deletions through the media dialog are cumulative according to the number of previous deletions.

## How has this been tested?
The demonstration video was recorded in a development installation with the PR #1768, but it was also tested in an installation with the stable v2.3.1.

## Types of changes
- Bug fix


https://github.com/user-attachments/assets/e6b8aa6d-08d8-4ef8-b96f-530c69846b1d

