### PR TITLE
Textual changes dashboard Help tab

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -30,7 +30,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/tools-import-screen/">Documentation on Import</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/support/forums">Support</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support forums</a>' ) . '</p>'
 );
 
 if ( current_user_can( 'install_plugins' ) ) {

--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -98,7 +98,7 @@ class Custom_Background {
 		get_current_screen()->set_help_sidebar(
 			'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 			'<p>' . __( '<a href="https://codex.wordpress.org/Appearance_Background_Screen">Documentation on Custom Background</a>' ) . '</p>' .
-			'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+			'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support forums</a>' ) . '</p>'
 		);
 
 		wp_enqueue_media();

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -854,7 +854,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://codex.wordpress.org/Dashboard_Updates_Screen">Documentation on Updating ClassicPress</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support Forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://forums.classicpress.net/c/support">Support forums</a>' ) . '</p>'
 );
 
 if ( 'upgrade-core' === $action ) {


### PR DESCRIPTION
## Description
All help tabs except 3 have the "Support forums" label.
Updated 3 files to match label from above.
And changed forum link in 1 file (from WP to CP).
To avoid more "wrong" instances I have checked the `admin-nl_NL` translation file.

## Screenshots

### Before
![Help - before](https://github.com/user-attachments/assets/b4479b59-5bc6-4a53-8b43-62aa699ba760)

### After
![Help - after](https://github.com/user-attachments/assets/7640316b-196c-4729-b202-e9b863d3b41c)

## Types of changes
- No breaking change
