### PR TITLE
Fix gallery editor sortable functionality

### DIFF
--- a/src/wp-admin/widgets-form.php
+++ b/src/wp-admin/widgets-form.php
@@ -22,7 +22,6 @@ if ( isset( $_GET['widgets-access'] ) ) {
 if ( 'on' === $widgets_access ) {
 	add_filter( 'admin_body_class', 'wp_widgets_access_body_class' );
 } else {
-	wp_enqueue_script( 'jquery-ui-sortable' );
 	wp_enqueue_script( 'admin-widgets' );
 
 	if ( wp_is_mobile() ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4868,6 +4868,8 @@ function wp_enqueue_media( $args = array() ) {
 
 	$strings['settings'] = $settings;
 
+	wp_enqueue_script( 'jquery-ui-sortable' );
+
 	// Ensure we enqueue media-editor first, that way media-views
 	// is registered internally before we try to localize it. See #24724.
 	wp_enqueue_script( 'media-editor' );


### PR DESCRIPTION
Related issue: [Galleries not sortable](https://github.com/ClassicPress/ClassicPress/issues/1826)

Related PR: [Make images in gallery widget sortable via drag and drop](https://github.com/ClassicPress/ClassicPress/pull/1713)
