### PR TITLE
Fix Quick Edit in Media Library

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3315,6 +3315,7 @@ function wp_ajax_quick_edit_attachment() {
 		'ID'           => $id,
 		'post_author'  => $post_author,
 		'post_date'    => $post_date,
+		'post_date_gmt'=> get_gmt_from_date( $post_date ),
 		'post_content' => $post_content,
 		'post_title'   => $post_title,
 		'post_excerpt' => $post_excerpt,

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3397,7 +3397,7 @@ function wp_ajax_quick_edit_attachment() {
 
 			<span class="delete"><a href="post.php?action=delete&amp;post=' . $id . '&amp;_wpnonce=' . esc_attr( $nonce ) . '" class="submitdelete aria-button-if-js" onclick="return showNotice.warn();" aria-label="' . esc_attr__( sprintf( 'Delete “%s” permanently', $post_title ) ) . '" role="button">' . esc_html__( 'Delete Permanently' ) . '</a> | </span>
 
-			<span class="view"><a href="' . esc_url( wp_get_attachment_url( $id ) ) . '" aria-label="' . esc_attr__( sprintf( 'View “%s”', $post_title ) ) . '" rel="bookmark">' . esc_html__( 'View' ) . '</a> | </span>
+			<span class="view"><a href="' . esc_url( get_permalink( $id ) ) . '" aria-label="' . esc_attr__( sprintf( 'View “%s”', $post_title ) ) . '" rel="bookmark">' . esc_html__( 'View' ) . '</a> | </span>
 
 			<span class="copy">
 				<span class="copy-to-clipboard-container">

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3312,15 +3312,15 @@ function wp_ajax_quick_edit_attachment() {
 
 	// Update attachment array.
 	$attachment_data = array(
-		'ID'           => $id,
-		'post_author'  => $post_author,
-		'post_date'    => $post_date,
-		'post_date_gmt'=> get_gmt_from_date( $post_date ),
-		'post_content' => $post_content,
-		'post_title'   => $post_title,
-		'post_excerpt' => $post_excerpt,
-		'post_type'    => 'attachment',
-		'post_name'    => strtolower( $post_title ),
+		'ID'            => $id,
+		'post_author'   => $post_author,
+		'post_date'     => $post_date,
+		'post_date_gmt' => get_gmt_from_date( $post_date ),
+		'post_content'  => $post_content,
+		'post_title'    => $post_title,
+		'post_excerpt'  => $post_excerpt,
+		'post_type'     => 'attachment',
+		'post_name'     => strtolower( $post_title ),
 	);
 	wp_update_post( $attachment_data, true );
 	$attachment = get_post( $id );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3373,6 +3373,21 @@ function wp_ajax_quick_edit_attachment() {
 		$link_end = '</a>';
 	}
 
+	$time = get_post_timestamp( $attachment );
+	if ( '0000-00-00 00:00:00' === $attachment->post_date ) {
+		$h_time = __( 'Unpublished' );
+	} else {
+		$time_diff = time() - $time;
+		if ( $time && $time_diff > 0 && $time_diff < DAY_IN_SECONDS ) {
+			/* translators: %s: Human-readable time difference. */
+			$h_time = sprintf( __( '%s ago' ), human_time_diff( $time ) );
+		} else {
+			$h_time = get_the_time( __( 'Y/m/d' ), $attachment );
+		}
+	}
+	$h_time .= '<time datetime="' . wp_date( 'Y/m/d', $time ) . '"></time>';
+	$h_time = apply_filters( 'media_date_column_time', $h_time, $attachment, 'date' );
+
 	/**
 	 * Output buffer is used here because the function prints directly
 	 * to the page, whereas we need to return in order to send as JSON.
@@ -3441,7 +3456,7 @@ function wp_ajax_quick_edit_attachment() {
 	<td class="alt column-alt" data-colname="' . esc_attr__( 'Alt Text' ) . '">' . esc_html( $alt ) . '</td>
 	<td class="caption column-caption" data-colname="' . esc_attr__( 'Caption' ) . '">' . esc_html( $post_excerpt ) . '</td>
 	<td class="desc column-desc" data-colname="' . esc_attr__( 'Description' ) . '">' . esc_html( $post_content ) . '</td>
-	<td class="date column-date" data-colname="' . esc_attr__( 'Date' ) . '">' . esc_html( $date ) . '</td>';
+	<td class="date column-date" data-colname="' . esc_attr__( 'Date' ) . '">' . $h_time . '</td>';
 
 	wp_send_json_success( $new_tr );
 }

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3302,10 +3302,10 @@ function wp_ajax_quick_edit_attachment() {
 		$day   = str_pad( absint( $_POST['jj'] ), 2, '0', STR_PAD_LEFT );
 		$date  = $year . '/' . $month . '/' . $day;
 
-		$current_date  = get_the_date( 'date_format', $attachment );
-		$exploded_date = explode( ' ', $current_date );
+		$current_date  = get_the_date( 'Y-m-d', $attachment );
 		$new_date      = $year . '-' . $month . '-' . $day;
-		if ( $new_date !== $exploded_date[3] . '-' . $exploded_date[2] . '-' . $exploded_date[1] ) {
+		$post_date     = $attachment->post_date;
+		if ( $new_date !== $current_date ) {
 			$post_date = $new_date . ' 00:00:00';
 		}
 	}
@@ -3322,6 +3322,7 @@ function wp_ajax_quick_edit_attachment() {
 		'post_name'    => strtolower( $post_title ),
 	);
 	wp_update_post( $attachment_data, true );
+	$attachment = get_post( $id );
 
 	// Update taxonomies and meta.
 	if ( empty( $_POST['media_category'] ) ) {

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -758,7 +758,7 @@ class WP_Media_List_Table extends WP_List_Table {
 			?>
 			<?php
 			if ( $user_can_edit ) {
-				$title = _draft_or_post_title( $post->post_parent );
+				$title = _draft_or_post_title( $post );
 				printf(
 					'<br><a href="#the-list" onclick="findPosts.open( \'media[]\', \'%s\' ); return false;" class="hide-if-no-js aria-button-if-js" aria-label="%s">%s</a>',
 					$post->ID,

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -436,6 +436,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				document.body.append( bulkEdit );
 				quickEdit.style.display = 'none';
 				document.body.append( quickEdit );
+				quickEdit.querySelector( '.inline-edit-save .notice-error' ).classList.add( 'hidden' );
 
 				/**
 				 * Handle the bulk action based on its value.

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -554,7 +554,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						} );
 
 						// Enable autocomplete for tags.
-						mediaTags = tr.querySelector( '.column-taxonomy-media_post_tag a' ) ? tr.querySelector( '.column-taxonomy-media_post_tag a' ).textContent : '';
+						mediaTags = tr.querySelector( '.column-taxonomy-media_post_tag a' ) ? tr.querySelector( '.column-taxonomy-media_post_tag' ).textContent : '';
 						autoCompleteTextarea( quickEdit.querySelector( 'textarea' ) );
 
 						// Split date into year, month, and day.
@@ -566,7 +566,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						// Fill the other relevant boxes.
 						quickEdit.querySelector( '[name="post_title"]' ).value = tr.querySelector( '.column-title strong a' ).textContent.trim();
 						quickEdit.querySelector( '[name="post_name"]' ).value = tr.querySelector( '.column-title .row-actions .copy-attachment-url' ).dataset.clipboardText;
-						quickEdit.querySelector( '#quick-media-tags' ).textContent = mediaTags;
+						quickEdit.querySelector( '#quick-media-tags' ).value = mediaTags;
 						quickEdit.querySelector( '[name="alt"]' ).value = tr.querySelector( '.column-alt' ).textContent;
 						quickEdit.querySelector( '[name="post_excerpt"]' ).value = tr.querySelector( '.column-caption' ).textContent;
 						quickEdit.querySelector( '[name="post_content"]' ).value = tr.querySelector( '.column-desc' ).textContent;

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -352,7 +352,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function hideColumns( postID ) {
 		document.querySelectorAll( '.hide-column-tog' ).forEach( function( hide ) {
 			if ( hide.checked === false ) {
-				document.getElementById( postID ).querySelector( '.' + hide.id.replace( '-hide', '' ) ).classList.add( 'hidden' );
+				document.getElementById( postID ).querySelector( '.' + hide.value ).classList.add( 'hidden' );
 			}
 		} );
 	}

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -509,8 +509,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 					} else if ( number === 1 && ! selectAll1.checked && ! selectAll2.checked ) {
 
-						// Quick Edit: reset all fields except nonce
-						inputs = quickEdit.querySelectorAll( 'input:not(#_inline_edit_attachment), select, textarea' );
+						// Quick Edit: reset all fields except nonce and media_category[]
+						inputs = quickEdit.querySelectorAll( 'input:not(#_inline_edit_attachment):not([name="media_category[]"]), select, textarea' );
 						inputs.forEach( function( input ) {
 							input.value = '';
 						} );

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -548,6 +548,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						categoriesList.forEach( function( item ) {
 							if ( catsArray.includes( item.querySelector( 'label' ).textContent ) ) {
 								item.querySelector( 'input' ).checked = true;
+							} else {
+								item.querySelector( 'input' ).checked = false;
 							}
 						} );
 

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -352,7 +352,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function hideColumns( postID ) {
 		document.querySelectorAll( '.hide-column-tog' ).forEach( function( hide ) {
 			if ( hide.checked === false ) {
-				document.getElementById( postID ).querySelector( '.' + hide.id.replace( '-hide', '' ) ).style.display = 'none';
+				document.getElementById( postID ).querySelector( '.' + hide.id.replace( '-hide', '' ) ).classList.add( 'hidden' );
 			}
 		} );
 	}

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -429,9 +429,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					optionValue = document.querySelector( 'select[name="action"]' ).value,
 					number = 0,
 					count = 0,
-					columns = [ ...document.querySelector( '.widefat thead tr' ).children ],
-					selectAll1 = document.getElementById( 'cb-select-all-1' ),
-					selectAll2 = document.getElementById( 'cb-select-all-2' );
+					columns = [ ...document.querySelector( '.widefat thead tr' ).children ];
 
 				// Set default state in case a Bulk or Quick Edit has already been opened.
 				bulkEdit.style.display = 'none';
@@ -508,7 +506,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						quickEdit.style.display = 'none';
 						document.body.append( quickEdit );
 
-					} else if ( number === 1 && ! selectAll1.checked && ! selectAll2.checked ) {
+					} else if ( number === 1 ) {
 
 						// Quick Edit: reset all fields except nonce and media_category[]
 						inputs = quickEdit.querySelectorAll( 'input:not(#_inline_edit_attachment):not([name="media_category[]"]), select, textarea' );

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -418,7 +418,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		document.getElementById( 'find-posts-close' ).addEventListener( 'click', findPosts.close );
 
 		// Binds the bulk action events to the submit buttons.
-		document.querySelectorAll( '#doaction, #doaction2' ).forEach( function( action ) {
+		var action = document.getElementById( 'doaction' );
+		if ( action ) {
 			action.addEventListener( 'click', function( event ) {
 				var tr, checkboxes, delButtons, dateSplit, author, authorsList, cats,
 					catsArray, categoriesList, mediaTags, hiddenTr, cancel, inputs,
@@ -584,7 +585,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								quickEdit.style.display = 'none';
 								document.body.append( quickEdit );
 							}, 100 );
-						} );
+						}, { once: true } );
 					} else {
 						document.querySelectorAll( 'tr' ).forEach( function( item ) {
 							if ( item.style.display === 'none' ) {
@@ -684,7 +685,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					} );
 				}
 			} );
-		} );
+		}
 
 		/**
 		 * Enables clicking on the entire table row.


### PR DESCRIPTION
## Multiple issues with Quick Edit in Media Library

### 1. Different markup
When comparing the table row outputted on page load and the one returned by the AJAX request after using Quick Edit, there are 3 differences that don't depend on Javascript manipulation:

#### Before
```html
<a href="https://classicpress.local/forest/">View</a>
<a aria-label="Attach “forest” to existing content">Attach</a>
<td data-colname="Date">5 mins ago <time datetime="2025/03/22"></time></td>
```
#### After
```html
<a href="https://classicpress.local/wp-content/uploads/2025/03/forest.jpg">View</a>
<a aria-label="Attach “(no title)” to existing content">Attach</a>
<td data-colname="Date">2025/03/22</td>
```

### 2. The date is not set correctly when saving the attachment

### 3. The date returned by the AJAX request is outdated

### 4. The media category is not set when saving in Quick Edit

### 5. The date markup returned by the AJAX request causes a null error and most Quick Edit fields to be empty when trying to re-edit an attachment, but an AJAX request is still possible if "Update" button is used

https://github.com/user-attachments/assets/7ff7f2e9-4d36-4da3-9c67-df7ca37f8a49

https://github.com/user-attachments/assets/2bc7eebe-7554-4e67-abdc-ca3360e42008

### 6. When applying a fix to set the media category choices when saving in Quick Edit, the choices are sometimes wrongly checked when loading the fields

```javascript
inputs = quickEdit.querySelectorAll( 'input:not(#_inline_edit_attachment):not([name="media_category[]"]), select, textarea' );
```
### 7. The saved media tags are not loaded when opening Quick Edit

### 8. Multiple AJAX submissions instead of a single one
Related PR: [Improve Media Quick Edit Functionality](https://github.com/ClassicPress/ClassicPress/pull/1738)

Logged errors look like:
```
WordPress database error Duplicate entry '110-8' for key 'wp_term_relationships.PRIMARY' for query INSERT INTO `wp_term_relationships` (`object_id`, `term_taxonomy_id`) VALUES (110, 8) made by do_action('wp_ajax_quick-edit-attachment'), WP_Hook->do_action, WP_Hook->apply_filters, wp_ajax_quick_edit_attachment, wp_set_object_terms
```

https://github.com/user-attachments/assets/a4f7bc74-1e9f-4d80-a8e8-459042542465

https://github.com/user-attachments/assets/cb0b88a1-a569-4ed0-8f0a-d57c6243fbbd

### 9. Unhiding columns with Screen Options doesn't work correctly
https://github.com/user-attachments/assets/f59b8e6c-f9ed-4df1-8a52-149c3ce45643

### 10. Quick Edit is not enabled when Media Library contains a single attachment
https://github.com/user-attachments/assets/e5682f32-74b7-49fe-81a4-1d2dc7e8deeb