### PR TITLE
Media video widget

### DIFF
--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -4,6 +4,8 @@
 
 /* eslint consistent-this: [ "error", "control" ] */
 
+/* global VIDEO_WIDGET */
+
 /**
  * @namespace wp.mediaWidgets
  * @memberOf  wp

--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -1,256 +1,361 @@
 /**
- * @output wp-admin/js/widgets/media-video-widget.js
+ * @output wp-admin/js/widgets/media-video-widgets.js
  */
 
 /* eslint consistent-this: [ "error", "control" ] */
-(function( component ) {
-	'use strict';
 
-	var VideoWidgetModel, VideoWidgetControl, VideoDetailsMediaFrame;
+/**
+ * @namespace wp.mediaWidgets
+ * @memberOf  wp
+ */
+
+/*
+ * @since CP 2.3.0
+ */
+document.addEventListener( 'DOMContentLoaded', function() {
 
 	/**
-	 * Custom video details frame that removes the replace-video state.
+	 * Open the media select frame to chose an item.
 	 *
-	 * @class    wp.mediaWidgets.controlConstructors~VideoDetailsMediaFrame
-	 * @augments wp.media.view.MediaFrame.VideoDetails
-	 *
-	 * @private
+	 * @return {void}
 	 */
-	VideoDetailsMediaFrame = wp.media.view.MediaFrame.VideoDetails.extend(/** @lends wp.mediaWidgets.controlConstructors~VideoDetailsMediaFrame.prototype */{
+	function selectMedia( widget ) {
+		var mediaUploader,
+			embedded = false;
 
-		/**
-		 * Create the default states.
-		 *
-		 * @return {void}
-		 */
-		createStates: function createStates() {
-			this.states.add([
-				new wp.media.controller.VideoDetails({
-					media: this.media
-				}),
-
-				new wp.media.controller.MediaLibrary({
-					type: 'video',
-					id: 'add-video-source',
-					title: wp.media.view.l10n.videoAddSourceTitle,
-					toolbar: 'add-video-source',
-					media: this.media,
-					menu: false
-				}),
-
-				new wp.media.controller.MediaLibrary({
-					type: 'text',
-					id: 'add-track',
-					title: wp.media.view.l10n.videoAddTrackTitle,
-					toolbar: 'add-track',
-					media: this.media,
-					menu: 'video-details'
-				})
-			]);
+		if ( mediaUploader ) {
+			mediaUploader.open();
+			return;
 		}
-	});
 
-	/**
-	 * Video widget model.
-	 *
-	 * See WP_Widget_Video::enqueue_admin_scripts() for amending prototype from PHP exports.
-	 *
-	 * @class    wp.mediaWidgets.modelConstructors.media_video
-	 * @augments wp.mediaWidgets.MediaWidgetModel
-	 */
-	VideoWidgetModel = component.MediaWidgetModel.extend({});
+		mediaUploader = wp.media( {
+			title: VIDEO_WIDGET.add_video,
+			button: {
+				text: VIDEO_WIDGET.add_to_widget
+			},
+			multiple: false,
+			library: {
+				type: 'video'
+			},
+			states: [
+				new wp.media.controller.Library( {
+					title: VIDEO_WIDGET.add_video,
+					library: wp.media.query({ type: 'video' }),
+					multiple: false,
+					priority: 20
+				} ),
+				new wp.media.controller.Embed( {
+					id: 'embed',
+					title: VIDEO_WIDGET.insert_from_url,
+					priority: 30
+				} )
+			]
+		} );
 
-	/**
-	 * Video widget control.
-	 *
-	 * See WP_Widget_Video::enqueue_admin_scripts() for amending prototype from PHP exports.
-	 *
-	 * @class    wp.mediaWidgets.controlConstructors.media_video
-	 * @augments wp.mediaWidgets.MediaWidgetControl
-	 */
-	VideoWidgetControl = component.MediaWidgetControl.extend(/** @lends wp.mediaWidgets.controlConstructors.media_video.prototype */{
+		// This runs once the modal is open
+		mediaUploader.on( 'ready', function() {
+			var separator = document.createElement( 'div' ),
+				addButton = mediaUploader.el.querySelector( '.media-button-select' ),
+				libraryButton = mediaUploader.el.querySelector( '#menu-item-library' );
 
-		/**
-		 * Show display settings.
-		 *
-		 * @type {boolean}
-		 */
-		showDisplaySettings: false,
+			separator.className = 'separator';
+			separator.setAttribute( 'role', 'presentation' );
+			libraryButton.after( separator );
 
-		/**
-		 * Cache of oembed responses.
-		 *
-		 * @type {Object}
-		 */
-		oembedResponses: {},
-
-		/**
-		 * Map model props to media frame props.
-		 *
-		 * @param {Object} modelProps - Model props.
-		 * @return {Object} Media frame props.
-		 */
-		mapModelToMediaFrameProps: function mapModelToMediaFrameProps( modelProps ) {
-			var control = this, mediaFrameProps;
-			mediaFrameProps = component.MediaWidgetControl.prototype.mapModelToMediaFrameProps.call( control, modelProps );
-			mediaFrameProps.link = 'embed';
-			return mediaFrameProps;
-		},
-
-		/**
-		 * Fetches embed data for external videos.
-		 *
-		 * @return {void}
-		 */
-		fetchEmbed: function fetchEmbed() {
-			var control = this, url;
-			url = control.model.get( 'url' );
-
-			// If we already have a local cache of the embed response, return.
-			if ( control.oembedResponses[ url ] ) {
-				return;
+			// Prevent duplicate separator lines
+			if ( mediaUploader.el.querySelectorAll( '.separator' ).length > 1 ) {
+				mediaUploader.el.querySelectorAll( '.separator' )[1].remove();
 			}
 
-			// If there is an in-flight embed request, abort it.
-			if ( control.fetchEmbedDfd && 'pending' === control.fetchEmbedDfd.state() ) {
-				control.fetchEmbedDfd.abort();
-			}
+			// Insert video from URL
+			mediaUploader.el.querySelector( '#menu-item-embed' ).addEventListener( 'click', function() {
+				var embed = document.createElement( 'div' );
 
-			control.fetchEmbedDfd = wp.apiRequest({
-				url: wp.media.view.settings.oEmbedProxyUrl,
-				data: {
-					url: control.model.get( 'url' ),
-					maxwidth: control.model.get( 'width' ),
-					maxheight: control.model.get( 'height' ),
-					discover: false
-				},
-				type: 'GET',
-				dataType: 'json',
-				context: control
-			});
+				embed.className = 'media-embed';
+				embed.innerHTML = '<span class="embed-url">' +
+					'<input id="embed-url-field" type="url" aria-label="' + VIDEO_WIDGET.insert_from_url + '" placeholder="https://">' +
+					'<span class="spinner"></span>' +
+					'</span>';
 
-			control.fetchEmbedDfd.done( function( response ) {
-				control.oembedResponses[ url ] = response;
-				control.renderPreview();
-			});
-
-			control.fetchEmbedDfd.fail( function() {
-				control.oembedResponses[ url ] = null;
-			});
-		},
-
-		/**
-		 * Whether a url is a supported external host.
-		 *
-		 * @deprecated since 4.9.
-		 *
-		 * @return {boolean} Whether url is a supported video host.
-		 */
-		isHostedVideo: function isHostedVideo() {
-			return true;
-		},
-
-		/**
-		 * Render preview.
-		 *
-		 * @return {void}
-		 */
-		renderPreview: function renderPreview() {
-			var control = this, previewContainer, previewTemplate, attachmentId, attachmentUrl, poster, html = '', isOEmbed = false, mime, error, urlParser, matches;
-			attachmentId = control.model.get( 'attachment_id' );
-			attachmentUrl = control.model.get( 'url' );
-			error = control.model.get( 'error' );
-
-			if ( ! attachmentId && ! attachmentUrl ) {
-				return;
-			}
-
-			// Verify the selected attachment mime is supported.
-			mime = control.selectedAttachment.get( 'mime' );
-			if ( mime && attachmentId ) {
-				if ( ! _.contains( _.values( wp.media.view.settings.embedMimes ), mime ) ) {
-					error = 'unsupported_file_type';
+				if ( embedded === false ) {
+					mediaUploader.el.querySelector( '.media-frame-content' ).append( embed );
+					embedded = true;
 				}
-			} else if ( ! attachmentId ) {
-				urlParser = document.createElement( 'a' );
-				urlParser.href = attachmentUrl;
-				matches = urlParser.pathname.toLowerCase().match( /\.(\w+)$/ );
-				if ( matches ) {
-					if ( ! _.contains( _.keys( wp.media.view.settings.embedMimes ), matches[1] ) ) {
-						error = 'unsupported_file_type';
+				if ( mediaUploader.el.querySelector( '.uploader-inline' ) ) {
+					mediaUploader.el.querySelector( '.uploader-inline' ).remove();
+				}
+				if ( mediaUploader.el.querySelector( '.attachments-browser' ) ) {
+					mediaUploader.el.querySelector( '.attachments-browser' ).remove();
+				}
+
+				mediaUploader.el.querySelector( '#embed-url-field' ).addEventListener( 'change', function( e ) {
+					var fileType  = e.target.value.split( '.' ).pop(),
+						error     = document.createElement( 'div' ),
+						video     = document.createElement( 'video' ),
+						source    = document.createElement( 'source' ),
+						buttons   = document.createElement( 'div' ),
+						message   = mediaUploader.el.querySelector( '#message' );
+
+					// Update values in hidden fields
+					widget.querySelector( '[data-property="url"]' ).value = e.target.value;
+					if ( widget.querySelector( '[data-property="' + fileType + '"]' ) ) {
+						if ( message ) {
+							message.remove();
+						}
+						widget.querySelector( '[data-property="' + fileType + '"]' ).value = e.target.value;
+
+						video.className = 'wp_video_shortcode';
+						video.style.width = '100%';
+						video.controls = true;
+
+						// Create source element
+						source.src = e.target.value;
+
+						// Append source to video
+						video.append( source );
+
+						// Add Edit and Replace buttons
+						buttons.className = 'media-widget-buttons';
+						buttons.innerHTML = '<button type="button" class="button edit-media">' + VIDEO_WIDGET.edit_video + '</button>' +
+							'<button type="button" class="button change-media select-media">' + VIDEO_WIDGET.replace_video + '</button>';
+
+						// Insert video according to whether this is a new insertion or replacement
+						if ( widget.querySelector( '.attachment-media-view' ) !== null ) {
+							widget.querySelector( '.media_video' ).append( video );
+							widget.querySelector( '.attachment-media-view' ).replaceWith( buttons );
+						} else { // replacement
+							widget.querySelector( '.wp-video' ).replaceWith( video );
+						}
+
+						// Activate Add to widget button
+						if ( addButton.disabled ) {
+							addButton.removeAttribute( 'disabled' );
+							addButton.textContent = VIDEO_WIDGET.add_to_widget;
+						}
+
+						addButton.addEventListener( 'click', function() {
+							document.querySelector( '.media-modal-close' ).click();
+
+							// Activate Save/Publish button
+							if ( document.body.className.includes( 'widgets-php' ) ) {
+								widget.classList.add( 'widget-dirty' );
+							}
+							widget.dispatchEvent( new Event( 'change' ) );
+						} );
+					} else {
+						if ( message == null ) {
+							error.id = 'message';
+							error.className = 'notice-error is-dismissible';
+							error.innerHTML = '<p style="color:#fff;background:red;padding:0.5em 1em;"></p>';
+							error.querySelector( 'p' ).textContent = VIDEO_WIDGET.unsupported_file_type;
+							e.target.before( error );
+						}
 					}
-				} else {
-					isOEmbed = true;
-				}
+				} );
+
+			} );
+
+			libraryButton.addEventListener( 'click', function() {
+				embedded = false;
+				addButton.textContent = VIDEO_WIDGET.add_to_widget;
+			} );
+		} );
+
+		// Insert video from media library
+		mediaUploader.on( 'select', function() {
+			var attachment = mediaUploader.state().get( 'selection' ).first().toJSON(),
+				fileType   = attachment.mime.split( '/' )[1],
+				video      = document.createElement( 'video' ),
+				source     = document.createElement( 'source' ),
+				buttons    = document.createElement( 'div' );
+
+			video.className = 'wp_video_shortcode';
+			video.style.width = '100%';
+			video.controls = true;
+
+			// Create source element
+			source.src = attachment.url;
+			source.type = attachment.mime;
+
+			// Append source to video
+			video.append( source );
+
+			// Add Edit and Replace buttons
+			buttons.className = 'media-widget-buttons';
+			buttons.innerHTML = '<button type="button" class="button edit-media">' + VIDEO_WIDGET.edit_video + '</button>' +
+				'<button type="button" class="button change-media select-media">' + VIDEO_WIDGET.replace_video + '</button>';
+
+			// Insert video according to whether this is a new insertion or replacement
+			if ( widget.querySelector( '.attachment-media-view' ) !== null ) {
+				widget.querySelector( '.media_video' ).append( video );
+				widget.querySelector( '.attachment-media-view' ).replaceWith( buttons );
+			} else { // replacement
+				widget.querySelector( '.wp-video' ).replaceWith( video );
 			}
 
-			if ( isOEmbed ) {
-				control.fetchEmbed();
-				if ( control.oembedResponses[ attachmentUrl ] ) {
-					poster = control.oembedResponses[ attachmentUrl ].thumbnail_url;
-					html = control.oembedResponses[ attachmentUrl ].html.replace( /\swidth="\d+"/, ' width="100%"' ).replace( /\sheight="\d+"/, '' );
-				}
+			// Update values in hidden fields
+			widget.querySelector( '[data-property="attachment_id"]' ).value = attachment.id;
+			widget.querySelector( '[data-property="url"]' ).value = attachment.url;
+			if ( widget.querySelector( '[data-property="' + fileType + '"]' ) ) {		
+				widget.querySelector( '[data-property="' + fileType + '"]' ).value = attachment.url;
+			} else {
+				console.error( VIDEO_WIDGET.unsupported_file_type );
 			}
 
-			previewContainer = control.$el.find( '.media-widget-preview' );
-			previewTemplate = wp.template( 'wp-media-widget-video-preview' );
+			// Activate Save/Publish button
+			if ( document.body.className.includes( 'widgets-php' ) ) {
+				widget.classList.add( 'widget-dirty' );
+			}
+			widget.dispatchEvent( new Event( 'change' ) );
+		} );
 
-			previewContainer.html( previewTemplate({
-				model: {
-					attachment_id: attachmentId,
-					html: html,
-					src: attachmentUrl,
-					poster: poster
-				},
-				is_oembed: isOEmbed,
-				error: error
-			}));
-			wp.mediaelement.initialize();
-		},
+		mediaUploader.open();
+	}
 
-		/**
-		 * Open the media image-edit frame to modify the selected item.
-		 *
-		 * @return {void}
-		 */
-		editMedia: function editMedia() {
-			var control = this, mediaFrame, metadata, updateCallback;
+	/**
+	 * Open the media frame to modify the selected item.
+	 *
+	 * @abstract
+	 * @return {void}
+	 */
+	function editMedia( widget ) {
+		var	frame,
+			videoURL = widget.querySelector( '[data-property="url"]' ).value,
+			videoID = widget.querySelector( '[data-property="attachment_id"]' ).value,
+			widgetContainer = widget.querySelector( '.widget-content' );
 
-			metadata = control.mapModelToMediaFrameProps( control.model.toJSON() );
-
-			// Set up the media frame.
-			mediaFrame = new VideoDetailsMediaFrame({
-				frame: 'video',
-				state: 'video-details',
-				metadata: metadata
-			});
-			wp.media.frame = mediaFrame;
-			mediaFrame.$el.addClass( 'media-widget' );
-
-			updateCallback = function( mediaFrameProps ) {
-
-				// Update cached attachment object to avoid having to re-fetch. This also triggers re-rendering of preview.
-				control.selectedAttachment.set( mediaFrameProps );
-
-				control.model.set( _.extend(
-					_.omit( control.model.defaults(), 'title' ),
-					control.mapMediaToModelProps( mediaFrameProps ),
-					{ error: false }
-				) );
-			};
-
-			mediaFrame.state( 'video-details' ).on( 'update', updateCallback );
-			mediaFrame.state( 'replace-video' ).on( 'replace', updateCallback );
-			mediaFrame.on( 'close', function() {
-				mediaFrame.detach();
-			});
-
-			mediaFrame.open();
+        if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="mp4"]' ).value;
 		}
-	});
+		if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="m4v"]' ).value;
+		}
+		if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="webm"]' ).value;
+		}
+		if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="ogv"]' ).value;
+		}
+		if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="flv"]' ).value;
+		}
+        if ( videoURL == null ) {
+            console.error( VIDEO_WIDGET.no_video_selected );
+            return;
+        }
 
-	// Exports.
-	component.controlConstructors.media_video = VideoWidgetControl;
-	component.modelConstructors.media_video = VideoWidgetModel;
+        // Open the media modal in edit mode
+        frame = wp.media( {
+            frame: 'video',
+            state: 'video-details',
+            metadata: wp.media.attachment( videoID )
+        } );
 
-})( wp.mediaWidgets );
+		// This runs once the modal is open
+		frame.on( 'ready', function() {
+			frame.el.querySelector( '#video-details-loop' ).checked = widget.querySelector( '[data-property="loop"]' ).value === '1' ? true : false;
+
+			updateFrame( frame, widget, videoURL );
+
+			frame.el.querySelector( '#menu-item-video-details' ).addEventListener( 'click', function() {
+				updateFrame( frame, widget, videoURL );
+			} );
+		} );
+
+        frame.open();
+    }
+    
+    function updateFrame( frame, widget, videoURL ) {
+		var video = document.createElement( 'video' ),
+			source = document.createElement( 'source' )
+			span = document.createElement( 'span' ),
+			fileType = videoURL.split( '.' ).pop(),
+			fileMime = frame.el.querySelector( '.add-media-source[data-mime="video/' + fileType + '"]' ),
+			autoplay = frame.el.querySelector( '#video-details-autoplay' ),
+			loop = frame.el.querySelector( '#video-details-loop' );
+
+		// Organize menu items in left-hand column
+		if ( frame.el.querySelector( '#menu-item-replace-video' ) ) {
+			frame.el.querySelector( '#menu-item-replace-video' ).remove();
+		}
+		if ( frame.el.querySelector( '#menu-item-select-poster-image' ) ) {
+			frame.el.querySelector( '#menu-item-select-poster-image' ).remove();
+		}
+		frame.el.querySelector( '#menu-item-add-track' ).textContent = VIDEO_WIDGET.add_subtitles;
+
+		video.className = 'wp_video_shortcode';
+		video.style.width = '100%';
+		video.controls = true;
+
+		// Create source element
+		source.src = videoURL;
+		source.type = 'video/' + fileType;
+
+		// Append source to video
+		video.append( source );
+		frame.el.querySelector( 'video' ).replaceWith( video );
+			
+		span.className = 'setting';
+		span.innerHTML = '<label for="video-details-' + fileType + '-source" class="name">' + fileType.toUpperCase() + '</label>' +
+			'<input type="text" id="video-details-' + fileType + '-source" readonly="" data-setting="' + fileType + '" value="' + videoURL + '">' +
+			'<button type="button" class="button-link remove-setting">' + VIDEO_WIDGET.remove_video_source + '</button>' +
+			'</span>';
+		if ( frame.el.querySelector( '[data-setting="' + fileType + '"]' ) == null ) {
+			frame.el.querySelector( '.wp-video' ).after( span );
+		}
+
+		// Remove current filetype button from alternate sources list
+		if ( fileMime ) {
+			fileMime.remove();
+		}
+
+		// Remove autoplay option
+		if ( autoplay ) {
+			autoplay.parentNode.remove();
+		}
+
+		// Set whether the video should loop or not
+		loop.addEventListener( 'change', function() {
+			if ( loop.checked ) {
+				widget.querySelector( '[data-property="loop"]' ).value = '1';
+			} else {
+				widget.querySelector( '[data-property="loop"]' ).value = '';				
+			}
+		} );
+
+		// Set preload option
+		frame.el.querySelectorAll( '.setting.preload .button' ).forEach( function( preload ) {
+			if ( preload.value === widget.querySelector( '[data-property="preload"]' ).value ) {
+				setTimeout( preload.click() );
+			}
+			preload.addEventListener( 'click', function() {
+				if ( preload.value === 'none' ) {
+					preload.value = '';
+				}
+				widget.querySelector( '[data-property="preload"]' ).value = preload.value;
+			} );
+		} );
+
+		// Activate Save button on widget after update
+		frame.el.querySelector( '.media-button-button' ).addEventListener( 'click', function() {
+			widget.dispatchEvent( new Event( 'change' ) );
+		} );
+	}
+
+	// Handle clicks on Add, Edit, and Replace Video buttons
+	document.addEventListener( 'click', function( e ) {
+		var base,
+			widget = e.target.closest( '.widget' );
+
+		if ( widget ) {
+			base = widget.querySelector( '.id_base' );
+			if ( base && base.value === 'media_video' && e.target.tagName === 'BUTTON' ) {
+				if ( e.target.className.includes( 'select-media' ) ) {
+					selectMedia( widget );
+				} else if ( e.target.className && e.target.className.includes( 'edit-media' ) ) {
+					editMedia( widget );
+				}
+			}
+		}
+	} );
+} );

--- a/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
+++ b/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
@@ -178,6 +178,11 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-overlay-loading svg {
     height: 5rem;
     width: 5rem;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 1;
 }
 
 .mejs-overlay-loading-bg-img {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1471,7 +1471,7 @@ function wp_default_styles( $styles ) {
 	// External libraries and friends.
 	$styles->add( 'imgareaselect', '/wp-includes/js/imgareaselect/imgareaselect.css', array(), '0.9.8' );
 	$styles->add( 'wp-jquery-ui-dialog', "/wp-includes/css/jquery-ui-dialog$suffix.css", array( 'dashicons' ) );
-	$styles->add( 'mediaelement', '/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css', array(), '4.2.17' );
+	$styles->add( 'mediaelement', "/wp-includes/js/mediaelement/mediaelementplayer-legacy$suffix.css", array(), '4.2.17' );
 	$styles->add( 'mediaelement-player', "/wp-includes/js/mediaelement/mediaelementplayer$suffix.css", array( 'mediaelement' ), '7.0.5' );
 	$styles->add( 'wp-mediaelement', "/wp-includes/js/mediaelement/wp-mediaelement$suffix.css", array( 'mediaelement' ) );
 	$styles->add( 'thickbox', '/wp-includes/js/thickbox/thickbox.css', array( 'dashicons' ) );

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -31,26 +31,6 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				'mime_type'   => 'video',
 			)
 		);
-
-		$this->l10n = array_merge(
-			$this->l10n,
-			array(
-				'no_media_selected'          => __( 'No video selected' ),
-				'add_media'                  => _x( 'Add Video', 'label for button in the video widget' ),
-				'replace_media'              => _x( 'Replace Video', 'label for button in the video widget; should preferably not be longer than ~13 characters long' ),
-				'edit_media'                 => _x( 'Edit Video', 'label for button in the video widget; should preferably not be longer than ~13 characters long' ),
-				'missing_attachment'         => sprintf(
-					/* translators: %s: URL to media library. */
-					__( 'That video cannot be found. Check your <a href="%s">media library</a> and make sure it was not deleted.' ),
-					esc_url( admin_url( 'upload.php' ) )
-				),
-				/* translators: %d: Widget count. */
-				'media_library_state_multi'  => _n_noop( 'Video Widget (%d)', 'Video Widget (%d)' ),
-				'media_library_state_single' => __( 'Video Widget' ),
-				/* translators: %s: A list of valid video file extensions. */
-				'unsupported_file_type'      => sprintf( __( 'Sorry, the video at the supplied URL cannot be loaded. Please check that the URL is for a supported video file (%s) or stream (e.g. YouTube and Vimeo).' ), '<code>.' . implode( '</code>, <code>.', wp_get_video_extensions() ) . '</code>' ),
-			)
-		);
 	}
 
 	/**

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -154,7 +154,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$title         = ! empty( $instance['title'] ) ? $instance['title'] : '';
 		$attachment_id = ! empty( $instance['attachment_id'] ) ? $instance['attachment_id'] : 0;
 		$url           = ! empty( $instance['url'] ) ? $instance['url'] : '';
-		$preload       = ! empty( $instance['preload'] ) ? $instance['preload'] : '';
+		$preload       = ! empty( $instance['preload'] ) ? $instance['preload'] : 'metadata';
 		$loop          = ! empty( $instance['loop'] ) ? true : false;
 		$content       = ! empty( $instance['content'] ) ? $instance['content'] : '';
 		$mp4           = ! empty( $instance['mp4'] ) ? $instance['mp4'] : '';
@@ -242,7 +242,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$instance['title']         = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
 		$instance['attachment_id'] = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
 		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
-		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : '';
+		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : 'metadata';
 		$instance['loop']          = ! empty( $new_instance['loop'] ) ? sanitize_text_field( $new_instance['loop'] ) : '';
 		$instance['content']       = ! empty( $new_instance['content'] ) ? wp_kses_post( $new_instance['content'] ) : '';
 		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -178,7 +178,6 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				$url = $flv;
 			}
 		}
-		$video_html = wp_video_shortcode( array( 'src' => $url ) );
 		?>
  
 		<div class="media-widget-control">
@@ -190,7 +189,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 			<?php
 			if ( $url ) {
 			?>
-				<div class="media-widget-preview media_video populated"><?php echo $video_html; ?></div>
+				<div class="media-widget-preview media_video populated"><?php echo wp_video_shortcode( array( 'src' => $url ) ); ?></div>
 
 				<fieldset class="media-widget-buttons">
 					<button type="button" class="button edit-media"><?php esc_html_e( 'Edit Video' ); ?></button>

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -220,7 +220,6 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		<input id="<?php echo esc_attr( $this->get_field_id( 'flv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flv' ) ); ?>" type="hidden" data-property="flv" class="media-widget-instance-property" value="<?php echo esc_attr( $flv ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
-		<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="hidden" data-property="title" class="media-widget-instance-property" value="<?php echo esc_attr( $title ); ?>">
 
         <?php
     }

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -188,7 +188,8 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 
 			<?php
 			if ( $url ) {
-			?>
+				?>
+
 				<div class="media-widget-preview media_video populated"><?php echo wp_video_shortcode( array( 'src' => $url ) ); ?></div>
 
 				<fieldset class="media-widget-buttons">
@@ -196,15 +197,15 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 					<button type="button" class="button change-media select-media"><?php esc_html_e( 'Replace Video' ); ?></button>
 				</fieldset>
 
-			<?php
+				<?php
 			} else {
-			?>
+				?>
 
 				<fieldset class="attachment-media-view">
 					<button type="button" class="select-media button-add-media"><?php esc_html_e( 'Add Video' ); ?></button>
 				</fieldset>
 
-			<?php
+				<?php
 			}
 			?>
 

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -162,6 +162,117 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 	}
 
 	/**
+	 * Outputs the settings update form.
+	 *
+	 * Now renders immediately with PHP instead of just-in-time JavaScript
+	 *
+	 * @since CP-2.5.0
+	 *
+	 * @param array $instance Current settings.
+	 */
+	public function form( $instance ) {
+		$title         = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		$attachment_id = ! empty( $instance['attachment_id'] ) ? $instance['attachment_id'] : 0;
+		$url           = ! empty( $instance['url'] ) ? $instance['url'] : '';
+		$preload       = ! empty( $instance['preload'] ) ? $instance['preload'] : '';
+		$loop          = ! empty( $instance['loop'] ) ? true : false;
+		$content       = ! empty( $instance['content'] ) ? $instance['content'] : '';
+		$mp4           = ! empty( $instance['mp4'] ) ? $instance['mp4'] : '';
+		$m4v           = ! empty( $instance['m4v'] ) ? $instance['m4v'] : '';
+		$webm          = ! empty( $instance['webm'] ) ? $instance['webm'] : '';
+		$ogv           = ! empty( $instance['ogv'] ) ? $instance['ogv'] : '';
+		$flv           = ! empty( $instance['flv'] ) ? $instance['flv'] : '';
+		$dw_include    = ! empty( $instance['dw_include'] ) ? $instance['dw_include'] : 0;
+		$dw_logged     = ! empty( $instance['dw_logged'] ) ? $instance['dw_logged'] : '';
+		$other_ids     = ! empty( $instance['other_ids'] ) ? $instance['other_ids'] : '';
+		?>
+ 
+		<div class="media-widget-control">
+			<fieldset>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" class="widefat" value="<?php echo esc_attr( $title ); ?>">
+			</fieldset>
+
+			<div class="media-widget-preview media_video">
+				<?php
+				if ( $attachment_id || $url ) {
+					$video_url = $attachment_id ? wp_get_attachment_url( $attachment_id ) : $url;
+					echo wp_video_shortcode( array( 'src' => $video_url ) );
+				}
+				?>
+			</div>
+
+			<?php
+			if ( $attachment_id || $url ) {
+			?>
+
+				<fieldset class="media-widget-buttons">
+					<button type="button" class="button edit-media"><?php esc_html_e( 'Edit Video' ); ?></button>
+					<button type="button" class="button change-media select-media"><?php esc_html_e( 'Replace Video' ); ?></button>
+				</fieldset>
+
+			<?php
+			} else {
+			?>
+
+				<fieldset class="attachment-media-view">
+					<button type="button" class="select-media button-add-media"><?php esc_html_e( 'Add Video' ); ?></button>
+				</fieldset>
+
+			<?php
+			}
+			?>
+
+		</div>
+
+		<input id="<?php echo esc_attr( $this->get_field_id( 'preload' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'preload' ) ); ?>" type="hidden" data-property="preload" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $preload ) ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'loop' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'loop' ) ); ?>" type="hidden" data-property="loop" class="media-widget-instance-property" value="<?php echo esc_attr( $loop ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'content' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'content' ) ); ?>" type="hidden" data-property="content" class="media-widget-instance-property" value="<?php echo esc_attr( $content ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'mp4' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'mp4' ) ); ?>" type="hidden" data-property="mp4" class="media-widget-instance-property" value="<?php echo esc_attr( $mp4 ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'm4v' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'm4v' ) ); ?>" type="hidden" data-property="m4v" class="media-widget-instance-property" value="<?php echo esc_attr( $m4v ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'webm' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'webm' ) ); ?>" type="hidden" data-property="webm" class="media-widget-instance-property" value="<?php echo esc_attr( $webm ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'ogv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'ogv' ) ); ?>" type="hidden" data-property="ogv" class="media-widget-instance-property" value="<?php echo esc_attr( $ogv ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'flv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flv' ) ); ?>" type="hidden" data-property="flv" class="media-widget-instance-property" value="<?php echo esc_attr( $flv ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="hidden" data-property="title" class="media-widget-instance-property" value="<?php echo esc_attr( $title ); ?>">
+
+        <?php
+    }
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @since CP-2.5.0
+	 *
+	 * @see WP_Widget::update()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+    public function update( $new_instance, $old_instance ) {
+        $instance = array();       
+		$instance['title']         = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
+		$instance['attachment_id'] = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
+		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
+		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : '';
+		$instance['loop']          = ! empty( $new_instance['loop'] ) ? sanitize_text_field( $new_instance['loop'] ) : '';
+		$instance['content']       = ! empty( $new_instance['content'] ) ? wp_kses_post( $new_instance['content'] ) : '';
+		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';
+		$instance['m4v']           = ! empty( $new_instance['m4v'] ) ? sanitize_url( $new_instance['m4v'] ) : '';
+		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : '';
+		$instance['ogv']           = ! empty( $new_instance['ogv'] ) ? sanitize_url( $new_instance['ogv'] ) : '';
+		$instance['flv']           = ! empty( $new_instance['flv'] ) ? sanitize_url( $new_instance['flv'] ) : '';
+		$instance['dw_include']    = ! empty( $new_instance['dw_include'] ) ? absint( $new_instance['dw_include'] ) : 0;
+		$instance['dw_logged']     = ! empty( $new_instance['dw_logged'] ) ? sanitize_text_field( $new_instance['dw_logged'] ) : '';
+		$instance['other_ids']     = ! empty( $new_instance['other_ids'] ) ? sanitize_text_field( $new_instance['other_ids'] ) : '';
+ 
+        return $instance;
+    }
+
+	/**
 	 * Enqueue preview scripts.
 	 *
 	 * These scripts normally are enqueued just-in-time when a video shortcode is used.
@@ -187,88 +298,30 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 	 */
 	public function enqueue_admin_scripts() {
 		parent::enqueue_admin_scripts();
+		wp_enqueue_style( 'wp-mediaelement' );
+		wp_enqueue_script( 'mediaelement-vimeo' );
+		wp_enqueue_script( 'wp-mediaelement' );
 
-		$handle = 'media-video-widget';
-		wp_enqueue_script( $handle );
-
-		$exported_schema = array();
-		foreach ( $this->get_instance_schema() as $field => $field_schema ) {
-			$exported_schema[ $field ] = wp_array_slice_assoc( $field_schema, array( 'type', 'default', 'enum', 'minimum', 'format', 'media_prop', 'should_preview_update' ) );
-		}
-		wp_add_inline_script(
-			$handle,
-			sprintf(
-				'wp.mediaWidgets.modelConstructors[ %s ].prototype.schema = %s;',
-				wp_json_encode( $this->id_base ),
-				wp_json_encode( $exported_schema )
+		wp_enqueue_script( 'media-video-widget' );
+		wp_localize_script(
+			'media-video-widget',
+			'VIDEO_WIDGET',
+			array(
+				'no_video_selected'          => __( 'No video selected' ),
+				'add_video'                  => _x( 'Add Video', 'label for button in the media widget' ),
+				'replace_video'              => _x( 'Replace Video', 'label for button in the media widget; should preferably not be longer than ~13 characters long' ),
+				'edit_video'                 => _x( 'Edit Video', 'label for button in the media widget; should preferably not be longer than ~13 characters long' ),
+				'add_to_widget'              => __( 'Add to Widget' ),
+				'insert_from_url'            => __( 'Insert from URL' ),
+				'missing_attachment'         => sprintf(
+					/* translators: %s: URL to media library. */
+					__( 'That file cannot be found. Check your <a href="%s">media library</a> and make sure it was not deleted.' ),
+					esc_url( admin_url( 'upload.php' ) )
+				),
+				'unsupported_file_type'      => __( 'Looks like this is not the correct kind of file. Please link to an appropriate file instead.' ),
+				'add_subtitles'              => __( 'Add Subtitles' ),
+				'remove_video_source'        => __( 'Remove video source' ),
 			)
 		);
-
-		wp_add_inline_script(
-			$handle,
-			sprintf(
-				'
-					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.mime_type = %2$s;
-					wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n = _.extend( {}, wp.mediaWidgets.controlConstructors[ %1$s ].prototype.l10n, %3$s );
-				',
-				wp_json_encode( $this->id_base ),
-				wp_json_encode( $this->widget_options['mime_type'] ),
-				wp_json_encode( $this->l10n )
-			)
-		);
-	}
-
-	/**
-	 * Render form template scripts.
-	 *
-	 * @since 4.8.0
-	 */
-	public function render_control_template_scripts() {
-		parent::render_control_template_scripts()
-		?>
-		<script type="text/html" id="tmpl-wp-media-widget-video-preview">
-			<# if ( data.error && 'missing_attachment' === data.error ) { #>
-				<?php
-				wp_admin_notice(
-					$this->l10n['missing_attachment'],
-					array(
-						'type'               => 'error',
-						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
-					)
-				);
-				?>
-			<# } else if ( data.error && 'unsupported_file_type' === data.error ) { #>
-				<?php
-				wp_admin_notice(
-					$this->l10n['unsupported_file_type'],
-					array(
-						'type'               => 'error',
-						'additional_classes' => array( 'notice-alt', 'notice-missing-attachment' ),
-					)
-				);
-				?>
-			<# } else if ( data.error ) { #>
-				<?php
-				wp_admin_notice(
-					__( 'Unable to preview media due to an unknown error.' ),
-					array(
-						'type'               => 'error',
-						'additional_classes' => array( 'notice-alt' ),
-					)
-				);
-				?>
-			<# } else if ( data.is_oembed && data.model.poster ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link">
-					<img src="{{ data.model.poster }}">
-				</a>
-			<# } else if ( data.is_oembed ) { #>
-				<a href="{{ data.model.src }}" target="_blank" class="media-widget-video-link no-poster">
-					<span class="dashicons dashicons-format-video"></span>
-				</a>
-			<# } else if ( data.model.src ) { #>
-				<?php wp_underscore_video_template(); ?>
-			<# } #>
-		</script>
-		<?php
 	}
 }

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Widget API: WP_Widget_Media_Audio class
+ * Widget API: WP_Widget_Media_Video class
  *
  * @package ClassicPress
  * @subpackage Widgets
@@ -8,14 +8,14 @@
  */
 
 /**
- * Core class that implements an audio widget.
+ * Core class that implements a video widget.
  *
  * @since 4.8.0
  *
  * @see WP_Widget_Media
  * @see WP_Widget
  */
-class WP_Widget_Media_Audio extends WP_Widget_Media {
+class WP_Widget_Media_Video extends WP_Widget_Media {
 
 	/**
 	 * Constructor.
@@ -24,11 +24,11 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 	 */
 	public function __construct() {
 		parent::__construct(
-			'media_audio',
-			__( 'Audio' ),
+			'media_video',
+			__( 'Video' ),
 			array(
-				'description' => __( 'Displays an audio player.' ),
-				'mime_type'   => 'audio',
+				'description' => __( 'Displays a video from the media library or from YouTube, Vimeo, or another provider.' ),
+				'mime_type'   => 'video',
 			)
 		);
 	}
@@ -45,27 +45,37 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 	 * @return array Schema for properties.
 	 */
 	public function get_instance_schema() {
+
 		$schema = array(
 			'preload' => array(
-				'type'        => 'string',
-				'enum'        => array( 'none', 'auto', 'metadata' ),
-				'default'     => 'none',
-				'description' => __( 'Preload' ),
+				'type'                  => 'string',
+				'enum'                  => array( 'none', 'auto', 'metadata' ),
+				'default'               => 'metadata',
+				'description'           => __( 'Preload' ),
+				'should_preview_update' => false,
 			),
 			'loop'    => array(
-				'type'        => 'boolean',
-				'default'     => false,
-				'description' => __( 'Loop' ),
+				'type'                  => 'boolean',
+				'default'               => false,
+				'description'           => __( 'Loop' ),
+				'should_preview_update' => false,
+			),
+			'content' => array(
+				'type'                  => 'string',
+				'default'               => '',
+				'sanitize_callback'     => 'wp_kses_post',
+				'description'           => __( 'Tracks (subtitles, captions, descriptions, chapters, or metadata)' ),
+				'should_preview_update' => false,
 			),
 		);
 
-		foreach ( wp_get_audio_extensions() as $audio_extension ) {
-			$schema[ $audio_extension ] = array(
+		foreach ( wp_get_video_extensions() as $video_extension ) {
+			$schema[ $video_extension ] = array(
 				'type'        => 'string',
 				'default'     => '',
 				'format'      => 'uri',
-				/* translators: %s: Audio extension. */
-				'description' => sprintf( __( 'URL to the %s audio source file' ), $audio_extension ),
+				/* translators: %s: Video extension. */
+				'description' => sprintf( __( 'URL to the %s video source file' ), $video_extension ),
 			);
 		}
 
@@ -87,102 +97,137 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 			$attachment = get_post( $instance['attachment_id'] );
 		}
 
+		$src = $instance['url'];
 		if ( $attachment ) {
 			$src = wp_get_attachment_url( $attachment->ID );
-		} else {
-			$src = $instance['url'];
 		}
 
-		echo wp_audio_shortcode(
-			array_merge(
-				$instance,
-				compact( 'src' )
-			)
-		);
+		if ( empty( $src ) ) {
+			return;
+		}
+
+		$youtube_pattern = '#^https?://(?:www\.)?(?:youtube\.com/watch|youtu\.be/)#';
+		$vimeo_pattern   = '#^https?://(.+\.)?vimeo\.com/.*#';
+
+		if ( $attachment || preg_match( $youtube_pattern, $src ) || preg_match( $vimeo_pattern, $src ) ) {
+			add_filter( 'wp_video_shortcode', array( $this, 'inject_video_max_width_style' ) );
+
+			echo wp_video_shortcode(
+				array_merge(
+					$instance,
+					compact( 'src' )
+				),
+				$instance['content']
+			);
+
+			remove_filter( 'wp_video_shortcode', array( $this, 'inject_video_max_width_style' ) );
+		} else {
+			echo $this->inject_video_max_width_style( wp_oembed_get( $src ) );
+		}
 	}
 
 	/**
-	 * Back-end widget form.
+	 * Inject max-width and remove height for videos too constrained to fit inside sidebars on frontend.
+	 *
+	 * @since 4.8.0
+	 *
+	 * @param string $html Video shortcode HTML output.
+	 * @return string HTML Output.
+	 */
+	public function inject_video_max_width_style( $html ) {
+		$html = preg_replace( '/\sheight="\d+"/', '', $html );
+		$html = preg_replace( '/\swidth="\d+"/', '', $html );
+		$html = preg_replace( '/(?<=width:)\s*\d+px(?=;?)/', '100%', $html );
+		return $html;
+	}
+
+	/**
+	 * Outputs the settings update form.
+	 *
+	 * Now renders immediately with PHP instead of just-in-time JavaScript
 	 *
 	 * @since CP-2.5.0
 	 *
-	 * @see WP_Widget::form()
-	 *
-	 * @param array $instance Previously saved values from database.
+	 * @param array $instance Current settings.
 	 */
 	public function form( $instance ) {
 		$title         = ! empty( $instance['title'] ) ? $instance['title'] : '';
 		$attachment_id = ! empty( $instance['attachment_id'] ) ? $instance['attachment_id'] : 0;
-		$preload       = ! empty( $instance['preload'] ) ? $instance['preload'] : 'none';
-		$loop          = ! empty( $instance['loop'] ) ? $instance['loop'] : '';
-		$mp3           = ! empty( $instance['mp3'] ) ? $instance['mp3'] : '';
-		$ogg           = ! empty( $instance['ogg'] ) ? $instance['ogg'] : '';
-		$flac          = ! empty( $instance['flac'] ) ? $instance['flac'] : '';
-		$m4a           = ! empty( $instance['m4a'] ) ? $instance['m4a'] : '';
-		$wav           = ! empty( $instance['wav'] ) ? $instance['wav'] : '';
 		$url           = ! empty( $instance['url'] ) ? $instance['url'] : '';
-		$nonce         = wp_create_nonce( 'audio_editor-' . $attachment_id );
+		$preload       = ! empty( $instance['preload'] ) ? $instance['preload'] : '';
+		$loop          = ! empty( $instance['loop'] ) ? true : false;
+		$content       = ! empty( $instance['content'] ) ? $instance['content'] : '';
+		$mp4           = ! empty( $instance['mp4'] ) ? $instance['mp4'] : '';
+		$m4v           = ! empty( $instance['m4v'] ) ? $instance['m4v'] : '';
+		$webm          = ! empty( $instance['webm'] ) ? $instance['webm'] : '';
+		$ogv           = ! empty( $instance['ogv'] ) ? $instance['ogv'] : '';
+		$flv           = ! empty( $instance['flv'] ) ? $instance['flv'] : '';
 
 		if ( $attachment_id && $url === '' ) {
 			$url = wp_get_attachment_url( $attachment_id );
-		} elseif ( $url === '' ) {
-			$url = $mp3;
-		} elseif ( $url === '' ) {
-			$url = $ogg;
-		} elseif ( $url === '' ) {
-			$url = $flac;
-		} elseif ( $url === '' ) {
-			$url = $m4a;
-		} elseif ( $url === '' ) {
-			$url = $wav;
 		}
-		$audio_html = wp_audio_shortcode( array( 'src' => $url ) );
+		if ( $url === '' ) {
+			$url = $mp4;
+		}
+		if ( $url === '' ) {
+			$url = $m4v;
+		}
+		if ( $url === '' ) {
+			$url = $webm;
+		}
+		if ( $url === '' ) {
+			$url = $ogv;
+		}
+		if ( $url === '' ) {
+			$url = $flv;
+		}
+		$video_html = wp_video_shortcode( array( 'src' => $url ) );
 		?>
-
-		<div class="media-widget-control selected">	
+ 
+		<div class="media-widget-control">
 			<fieldset>
-				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:' ); ?></label>
-				<input id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" class="widefat" type="text" value="<?php echo esc_attr( $title ); ?>">
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" class="widefat" value="<?php echo esc_attr( $title ); ?>">
 			</fieldset>
 
 			<?php
 			if ( $url ) {
 			?>
-				<div class="media-widget-preview media_audio populated"><?php echo $audio_html; ?></div>
+				<div class="media-widget-preview media_video populated"><?php echo $video_html; ?></div>
 
 				<fieldset class="media-widget-buttons">
-					<button type="button" class="button edit-media selected" data-edit-nonce="<?php echo esc_attr( $nonce ); ?>"><?php esc_html_e( 'Edit Audio' ); ?></button>
-					<button type="button" class="button change-media select-media selected"><?php esc_html_e( 'Replace Audio' ); ?></button>
+					<button type="button" class="button edit-media"><?php esc_html_e( 'Edit Video' ); ?></button>
+					<button type="button" class="button change-media select-media"><?php esc_html_e( 'Replace Video' ); ?></button>
 				</fieldset>
 
 			<?php
 			} else {
 			?>
 
-				<div class="media-widget-preview media_audio">
-					<div class="attachment-media-view">
-						<button type="button" class="select-media button-add-media"><?php esc_html_e( 'Add Audio' ); ?></button>
-					</div>
-				</div>
+				<fieldset class="attachment-media-view">
+					<button type="button" class="select-media button-add-media"><?php esc_html_e( 'Add Video' ); ?></button>
+				</fieldset>
 
 			<?php
 			}
 			?>
 
-			<input id="<?php echo esc_attr( $this->get_field_id( 'preload' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'preload' ) ); ?>" type="hidden" data-property="preload" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $preload ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'loop' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'loop' ) ); ?>" type="hidden" data-property="loop" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $loop ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'mp3' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'mp3' ) ); ?>" type="hidden" data-property="mp3" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $mp3 ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'ogg' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'ogg' ) ); ?>" type="hidden" data-property="ogg" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $ogg ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'flac' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flac' ) ); ?>" type="hidden" data-property="flac" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $flac ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'm4a' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'm4a' ) ); ?>" type="hidden" data-property="m4a" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $m4a ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'wav' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'wav' ) ); ?>" type="hidden" data-property="wav" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $wav ) ); ?>">
-			<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">			
-			<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
-
 		</div>
 
-		<?php
-	}
+		<input id="<?php echo esc_attr( $this->get_field_id( 'preload' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'preload' ) ); ?>" type="hidden" data-property="preload" class="media-widget-instance-property" value="<?php echo esc_attr( esc_attr( $preload ) ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'loop' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'loop' ) ); ?>" type="hidden" data-property="loop" class="media-widget-instance-property" value="<?php echo esc_attr( $loop ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'content' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'content' ) ); ?>" type="hidden" data-property="content" class="media-widget-instance-property" value="<?php echo esc_attr( $content ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'mp4' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'mp4' ) ); ?>" type="hidden" data-property="mp4" class="media-widget-instance-property" value="<?php echo esc_attr( $mp4 ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'm4v' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'm4v' ) ); ?>" type="hidden" data-property="m4v" class="media-widget-instance-property" value="<?php echo esc_attr( $m4v ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'webm' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'webm' ) ); ?>" type="hidden" data-property="webm" class="media-widget-instance-property" value="<?php echo esc_attr( $webm ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'ogv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'ogv' ) ); ?>" type="hidden" data-property="ogv" class="media-widget-instance-property" value="<?php echo esc_attr( $ogv ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'flv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flv' ) ); ?>" type="hidden" data-property="flv" class="media-widget-instance-property" value="<?php echo esc_attr( $flv ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="hidden" data-property="title" class="media-widget-instance-property" value="<?php echo esc_attr( $title ); ?>">
+
+        <?php
+    }
 
 	/**
 	 * Sanitize widget form values as they are saved.
@@ -196,26 +241,30 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 	 *
 	 * @return array Updated safe values to be saved.
 	 */
-	public function update( $new_instance, $old_instance ) {
-		$instance = array();
+    public function update( $new_instance, $old_instance ) {
+        $instance = array();       
 		$instance['title']         = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
 		$instance['attachment_id'] = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
+		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
 		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : '';
 		$instance['loop']          = ! empty( $new_instance['loop'] ) ? sanitize_text_field( $new_instance['loop'] ) : '';
-		$instance['mp3']           = ! empty( $new_instance['mp3'] ) ? sanitize_text_field( $new_instance['mp3'] ) : '';
-		$instance['ogg']           = ! empty( $new_instance['ogg'] ) ? sanitize_text_field( $new_instance['ogg'] ) : '';
-		$instance['flac']          = ! empty( $new_instance['flac'] ) ? sanitize_text_field( $new_instance['flac'] ) : '';
-		$instance['m4a']           = ! empty( $new_instance['m4a'] ) ? sanitize_text_field( $new_instance['m4a'] ) : '';
-		$instance['wav']           = ! empty( $new_instance['wav'] ) ? sanitize_text_field( $new_instance['wav'] ) : '';
-		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
-
-		return $instance;
-	}
+		$instance['content']       = ! empty( $new_instance['content'] ) ? wp_kses_post( $new_instance['content'] ) : '';
+		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';
+		$instance['m4v']           = ! empty( $new_instance['m4v'] ) ? sanitize_url( $new_instance['m4v'] ) : '';
+		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : '';
+		$instance['ogv']           = ! empty( $new_instance['ogv'] ) ? sanitize_url( $new_instance['ogv'] ) : '';
+		$instance['flv']           = ! empty( $new_instance['flv'] ) ? sanitize_url( $new_instance['flv'] ) : '';
+		$instance['dw_include']    = ! empty( $new_instance['dw_include'] ) ? absint( $new_instance['dw_include'] ) : 0;
+		$instance['dw_logged']     = ! empty( $new_instance['dw_logged'] ) ? sanitize_text_field( $new_instance['dw_logged'] ) : '';
+		$instance['other_ids']     = ! empty( $new_instance['other_ids'] ) ? sanitize_text_field( $new_instance['other_ids'] ) : '';
+ 
+        return $instance;
+    }
 
 	/**
 	 * Enqueue preview scripts.
 	 *
-	 * These scripts normally are enqueued just-in-time when an audio shortcode is used.
+	 * These scripts normally are enqueued just-in-time when a video shortcode is used.
 	 * In the customizer, however, widgets can be dynamically added and rendered via
 	 * selective refresh, and so it is important to unconditionally enqueue them in
 	 * case a widget does get added.
@@ -224,42 +273,43 @@ class WP_Widget_Media_Audio extends WP_Widget_Media {
 	 */
 	public function enqueue_preview_scripts() {
 		/** This filter is documented in wp-includes/media.php */
-		if ( 'mediaelement' === apply_filters( 'wp_audio_shortcode_library', 'mediaelement' ) ) {
+		if ( 'mediaelement' === apply_filters( 'wp_video_shortcode_library', 'mediaelement' ) ) {
 			wp_enqueue_style( 'wp-mediaelement' );
+			wp_enqueue_script( 'mediaelement-vimeo' );
 			wp_enqueue_script( 'wp-mediaelement' );
 		}
 	}
 
 	/**
-	 * Loads the required media files for the media manager and scripts for media widgets.
+	 * Loads the required scripts and styles for the widget control.
 	 *
 	 * @since 4.8.0
 	 */
 	public function enqueue_admin_scripts() {
+		parent::enqueue_admin_scripts();
 		wp_enqueue_style( 'wp-mediaelement' );
+		wp_enqueue_script( 'mediaelement-vimeo' );
 		wp_enqueue_script( 'wp-mediaelement' );
 
-		wp_enqueue_script( 'media-audio-widget' );
+		wp_enqueue_script( 'media-video-widget' );
 		wp_localize_script(
-			'media-audio-widget',
-			'AUDIO_WIDGET',
+			'media-video-widget',
+			'VIDEO_WIDGET',
 			array(
-				'no_audio_selected'          => __( 'No audio selected' ),
-				'add_audio'                  => _x( 'Add Audio', 'label for button in the audio widget' ),
-				'add_to_widget'              => __( 'Add to widget' ),
-				'replace_audio'              => _x( 'Replace Audio', 'label for button in the audio widget; should preferably not be longer than ~13 characters long' ),
-				'edit_audio'                 => _x( 'Edit Audio', 'label for button in the audio widget; should preferably not be longer than ~13 characters long' ),
+				'no_video_selected'          => __( 'No video selected' ),
+				'add_video'                  => _x( 'Add Video', 'label for button in the media widget' ),
+				'replace_video'              => _x( 'Replace Video', 'label for button in the media widget; should preferably not be longer than ~13 characters long' ),
+				'edit_video'                 => _x( 'Edit Video', 'label for button in the media widget; should preferably not be longer than ~13 characters long' ),
+				'add_to_widget'              => __( 'Add to Widget' ),
+				'insert_from_url'            => __( 'Insert from URL' ),
 				'missing_attachment'         => sprintf(
 					/* translators: %s: URL to media library. */
-					__( 'That audio file cannot be found. Check your <a href="%s">media library</a> and make sure it was not deleted.' ),
+					__( 'That file cannot be found. Check your <a href="%s">media library</a> and make sure it was not deleted.' ),
 					esc_url( admin_url( 'upload.php' ) )
 				),
-				/* translators: %d: Widget count. */
-				'media_library_state_multi'  => _n_noop( 'Audio Widget (%d)', 'Audio Widget (%d)' ),
-				'media_library_state_single' => __( 'Audio Widget' ),
-				'unsupported_file_type'      => __( 'Looks like this is not the correct kind of file. Please link to an audio file instead.' ),
-				'insert_from_url'            => __( 'Insert from URL' ),
-				'remove_audio_source'        => __( 'Remove audio source' ),
+				'unsupported_file_type'      => __( 'Looks like this is not the correct kind of file. Please link to an appropriate file instead.' ),
+				'add_subtitles'              => __( 'Add Subtitles' ),
+				'remove_video_source'        => __( 'Remove video source' ),
 			)
 		);
 	}

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -163,23 +163,20 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$ogv           = ! empty( $instance['ogv'] ) ? $instance['ogv'] : '';
 		$flv           = ! empty( $instance['flv'] ) ? $instance['flv'] : '';
 
-		if ( $attachment_id && $url === '' ) {
-			$url = wp_get_attachment_url( $attachment_id );
-		}
 		if ( $url === '' ) {
-			$url = $mp4;
-		}
-		if ( $url === '' ) {
-			$url = $m4v;
-		}
-		if ( $url === '' ) {
-			$url = $webm;
-		}
-		if ( $url === '' ) {
-			$url = $ogv;
-		}
-		if ( $url === '' ) {
-			$url = $flv;
+			if ( $attachment_id ) {
+				$url = wp_get_attachment_url( $attachment_id );
+			} elseif ( $mp4 ) {
+				$url = $mp4;
+			} elseif ( $m4v ) {
+				$url = $m4v;
+			} elseif ( $webm ) {
+				$url = $webm;
+			} elseif ( $ogv ) {
+				$url = $ogv;
+			} elseif ( $flv ) {
+				$url = $flv;
+			}
 		}
 		$video_html = wp_video_shortcode( array( 'src' => $url ) );
 		?>

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -401,7 +401,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 */
 	public function enqueue_admin_scripts() {
 		wp_enqueue_media();
-		wp_enqueue_script( 'media-widgets' );
 	}
 
 	/**


### PR DESCRIPTION
This PR follows PRs #1819, #1820, and #1821 in that it uses PHP instead of backbone.js templates to build a media widget, but this one focuses on building the media video widget.