### PR TITLE
Fix update link in dashboard

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -89,14 +89,14 @@ function list_core_update( $update ) {
 			}
 
 			if ( ! $mysql_compat && ! $php_compat ) {
-				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.' ), sanitize_title( $update->current ), $update->php_version, $update->mysql_version, $php_version, $mysql_version );
+				/* translators: 1: ClassicPress version number, 2: ClassicPress version number, 3: Minimum required PHP version number, 4: Minimum required MySQL version number, 5: Current PHP version number, 6: Current MySQL version number */
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> requires PHP version %3$s or higher and MySQL version %4$s or higher. You are running PHP version %5$s and MySQL version %6$s.' ), sanitize_title( $update->current ), $update->current, $update->php_version, $update->mysql_version, $php_version, $mysql_version );
 			} elseif ( ! $php_compat ) {
-				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.' ), sanitize_title( $update->current ), $update->php_version, $php_version );
+				/* translators: 1: ClassicPress version number, 2: ClassicPress version number, 3: Minimum required PHP version number, 4: Current PHP version number */
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> requires PHP version %3$s or higher. You are running version %4$s.' ), sanitize_title( $update->current ), $update->current, $update->php_version, $php_version );
 			} elseif ( ! $mysql_compat ) {
-				/* translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.' ), sanitize_title( $update->current ), $update->mysql_version, $mysql_version );
+				/* translators: 1: ClassicPress version number, 2: ClassicPress version number, 3: Minimum required MySQL version number, 4: Current MySQL version number */
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> requires MySQL version %3$s or higher. You are running version %4$s.' ), sanitize_title( $update->current ), $update->current, $update->mysql_version, $mysql_version );
 			} else {              /* translators: 1: ClassicPress version number, 2: ClassicPress version number including locale if necessary */
 				$message = sprintf( __( 'You can update to <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> automatically:' ), sanitize_title( $update->current ), $version_string );
 			}

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -90,15 +90,15 @@ function list_core_update( $update ) {
 
 			if ( ! $mysql_compat && ! $php_compat ) {
 				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Minimum required MySQL version number, 4: Current PHP version number, 5: Current MySQL version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.' ), $update->current, $update->php_version, $update->mysql_version, $php_version, $mysql_version );
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher and MySQL version %3$s or higher. You are running PHP version %4$s and MySQL version %5$s.' ), sanitize_title( $update->current ), $update->php_version, $update->mysql_version, $php_version, $mysql_version );
 			} elseif ( ! $php_compat ) {
 				/* translators: 1: ClassicPress version number, 2: Minimum required PHP version number, 3: Current PHP version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.' ), $update->current, $update->php_version, $php_version );
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires PHP version %2$s or higher. You are running version %3$s.' ), sanitize_title( $update->current ), $update->php_version, $php_version );
 			} elseif ( ! $mysql_compat ) {
 				/* translators: 1: ClassicPress version number, 2: Minimum required MySQL version number, 3: Current MySQL version number */
-				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.' ), $update->current, $update->mysql_version, $mysql_version );
+				$message = sprintf( __( 'You cannot update because <a href="https://www.classicpress.net/version/%1$s">ClassicPress %1$s</a> requires MySQL version %2$s or higher. You are running version %3$s.' ), sanitize_title( $update->current ), $update->mysql_version, $mysql_version );
 			} else {              /* translators: 1: ClassicPress version number, 2: ClassicPress version number including locale if necessary */
-				$message = sprintf( __( 'You can update to <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> automatically:' ), $update->current, $version_string );
+				$message = sprintf( __( 'You can update to <a href="https://www.classicpress.net/version/%1$s">ClassicPress %2$s</a> automatically:' ), sanitize_title( $update->current ), $version_string );
 			}
 			if ( ! $mysql_compat || ! $php_compat ) {
 				$show_buttons = false;


### PR DESCRIPTION
## Description
The update link at page `wp-admin/update-core.php` returns a 404. 
The version number in the URL contains `.` instead of `-` (2.4.1 instead of 2-4-1).

I have fixed this by using `sanitize_title()`, which is also used in file [wp-admin/includes/update.php](https://github.com/ClassicPress/ClassicPress/blob/develop/src/wp-admin/includes/update.php#L296) (for the "please update now" message). 

## Screenshots
![404](https://github.com/user-attachments/assets/61174033-4dc3-4df4-8827-bb657217b3d1)

![Redirects to GH](https://github.com/user-attachments/assets/670cbf0f-7604-44d9-8532-8f38ab187fc0)


## Types of changes
- Bugfix