### PR TITLE
Restore use of parent class `update()` function in Image Widget

### DIFF
--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -430,39 +430,6 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 	}
 
 	/**
-	 * Sanitize widget form values as they are saved.
-	 *
-	 * @since CP-2.5.0
-	 *
-	 * @see WP_Widget::update()
-	 *
-	 * @param array $new_instance Values just sent to be saved.
-	 * @param array $old_instance Previously saved values from database.
-	 *
-	 * @return array Updated safe values to be saved.
-	 */
-	public function update( $new_instance, $old_instance ) {
-		$instance = array();
-		$instance['title']             = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
-		$instance['attachment_id']     = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
-		$instance['url']               = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
-		$instance['size']              = ! empty( $new_instance['size'] ) ? sanitize_text_field( $new_instance['size'] ) : '';
-		$instance['width']             = ! empty( $new_instance['width'] ) ? absint( $new_instance['width'] ) : 0;
-		$instance['height']            = ! empty( $new_instance['height'] ) ? absint( $new_instance['height'] ) : 0;
-		$instance['caption']           = ! empty( $new_instance['caption'] ) ? wp_kses_post( $new_instance['caption'] ) : '';
-		$instance['alt']               = ! empty( $new_instance['alt'] ) ? sanitize_text_field( $new_instance['alt'] ) : '';
-		$instance['link_type']         = ! empty( $new_instance['link_type'] ) ? sanitize_text_field( $new_instance['link_type'] ) : '';
-		$instance['link_url']          = ! empty( $new_instance['link_url'] ) ? sanitize_url( $new_instance['link_url'] ) : '';
-		$instance['image_classes']     = ! empty( $new_instance['image_classes'] ) ? $this->sanitize_token_list( $new_instance['image_classes'] ) : '';
-		$instance['link_classes']      = ! empty( $new_instance['link_classes'] ) ? $this->sanitize_token_list( $new_instance['link_classes'] ) : '';
-		$instance['link_rel']          = ! empty( $new_instance['link_rel'] ) ? $this->sanitize_token_list( $new_instance['link_rel'] ) : '';
-		$instance['link_target_blank'] = ! empty( $new_instance['link_target_blank'] ) ? '_blank' : '';
-		$instance['link_image_title']  = ! empty( $new_instance['link_image_title'] ) ? sanitize_text_field( $new_instance['link_image_title'] ) : '';
-
-		return $instance;
-	}
-
-	/**
 	 * Loads the required media files for the media manager and scripts for media widgets.
 	 *
 	 * @since 4.8.0

--- a/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
@@ -125,118 +125,283 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 	 */
 	public function test_update() {
 		$widget   = new WP_Widget_Media_Image();
-		$instance = array(
-			'title'             => '',
-			'attachment_id'     => 0,
-			'url'               => '',
-			'size'              => '',
-			'width'             => 0,
-			'height'            => 0,
-			'caption'           => '',
-			'alt'               => '',
-			'link_type'         => '',
-			'link_url'          => '',
-			'image_classes'     => '',
-			'link_classes'      => '',
-			'link_rel'          => '',
-			'link_target_blank' => '',
-			'link_image_title'  => '',
-		);
+		$instance = array();
 
-		// Test valid widget details.
+		// Should return valid attachment ID.
 		$expected = array(
-			'title'             => 'What a title',
-			'attachment_id'     => 1,
-			'url'               => 'https://example.org',
-			'size'              => 'full',
-			'width'             => 300,
-			'height'            => 200,
-			'caption'           => 'A caption with <a href="#">link</a>',
-			'alt'               => 'A water tower',
-			'link_type'         => 'file',
-			'link_url'          => 'https://example.org',
-			'image_classes'     => 'A water tower',
-			'link_classes'      => 'A water tower',
-			'link_rel'          => 'previous',
-			'link_target_blank' => '_blank',
-			'link_image_title'  => 'A water tower',
+			'attachment_id' => 1,
 		);
 		$result   = $widget->update( $expected, $instance );
-		$this->assertSameSetsWithIndex( $expected, $result );
+		$this->assertSame( $expected, $result );
 
-		// Test invalid widget details.
-		$expected = array(
-			'title'             => '<h1>W00t!</h1>',
-			'attachment_id'     => 'media',
-			'url'               => 'not_a_url',
-			'size'              => 'big league',
-			'width'             => 'wide',
-			'height'            => 'high',
-			'caption'           => '"><i onload="alert(\'hello\')" />',
-			'alt'               => '"><i onload="alert(\'hello\')" />',
-			'link_type'         => 'interesting',
-			'link_url'          => 'not_a_url',
-			'image_classes'     => '"><i onload="alert(\'hello\')" />',
-			'link_classes'      => '"><i onload="alert(\'hello\')" />',
-			'link_rel'          => '"><i onload="alert(\'hello\')" />',
-			'link_target_blank' => 'top',
-			'link_image_title'  => '<h1>W00t!</h1>',
-			'imaginary_key'     => 'value',
+		// Should filter invalid attachment ID.
+		$result = $widget->update(
+			array(
+				'attachment_id' => 'media',
+			),
+			$instance
 		);
+		$this->assertSame( $result, $instance );
 
-		// Invalid attachment title.
-		$result = $widget->update( $expected, $instance );
-		$this->assertNotSame( $expected['title'], $result['title'] );
+		// Should return valid attachment url.
+		$expected = array(
+			'url' => 'https://example.org',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid URL.
-		$this->assertNotSame( $expected['url'], $result['url'] );
+		// Should filter invalid attachment url.
+		$result = $widget->update(
+			array(
+				'url' => 'not_a_url',
+			),
+			$instance
+		);
+		$this->assertNotSame( $result, $instance );
 		$this->assertStringStartsWith( 'http://', $result['url'] );
 
-		// Invalid image size.
-		//$this->assertNotSame( $expected['size'], $result['size'] );
+		// Should return valid attachment title.
+		$expected = array(
+			'title' => 'What a title',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid image width.
-		$this->assertNotSame( $expected['width'], $result['width'] );
+		// Should filter invalid attachment title.
+		$result = $widget->update(
+			array(
+				'title' => '<h1>W00t!</h1>',
+			),
+			$instance
+		);
+		$this->assertNotSame( $result, $instance );
 
-		// Invalid image height.
-		$this->assertNotSame( $expected['height'], $result['height'] );
+		// Should return valid image size.
+		$expected = array(
+			'size' => 'thumbnail',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid image caption.
-		$this->assertNotSame( $expected['caption'], $result['caption'] );
-		$this->assertSame( $result['caption'], '"&gt;<i />' );
+		// Should filter invalid image size.
+		$result = $widget->update(
+			array(
+				'size' => 'big league',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
 
-		// Invalid alt text.
-		$this->assertNotSame( $expected['alt'], $result['alt'] );
-		$this->assertSame( $result['alt'], '">' );
+		// Should return valid image width.
+		$expected = array(
+			'width' => 300,
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid link type.
-		$this->assertNotSame( $result['link_type'], $instance['link_type'] );
+		// Should filter invalid image width.
+		$result = $widget->update(
+			array(
+				'width' => 'wide',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
 
-		// Invalid link url.
-		$this->assertNotSame( $expected['link_url'], $result['link_url'] );
+		// Should return valid image height.
+		$expected = array(
+			'height' => 200,
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid image height.
+		$result = $widget->update(
+			array(
+				'height' => 'high',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
+
+		// Should return valid image caption.
+		$expected = array(
+			'caption' => 'A caption with <a href="#">link</a>',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid image caption.
+		$result = $widget->update(
+			array(
+				'caption' => '"><i onload="alert(\'hello\')" />',
+			),
+			$instance
+		);
+		$this->assertSame(
+			$result,
+			array(
+				'caption' => '"&gt;<i />',
+			)
+		);
+
+		// Should return valid alt text.
+		$expected = array(
+			'alt' => 'A water tower',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid alt text.
+		$result = $widget->update(
+			array(
+				'alt' => '"><i onload="alert(\'hello\')" />',
+			),
+			$instance
+		);
+		$this->assertSame(
+			$result,
+			array(
+				'alt' => '">',
+			)
+		);
+
+		// Should return valid link type.
+		$expected = array(
+			'link_type' => 'file',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid link type.
+		$result = $widget->update(
+			array(
+				'link_type' => 'interesting',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
+
+		// Should return valid link url.
+		$expected = array(
+			'link_url' => 'https://example.org',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid link url.
+		$result = $widget->update(
+			array(
+				'link_url' => 'not_a_url',
+			),
+			$instance
+		);
+		$this->assertNotSame( $result, $instance );
 		$this->assertStringStartsWith( 'http://', $result['link_url'] );
 
-		// Invalid image classes.
-		$this->assertNotSame( $expected['image_classes'], $result['image_classes'] );
-		$this->assertSame( $result['image_classes'], 'i onloadalerthello' );
+		// Should return valid image classes.
+		$expected = array(
+			'image_classes' => 'A water tower',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid link classes.
-		$this->assertNotSame( $expected['link_classes'], $result['link_classes'] );
-		$this->assertSame( $result['link_classes'], 'i onloadalerthello' );
+		// Should filter invalid image classes.
+		$result = $widget->update(
+			array(
+				'image_classes' => '"><i onload="alert(\'hello\')" />',
+			),
+			$instance
+		);
+		$this->assertSame(
+			$result,
+			array(
+				'image_classes' => 'i onloadalerthello',
+			)
+		);
 
-		// Invalid rel text.
-		$this->assertNotSame( $expected['link_rel'], $result['link_rel'] );
-		$this->assertSame( $result['link_rel'], 'i onloadalerthello' );
+		// Should return valid link classes.
+		$expected = array(
+			'link_classes' => 'A water tower',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid  link target.
-		$this->assertNotSame( $result['link_target_blank'], $instance['link_target_blank'] );
+		// Should filter invalid link classes.
+		$result = $widget->update(
+			array(
+				'link_classes' => '"><i onload="alert(\'hello\')" />',
+			),
+			$instance
+		);
+		$this->assertSame(
+			$result,
+			array(
+				'link_classes' => 'i onloadalerthello',
+			)
+		);
 
-		// Invalid image title.
-		$this->assertNotSame( $result['link_image_title'], $instance['link_image_title'] );
+		// Should return valid rel text.
+		$expected = array(
+			'link_rel' => 'previous',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
 
-		// Invalid key.
-		$this->assertArrayNotHasKey( 'imaginary_key', $result );
-		$this->assertNotContains( 'key', $result );
+		// Should filter invalid rel text.
+		$result = $widget->update(
+			array(
+				'link_rel' => '"><i onload="alert(\'hello\')" />',
+			),
+			$instance
+		);
+		$this->assertSame(
+			$result,
+			array(
+				'link_rel' => 'i onloadalerthello',
+			)
+		);
+
+		// Should return valid link target.
+		$expected = array(
+			'link_target_blank' => false,
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid  link target.
+		$result = $widget->update(
+			array(
+				'link_target_blank' => 'top',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
+
+		// Should return valid image title.
+		$expected = array(
+			'image_title' => 'What a title',
+		);
+		$result   = $widget->update( $expected, $instance );
+		$this->assertSame( $expected, $result );
+
+		// Should filter invalid image title.
+		$result = $widget->update(
+			array(
+				'image_title' => '<h1>W00t!</h1>',
+			),
+			$instance
+		);
+		$this->assertNotSame( $result, $instance );
+
+		// Should filter invalid key.
+		$result = $widget->update(
+			array(
+				'imaginary_key' => 'value',
+			),
+			$instance
+		);
+		$this->assertSame( $result, $instance );
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR is a follow up to #1819, based on finding while reviewing and checking #1820, #1821 and #1822

The parent class `update()` function can be used without the need to create and maintain child class functions with the additional benefit that form submissions are automatically sanitized, which helps with PHPUnit tests.

## Motivation and context
Simplification of Media Widget code 

## How has this been tested?
PHPUnit tests and local widget testing.

## Screenshots
N/A

## Types of changes
- Enhancement
