### PR TITLE
Remove unnecessary escaping from Block Compatibility tests

### DIFF
--- a/src/wp-includes/classicpress/class-cp-debug-compat.php
+++ b/src/wp-includes/classicpress/class-cp-debug-compat.php
@@ -66,7 +66,7 @@ class CP_Debug_Compat {
 	public function test_plugin() {
 		$options = $this->get_options();
 		$result = array(
-			'label'       => esc_html__( 'Plugins using block functions' ),
+			'label'       => __( 'Plugins using block functions' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => 'Compatibility',
@@ -85,7 +85,7 @@ class CP_Debug_Compat {
 		$action  = esc_html__( 'Plugins on this list may have issues.' );
 		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
 		$result = array(
-			'label'       => esc_html__( 'Plugins using block functions' ),
+			'label'       => __( 'Plugins using block functions' ),
 			'status'      => 'recommended',
 			'badge'       => array(
 				'label' => 'Compatibility',
@@ -101,7 +101,7 @@ class CP_Debug_Compat {
 	public function test_theme() {
 		$options = $this->get_options();
 		$result = array(
-			'label'       => esc_html__( 'Themes using block functions' ),
+			'label'       => __( 'Themes using block functions' ),
 			'status'      => 'good',
 			'badge'       => array(
 				'label' => 'Compatibility',
@@ -121,7 +121,7 @@ class CP_Debug_Compat {
 		$action  = esc_html__( 'Themes on this list may have issues.' );
 		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
 		$result = array(
-			'label'       => esc_html__( 'Themes using block functions' ),
+			'label'       => __( 'Themes using block functions' ),
 			'status'      => 'recommended',
 			'badge'       => array(
 				'label' => 'Compatibility',


### PR DESCRIPTION
## Description
Remove unnecessary escaping from Block Compatibility tests that breaks l10n.

## Motivation and context
Closes #1869.

## How has this been tested?
Local testing

## Screenshots


### Before
<img width="295" alt="image" src="https://github.com/user-attachments/assets/4c1af956-843f-4c46-b483-a66f691375af" />


### After
<img width="284" alt="image" src="https://github.com/user-attachments/assets/0678be16-28d9-43df-8146-20c3fb761aad" />


## Types of changes
- Bug fix

