### PR TITLE
Fix WP-CLI

### DIFF
--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -19,7 +19,7 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public function __construct() {
-		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'add_cp_version_to_scope' ) );
+		WP_CLI::add_hook( 'after_wp_config_load', array( __CLASS__, 'add_cp_version_to_scope' ) );
 		WP_CLI::add_hook( 'before_invoke:core check-update', array( __CLASS__, 'correct_core_check_update' ) );
 	}
 


### PR DESCRIPTION
WP-CLI bootstraps CP load, so we introduced a fix to bring `$cp_version` in scope in `src/wp-includes/class-fix-wpcli.php`.
That was done at `after_wp_load` that is too late for plugins using `classicpress_version()`.

@citrika please can you check if this fix solves #1817?

## How has this been tested?
Reproduced in a local installation.


## Types of changes
- Bug fix

