### PR TITLE
Restore visibility to maximum upload file size line within Filepond

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -115,6 +115,7 @@
 }
 #post-upload-info {
 	margin-top: -6em;
+	position: relative;
 }
 .filepond--drop-label {
 	background-color: #ecf7e9;


### PR DESCRIPTION
After merging #1833, the line specifying the maximum file upload size was rendered invisible. This PR restores its visibility.

Before:
![Screenshot at 2025-03-29 10-46-20](https://github.com/user-attachments/assets/1411bb46-61a7-4d62-b2ce-4e66ae1c544e)

After:
![Screenshot at 2025-03-29 10-45-50](https://github.com/user-attachments/assets/c815eadc-5137-472e-9232-b774f6ac17fe)
