### PR TITLE
Make media grid attachment details modal header sticky 

### DIFF
--- a/src/wp-admin/css/media-grid.css
+++ b/src/wp-admin/css/media-grid.css
@@ -69,7 +69,13 @@
 .imgedit-group-top h2 {
 	display: inline-block;
 }
-.imgedit-wrap {
+.media-modal-content .imgedit-wrap {
+	position: absolute;
+	overflow: auto;
+	top: 50px;
+	bottom: 0;
+	right: 0;
+	left: 0;
 	box-shadow: inset 0 4px 4px -4px rgba(0, 0, 0, 0.1);
 }
 .imgedit-settings .imgedit-help-toggle {
@@ -237,6 +243,18 @@
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 12px;
 }
+.media-frame-title,
+.media-modal-content .edit-attachment-frame .edit-media-header {
+	position: sticky;
+	top: 0;
+	background-color: #fff;
+	z-index: 10;
+	border-bottom: 1px solid #dcdcde;
+}
+.media-modal-content .edit-attachment-frame .edit-media-header {
+	overflow: revert;
+	z-index: 11;
+}
 .media-frame-title h2 {
 	padding: 0 16px;
 	font-size: 22px;
@@ -374,4 +392,24 @@ dialog::backdrop {
 }
 .filepond--file-info .filepond--file-info-main {
 	line-height: 1.3;
+}
+
+@media screen and (min-width: 481px) {
+	.media-modal-content .edit-attachment-frame .edit-media-header .media-navigation {
+		border-bottom: none;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	.media-modal-content .edit-attachment-frame .media-frame-content {
+		margin-top: 64px;
+	}
+	.attachment-media-view .media-navigation {
+		margin-bottom: 1em;
+		position: fixed;
+		top: calc(5% + 50px);
+		background-color: #fff;
+		z-index: 10;
+		width: calc(100% - 30px);
+	}
 }


### PR DESCRIPTION
@citrika pointed out some time ago that the header in the media grid attachment details modal should remain in place when the user scrolls down. This PR accomplishes that, as shown below at different screen widths:

![Screenshot at 2025-04-04 23-06-07](https://github.com/user-attachments/assets/93e1339c-c2b0-4909-aa4b-50a9650e0c32)

![Screenshot at 2025-04-04 23-06-40](https://github.com/user-attachments/assets/32947199-6f6e-4ab2-97e9-8c3c957501f0)

![Screenshot at 2025-04-04 23-07-07](https://github.com/user-attachments/assets/e78124dd-46bc-4a13-9b4b-f91d45824ffa)

To reproduce, go the media grid and select a file. Ensure that the height of the screen is less than the height of the modal contents, and scroll down. The header should stay in place while the content disappears underneath it (only to return if scrolling is reversed).
