### PR TITLE
Media grid default number of items

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -192,10 +192,8 @@ if ( 'grid' === $mode ) {
 	$mimes_list = implode( ',', $allowed_mimes );
 
 	// Get the user's preferred items per page.
-	$user = get_current_user_id();
-	$screen = get_current_screen();
-	$screen_option = $screen->get_option( 'per_page', 'option' );
-	$per_page = get_user_meta( $user, $screen_option, true );
+	$user_id = get_current_user_id();
+	$per_page = get_user_meta( $user_id, 'media_grid_per_page', true );
 	if ( empty( $per_page ) || $per_page < 1 ) {
 		$per_page = 80;
 	}

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -197,7 +197,7 @@ if ( 'grid' === $mode ) {
 	$screen_option = $screen->get_option( 'per_page', 'option' );
 	$per_page = get_user_meta( $user, $screen_option, true );
 	if ( empty( $per_page ) || $per_page < 1 ) {
-		$per_page = $screen->get_option( 'per_page', 'default' );
+		$per_page = 80;
 	}
 
 	// Fetch media items.


### PR DESCRIPTION
In the media grid view, the default value is currently set as the default value set on the `Settings -> Reading` page. This is typically too low; the default was formerly 80, and this PR reinstates that number as the default.