### PR TITLE
Update php-compatibility test to use current PHP version

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.4'
           coverage: none
           tools: composer, cs2pr
 


### PR DESCRIPTION
## Description
The current PHP Compatibility test uses the `setup-php` action but configures PHP to version 7.4. A more modern, current version of PHP would be more sensible.

## Motivation and context
Modernisation.

## How has this been tested?
Action will run on this PR.

## Screenshots
N/A

## Types of changes
- Enhancement