### PR TITLE
Add core translation update checks

### DIFF
--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -48,9 +48,13 @@ function translations_api( $type, $args = null ) {
 			// Get ClassicPress core translations from the ClassicPress.net API.
 			$stats['cp_version'] = $cp_version;
 			$options['method']   = 'GET';
+
+			// Use {major}.{minor} version number format for API endpoint
+			preg_match( '#\d+\.\d+#', $cp_version, $api );
+
 			$url                 = add_query_arg(
 				$stats,
-				'https://api-v1.classicpress.net/translations/core/' . classicpress_version_short() . '/translations.json'
+				'https://api-v1.classicpress.net/translations/core/' . $api[0] . '/translations.json'
 			);
 			$request             = wp_remote_request( $url, $options );
 		} else {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 			$options['method']   = 'GET';
 			$url                 = add_query_arg(
 				$stats,
-				'https://api-v1.classicpress.net/translations/core/2.0.0/translations.json'
+				'https://api-v1.classicpress.net/translations/core/' . classicpress_version_short() . '/translations.json'
 			);
 			$request             = wp_remote_request( $url, $options );
 		} else {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1119,6 +1119,7 @@ function cp_translation_file_updates() {
 					'slug'       => 'default',
 					'language'   => $translation['language'],
 					'package'    => $translation['package'],
+					'version'    => $translation['version'],
 					'autoupdate' => true,
 				);
 			}

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1160,6 +1160,8 @@ add_action( 'load-update-core.php', 'wp_update_themes' );
 add_action( 'admin_init', '_maybe_update_themes' );
 add_action( 'wp_update_themes', 'wp_update_themes' );
 
+add_action( 'load-update-core.php', 'cp_get_translation_updates' );
+
 add_action( 'update_option_WPLANG', 'wp_clean_update_cache', 10, 0 );
 
 add_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1131,7 +1131,11 @@ function cp_translation_file_updates() {
 	}
 
 	$updates = get_site_transient( 'update_core' );
-	$updates->translations[] = $translation_updates;
+	if ( isset( $updates->translations ) ) {
+		$updates->translations = array_merge( $updates->translations, $translation_updates );
+	} else {
+		$updates->translations = $translation_updates;
+	}
 	set_site_transient( 'update_core', $updates );
 }
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1088,7 +1088,7 @@ function cp_translation_file_updates() {
 	$installed_translations = wp_get_installed_translations( 'core' );
 
 	// return if no translation files installed
-	if ( empty( $installed_translation ) ) {
+	if ( empty( $installed_translations ) ) {
 		return;
 	}
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1083,7 +1083,7 @@ function _wp_delete_all_temp_backups() {
  *
  * @since CP-2.5.0
  */
-function cp_translation_file_updates() {
+function cp_get_translation_updates() {
 	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 	$installed_translations = wp_get_installed_translations( 'core' );
 
@@ -1146,7 +1146,7 @@ if ( ( ! is_main_site() && ! is_network_admin() ) || wp_doing_ajax() ) {
 
 add_action( 'admin_init', '_maybe_update_core' );
 add_action( 'wp_version_check', 'wp_version_check' );
-add_action( 'wp_version_check', 'cp_translation_file_updates' );
+add_action( 'wp_version_check', 'cp_get_translation_updates' );
 
 add_action( 'load-plugins.php', 'wp_update_plugins' );
 add_action( 'load-update.php', 'wp_update_plugins' );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1132,7 +1132,7 @@ function cp_translation_file_updates() {
 
 	$updates = get_site_transient( 'update_core' );
 	if ( isset( $updates->translations ) ) {
-		$updates->translations = array_merge( $updates->translations, $translation_updates );
+		$updates->translations = array_unique( array_merge( $updates->translations, $translation_updates ), SORT_REGULAR );
 	} else {
 		$updates->translations = $translation_updates;
 	}


### PR DESCRIPTION
## Description
This PR introduces and hooks a function to check for translation file updates from the ClassicPress API and where these are found, injects them into the update transient stored in the database.

## Motivation and context
This will allow for in-release translation file updates as translation packs are improved and updated.

## How has this been tested?
So far only local testing.

## Screenshots
N/A

## Types of changes
- New feature
