### PR TITLE
Fix broken `sprintf()` call when deleting a backup

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1200,8 +1200,7 @@ class WP_Upgrader {
 			if ( ! $wp_filesystem->delete( $temp_backup_dir, true ) ) {
 				$errors->add(
 					'temp_backup_delete_failed',
-					sprintf( $this->strings['temp_backup_delete_failed'] ),
-					$args['slug']
+					sprintf( $this->strings['temp_backup_delete_failed'], $args['slug'] )
 				);
 				continue;
 			}


### PR DESCRIPTION
## Description
WP-r56550: Upgrade/Install: Fix broken `sprintf()` call when deleting a backup.

In `WP_Upgrader::delete_temp_backup()`, a malformed `sprintf()` call did not pass the value, triggering a Warning in PHP 7 and a Fatal Error in PHP 8.

This fixes the malformed `sprintf()` call by correctly passing the value.

Follow-up to https://core.trac.wordpress.org/changeset/55720.

WP:Props akihiroharai, afragen.
Fixes https://core.trac.wordpress.org/ticket/59320.

---

Merges https://core.trac.wordpress.org/changeset/56550 / WordPress/wordpress-develop@2a13d9321c to ClassicPress.

## Motivation and context
Fixes #1836 

## How has this been tested?
Backport

## Screenshots
<!--
Screenshots are very helpful for reviewers to quickly see how your change works.
-->

### Before
N/A

## Types of changes
- Bug fix