### PR TITLE
Fix 404 for default favicon

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1730,7 +1730,7 @@ function do_favicon() {
 	 */
 	do_action( 'do_faviconico' );
 
-	wp_redirect( get_site_icon_url( 32, includes_url( 'images/w-logo-blue-white-bg.png' ) ) );
+	wp_redirect( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) );
 	exit;
 }
 


### PR DESCRIPTION
## Description
See #1863 for background and this proposed solution

## Motivation and context
Will fix a browser 404 error for site favicon
Fixes #1863

## How has this been tested?
Will need nightly testing on live sites, modern browsers prefer favicon via HTTPS connection.

## Screenshots
Not available at time of PR, can be added in comments below on testing.

## Types of changes
- Bug fix