### PR TITLE
Prevent media grid collapse on bulk-selection

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -130,6 +130,7 @@
 .media-item {
 	cursor: pointer;
 	margin-bottom: 0;
+	position: relative;
 }
 .media-item:focus,
 .media-item.selected:focus {
@@ -149,9 +150,9 @@
 	width: 24px;
 	padding: 0;
 	border: 0;
-	margin-top: -105%;
-	margin-left: 87%;
-	position: relative;
+	top: -5px;
+	right: -5px;
+	position: absolute;
 	z-index: 10;
 	outline: none;
 	background: #f0f0f1;


### PR DESCRIPTION
## Description
The media grid is collapsed when bulk-selecting all the items.

## Types of changes
- Bug fix


https://github.com/user-attachments/assets/45c4740f-a762-4cf7-8aa6-9f13791a61c4

