### PR TITLE
Fix for core theme jQuery deprecation

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/js/navigation.js
+++ b/src/wp-content/themes/twentyseventeen/assets/js/navigation.js
@@ -26,7 +26,7 @@
 		// Set the active submenu initial state.
 		container.find( '.current-menu-ancestor > .sub-menu' ).addClass( 'toggled-on' );
 
-		container.find( '.dropdown-toggle' ).click( function( e ) {
+		container.find( '.dropdown-toggle' ).on( 'click', function( e ) {
 			var _this = $( this ),
 				screenReaderSpan = _this.find( '.screen-reader-text' );
 


### PR DESCRIPTION
## Description
For the TwentySeventeen theme and the ClassicPress child theme, there are browser deprecation warnings linked to a line in `twentyseventeen/assets/js/navigation.js` and the `.click()` handler.

## Motivation and context
Fix deprecation warning in browser console.

## How has this been tested?
Local testing with Safari browser.

## Screenshots
### Before
![Screenshot 2025-02-23 at 11 51 52](https://github.com/user-attachments/assets/cd5e2c94-51b9-4b1d-8a3d-97d816edf3e7)

### After
N/A

## Types of changes
- Bug fix