### PR TITLE
Update to use official `grunt-sass` release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-legacy-util": "2.0.1",
     "grunt-replace": "2.0.2",
     "grunt-rtlcss": "2.0.2",
-    "grunt-sass": "github:mattyrob/grunt-sass#add/modern-api",
+    "grunt-sass": "4.0.0",
     "grunt-webpack": "7.0.0",
     "ink-docstrap": "1.3.2",
     "install-changed": "^1.1.0",


### PR DESCRIPTION
## Description
In October when we [updated](https://github.com/ClassicPress/ClassicPress/pull/1566) to using more modern versions of SASS a PR was submitted [upstream](https://github.com/sindresorhus/grunt-sass/pull/312) to enhance one of our package dependencies.

This upstream PR has now been merged and a [new release](https://github.com/sindresorhus/grunt-sass/releases/tag/v4.0.0) made.

This PR moves the package.json file to using the main stream package rather than a branch so any future updates are notified.

## Motivation and context
To ensure future updates are notified.

## How has this been tested?
PR upstream merged and looks good - PR tests will run.

## Screenshots
N/A

## Types of changes
- Enhancement
