### PR TITLE
Disable attachment editing and deleting in media dialog when user is unauthorized

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -433,6 +433,7 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $meta['nonces']['update'];
 					$delete_nonce = $meta['nonces']['delete'];
 					$edit_nonce   = $meta['nonces']['edit'];
+					$editable     = current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
 					$erasable     = current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '">';
 
@@ -475,6 +476,7 @@ if ( 'grid' === $mode ) {
 						data-update-nonce="<?php echo $update_nonce; ?>"
 						data-delete-nonce="<?php echo $delete_nonce; ?>"
 						data-edit-nonce="<?php echo $edit_nonce; ?>"
+						data-editable="<?php echo $editable; ?>"
 						data-erasable="<?php echo $erasable; ?>"
 						>
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -433,6 +433,7 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $meta['nonces']['update'];
 					$delete_nonce = $meta['nonces']['delete'];
 					$edit_nonce   = $meta['nonces']['edit'];
+					$erasable     = current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '">';
 
 					// Use an icon if the file uploaded is not an image
@@ -474,6 +475,7 @@ if ( 'grid' === $mode ) {
 						data-update-nonce="<?php echo $update_nonce; ?>"
 						data-delete-nonce="<?php echo $delete_nonce; ?>"
 						data-edit-nonce="<?php echo $edit_nonce; ?>"
+						data-erasable="<?php echo $erasable; ?>"
 						>
 
 						<div class="select-attachment-preview <?php echo esc_attr( 'type-' . $file_type . ' subtype-' . $subtype . ' ' . $orientation ); ?>">

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -286,6 +286,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			authorLink = item.dataset.authorLink,
 			orientation = item.dataset.orientation ? ' ' + item.dataset.orientation : '',
 			menuOrder = item.dataset.menuOrder,
+			editable = item.dataset.editable,
 			erasable = item.dataset.erasable,
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
@@ -359,6 +360,24 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		dialog.querySelector( '#edit-more' ).href = ajaxurl.replace( 'admin-ajax.php', 'post.php?post=' + id + '&action=edit' );
 		dialog.querySelector( '#download-file' ).href = url;
 
+		if ( editable === '1' ) {
+			dialog.querySelector( '#attachment-details-two-column-alt-text' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '#attachment-details-two-column-title' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '#attachment-details-two-column-caption' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '#attachment-details-two-column-description' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '#attachments-' + id + '-media_category' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '#attachments-' + id + '-media_post_tag' ).removeAttribute( 'readonly' );
+			dialog.querySelector( '.edit-attachment' ).style.display = '';
+		} else {
+			dialog.querySelector( '#attachment-details-two-column-alt-text' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '#attachment-details-two-column-title' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '#attachment-details-two-column-caption' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '#attachment-details-two-column-description' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '#attachments-' + id + '-media_category' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '#attachments-' + id + '-media_post_tag' ).setAttribute( 'readonly', true );
+			dialog.querySelector( '.edit-attachment' ).style.display = 'none';
+		}
+
 		if ( erasable === '1' ) {
 			dialog.querySelector( '.delete-attachment' ).style.display = '';
 			dialog.querySelectorAll( '.links-separator' )[2].style.display = '';
@@ -405,7 +424,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		// Update media categories and tags
 		dialog.querySelectorAll( '.compat-item input' ).forEach( function( input ) {
 			input.addEventListener( 'blur', function() {
-				updateMediaTaxOrTag( input, id );
+				if ( editable === '1' ) {
+					updateMediaTaxOrTag( input, id );
+				}
 			} );
 		} );
 	}
@@ -832,7 +853,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	dialog.querySelectorAll( '.settings input, .settings textarea' ).forEach( function( input ) {
 		input.addEventListener( 'blur', function() {
 			var id = queryParams.get( 'item' );
-			updateDetails( input, id );
+			var item = document.getElementById( 'media-' + id );
+			if ( item.dataset.editable === '1' ) {
+				updateDetails( input, id );
+			}
 		} );
 	} );
 

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -286,6 +286,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			authorLink = item.dataset.authorLink,
 			orientation = item.dataset.orientation ? ' ' + item.dataset.orientation : '',
 			menuOrder = item.dataset.menuOrder,
+			erasable = item.dataset.erasable,
 			prev = item.previousElementSibling ? item.previousElementSibling.id : '',
 			next = item.nextElementSibling ? item.nextElementSibling.id : '',
 			order = item.dataset.order,
@@ -357,6 +358,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		dialog.querySelector( '#view-attachment').href = link;
 		dialog.querySelector( '#edit-more' ).href = ajaxurl.replace( 'admin-ajax.php', 'post.php?post=' + id + '&action=edit' );
 		dialog.querySelector( '#download-file' ).href = url;
+
+		if ( erasable === '1' ) {
+			dialog.querySelector( '.delete-attachment' ).style.display = '';
+			dialog.querySelectorAll( '.links-separator' )[2].style.display = '';
+		} else {
+			dialog.querySelector( '.delete-attachment' ).style.display = 'none';
+			dialog.querySelectorAll( '.links-separator' )[2].style.display = 'none';
+		}
+
 		leftIcon.setAttribute( 'data-prev', prev );
 		rightIcon.setAttribute( 'data-next', next );
 


### PR DESCRIPTION
## Motivation and context
In list mode, the functionality to edit and delete attachments is disabled when the user doesn't have the required permissions. But in grid mode, the "Edit image" and "Delete permanently" buttons are always visible regardless of the permissions, and also it's possible to interact with the "Alternative Text", "Title", "Caption", "Description", "Media Categories", and "Media Tags" fields causing silent "403" errors and a WSOD.

## How has this been tested?
With a user account with "Author" role.

## Types of changes
- Bug fix

## Before

https://github.com/user-attachments/assets/75607261-5b5f-4b11-8d81-07452bcd1ba4

## After

https://github.com/user-attachments/assets/2a290251-cc31-4a7a-a024-92ae90c3e0cd


