### PR TITLE
Fix random deprecated notice related to WP-CLI

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -104,7 +104,8 @@ if ( ! function_exists( 'classicpress_version' ) ) {
 if ( ! function_exists( 'classicpress_version_short' ) ) {
 	function classicpress_version_short() {
 		global $cp_version;
-		return preg_replace( '#[+-].*$#', '', $cp_version );
+		$version = $cp_version ? preg_replace( '#[+-].*$#', '', $cp_version ) : '';
+		return $version;
 	}
 }
 


### PR DESCRIPTION
I can't reproduce it now, but it's been logged a couple of times.

```
PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /srv/classicpress_local/wp-includes/version.php on line 107
PHP Stack trace:
PHP   1. {main}() /usr/local/bin/wp:0
PHP   2. include() /usr/local/bin/wp:4
PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:20
PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:32
PHP   5. WP_CLI\Bootstrap\LaunchRunner->process($state = class WP_CLI\Bootstrap\BootstrapState { private $state = ['context_manager' => class WP_CLI\ContextManager { ... }] }) phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:83
PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:28
PHP   7. WP_CLI\Runner->load_wordpress() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1294
PHP   8. require() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1375
PHP   9. do_action($hook_name = 'wp_loaded') /srv/classicpress_local/wp-settings.php:594
PHP  10. WP_Hook->do_action($args = [0 => '']) /srv/classicpress_local/wp-includes/plugin.php:517
PHP  11. WP_Hook->apply_filters($value = '', $args = [0 => '']) /srv/classicpress_local/wp-includes/class-wp-hook.php:332
PHP  12. _wp_cron('') /srv/classicpress_local/wp-includes/class-wp-hook.php:308
PHP  13. spawn_cron($gmt_time = 1740724621.962578) /srv/classicpress_local/wp-includes/cron.php:1002
PHP  14. wp_remote_post($url = 'https://classicpress.local/wp-cron.php?doing_wp_cron=1740724621.9625780582427978515625', $args = ['timeout' => 0.01, 'blocking' => FALSE, 'sslverify' => FALSE]) /srv/classicpress_local/wp-includes/cron.php:930
PHP  15. WP_Http->post($url = 'https://classicpress.local/wp-cron.php?doing_wp_cron=1740724621.9625780582427978515625', $args = ['timeout' => 0.01, 'blocking' => FALSE, 'sslverify' => FALSE]) /srv/classicpress_local/wp-includes/http.php:179
PHP  16. WP_Http->request($url = 'https://classicpress.local/wp-cron.php?doing_wp_cron=1740724621.9625780582427978515625', $args = ['method' => 'POST', 'timeout' => 0.01, 'blocking' => FALSE, 'sslverify' => FALSE]) /srv/classicpress_local/wp-includes/class-wp-http.php:640
PHP  17. classicpress_user_agent($include_site_id = *uninitialized*) /srv/classicpress_local/wp-includes/class-wp-http.php:192
PHP  18. classicpress_version_short() /srv/classicpress_local/wp-includes/http.php:794
PHP  19. preg_replace($pattern = '#[+-].*$#', $replacement = '', $subject = NULL) /srv/classicpress_local/wp-includes/version.php:107
```

I'm using the latest version of WP-CLI (2.11.0), and this filter in a MU-plugin:
```php
add_filter( 'https_ssl_verify', '__return_false' );
```