### PR TITLE
Port some CSS from PR #1771

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -876,7 +876,7 @@ border color while dragging a file over the uploader drop area */
 	clear: both;
 }
 
-.copy-to-clipboard-container .copy-attachment-url {
+.copy-to-clipboard-container button.copy-attachment-url {
 	white-space: normal;
 }
 
@@ -1178,6 +1178,13 @@ border color while dragging a file over the uploader drop area */
 	outline: 2px solid transparent;
 }
 
+/* Caret next to "Restore original image" */
+.button-link .imgedit-help-toggle {
+	margin: 0;
+	border: 0;
+	text-decoration: none;
+}
+
 .form-table td.imgedit-response {
 	padding: 0;
 }
@@ -1282,7 +1289,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;
@@ -1407,10 +1414,39 @@ audio, video {
 	.edit-attachment-frame .attachment-media-view .thumbnail {
 		padding: 0 16px 16px;
 	}
+
+	.imgedit-settings .imgedit-scale-button-wrapper {
+		display: block;
+	}
 }
 
 @media only screen and (max-width: 640px), screen and (max-height: 400px) {
 	.upload-php .mode-grid .media-sidebar{
 		max-width: 100%;
+	}
+}
+
+@media only screen and (max-width: 900px) {
+	.attachment-details .attachment-info .copy-to-clipboard-container {
+		margin: 10px 0 0 0;
+		padding-top: 0;
+	}
+
+	.attachment-details .compat-item label span,
+	.attachment-details .setting .name,
+	.attachment-details .setting input[type="text"],
+	.attachment-details .setting textarea,
+	.attachment-details .setting + .description {
+		float: none;
+		width: 98%;
+		max-width: none;
+		height: auto;
+	}
+
+	.attachment-details .setting + .description {
+		clear: both;
+		font-size: 12px;
+		font-style: normal;
+		margin-bottom: 10px;
 	}
 }

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -387,6 +387,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		// Show modal
 		dialog.classList.add( 'modal-loading' );
 
+		document.body.style.overflow = 'hidden';
+
 		// Fix wrong image flash
 		setTimeout( function() {
 			dialog.showModal();
@@ -832,6 +834,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		queryParams.delete( 'mode' );
 		history.replaceState( null, null, location.href.split('?')[0] ); // reset URL params
 		dialog.classList.remove( 'modal-loading' );
+		document.body.style.overflow = '';
 		dialog.close();
 		if ( focusID != null ) { // set focus correctly
 			document.getElementById( focusID ).focus();


### PR DESCRIPTION
I ported some of the CSS from PR #1771 skipping the sticky header because I found it complicated to adapt it to the current markup.

## Attachment view screen in mobile before applying this CSS
![mobile_before](https://github.com/user-attachments/assets/9959835d-696c-4d5c-b9bc-ce4c4018c8a5)

## Attachment view screen in mobile after changing specificity in the copy-to-clipboard container
```css
.copy-to-clipboard-container button.copy-attachment-url {
	white-space: normal;
}
```
![mobile_intermediate](https://github.com/user-attachments/assets/4f9a6436-1e03-461f-b926-d9415830f3af)

## Attachment view screen in mobile after applying multiple properties in a media query
This was ported from WP
```css
@media only screen and (max-width: 900px) {
	.attachment-details .attachment-info .copy-to-clipboard-container {
		margin: 10px 0 0 0;
		padding-top: 0;
	}

	.attachment-details .compat-item label span,
	.attachment-details .setting .name,
	.attachment-details .setting input[type="text"],
	.attachment-details .setting textarea,
	.attachment-details .setting + .description {
		float: none;
		width: 98%;
		max-width: none;
		height: auto;
	}

	.attachment-details .setting + .description {
		clear: both;
		font-size: 12px;
		font-style: normal;
		margin-bottom: 10px;
	}
}
```
![mobile_after](https://github.com/user-attachments/assets/75a0753f-5be0-4d47-b1d7-7fc58ec6c8db)

## Image edit screen in mobile before applying this CSS
![edit-image_before](https://github.com/user-attachments/assets/6355fb2b-2bd9-4f06-8a42-effab94445ae)

## Image edit screen in mobile after applying this CSS
```css
@media only screen and (max-width: 480px) {
	.imgedit-settings .imgedit-scale-button-wrapper {
		display: block;
	}
}
```
```css
.button-link .imgedit-help-toggle {
	margin: 0;
	border: 0;
	text-decoration: none;
}
```
![edit-image_after](https://github.com/user-attachments/assets/2575d210-99fc-44df-9a5b-2c5344e66125)






