### PR TITLE
Correct $editable check in upload.php

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -433,7 +433,7 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $meta['nonces']['update'];
 					$delete_nonce = $meta['nonces']['delete'];
 					$edit_nonce   = $meta['nonces']['edit'];
-					$editable     = current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
+					$editable     = current_user_can( 'edit_post', $attachment->ID ) ? 1 : 0;
 					$erasable     = current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '">';
 


### PR DESCRIPTION
PR #1854 added two important `current_user_can()` checks for the capability to edit or delete a post. However, both of them actually check for the same thing: 
```
current_user_can( 'delete_post', $attachment->ID ) ? 1 : 0;
```
The `$editable` check should actually be:
```
current_user_can( 'edit_post', $attachment->ID ) ? 1 : 0;
```
This PR rectifies that.