### PR TITLE
Fix unneeded extra 10px for images

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2406,7 +2406,7 @@ function img_caption_shortcode( $attr, $content = '' ) {
 	$class = trim( 'wp-caption ' . $atts['align'] . ' ' . $atts['class'] );
 
 	// HTML5 captions never added the extra 10px to the image width.
-	$width = ( 10 + $atts['width'] );
+	$width = $atts['width'];
 
 	/**
 	 * Filters the width of an image's caption.

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -172,7 +172,7 @@ CAP;
 		$this->assertSame( 1, substr_count( $result, 'alignnone' ) );
 		$this->assertSame( 1, substr_count( $result, self::CAPTION ) );
 
-		$this->assertSame( 1, substr_count( $result, 'width: 30' ) );
+		$this->assertSame( 1, substr_count( $result, 'width: 20' ) );
 	}
 
 	public function test_img_caption_shortcode_with_old_format_id_and_align() {

--- a/tests/phpunit/tests/shortcode.php
+++ b/tests/phpunit/tests/shortcode.php
@@ -555,7 +555,7 @@ EOF;
 			),
 			array(
 				'[caption caption="test" width="2"]<div>hello</div>[/caption]',
-				'<figure style="width: 12px" class="wp-caption alignnone"><div>hello</div><figcaption class="wp-caption-text">test</figcaption></figure>',
+				'<figure style="width: 2px" class="wp-caption alignnone"><div>hello</div><figcaption class="wp-caption-text">test</figcaption></figure>',
 			),
 			array(
 				'<div [gallery]>',

--- a/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
@@ -601,7 +601,7 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 			)
 		);
 		$output = ob_get_clean();
-		$this->assertStringContainsString( 'style="width: 310px"', $output );
+		$this->assertStringContainsString( 'style="width: 300px"', $output );
 		$this->assertStringContainsString( '<figcaption class="wp-caption-text">Caption for an image with custom size</figcaption>', $output );
 	}
 


### PR DESCRIPTION
Wordpress line is:
$width = $html5 ? $atts['width'] : ( 10 + $atts['width'] );

So if ClassicPress uses html5, it must be $atts['width'] without extra 10px

## Motivation and context

The code will work the same way as in WordPress, making the migration process much easier.

## How has this been tested?

It just make figure width same as img width.


- Bug fix
- Breaking change maybe