### PR TITLE
Consistent whitespace in Quick Edit across screens

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1119,6 +1119,22 @@ tr.inline-edit-row td {
 	float: left;
 }
 
+/* Consistent whitespace in Quick Edit across screens */
+.upload-php .inline-edit-row fieldset.inline-edit-date label {
+	display: none;
+}
+.edit-php .inline-edit-row fieldset.inline-edit-date input[name=jj] {
+	margin-right: 5px;
+}
+.edit-php .inline-edit-row fieldset.inline-edit-date input[name=hh] {
+	margin-right: 3px;
+}
+.upload-php .inline-edit-row fieldset.inline-edit-date input[name=aa],
+.edit-php .inline-edit-row fieldset.inline-edit-date input[name=aa],
+.edit-php .inline-edit-row fieldset.inline-edit-date input[name=mn] {
+	margin-left: 3px;
+}
+
 #bulk-titles,
 ul.cat-checklist {
 	height: 14em;

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -1213,7 +1213,7 @@ class WP_Media_List_Table extends WP_List_Table {
 							<fieldset class="inline-edit-date">
 								<legend><span class="title"><?php echo esc_html_e( 'Date' ); ?></span></legend>
 								<div class="timestamp-wrap">
-									<label for="quick-month" style="display:none;">
+									<label for="quick-month">
 										<span class="screen-reader-text"><?php echo esc_html_e( 'Month' ); ?></span>
 									</label>
 									<select id="quick-month" class="form-required" name="mm">


### PR DESCRIPTION
### Before

#### Media Library
![media-library_before](https://github.com/user-attachments/assets/4e93b4ee-3997-4f0e-9229-d909d6cbbcef)

#### Post Edit
![post-edit_before](https://github.com/user-attachments/assets/f2992282-4159-4c49-8941-88c9aebdaf54)

### After

#### Media Library
![media-library_after](https://github.com/user-attachments/assets/d2b3b5a1-f3fd-42c6-918d-d47f0b80fbc0)

#### Post Edit
![post-edit_after](https://github.com/user-attachments/assets/d53701ff-a829-4256-a41d-0b79cd6b0a23)

