### PR TITLE
Improve keyboard navigation in Themes screen

### DIFF
--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -874,7 +874,10 @@ themes.view.Details = wp.Backbone.View.extend({
 
 	previousTheme: function() {
 		var self = this;
-		self.trigger( 'theme:previous', self.model.cid );
+		// Disable previous at the zero position.
+		if ( 0 !== this.model.collection.indexOf( this.model ) ) {
+			self.trigger( 'theme:previous', self.model.cid );
+		}
 		return false;
 	},
 
@@ -1103,7 +1106,7 @@ themes.view.Themes = wp.Backbone.View.extend({
 		} );
 
 		// Bind keyboard events.
-		$( 'body' ).on( 'keyup', function( event ) {
+		$( 'body' ).on( 'keydown', function( event ) {
 			if ( ! self.overlay ) {
 				return;
 			}


### PR DESCRIPTION
## Motivation and context
When navigating to previous items in the Themes screen with the left arrow key, the loop doesn't stop at the first item as opposed to the button navigation.
Also the "keydown" event is more convenient than the "keyup" one to keep the key pressed to navigate.
This also happens in the latest version of WordPress.