### PR TITLE
Exclude `languages` folder from `phpcs` checks

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -89,6 +89,9 @@
 	<!-- Themes except the twenty* themes. -->
 	<exclude-pattern>/src/wp-content/themes/(?!twenty|the-classicpress-theme)*</exclude-pattern>
 
+	<!-- Languages. -->
+	<exclude-pattern>/src/wp-content/languages/*</exclude-pattern>
+
 	<rule ref="WordPress-Core"/>
 	<rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
 


### PR DESCRIPTION
When a non en-US locale is used translations are installed for core, plugins and theme.
Running `phpcs` returns lot of errors on those files.

## Motivation and context
Easier testing.

## How has this been tested?
`composer run phpcs`

## Types of changes
- Bug fix

