### PR TITLE
Ensure video can be added to media video widget

### DIFF
--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -160,7 +160,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				fileType   = attachment.mime.split( '/' )[1],
 				video      = document.createElement( 'video' ),
 				source     = document.createElement( 'source' ),
-				buttons    = document.createElement( 'div' );
+				buttons    = document.createElement( 'div' ),
+				mediaView  = widget.querySelector( '.attachment-media-view' );
 
 			video.className = 'wp_video_shortcode';
 			video.style.width = '100%';
@@ -179,9 +180,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				'<button type="button" class="button change-media select-media">' + VIDEO_WIDGET.replace_video + '</button>';
 
 			// Insert video according to whether this is a new insertion or replacement
-			if ( widget.querySelector( '.attachment-media-view' ) !== null ) {
-				widget.querySelector( '.media_video' ).append( video );
-				widget.querySelector( '.attachment-media-view' ).replaceWith( buttons );
+			if ( mediaView !== null ) {
+				mediaView.before( video );
+				mediaView.replaceWith( buttons );
 			} else { // replacement
 				widget.querySelector( '.wp-video' ).replaceWith( video );
 			}

--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -162,7 +162,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				source     = document.createElement( 'source' ),
 				buttons    = document.createElement( 'div' ),
 				mediaView  = widget.querySelector( '.attachment-media-view' ),
-				vidInputs  = widget.querySelectorAll( '[data-property="mp4"], [data-property="m4v"], [data-property="webm"], [data-property="ogv"], [data-property="flv"], [data-property="mov"]' );
+				vidInputs  = widget.querySelectorAll( '[data-property="mp4"], [data-property="m4v"], [data-property="webm"], [data-property="ogv"], [data-property="flv"], [data-property="mov"], [data-property="quicktime"]' );
 
 			video.className = 'wp_video_shortcode';
 			video.style.width = '100%';

--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -229,7 +229,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			videoURL = widget.querySelector( '[data-property="url"]' ).value,
 			videoID = widget.querySelector( '[data-property="attachment_id"]' ).value;
 
-        if ( videoURL === null ) {
+		if ( videoURL === null ) {
 			videoURL = widget.querySelector( '[data-property="mp4"]' ).value;
 		}
 		if ( videoURL === null ) {
@@ -244,17 +244,20 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		if ( videoURL === null ) {
 			videoURL = widget.querySelector( '[data-property="flv"]' ).value;
 		}
-        if ( videoURL == null ) {
-            console.error( VIDEO_WIDGET.no_video_selected );
-            return;
-        }
+		if ( videoURL === null ) {
+			videoURL = widget.querySelector( '[data-property="mov"]' ).value;
+		}
+		if ( videoURL === null ) {
+			console.error( VIDEO_WIDGET.no_video_selected );
+			return;
+		}
 
-        // Open the media modal in edit mode
-        frame = wp.media( {
-            frame: 'video',
-            state: 'video-details',
-            metadata: wp.media.attachment( videoID )
-        } );
+		// Open the media modal in edit mode
+		frame = wp.media( {
+			frame: 'video',
+			state: 'video-details',
+			metadata: wp.media.attachment( videoID )
+		} );
 
 		// This runs once the modal is open
 		frame.on( 'ready', function() {
@@ -267,10 +270,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} );
 		} );
 
-        frame.open();
-    }
+		frame.open();
+	}
 
-    function updateFrame( frame, widget, videoURL ) {
+	function updateFrame( frame, widget, videoURL ) {
 		var video = document.createElement( 'video' ),
 			source = document.createElement( 'source' ),
 			span = document.createElement( 'span' ),

--- a/src/wp-admin/js/widgets/media-video-widget.js
+++ b/src/wp-admin/js/widgets/media-video-widget.js
@@ -161,7 +161,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				video      = document.createElement( 'video' ),
 				source     = document.createElement( 'source' ),
 				buttons    = document.createElement( 'div' ),
-				mediaView  = widget.querySelector( '.attachment-media-view' );
+				mediaView  = widget.querySelector( '.attachment-media-view' ),
+				vidInputs  = widget.querySelectorAll( '[data-property="mp4"], [data-property="m4v"], [data-property="webm"], [data-property="ogv"], [data-property="flv"], [data-property="mov"]' );
 
 			video.className = 'wp_video_shortcode';
 			video.style.width = '100%';
@@ -179,12 +180,23 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			buttons.innerHTML = '<button type="button" class="button edit-media">' + VIDEO_WIDGET.edit_video + '</button>' +
 				'<button type="button" class="button change-media select-media">' + VIDEO_WIDGET.replace_video + '</button>';
 
-			// Insert video according to whether this is a new insertion or replacement
+			// Insert video according to whether this is a new insertion ...
 			if ( mediaView !== null ) {
 				mediaView.before( video );
 				mediaView.replaceWith( buttons );
-			} else { // replacement
-				widget.querySelector( '.wp-video' ).replaceWith( video );
+
+			// ... or replacement
+			} else {
+				vidInputs.forEach( function( vidInput ) {
+					vidInput.value = '';
+				} );
+				if ( widget.querySelector( '.wp-embedded-video' ) ) {
+					widget.querySelector( '.wp-embedded-video' ).replaceWith( video );
+				} else if ( widget.querySelector( '.wp-video' ) ) {
+					widget.querySelector( '.wp-video' ).replaceWith( video );
+				} else if ( widget.querySelector( '.wp_video_shortcode' ) ) {
+					widget.querySelector( '.wp_video_shortcode' ).replaceWith( video );
+				}
 			}
 
 			// Update values in hidden fields

--- a/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
+++ b/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
@@ -1,31 +1,31 @@
 /* Accessibility: hide screen reader texts (and prefer "top" for RTL languages).
 Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-how/ */
 .mejs-offscreen {
-    border: 0;
-    clip: rect( 1px, 1px, 1px, 1px );
-    -webkit-clip-path: inset( 50% );
-            clip-path: inset( 50% );
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-    word-wrap: normal;
+	border: 0;
+	clip: rect( 1px, 1px, 1px, 1px );
+	-webkit-clip-path: inset( 50% );
+			clip-path: inset( 50% );
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+	word-wrap: normal;
 }
 
 .mejs-container {
-    background: #000;
-    box-sizing: border-box;
-    font-family: 'Helvetica', Arial, serif;
-    position: relative;
-    text-align: left;
-    text-indent: 0;
-    vertical-align: top;
+	background: #000;
+	box-sizing: border-box;
+	font-family: 'Helvetica', Arial, serif;
+	position: relative;
+	text-align: left;
+	text-indent: 0;
+	vertical-align: top;
 }
 
 .mejs-container * {
-    box-sizing: border-box;
+	box-sizing: border-box;
 }
 
 /* Hide native play button and control bar from iOS to favor plugin button */
@@ -33,151 +33,152 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-container video::-webkit-media-controls-panel,
 .mejs-container video::-webkit-media-controls-panel-container,
 .mejs-container video::-webkit-media-controls-start-playback-button {
-    -webkit-appearance: none;
-    display: none !important;
+	-webkit-appearance: none;
+	display: none !important;
 }
 
 .mejs-fill-container,
 .mejs-fill-container .mejs-container {
-    height: 100%;
-    width: 100%;
+	height: 100%;
+	width: 100%;
 }
 
 .mejs-fill-container {
-    background: transparent;
-    margin: 0 auto;
-    overflow: hidden;
-    position: relative;
+	background: transparent;
+	margin: 0 auto;
+	overflow: hidden;
+	position: relative;
 }
 
 .mejs-container:focus {
-    outline: none;
+	outline: none;
 }
 
 .mejs-iframe-overlay {
-    height: 100%;
-    position: absolute;
-    width: 100%;
+	height: 100%;
+	position: absolute;
+	width: 100%;
 }
 
 .mejs-embed,
 .mejs-embed body {
-    background: #000;
-    height: 100%;
-    margin: 0;
-    overflow: hidden;
-    padding: 0;
-    width: 100%;
+	background: #000;
+	height: 100%;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
+	width: 100%;
 }
 
 .mejs-fullscreen {
-    overflow: hidden !important;
+	overflow: hidden !important;
 }
 
 .mejs-container-fullscreen {
-    bottom: 0;
-    left: 0;
-    overflow: hidden;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: 1000;
+	bottom: 0;
+	left: 0;
+	overflow: hidden;
+	position: fixed;
+	right: 0;
+	top: 0;
+	z-index: 1000;
 }
 
 .mejs-container-fullscreen .mejs-mediaelement,
 .mejs-container-fullscreen video {
-    height: 100% !important;
-    width: 100% !important;
+	height: 100% !important;
+	width: 100% !important;
 }
 
 /* Start: LAYERS */
 .mejs-background {
-    left: 0;
-    position: absolute;
-    top: 0;
+	left: 0;
+	position: absolute;
+	top: 0;
 }
 
 .mejs-mediaelement {
-    height: 100%;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-    z-index: 0;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
+	z-index: 0;
 }
 
 .mejs-poster {
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: cover;
-    left: 0;
-    position: absolute;
-    top: 0;
-    z-index: 1;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	background-size: cover;
+	left: 0;
+	position: absolute;
+	top: 0;
+	z-index: 1;
 }
 
 :root .mejs-poster-img {
-    display: none;
+	display: none;
 }
 
 .mejs-poster-img {
-    border: 0;
-    padding: 0;
+	border: 0;
+	padding: 0;
 }
 
 .mejs-overlay {
-    -webkit-box-align: center;
-    -webkit-align-items: center;
-        -ms-flex-align: center;
-            align-items: center;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    -webkit-box-pack: center;
-    -webkit-justify-content: center;
-        -ms-flex-pack: center;
-            justify-content: center;
-    left: 0;
-    position: absolute;
-    top: 0;
+	-webkit-box-align: center;
+	-webkit-align-items: center;
+		-ms-flex-align: center;
+			align-items: center;
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-pack: center;
+	-webkit-justify-content: center;
+		-ms-flex-pack: center;
+			justify-content: center;
+	left: 0;
+	position: absolute;
+	top: 0;
 }
 
 .mejs-layer {
-    z-index: 1;
+	z-index: 1;
 }
 
 .mejs-overlay-play {
-    cursor: pointer;
+	cursor: pointer;
 }
 
 .mejs-overlay-button {
-    background: transparent;
-    border: 0;
+	background: transparent;
+	border: 0;
 }
 
 .mejs-overlay:hover .mejs-overlay-button svg {
-    opacity: 1;
+	opacity: 1;
 }
 
 .mejs-overlay-button svg {
-    opacity: 0.75;
+	opacity: 0.75;
 }
 
 .mejs-overlay-button:focus svg {
-    opacity: 1;
+	opacity: 1;
 }
 
 .mejs-overlay-button,
 .mejs-overlay-button svg {
-    height: 5rem;
-    width: 5rem;
+	height: 5rem;
+	width: 5rem;
 }
 
 .mejs-overlay-loading,
-.mejs-overlay-loading svg {
-    height: 5rem;
-    width: 5rem;
+.mejs-overlay-loading svg,
+.mejs-icon-overlay-play {
+	height: 5rem;
+	width: 5rem;
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -186,89 +187,89 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 }
 
 .mejs-overlay-loading-bg-img {
-    -webkit-animation: mejs-loading-spinner 1s linear infinite;
-            animation: mejs-loading-spinner 1s linear infinite;
-    display: block;
-    height: 5rem;
-    width: 5rem;
-    z-index: 1;
+	-webkit-animation: mejs-loading-spinner 1s linear infinite;
+			animation: mejs-loading-spinner 1s linear infinite;
+	display: block;
+	height: 5rem;
+	width: 5rem;
+	z-index: 1;
 }
 
 @-webkit-keyframes mejs-loading-spinner {
-    100% {
-        -webkit-transform: rotate(360deg);
-                transform: rotate(360deg);
-    }
+	100% {
+		-webkit-transform: rotate(360deg);
+				transform: rotate(360deg);
+	}
 }
 
 @keyframes mejs-loading-spinner {
-    100% {
-        -webkit-transform: rotate(360deg);
-                transform: rotate(360deg);
-    }
+	100% {
+		-webkit-transform: rotate(360deg);
+				transform: rotate(360deg);
+	}
 }
 
 /* End: LAYERS */
 
 /* Start: CONTROL BAR */
 .mejs-controls {
-    bottom: 0;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -ms-flexbox;
-    display: flex;
-    height: 2.5rem;
-    left: 0;
-    list-style-type: none;
-    margin: 0;
-    padding: 0 0.625rem;
-    position: absolute;
-    width: 100%;
-    z-index: 3;
+	bottom: 0;
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
+	display: flex;
+	height: 2.5rem;
+	left: 0;
+	list-style-type: none;
+	margin: 0;
+	padding: 0 0.625rem;
+	position: absolute;
+	width: 100%;
+	z-index: 3;
 }
 
 .mejs-controls:not([style*='display: none']) {
-    background: rgba(255, 0, 0, 0.7);
-    background: -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.35));
-    background: linear-gradient(transparent, rgba(0, 0, 0, 0.35));
+	background: rgba(255, 0, 0, 0.7);
+	background: -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.35));
+	background: linear-gradient(transparent, rgba(0, 0, 0, 0.35));
 }
 
 .mejs-button,
 .mejs-time,
 .mejs-time-rail {
-    font-size: 0.625rem;
-    height: 2.5rem;
-    line-height: 0.625rem;
-    margin: 0;
-    width: 2rem;
+	font-size: 0.625rem;
+	height: 2.5rem;
+	line-height: 0.625rem;
+	margin: 0;
+	width: 2rem;
 }
 
 .mejs-button > button {
-    background-color: transparent;
-    border: 0;
-    color: #fff;
-    cursor: pointer;
-    display: block;
-    font-size: 0;
-    height: 1.125rem;
-    line-height: 0;
-    margin: 0.625rem 0.375rem;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    text-decoration: none;
-    width: 1.125rem;
+	background-color: transparent;
+	border: 0;
+	color: #fff;
+	cursor: pointer;
+	display: block;
+	font-size: 0;
+	height: 1.125rem;
+	line-height: 0;
+	margin: 0.625rem 0.375rem;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	text-decoration: none;
+	width: 1.125rem;
 }
 
 .mejs-button svg {
-    fill: currentColor;
-    height: 1.125rem;
-    width: 1.125rem;
+	fill: currentColor;
+	height: 1.125rem;
+	width: 1.125rem;
 }
 
 /* :focus for accessibility */
 .mejs-button > button:focus {
-    outline: dotted 0.125rem #fff;
+	outline: dotted 0.125rem #fff;
 }
 
 .mejs-container-keyboard-inactive a,
@@ -277,75 +278,75 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-container-keyboard-inactive button:focus,
 .mejs-container-keyboard-inactive [role=slider],
 .mejs-container-keyboard-inactive [role=slider]:focus {
-    outline: 0;
+	outline: 0;
 }
 
 /* End: CONTROL BAR */
 
 /* Start: Play (Play / Pause / Replay) */
 .mejs-playpause-button svg {
-    display: none;
+	display: none;
 }
 
 .mejs-play svg.mejs-icon-play {
-    display: block;
+	display: block;
 }
 
 .mejs-pause svg.mejs-icon-pause {
-    display: block;
+	display: block;
 }
 
 .mejs-replay svg.mejs-icon-replay {
-    display: block;
+	display: block;
 }
 /* End: Play (Play / Pause / Replay) */
 
 /* Start: Fullscreen (Fullscreen / Unfullscreen) */
 .mejs-fullscreen-button svg.mejs-icon-unfullscreen {
-    display: none;
+	display: none;
 }
 .mejs-fullscreen svg.mejs-icon-fullscreen {
-    display: block;
+	display: block;
 }
 
 .mejs-fullscreen svg.mejs-icon-unfullscreen {
-    display: none;
+	display: none;
 }
 
 .mejs-unfullscreen svg.mejs-icon-unfullscreen {
-    display: block;
+	display: block;
 }
 
 .mejs-unfullscreen svg.mejs-icon-fullscreen {
-    display: none;
+	display: none;
 }
 /* End: Fullscreen (Fullscreen / Unfullscreen) */
 
 /* Start: Time (Current / Duration) */
 .mejs-time {
-    box-sizing: content-box;
-    color: #fff;
-    font-size: 0.6875rem;
-    font-weight: bold;
-    height: 1.5rem;
-    overflow: hidden;
-    padding: 1rem 0.375rem 0;
-    text-align: center;
-    width: auto;
+	box-sizing: content-box;
+	color: #fff;
+	font-size: 0.6875rem;
+	font-weight: bold;
+	height: 1.5rem;
+	overflow: hidden;
+	padding: 1rem 0.375rem 0;
+	text-align: center;
+	width: auto;
 }
 /* End: Time (Current / Duration) */
 
 /* Start: Progress Bar */
 .mejs-time-rail {
-    direction: ltr;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-        -ms-flex-positive: 1;
-            flex-grow: 1;
-    height: 2.5rem;
-    margin: 0 0.625rem;
-    padding-top: 0.625rem;
-    position: relative;
+	direction: ltr;
+	-webkit-box-flex: 1;
+	-webkit-flex-grow: 1;
+		-ms-flex-positive: 1;
+			flex-grow: 1;
+	height: 2.5rem;
+	margin: 0 0.625rem;
+	padding-top: 0.625rem;
+	position: relative;
 }
 
 .mejs-time-total,
@@ -357,474 +358,474 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-time-float-current,
 .mejs-time-float-corner,
 .mejs-time-marker {
-    border-radius: 0.125rem;
-    cursor: pointer;
-    display: block;
-    height: 0.625rem;
-    position: absolute;
+	border-radius: 0.125rem;
+	cursor: pointer;
+	display: block;
+	height: 0.625rem;
+	position: absolute;
 }
 
 .mejs-time-total {
-    background: rgba(255, 255, 255, 0.3);
-    margin: 0.3125rem 0 0;
-    width: 100%;
+	background: rgba(255, 255, 255, 0.3);
+	margin: 0.3125rem 0 0;
+	width: 100%;
 }
 
 .mejs-time-buffering {
-    -webkit-animation: buffering-stripes 2s linear infinite;
-            animation: buffering-stripes 2s linear infinite;
-    background: -webkit-linear-gradient(135deg, rgba(255, 255, 255, 0.4) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.4) 75%, transparent 75%, transparent);
-    background: linear-gradient(-45deg, rgba(255, 255, 255, 0.4) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.4) 75%, transparent 75%, transparent);
-    background-size: 0.9375rem 0.9375rem;
-    width: 100%;
+	-webkit-animation: buffering-stripes 2s linear infinite;
+			animation: buffering-stripes 2s linear infinite;
+	background: -webkit-linear-gradient(135deg, rgba(255, 255, 255, 0.4) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.4) 75%, transparent 75%, transparent);
+	background: linear-gradient(-45deg, rgba(255, 255, 255, 0.4) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.4) 50%, rgba(255, 255, 255, 0.4) 75%, transparent 75%, transparent);
+	background-size: 0.9375rem 0.9375rem;
+	width: 100%;
 }
 
 @-webkit-keyframes buffering-stripes {
-    from {
-        background-position: 0 0;
-    }
-    to {
-        background-position: 1.875rem 0;
-    }
+	from {
+		background-position: 0 0;
+	}
+	to {
+		background-position: 1.875rem 0;
+	}
 }
 
 @keyframes buffering-stripes {
-    from {
-        background-position: 0 0;
-    }
-    to {
-        background-position: 1.875rem 0;
-    }
+	from {
+		background-position: 0 0;
+	}
+	to {
+		background-position: 1.875rem 0;
+	}
 }
 
 .mejs-time-loaded {
-    background: rgba(255, 255, 255, 0.3);
+	background: rgba(255, 255, 255, 0.3);
 }
 
 .mejs-time-current,
 .mejs-time-handle-content {
-    background: rgba(255, 255, 255, 0.9);
+	background: rgba(255, 255, 255, 0.9);
 }
 
 .mejs-time-hovered {
-    background: rgba(255, 255, 255, 0.5);
-    z-index: 10;
+	background: rgba(255, 255, 255, 0.5);
+	z-index: 10;
 }
 
 .mejs-time-hovered.negative {
-    background: rgba(0, 0, 0, 0.2);
+	background: rgba(0, 0, 0, 0.2);
 }
 
 .mejs-time-current,
 .mejs-time-buffering,
 .mejs-time-loaded,
 .mejs-time-hovered {
-    left: 0;
-    -webkit-transform: scaleX(0);
-        -ms-transform: scaleX(0);
-            transform: scaleX(0);
-    -webkit-transform-origin: 0 0;
-        -ms-transform-origin: 0 0;
-            transform-origin: 0 0;
-    -webkit-transition: 0.15s ease-in all;
-    transition: 0.15s ease-in all;
-    width: 100%;
+	left: 0;
+	-webkit-transform: scaleX(0);
+		-ms-transform: scaleX(0);
+			transform: scaleX(0);
+	-webkit-transform-origin: 0 0;
+		-ms-transform-origin: 0 0;
+			transform-origin: 0 0;
+	-webkit-transition: 0.15s ease-in all;
+	transition: 0.15s ease-in all;
+	width: 100%;
 }
 
 .mejs-time-buffering {
-    -webkit-transform: scaleX(1);
-        -ms-transform: scaleX(1);
-            transform: scaleX(1);
+	-webkit-transform: scaleX(1);
+		-ms-transform: scaleX(1);
+			transform: scaleX(1);
 }
 
 .mejs-time-hovered {
-    -webkit-transition: height 0.1s cubic-bezier(0.44, 0, 1, 1);
-    transition: height 0.1s cubic-bezier(0.44, 0, 1, 1);
+	-webkit-transition: height 0.1s cubic-bezier(0.44, 0, 1, 1);
+	transition: height 0.1s cubic-bezier(0.44, 0, 1, 1);
 }
 
 .mejs-time-hovered.no-hover {
-    -webkit-transform: scaleX(0) !important;
-        -ms-transform: scaleX(0) !important;
-            transform: scaleX(0) !important;
+	-webkit-transform: scaleX(0) !important;
+		-ms-transform: scaleX(0) !important;
+			transform: scaleX(0) !important;
 }
 
 .mejs-time-handle,
 .mejs-time-handle-content {
-    border: 0.25rem solid transparent;
-    cursor: pointer;
-    left: 0;
-    position: absolute;
-    -webkit-transform: translateX(0);
-        -ms-transform: translateX(0);
-            transform: translateX(0);
-    z-index: 11;
+	border: 0.25rem solid transparent;
+	cursor: pointer;
+	left: 0;
+	position: absolute;
+	-webkit-transform: translateX(0);
+		-ms-transform: translateX(0);
+			transform: translateX(0);
+	z-index: 11;
 }
 
 .mejs-time-handle-content {
-    border: 0.25rem solid rgba(255, 255, 255, 0.9);
-    border-radius: 50%;
-    height: 0.625rem;
-    left: -0.4375rem;
-    top: -0.25rem;
-    -webkit-transform: scale(0);
-        -ms-transform: scale(0);
-            transform: scale(0);
-    width: 0.625rem;
+	border: 0.25rem solid rgba(255, 255, 255, 0.9);
+	border-radius: 50%;
+	height: 0.625rem;
+	left: -0.4375rem;
+	top: -0.25rem;
+	-webkit-transform: scale(0);
+		-ms-transform: scale(0);
+			transform: scale(0);
+	width: 0.625rem;
 }
 
 .mejs-time-rail:hover .mejs-time-handle-content,
 .mejs-time-rail .mejs-time-handle-content:focus,
 .mejs-time-rail .mejs-time-handle-content:active {
-    -webkit-transform: scale(1);
-        -ms-transform: scale(1);
-            transform: scale(1);
+	-webkit-transform: scale(1);
+		-ms-transform: scale(1);
+			transform: scale(1);
 }
 
 .mejs-time-float {
-    background: #eee;
-    border: solid 1px #333;
-    bottom: 100%;
-    color: #111;
-    display: none;
-    height: 1.0625rem;
-    margin-bottom: 0.5625rem;
-    position: absolute;
-    text-align: center;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    width: 2.25rem;
+	background: #eee;
+	border: solid 1px #333;
+	bottom: 100%;
+	color: #111;
+	display: none;
+	height: 1.0625rem;
+	margin-bottom: 0.5625rem;
+	position: absolute;
+	text-align: center;
+	-webkit-transform: translateX(-50%);
+		-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+	width: 2.25rem;
 }
 
 .mejs-time-float-current {
-    display: block;
-    left: 0;
-    margin: 0.125rem;
-    text-align: center;
-    width: 1.875rem;
+	display: block;
+	left: 0;
+	margin: 0.125rem;
+	text-align: center;
+	width: 1.875rem;
 }
 
 .mejs-time-float-corner {
-    border: solid 0.3125rem #eee;
-    border-color: #eee transparent transparent;
-    border-radius: 0;
-    display: block;
-    height: 0;
-    left: 50%;
-    line-height: 0;
-    position: absolute;
-    top: 100%;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    width: 0;
+	border: solid 0.3125rem #eee;
+	border-color: #eee transparent transparent;
+	border-radius: 0;
+	display: block;
+	height: 0;
+	left: 50%;
+	line-height: 0;
+	position: absolute;
+	top: 100%;
+	-webkit-transform: translateX(-50%);
+		-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+	width: 0;
 }
 
 .mejs-long-video .mejs-time-float {
-    margin-left: -1.4375rem;
-    width: 4rem;
+	margin-left: -1.4375rem;
+	width: 4rem;
 }
 
 .mejs-long-video .mejs-time-float-current {
-    width: 3.75rem;
+	width: 3.75rem;
 }
 
 .mejs-broadcast {
-    color: #fff;
-    height: 0.625rem;
-    position: absolute;
-    top: 0.9375rem;
-    width: 100%;
+	color: #fff;
+	height: 0.625rem;
+	position: absolute;
+	top: 0.9375rem;
+	width: 100%;
 }
 
 /* End: Progress Bar */
 
 /* Start: Mute/Volume */
 .mejs-volume-button {
-    position: relative;
+	position: relative;
 }
 
 .mejs-volume-button > .mejs-volume-slider {
-    -webkit-backface-visibility: hidden;
-    background: rgba(50, 50, 50, 0.7);
-    border-radius: 0;
-    bottom: 100%;
-    display: none;
-    height: 7.1875rem;
-    left: 50%;
-    margin: 0;
-    position: absolute;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    width: 1.5625rem;
-    z-index: 1;
+	-webkit-backface-visibility: hidden;
+	background: rgba(50, 50, 50, 0.7);
+	border-radius: 0;
+	bottom: 100%;
+	display: none;
+	height: 7.1875rem;
+	left: 50%;
+	margin: 0;
+	position: absolute;
+	-webkit-transform: translateX(-50%);
+		-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+	width: 1.5625rem;
+	z-index: 1;
 }
 
 .mejs-volume-button:hover {
-    border-radius: 0 0 0.25rem 0.25rem;
+	border-radius: 0 0 0.25rem 0.25rem;
 }
 
 .mejs-volume-total {
-    background: rgba(255, 255, 255, 0.5);
-    height: 6.25rem;
-    left: 50%;
-    margin: 0;
-    position: absolute;
-    top: 0.5rem;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    width: 0.125rem;
+	background: rgba(255, 255, 255, 0.5);
+	height: 6.25rem;
+	left: 50%;
+	margin: 0;
+	position: absolute;
+	top: 0.5rem;
+	-webkit-transform: translateX(-50%);
+		-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+	width: 0.125rem;
 }
 
 .mejs-volume-current {
-    background: rgba(255, 255, 255, 0.9);
-    left: 0;
-    margin: 0;
-    position: absolute;
-    width: 100%;
+	background: rgba(255, 255, 255, 0.9);
+	left: 0;
+	margin: 0;
+	position: absolute;
+	width: 100%;
 }
 
 .mejs-volume-handle {
-    background: rgba(255, 255, 255, 0.9);
-    border: 1px solid #fff;
-    border-radius: 1px;
-    cursor: ns-resize;
-    height: 0.375rem;
-    left: 50%;
-    position: absolute;
-    -webkit-transform: translateX(-50%);
-        -ms-transform: translateX(-50%);
-            transform: translateX(-50%);
-    width: 1rem;
+	background: rgba(255, 255, 255, 0.9);
+	border: 1px solid #fff;
+	border-radius: 1px;
+	cursor: ns-resize;
+	height: 0.375rem;
+	left: 50%;
+	position: absolute;
+	-webkit-transform: translateX(-50%);
+		-ms-transform: translateX(-50%);
+			transform: translateX(-50%);
+	width: 1rem;
 }
 
 .mejs-horizontal-volume-slider {
-    display: block;
-    height: 2.25rem;
-    position: relative;
-    vertical-align: middle;
-    width: 3.5rem;
+	display: block;
+	height: 2.25rem;
+	position: relative;
+	vertical-align: middle;
+	width: 3.5rem;
 }
 
 .mejs-horizontal-volume-total {
-    background: rgba(50, 50, 50, 0.8);
-    border-radius: 0.125rem;
-    font-size: 1px;
-    height: 0.5rem;
-    left: 0;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    top: 1rem;
-    width: 3.125rem;
+	background: rgba(50, 50, 50, 0.8);
+	border-radius: 0.125rem;
+	font-size: 1px;
+	height: 0.5rem;
+	left: 0;
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	top: 1rem;
+	width: 3.125rem;
 }
 
 .mejs-horizontal-volume-current {
-    background: rgba(255, 255, 255, 0.8);
-    border-radius: 0.125rem;
-    font-size: 1px;
-    height: 100%;
-    left: 0;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
+	background: rgba(255, 255, 255, 0.8);
+	border-radius: 0.125rem;
+	font-size: 1px;
+	height: 100%;
+	left: 0;
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
 }
 
 .mejs-horizontal-volume-handle {
-    display: none;
+	display: none;
 }
 
 .mejs-mute svg,
 .mejs-unmute svg {
-    stroke: currentColor;
+	stroke: currentColor;
 }
 
 .mejs-volume-button svg {
-    display: none;
+	display: none;
 }
 
 .mejs-mute .mejs-icon-mute {
-    display: block;
+	display: block;
 }
 
 .mejs-unmute .mejs-icon-unmute {
-    display: block;
+	display: block;
 }
 /* End: Mute/Volume */
 
 /* Start: Track (Captions and Chapters) */
 .mejs-captions-button,
 .mejs-chapters-button {
-    position: relative;
+	position: relative;
 }
 
 .mejs-chapters-button svg,
 .mejs-captions-button svg {
-    padding-top: 0.125rem;
+	padding-top: 0.125rem;
 }
 
 .mejs-captions-button > .mejs-captions-selector,
 .mejs-chapters-button > .mejs-chapters-selector {
-    background: rgba(50, 50, 50, 0.7);
-    border: solid 1px transparent;
-    border-radius: 0;
-    bottom: 100%;
-    margin-right: -2.6875rem;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    right: 50%;
-    visibility: visible;
-    width: 5.375rem;
+	background: rgba(50, 50, 50, 0.7);
+	border: solid 1px transparent;
+	border-radius: 0;
+	bottom: 100%;
+	margin-right: -2.6875rem;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	right: 50%;
+	visibility: visible;
+	width: 5.375rem;
 }
 
 /* reduced opacity if captions button is in toggle mode and deactivated */
 .mejs-captions-button-toggle {
-    opacity: 0.7;
+	opacity: 0.7;
 }
 /* normal opacity if captions button is in toggle mode and activated */
 .mejs-captions-button-toggle-on {
-    opacity: 1;
+	opacity: 1;
 }
 
 .mejs-chapters-button > .mejs-chapters-selector {
-    margin-right: -3.4375rem;
-    width: 6.875rem;
+	margin-right: -3.4375rem;
+	width: 6.875rem;
 }
 
 .mejs-captions-selector-list,
 .mejs-chapters-selector-list {
-    list-style-type: none !important;
-    margin: 0;
-    overflow: hidden;
-    padding: 0;
+	list-style-type: none !important;
+	margin: 0;
+	overflow: hidden;
+	padding: 0;
 }
 
 .mejs-captions-selector-list-item,
 .mejs-chapters-selector-list-item {
-    color: #fff;
-    cursor: pointer;
-    display: block;
-    list-style-type: none !important;
-    margin: 0 0 0.375rem;
-    overflow: hidden;
-    padding: 0;
+	color: #fff;
+	cursor: pointer;
+	display: block;
+	list-style-type: none !important;
+	margin: 0 0 0.375rem;
+	overflow: hidden;
+	padding: 0;
 }
 
 .mejs-captions-selector-list-item:hover,
 .mejs-chapters-selector-list-item:hover {
-    background-color: rgb(200, 200, 200) !important;
-    background-color: rgba(255, 255, 255, 0.4) !important;
+	background-color: rgb(200, 200, 200) !important;
+	background-color: rgba(255, 255, 255, 0.4) !important;
 }
 
 .mejs-captions-selector-input,
 .mejs-chapters-selector-input {
-    clear: both;
-    float: left;
-    left: -62.5rem;
-    margin: 0.1875rem 0.1875rem 0 0.3125rem;
-    position: absolute;
+	clear: both;
+	float: left;
+	left: -62.5rem;
+	margin: 0.1875rem 0.1875rem 0 0.3125rem;
+	position: absolute;
 }
 
 .mejs-captions-selector-label,
 .mejs-chapters-selector-label {
-    cursor: pointer;
-    float: left;
-    font-size: 0.625rem;
-    line-height: 0.9375rem;
-    padding: 0.25rem 0.625rem 0;
-    width: 100%;
+	cursor: pointer;
+	float: left;
+	font-size: 0.625rem;
+	line-height: 0.9375rem;
+	padding: 0.25rem 0.625rem 0;
+	width: 100%;
 }
 
 .mejs-captions-selector-list-item:hover .mejs-captions-selector-label,
 .mejs-chapters-selector-list-item:hover .mejs-chapters-selector-label {
-    text-decoration: underline;
+	text-decoration: underline;
 }
 
 .mejs-captions-selected,
 .mejs-chapters-selected {
-    color: rgba(33, 248, 248, 1);
-    font-weight: bold;
+	color: rgba(33, 248, 248, 1);
+	font-weight: bold;
 }
 
 .mejs-captions-translations {
-    font-size: 0.625rem;
-    margin: 0 0 0.3125rem;
+	font-size: 0.625rem;
+	margin: 0 0 0.3125rem;
 }
 
 .mejs-captions-layer {
-    bottom: 0;
-    color: #fff;
-    font-size: 1rem;
-    left: 0;
-    line-height: 1.25rem;
-    position: absolute;
-    text-align: center;
+	bottom: 0;
+	color: #fff;
+	font-size: 1rem;
+	left: 0;
+	line-height: 1.25rem;
+	position: absolute;
+	text-align: center;
 }
 
 .mejs-captions-layer a {
-    color: #fff;
-    text-decoration: underline;
+	color: #fff;
+	text-decoration: underline;
 }
 
 .mejs-captions-layer[lang=ar] {
-    font-size: 1.25rem;
-    font-weight: normal;
+	font-size: 1.25rem;
+	font-weight: normal;
 }
 
 .mejs-captions-position {
-    bottom: 0.9375rem;
-    left: 0;
-    position: absolute;
-    width: 100%;
+	bottom: 0.9375rem;
+	left: 0;
+	position: absolute;
+	width: 100%;
 }
 
 .mejs-captions-position-hover {
-    bottom: 2.1875rem;
+	bottom: 2.1875rem;
 }
 
 .mejs-captions-text,
 .mejs-captions-text * {
-    background: rgba(20, 20, 20, 0.5);
-    box-shadow: 0.3125rem 0 0 rgba(20, 20, 20, 0.5), -0.3125rem 0 0 rgba(20, 20, 20, 0.5);
-    padding: 0;
-    white-space: pre-wrap;
+	background: rgba(20, 20, 20, 0.5);
+	box-shadow: 0.3125rem 0 0 rgba(20, 20, 20, 0.5), -0.3125rem 0 0 rgba(20, 20, 20, 0.5);
+	padding: 0;
+	white-space: pre-wrap;
 }
 
 .mejs-container.mejs-hide-cues video::-webkit-media-text-track-container {
-    display: none;
+	display: none;
 }
 /* End: Track (Captions and Chapters) */
 
 /* Start: Error */
 .mejs-overlay-error {
-    position: relative;
+	position: relative;
 }
 .mejs-overlay-error > img {
-    left: 0;
-    max-width: 100%;
-    position: absolute;
-    top: 0;
-    z-index: -1;
+	left: 0;
+	max-width: 100%;
+	position: absolute;
+	top: 0;
+	z-index: -1;
 }
 .mejs-cannotplay,
 .mejs-cannotplay a {
-    color: #fff;
-    font-size: 0.8em;
+	color: #fff;
+	font-size: 0.8em;
 }
 
 .mejs-cannotplay {
-    position: relative;
+	position: relative;
 }
 
 .mejs-cannotplay p,
 .mejs-cannotplay a {
-    display: inline-block;
-    padding: 0 0.9375rem;
-    width: 100%;
+	display: inline-block;
+	padding: 0 0.9375rem;
+	width: 100%;
 }
 /* End: Error */

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3356,7 +3356,7 @@ function wp_get_video_extensions() {
 	 * @since 3.6.0
 	 *
 	 * @param string[] $extensions An array of supported video formats. Defaults are
-	 *                             'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov'.
+	 *                             'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov', 'quicktime'.
 	 */
 	return apply_filters( 'wp_video_extensions', array( 'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov', 'quicktime' ) );
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3358,7 +3358,7 @@ function wp_get_video_extensions() {
 	 * @param string[] $extensions An array of supported video formats. Defaults are
 	 *                             'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov'.
 	 */
-	return apply_filters( 'wp_video_extensions', array( 'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov' ) );
+	return apply_filters( 'wp_video_extensions', array( 'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov', 'quicktime' ) );
 }
 
 /**

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3356,9 +3356,9 @@ function wp_get_video_extensions() {
 	 * @since 3.6.0
 	 *
 	 * @param string[] $extensions An array of supported video formats. Defaults are
-	 *                             'mp4', 'm4v', 'webm', 'ogv', 'flv'.
+	 *                             'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov'.
 	 */
-	return apply_filters( 'wp_video_extensions', array( 'mp4', 'm4v', 'webm', 'ogv', 'flv' ) );
+	return apply_filters( 'wp_video_extensions', array( 'mp4', 'm4v', 'webm', 'ogv', 'flv', 'mov' ) );
 }
 
 /**

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -162,6 +162,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$webm          = ! empty( $instance['webm'] ) ? $instance['webm'] : '';
 		$ogv           = ! empty( $instance['ogv'] ) ? $instance['ogv'] : '';
 		$flv           = ! empty( $instance['flv'] ) ? $instance['flv'] : '';
+		$mov           = ! empty( $instance['mov'] ) ? $instance['mov'] : '';
 
 		if ( $url === '' ) {
 			if ( $attachment_id ) {
@@ -176,6 +177,8 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				$url = $ogv;
 			} elseif ( $flv ) {
 				$url = $flv;
+			} elseif ( $mov ) {
+				$url = $mov;
 			}
 		}
 		?>
@@ -219,6 +222,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		<input id="<?php echo esc_attr( $this->get_field_id( 'webm' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'webm' ) ); ?>" type="hidden" data-property="webm" class="media-widget-instance-property" value="<?php echo esc_attr( $webm ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'ogv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'ogv' ) ); ?>" type="hidden" data-property="ogv" class="media-widget-instance-property" value="<?php echo esc_attr( $ogv ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'flv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flv' ) ); ?>" type="hidden" data-property="flv" class="media-widget-instance-property" value="<?php echo esc_attr( $flv ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'mov' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'mov' ) ); ?>" type="hidden" data-property="mov" class="media-widget-instance-property" value="<?php echo esc_attr( $mov ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
 

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -226,35 +226,6 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 	}
 
 	/**
-	 * Sanitize widget form values as they are saved.
-	 *
-	 * @since CP-2.5.0
-	 *
-	 * @see WP_Widget::update()
-	 *
-	 * @param array $new_instance Values just sent to be saved.
-	 * @param array $old_instance Previously saved values from database.
-	 *
-	 * @return array Updated safe values to be saved.
-	 */
-	public function update( $new_instance, $old_instance ) {
-		$instance = array();
-		$instance['title']         = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
-		$instance['attachment_id'] = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
-		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
-		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : 'metadata';
-		$instance['loop']          = ! empty( $new_instance['loop'] ) ? true : false;
-		$instance['content']       = ! empty( $new_instance['content'] ) ? sanitize_text_field( $new_instance['content'] ) : '';
-		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';
-		$instance['m4v']           = ! empty( $new_instance['m4v'] ) ? sanitize_url( $new_instance['m4v'] ) : '';
-		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : '';
-		$instance['ogv']           = ! empty( $new_instance['ogv'] ) ? sanitize_url( $new_instance['ogv'] ) : '';
-		$instance['flv']           = ! empty( $new_instance['flv'] ) ? sanitize_url( $new_instance['flv'] ) : '';
-
-		return $instance;
-	}
-
-	/**
 	 * Enqueue preview scripts.
 	 *
 	 * These scripts normally are enqueued just-in-time when a video shortcode is used.

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -163,6 +163,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$ogv           = ! empty( $instance['ogv'] ) ? $instance['ogv'] : '';
 		$flv           = ! empty( $instance['flv'] ) ? $instance['flv'] : '';
 		$mov           = ! empty( $instance['mov'] ) ? $instance['mov'] : '';
+		$quicktime     = ! empty( $instance['quicktime'] ) ? $instance['quicktime'] : '';
 
 		if ( $url === '' ) {
 			if ( $attachment_id ) {
@@ -179,6 +180,8 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 				$url = $flv;
 			} elseif ( $mov ) {
 				$url = $mov;
+			} elseif ( $quicktime ) {
+				$url = $quicktime;
 			}
 		}
 		?>
@@ -223,6 +226,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		<input id="<?php echo esc_attr( $this->get_field_id( 'ogv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'ogv' ) ); ?>" type="hidden" data-property="ogv" class="media-widget-instance-property" value="<?php echo esc_attr( $ogv ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'flv' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'flv' ) ); ?>" type="hidden" data-property="flv" class="media-widget-instance-property" value="<?php echo esc_attr( $flv ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'mov' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'mov' ) ); ?>" type="hidden" data-property="mov" class="media-widget-instance-property" value="<?php echo esc_attr( $mov ); ?>">
+		<input id="<?php echo esc_attr( $this->get_field_id( 'quicktime' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'quicktime' ) ); ?>" type="hidden" data-property="quicktime" class="media-widget-instance-property" value="<?php echo esc_attr( $quicktime ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
 		<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
 

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -226,6 +226,35 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 	}
 
 	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @since CP-2.5.0
+	 *
+	 * @see WP_Widget::update()
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+		$instance['title']         = ! empty( $new_instance['title'] ) ? sanitize_text_field( $new_instance['title'] ) : '';
+		$instance['attachment_id'] = ! empty( $new_instance['attachment_id'] ) ? absint( $new_instance['attachment_id'] ) : 0;
+		$instance['url']           = ! empty( $new_instance['url'] ) ? sanitize_url( $new_instance['url'] ) : '';
+		$instance['preload']       = ! empty( $new_instance['preload'] ) ? sanitize_text_field( $new_instance['preload'] ) : 'metadata';
+		$instance['loop']          = ! empty( $new_instance['loop'] ) ? true : false;
+		$instance['content']       = ! empty( $new_instance['content'] ) ? sanitize_text_field( $new_instance['content'] ) : '';
+		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';
+		$instance['m4v']           = ! empty( $new_instance['m4v'] ) ? sanitize_url( $new_instance['m4v'] ) : '';
+		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : 'none';
+		$instance['ogv']           = ! empty( $new_instance['ogv'] ) ? sanitize_url( $new_instance['ogv'] ) : '';
+		$instance['flv']           = ! empty( $new_instance['flv'] ) ? sanitize_url( $new_instance['flv'] ) : '';
+
+		return $instance;
+	}
+
+	/**
 	 * Enqueue preview scripts.
 	 *
 	 * These scripts normally are enqueued just-in-time when a video shortcode is used.

--- a/src/wp-includes/widgets/class-wp-widget-media-video.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-video.php
@@ -247,7 +247,7 @@ class WP_Widget_Media_Video extends WP_Widget_Media {
 		$instance['content']       = ! empty( $new_instance['content'] ) ? sanitize_text_field( $new_instance['content'] ) : '';
 		$instance['mp4']           = ! empty( $new_instance['mp4'] ) ? sanitize_url( $new_instance['mp4'] ) : '';
 		$instance['m4v']           = ! empty( $new_instance['m4v'] ) ? sanitize_url( $new_instance['m4v'] ) : '';
-		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : 'none';
+		$instance['webm']          = ! empty( $new_instance['webm'] ) ? sanitize_url( $new_instance['webm'] ) : '';
 		$instance['ogv']           = ! empty( $new_instance['ogv'] ) ? sanitize_url( $new_instance['ogv'] ) : '';
 		$instance['flv']           = ! empty( $new_instance['flv'] ) ? sanitize_url( $new_instance['flv'] ) : '';
 


### PR DESCRIPTION
Attempting to add a video to the widget for the first time doesn't always work because an element to which it will be added does not always exist. (This does not affect occasions when one video is replaced by another.)

This PR fixes that issue.