### PR TITLE
Fix fatal when listing incompatible plugins

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1275,7 +1275,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		if ( ! $compatible_php || ! $compatible_wp ) {
 			printf(
 				'<tr class="plugin-update-tr">' .
-				'<td colspan="%s" class="plugin-update colspanchange">' .
+				'<td colspan="%s" class="plugin-update colspanchange">',
 				esc_attr( $this->get_column_count() )
 			);
 


### PR DESCRIPTION
Fixes a fatal error when listing plugins where one is incompatible with ClassicPress. `printf` requires two arguments and this call only gives one. If you compare with the [other version](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/includes/class-wp-plugins-list-table.php#L1413-L1416) it would appear this was introduced when refactoring the HTML into multiple parts.