### PR TITLE
Correct typo for file upload gallery

### DIFF
--- a/src/wp-admin/js/gallery.js
+++ b/src/wp-admin/js/gallery.js
@@ -9,7 +9,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	var gallerySortable, gallerySortableInit, sortIt, clearAll, w, desc = false;
 
 	gallerySortableInit = function() {
-		gallerySortable = Sortable.create( document.getElementById( '#media-items' ), {
+		gallerySortable = Sortable.create( document.getElementById( 'media-items' ), {
 			group: 'items',
 			sort: true,
 			placeholder: 'sorthelper',


### PR DESCRIPTION
This is a simple change that removes the unnecessary `#` from the selector specified by `document.getElementById`.