### PR TITLE
ClassicPress theme - updated footer area

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/footer.php
+++ b/src/wp-content/themes/the-classicpress-theme/footer.php
@@ -50,7 +50,8 @@
 	<footer id="legal">
 		<div class="cplegal">
 			<div class="cpcopyright">
-				<p><?php esc_html_e( 'Copyright', 'the-classicpress-theme' ); ?> <?php echo esc_attr( gmdate( 'Y' ) ); ?> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php bloginfo( 'name' ); ?>"><?php bloginfo( 'name' ); ?></a></p>
+				<?php /* translators: 1: year, 2: site title. */ ?>
+				<p><?php printf( esc_html( '&copy; %1$s %2$s.', 'the-classicpress-theme' ), esc_html( gmdate( 'Y' ) ), esc_html( get_bloginfo( 'name' ) ) ); ?> <?php esc_html_e( 'All Rights Reserved.', 'the-classicpress-theme' ); ?></p>
 			</div>
 			<div class="cppolicy">
 				<?php if ( ! empty( get_privacy_policy_url() ) ) { ?>

--- a/src/wp-content/themes/the-classicpress-theme/footer.php
+++ b/src/wp-content/themes/the-classicpress-theme/footer.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * The template for displaying the footer
  *
@@ -7,53 +6,59 @@
  *
  * @package Susty
  */
+
 ?>
 
-</div>
+	</div>
 
-<footer id="colophon">
-	<div class="classic">
-		<div class="footerleft">
-			<a id="footer-logo" href="<?php echo esc_url( home_url() ); ?>"><img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/images/classicpress-logo-feather-white.svg' ); ?>" alt="<?php esc_attr_e( 'ClassicPress feather logo', 'the-classicpress-theme' ); ?>" width="90"></a>
-			<div class="registration">
-				<p><?php esc_html_e( 'The ClassicPress project is under the direction of The ClassicPress Initiative, a nonprofit organization registered under section 501(c)(3) of the United States IRS code.', 'the-classicpress-theme' ); ?></p>
-				<ul class="social-menu">
-					<li><a href="<?php echo esc_url( home_url( '/forums/' ) ); ?>" target="_blank" title="<?php esc_attr_e( 'Forums', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-discourse"></i><span class="screen-reader-text"><?php esc_html_e( 'Support forums', 'the-classicpress-theme' ); ?></span></a></li>
-					<li><a href="https://classicpress.zulipchat.com/register/" target="_blank" title="<?php esc_attr_e( 'Zulip', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-zulip"></i><span class="screen-reader-text"><?php esc_html_e( 'Join on Zulip Chat', 'the-classicpress-theme' ); ?></span></a></li>
-					<li><a href="https://github.com/ClassicPress" target="_blank" title="<?php esc_attr_e( 'GitHub', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-github"></i><span class="screen-reader-text"><?php esc_html_e( 'Visit GitHub', 'the-classicpress-theme' ); ?></span></a></li>
-					<li><a href="https://fosstodon.org/@classicpress" target="_blank" title="<?php esc_attr_e( 'Mastodon', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-mastodon"></i><span class="screen-reader-text"><?php esc_html_e( 'Follow on Mastodon', 'the-classicpress-theme' ); ?></span></a></li>
-					<li><a href="https://twitter.com/GetClassicPress" target="_blank" title="<?php esc_attr_e( 'Twitter', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-twitter"></i><span class="screen-reader-text"><?php esc_html_e( 'Follow on Twitter', 'the-classicpress-theme' ); ?></span></a></li>
-					<li><a href="https://www.facebook.com/GetClassicPress" target="_blank" title="<?php esc_attr_e( 'Facebook', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-facebook-f"></i><span class="screen-reader-text"><?php esc_html_e( 'Like on Facebook', 'the-classicpress-theme' ); ?></span></a></li>
-				</ul>
+	<footer id="colophon">
+		<div class="classic">
+			<div class="footerleft">
+				<?php if ( is_active_sidebar( 'footer' ) ) { ?>
+					<?php dynamic_sidebar( 'footer' ); ?>
+				<?php } else { ?>
+					<a id="footer-logo" href="<?php echo esc_url( home_url() ); ?>"><img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/images/classicpress-logo-feather-white.svg' ); ?>" alt="<?php esc_attr_e( 'ClassicPress feather logo', 'the-classicpress-theme' ); ?>" width="90"></a>
+					<div class="registration">
+						<p><?php esc_html_e( 'The ClassicPress project is under the direction of The ClassicPress Initiative, a nonprofit organization registered under section 501(c)(3) of the United States IRS code.', 'the-classicpress-theme' ); ?></p>
+						<ul class="social-menu">
+							<li><a href="https://forums.classicpress.net" target="_blank" title="<?php esc_attr_e( 'Forums', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-discourse"></i><span class="screen-reader-text"><?php esc_html_e( 'Support forums', 'the-classicpress-theme' ); ?></span></a></li>
+							<li><a href="https://classicpress.zulipchat.com/register/" target="_blank" title="<?php esc_attr_e( 'Zulip', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-zulip"></i><span class="screen-reader-text"><?php esc_html_e( 'Join on Zulip Chat', 'the-classicpress-theme' ); ?></span></a></li>
+							<li><a href="https://github.com/ClassicPress" target="_blank" title="<?php esc_attr_e( 'GitHub', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-github"></i><span class="screen-reader-text"><?php esc_html_e( 'Visit GitHub', 'the-classicpress-theme' ); ?></span></a></li>
+							<li><a href="https://fosstodon.org/@classicpress" target="_blank" title="<?php esc_attr_e( 'Mastodon', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-mastodon"></i><span class="screen-reader-text"><?php esc_html_e( 'Follow on Mastodon', 'the-classicpress-theme' ); ?></span></a></li>
+							<li><a href="https://twitter.com/GetClassicPress" target="_blank" title="<?php esc_attr_e( 'Twitter', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-twitter"></i><span class="screen-reader-text"><?php esc_html_e( 'Follow on Twitter', 'the-classicpress-theme' ); ?></span></a></li>
+							<li><a href="https://www.facebook.com/GetClassicPress" target="_blank" title="<?php esc_attr_e( 'Facebook', 'the-classicpress-theme' ); ?>" rel="noreferrer noopener"><i class="cpicon-facebook-f"></i><span class="screen-reader-text"><?php esc_html_e( 'Like on Facebook', 'the-classicpress-theme' ); ?></span></a></li>
+						</ul>
+					</div>
+				<?php } ?>
+			</div>
+			<?php if ( has_nav_menu( 'footer-menu' ) ) { ?>
+				<div class="footerright">
+					<?php
+					wp_nav_menu(
+						array(
+							'theme_location' => 'footer-menu',
+							'depth'          => 1,
+							'menu_id'        => 'footmenu',
+							'menu_class'     => 'nav',
+						)
+					);
+					?>
+				</div>
+			<?php } ?>
+		</div>
+	</footer>
+	<footer id="legal">
+		<div class="cplegal">
+			<div class="cpcopyright">
+				<p><?php esc_html_e( 'Copyright', 'the-classicpress-theme' ); ?> <?php echo esc_attr( gmdate( 'Y' ) ); ?> <a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php bloginfo( 'name' ); ?>"><?php bloginfo( 'name' ); ?></a></p>
+			</div>
+			<div class="cppolicy">
+				<?php if ( ! empty( get_privacy_policy_url() ) ) { ?>
+					<p><a href="<?php echo esc_url( get_privacy_policy_url() ); ?>"><?php esc_html_e( 'Privacy Policy', 'the-classicpress-theme' ); ?></a></p>
+				<?php } ?>
 			</div>
 		</div>
-		<div class="footerright">
-			<?php
-			$footmenu = wp_nav_menu(
-				array(
-					'theme_location' => 'footer-menu',
-					'depth'          => 1,
-					'menu_id'        => 'footmenu',
-					'menu_class'     => 'nav',
-				)
-			);
-			if ( $footmenu ) {
-				echo $footmenu; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			}
-			?>
-		</div>
-	</div>
-</footer>
-<footer id="legal">
-	<div class="cplegal">
-		<div class="cpcopyright">
-			<p>© 2018-<?php echo esc_attr( gmdate( 'Y' ) ); ?> ClassicPress. All Rights Reserved.</p>
-		</div>
-		<div class="cppolicy">
-			<p><a href="<?php echo esc_url( get_privacy_policy_url() ); ?>">Privacy Policy</a></p>
-		</div>
-	</div>
-</footer>
+	</footer>
 
 </div>
 

--- a/src/wp-content/themes/the-classicpress-theme/footer.php
+++ b/src/wp-content/themes/the-classicpress-theme/footer.php
@@ -15,7 +15,9 @@
 		<div class="classic">
 			<div class="footerleft">
 				<?php if ( is_active_sidebar( 'footer' ) ) { ?>
-					<?php dynamic_sidebar( 'footer' ); ?>
+					<div class="footer-widgets">
+						<?php dynamic_sidebar( 'footer' ); ?>
+					</div>
 				<?php } else { ?>
 					<a id="footer-logo" href="<?php echo esc_url( home_url() ); ?>"><img src="<?php echo esc_url( get_stylesheet_directory_uri() . '/images/classicpress-logo-feather-white.svg' ); ?>" alt="<?php esc_attr_e( 'ClassicPress feather logo', 'the-classicpress-theme' ); ?>" width="90"></a>
 					<div class="registration">

--- a/src/wp-content/themes/the-classicpress-theme/functions.php
+++ b/src/wp-content/themes/the-classicpress-theme/functions.php
@@ -181,26 +181,37 @@ function cp_tiny_css( $wp ) {
 }
 add_filter( 'mce_css', 'cp_tiny_css' );
 
-
-/* Add widgets to blog sidebar */
+/**
+ * Add widgets to sidebar and footer
+ */
 if ( function_exists( 'register_sidebar' ) ) {
 	register_sidebar(
 		array(
 			'id'            => 'blog-sidebar',
-			'name'          => 'Blog Sidebar',
+			'name'          => esc_html__( 'Blog Sidebar', 'the-classicpress-theme' ),
 			'before_widget' => '<div class="widget-container">',
 			'after_widget'  => '</div>',
-			'before_title'  => '<h3>',
+			'before_title'  => '<h3 class="widget-title">',
 			'after_title'   => '</h3>',
 		)
 	);
 	register_sidebar(
 		array(
 			'id'            => 'main-sidebar',
-			'name'          => 'Main Sidebar',
+			'name'          => esc_html__( 'Main Sidebar', 'the-classicpress-theme' ),
 			'before_widget' => '<div class="widget-container">',
 			'after_widget'  => '</div>',
-			'before_title'  => '<h3>',
+			'before_title'  => '<h3 class="widget-title">',
+			'after_title'   => '</h3>',
+		)
+	);
+	register_sidebar(
+		array(
+			'id'            => 'footer',
+			'name'          => esc_html__( 'Footer', 'the-classicpress-theme' ),
+			'before_widget' => '<div class="widget-container">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h3 class="widget-title">',
 			'after_title'   => '</h3>',
 		)
 	);
@@ -216,14 +227,12 @@ add_filter( 'the_content', 'cp_remove_empty_p', 20, 1 );
 // Add excerpts to pages
 add_post_type_support( 'page', 'excerpt' );
 
-
 /**
  * Simplify blog detection
  */
 function is_blog() {
 	return ( is_archive() || is_author() || is_category() || is_home() || is_tag() ) && 'post' == get_post_type();
 }
-
 
 /**
  * Set our own version string for the theme's stylesheet
@@ -235,7 +244,6 @@ function cp_susty_override_style_css_version( $version, $type, $handle ) {
 	return cp_susty_get_asset_version();
 }
 add_filter( 'classicpress_asset_version', 'cp_susty_override_style_css_version', 10, 3 );
-
 
 /**
  * Add the page slug as a class to the <body>

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1764,18 +1764,19 @@ table.cp-logo-list .cp-logo-description {
 	padding: 0;
 }
 .footerleft {
-	min-height: 50px;
-	width: 100%;
-	padding: 0 1em;
 	display: flex;
 	flex-direction: row;
+	flex-basis: 56rem;
+	flex-grow: 1;
+	flex-shrink: 1;
+	padding: 0 1rem;
 	gap: 2rem;
 }
 .footerright {
-	min-height: 50px;
-	width: 100%;
-	max-width: 12.15rem;
-	padding: 0 1em;
+	flex-basis: 12rem;
+	flex-grow: 1;
+	flex-shrink: 1;
+	padding: 0 1rem;
 }
 #footer-logo {
 	max-width: 90px;
@@ -1932,7 +1933,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 /* MEDIA QUERIES */
 @media screen and (max-width: 600px) {
 	.classic,
-	.footerleft,
 	.cplegal {
 		display: block;
 	}
@@ -1945,9 +1945,16 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		max-width: 100%;
 		text-align: center;
 	}
+	.footerleft {
+		flex-direction: column;
+		gap: 0;
+	}
 	.footerleft img {
 		float: none;
 		margin: 0 0 0.3em 0;
+	}
+	.registration {
+		max-width: 100%;
 	}
 	.sponsors-inner {
 		flex-direction: column;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1644,7 +1644,7 @@ table.cp-logo-list .cp-logo-description {
 	border-radius: var(--tcpt-border-radius);
 	margin: 0.3em 0 1.5em 0;
 }
-#sidebar h3 {
+#sidebar h3.widget-title {
 	padding-top: 0.1em;
 	margin-bottom: 0.2em;
 	font-size: 1.3em;
@@ -1766,11 +1766,10 @@ table.cp-logo-list .cp-logo-description {
 .footerleft {
 	min-height: 50px;
 	width: 100%;
-	max-width: 550px;
 	padding: 0 1em;
 	display: flex;
 	flex-direction: row;
-	gap: 1rem;
+	gap: 2rem;
 }
 .footerright {
 	min-height: 50px;
@@ -1788,12 +1787,24 @@ table.cp-logo-list .cp-logo-description {
 	margin: 0;
 	max-width: 90px;
 }
+.footerleft a {
+	color: #ddd;
+}
 .footerleft a:hover {
 	text-decoration: none;
 	border: 0;
 }
+.footerleft h3.widget-title {
+	padding-top: 0;
+	color: #fff;
+}
+.footerleft .widget-container {
+	flex-basis: 50%;
+	margin-top: 0;
+}
 .registration {
-	margin: 00 0 1em;
+	max-width: 400px;
+	margin: 0 0 1em;
 }
 .social-menu {
 	width: 100%;
@@ -1921,9 +1932,9 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 /* MEDIA QUERIES */
 @media screen and (max-width: 600px) {
 	.classic,
+	.footerleft,
 	.cplegal {
 		display: block;
-		justify-content: normal;
 	}
 	.footerleft,
 	.footerright,
@@ -1937,11 +1948,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	.footerleft img {
 		float: none;
 		margin: 0 0 0.3em 0;
-	}
-	footer .classic {
-		display: flex;
-		flex-direction: column;
-		gap: 2em;
 	}
 	.sponsors-inner {
 		flex-direction: column;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1764,19 +1764,24 @@ table.cp-logo-list .cp-logo-description {
 	padding: 0;
 }
 .footerleft {
+	min-height: 50px;
+	width: 100%;
+	max-width: 60rem;
+	padding: 0 1em;
 	display: flex;
 	flex-direction: row;
-	flex-basis: 56rem;
-	flex-grow: 1;
-	flex-shrink: 1;
-	padding: 0 1rem;
-	gap: 2rem;
+	gap: 1em;
 }
 .footerright {
-	flex-basis: 12rem;
-	flex-grow: 1;
-	flex-shrink: 1;
-	padding: 0 1rem;
+	min-height: 50px;
+	width: 100%;
+	max-width: 12rem;
+	padding: 0 1em;
+}
+.footer-widgets {
+	display: flex;
+	flex-direction: row;
+	gap: 1em;
 }
 #footer-logo {
 	max-width: 90px;
@@ -1795,11 +1800,11 @@ table.cp-logo-list .cp-logo-description {
 	text-decoration: none;
 	border: 0;
 }
-.footerleft h3.widget-title {
+.footer-widgets h3.widget-title {
 	padding-top: 0;
 	color: #fff;
 }
-.footerleft .widget-container {
+.footer-widgets .widget-container {
 	flex-basis: 50%;
 	margin-top: 0;
 }
@@ -1933,11 +1938,13 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 /* MEDIA QUERIES */
 @media screen and (max-width: 600px) {
 	.classic,
+	.footer-widgets,
 	.cplegal {
 		display: block;
 	}
 	.footerleft,
 	.footerright,
+	.footer-widgets,
 	.cpcopyright,
 	.cppolicy,
 	.footersponsor {
@@ -1951,6 +1958,9 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	}
 	.registration {
 		max-width: 100%;
+	}
+	.social-menu {
+		justify-content: center;
 	}
 	.sponsors-inner {
 		flex-direction: column;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1945,10 +1945,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		max-width: 100%;
 		text-align: center;
 	}
-	.footerleft {
-		flex-direction: column;
-		gap: 0;
-	}
 	.footerleft img {
 		float: none;
 		margin: 0 0 0.3em 0;


### PR DESCRIPTION
## Description
You can now change the footer content from static to variable, by using widgets.

## Motivation and context
Footer contains static content, which may not be attractive for users,

## Screenshots
![Footer default](https://github.com/user-attachments/assets/7a69b13b-afef-4326-ad0a-afe2b2437084)
![Footer with widgets](https://github.com/user-attachments/assets/b680b908-42f3-40d2-b8d0-f01c078bbfc4)


### Before
A footer menu and static CP-related content.

### After
By default a footer menu and static CP-related content. But you can replace this with variable content, by using widgets.

## Types of changes
No breaking changes.
