### PR TITLE
Media Quick Edit Layout improvements

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1012,7 +1012,7 @@ tr.inline-edit-row td {
 	padding: 0;
 }
 
-.inline-edit-row fieldset label span.input-text-wrap,
+.inline-edit-row fieldset span.input-text-wrap,
 .inline-edit-row fieldset .timestamp-wrap {
 	display: block;
 	margin-left: 6em;
@@ -1022,8 +1022,12 @@ tr.inline-edit-row td {
 	clear: both;
 }
 
-.quick-edit-row-post fieldset.inline-edit-col-right label span.title {
+.edit-php .quick-edit-row-post fieldset.inline-edit-col-right label span.title,
+.upload-php .quick-edit-row-post fieldset.inline-edit-col-right label span.title {
 	width: auto;
+}
+
+.edit-php .quick-edit-row-post fieldset.inline-edit-col-right label span.title {
 	padding-right: 0.5em;
 }
 
@@ -1044,7 +1048,7 @@ tr.inline-edit-row td {
 	vertical-align: middle;
 }
 
-.inline-edit-row fieldset label textarea {
+.inline-edit-row fieldset textarea {
 	width: 100%;
 	height: 4em;
 	vertical-align: top;
@@ -2088,7 +2092,7 @@ div.action-links,
 		padding: 0;
 	}
 
-	.inline-edit-row fieldset label span.input-text-wrap,
+	.inline-edit-row fieldset span.input-text-wrap,
 	.inline-edit-row fieldset .timestamp-wrap {
 		margin-left: 0;
 	}

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -1112,7 +1112,7 @@ class WP_Media_List_Table extends WP_List_Table {
 							</div>
 						</div>
 					</fieldset>
-			
+
 					<fieldset class="inline-edit-col-center inline-edit-categories">
 						<div class="inline-edit-col">
 							<span class="title inline-edit-categories-label"><?php echo esc_html_e( 'Media Categories' ); ?></span>
@@ -1172,17 +1172,17 @@ class WP_Media_List_Table extends WP_List_Table {
 					</fieldset>
 
 					<div class="submit inline-edit-save">
-						<input id="bulk-edit-update" type="submit" name="bulk_edit" class="button button-primary" value="<?php esc_attr_e( 'Update' ); ?>">				
+						<input id="bulk-edit-update" type="submit" name="bulk_edit" class="button button-primary" value="<?php esc_attr_e( 'Update' ); ?>">
 						<button type="button" class="button cancel"><?php esc_html_e( 'Cancel' ); ?></button>
-				
+
 						<input type="hidden" name="upload" value="list">
 						<input type="hidden" name="screen" value="upload">
-				
+
 						<div class="notice notice-error notice-alt inline hidden">
 							<p class="error"></p>
 						</div>
 					</div>
-					
+
 				</div>
 			</td>
 		</tr>
@@ -1207,8 +1207,8 @@ class WP_Media_List_Table extends WP_List_Table {
 							<fieldset class="inline-edit-date">
 								<legend><span class="title"><?php echo esc_html_e( 'Date' ); ?></span></legend>
 								<div class="timestamp-wrap">
-									<label for="quick-month">
-										<span class="screen-reader-text"><?php echo esc_html_e( 'Month' ); ?></span>				
+									<label for="quick-month" style="display:none;">
+										<span class="screen-reader-text"><?php echo esc_html_e( 'Month' ); ?></span>
 									</label>
 									<select id="quick-month" class="form-required" name="mm">
 										<option value="01" data-text="Jan"><?php echo esc_html_e( '01-Jan' ); ?></option>
@@ -1227,11 +1227,11 @@ class WP_Media_List_Table extends WP_List_Table {
 									<label for="quick-day">
 										<span class="screen-reader-text"><?php echo esc_html_e( 'Day' ); ?></span>
 									</label>
-									<input id="quick-day" type="number" name="jj" value="" size="2" maxlength="2" autocomplete="off" class="form-required" style="width:3.7em">&nbsp;,
+									<input id="quick-day" type="text" name="jj" value="" size="2" maxlength="2" autocomplete="off" class="form-required">&nbsp;,
 									<label for="quick-year">
 										<span class="screen-reader-text"><?php echo esc_html_e( 'Year' ); ?></span>
 									</label>
-									<input id="quick-year" type="number" name="aa" value="" size="4" maxlength="4" autocomplete="off" class="form-required" style="width:5em">
+									<input id="quick-year" type="text" name="aa" value="" size="4" maxlength="4" autocomplete="off" class="form-required">
 								</div>
 								<input type="hidden" id="ss" name="ss" value="30">
 							</fieldset>
@@ -1254,7 +1254,7 @@ class WP_Media_List_Table extends WP_List_Table {
 							</select>
 						</div>
 					</fieldset>
-			
+
 					<fieldset class="inline-edit-col-center inline-edit-categories">
 						<div class="inline-edit-col">
 							<span class="title inline-edit-categories-label"><?php echo esc_html_e( 'Media Categories' ); ?></span>
@@ -1279,15 +1279,17 @@ class WP_Media_List_Table extends WP_List_Table {
 
 					<fieldset class="inline-edit-col-right">
 						<div class="inline-edit-tags-wrap">
-							<label for="quick-media-tags" class="inline-edit-tags">
+							<label for="quick-media-tags">
 								<span class="title"><?php esc_html_e( 'Media Tags' ); ?></span>
 							</label>
+							<label class="inline-edit-tags">
 							<div id="inline-container" class="inline-container">
 								<div hidden></div>
 								<textarea id="quick-media-tags" data-wp-taxonomy="media_post_tag" cols="22" rows="1" name="media_post_tag" class="media_post_tag" aria-describedby="inline-edit-post_tag-desc"></textarea>
 								<div class="container__suggestions"></div>
 							</div>
 							<p class="howto" id="inline-edit-post_tag-desc"><?php esc_html_e( 'Separate tags with commas' ); ?></p>
+							<label>
 						</div>
 
 						<div id="attachment-attributes">
@@ -1316,12 +1318,12 @@ class WP_Media_List_Table extends WP_List_Table {
 
 					<div class="submit inline-edit-save">
 						<?php wp_nonce_field( 'quickeditattachment', '_inline_edit_attachment', false ); ?>
-						<button id="quick-edit-update" type="button" class="button button-primary save"><?php esc_attr_e( 'Update' ); ?></button>				
+						<button id="quick-edit-update" type="button" class="button button-primary save"><?php esc_attr_e( 'Update' ); ?></button>
 						<button type="button" class="button cancel"><?php esc_html_e( 'Cancel' ); ?></button>
-				
+
 						<input type="hidden" name="upload" value="list">
 						<input type="hidden" name="screen" value="upload">
-				
+
 						<div class="notice notice-error notice-alt inline hidden">
 							<p class="error"></p>
 						</div>

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -1144,7 +1144,7 @@ class WP_Media_List_Table extends WP_List_Table {
 								</label>
 								<div id="inline-container" class="inline-container">
 									<div hidden></div>
-									<textarea data-wp-taxonomy="media_post_tag" cols="22" rows="1" name="media_post_tag" class="media_post_tag" aria-describedby="inline-edit-post_tag-desc"></textarea>
+									<textarea data-wp-taxonomy="media_post_tag" cols="22" rows="1" name="media_post_tag" class="media_post_tag" id="quick-media-tags" aria-describedby="inline-edit-post_tag-desc"></textarea>
 									<div class="container__suggestions"></div>
 								</div>
 								<input id="tags-list" value="<?php echo $tags_string; ?>" hidden>

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -1138,15 +1138,17 @@ class WP_Media_List_Table extends WP_List_Table {
 
 					<fieldset class="inline-edit-col-right">
 						<div class="inline-edit-tags-wrap">
-							<label class="inline-edit-tags">
-								<span class="title"><?php esc_html_e( 'Media Tags' ); ?></span>
+							<div class="inline-edit-tags">
+								<label for="quick-media-tags">
+									<span class="title"><?php esc_html_e( 'Media Tags' ); ?></span>
+								</label>
 								<div id="inline-container" class="inline-container">
 									<div hidden></div>
 									<textarea data-wp-taxonomy="media_post_tag" cols="22" rows="1" name="media_post_tag" class="media_post_tag" aria-describedby="inline-edit-post_tag-desc"></textarea>
 									<div class="container__suggestions"></div>
 								</div>
 								<input id="tags-list" value="<?php echo $tags_string; ?>" hidden>
-							</label>
+							</div>
 							<p class="howto" id="inline-edit-post_tag-desc"><?php esc_html_e( 'Separate tags with commas' ); ?></p>
 						</div>
 						<div class="inline-edit-col">
@@ -1197,12 +1199,16 @@ class WP_Media_List_Table extends WP_List_Table {
 							<label for="quick-title">
 								<span class="title"><?php echo esc_html_e( 'Title' ); ?></span>
 							</label>
-							<input id="quick-title" type="text" name="post_title" class="input-text-wrap ptitle" value="">
+							<span class="input-text-wrap">
+								<input id="quick-title" type="text" name="post_title" class="input-text-wrap ptitle" value="">
+							</span>
 
 							<label for="quick-slug">
 								<span class="title"><?php echo esc_html_e( 'URL' ); ?></span>
 							</label>
-							<input id="quick-slug" type="text" name="post_name" value="" class="input-text-wrap" autocomplete="off" spellcheck="false" readonly>
+							<span class="input-text-wrap">
+								<input id="quick-slug" type="text" name="post_name" value="" class="input-text-wrap" autocomplete="off" spellcheck="false" readonly>
+							</span>
 
 							<fieldset class="inline-edit-date">
 								<legend><span class="title"><?php echo esc_html_e( 'Date' ); ?></span></legend>
@@ -1282,14 +1288,14 @@ class WP_Media_List_Table extends WP_List_Table {
 							<label for="quick-media-tags">
 								<span class="title"><?php esc_html_e( 'Media Tags' ); ?></span>
 							</label>
-							<label class="inline-edit-tags">
+							<div class="inline-edit-tags">
 							<div id="inline-container" class="inline-container">
 								<div hidden></div>
 								<textarea id="quick-media-tags" data-wp-taxonomy="media_post_tag" cols="22" rows="1" name="media_post_tag" class="media_post_tag" aria-describedby="inline-edit-post_tag-desc"></textarea>
 								<div class="container__suggestions"></div>
 							</div>
 							<p class="howto" id="inline-edit-post_tag-desc"><?php esc_html_e( 'Separate tags with commas' ); ?></p>
-							<label>
+							</div>
 						</div>
 
 						<div id="attachment-attributes">
@@ -1297,21 +1303,27 @@ class WP_Media_List_Table extends WP_List_Table {
 								<label for="attachment-alt" class="alignleft">
 									<span class="title"><?php esc_html_e( 'Alt Text' ); ?></span>
 								</label>
-								<input id="attachment-alt" type="text" name="alt" value="">
+								<span class="input-text-wrap">
+									<input id="attachment-alt" type="text" name="alt" value="">
+								</span>
 							</div>
 
 							<div class="inline-edit-col">
 								<label for="attachment-caption" class="alignleft">
 									<span class="title"><?php esc_html_e( 'Caption' ); ?></span>
 								</label>
-								<input id="attachment-caption" type="text" name="post_excerpt" value="">
+								<span class="input-text-wrap">
+									<input id="attachment-caption" type="text" name="post_excerpt" value="">
+								</span>
 							</div>
 
 							<div class="inline-edit-col">
 								<label for="attachment-description" class="alignleft">
 									<span class="title"><?php esc_html_e( 'Description' ); ?></span>
 								</label>
-								<input id="attachment-decription" type="text" name="post_content" value="">
+								<span class="input-text-wrap">
+									<input id="attachment-decription" type="text" name="post_content" value="">
+								</span>
 							</div>
 						</div>
 					</fieldset>


### PR DESCRIPTION
## Description
While reviewing other PRs addressing the Quick Edit feature in the Media table, I noticed some layout discrepancies as compared to the Quick Edit are on the Posts table.

## Motivation and context
This PR aims to address those discrepancies and produce a consistent UI experience.

In particular this PR address the date fields indentation and ensures the tags text area is below the heading and given adequate screen space.

## How has this been tested?
Local testing and screen shots below, needs assessment that HTML syntax remains valid.

## Screenshots
### Before
![Screenshot 2025-03-15 at 16 58 09](https://github.com/user-attachments/assets/e46d80ba-8ce3-47d7-9759-b98756c7d359)

### After
![Screenshot 2025-03-15 at 17 10 16](https://github.com/user-attachments/assets/637a14ae-5c28-43a4-b2b1-72ab4c9b726d)

Post screen for comparison
![Screenshot 2025-03-15 at 16 58 21](https://github.com/user-attachments/assets/a49fe722-54ee-46fd-a26d-6885b4479b5a)

## Types of changes
- Bug fix