### PR TITLE
Fix problem with `post__in` parameter in wp_ajax_query_attachments()

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3009,6 +3009,13 @@ function wp_ajax_query_attachments() {
 		add_filter( 'wp_allow_query_attachment_by_filename', '__return_true' );
 	}
 
+	// Ensure that the list of posts to be retrieved is an array.
+	if ( isset( $query['post__in'] ) ) {
+		if ( ! is_array( $query['post__in'] ) ) {
+			$query['post__in'] = explode( ',', $query['post__in'] );
+		}
+	}
+
 	/**
 	 * Filters the arguments passed to WP_Query during an Ajax
 	 * call for querying attachments.

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3016,6 +3016,13 @@ function wp_ajax_query_attachments() {
 		}
 	}
 
+	// Ensure that the list of posts to be excluded is an array.
+	if ( isset( $query['post__not_in'] ) ) {
+		if ( ! is_array( $query['post__not_in'] ) ) {
+			$query['post__not_in'] = explode( ',', $query['post__not_in'] );
+		}
+	}
+
 	/**
 	 * Filters the arguments passed to WP_Query during an Ajax
 	 * call for querying attachments.


### PR DESCRIPTION
I have been fighting with this for hours and it seems to be a bug. It's been reported many times on the internet, but no-one has a fix (except where there's been an obvious typo). The problem seems to have existed for over ten years! So here are the details.

`WP_Query()` takes a number of parameters, including `'post_in'`, which must be an array. This causes no problems when only PHP is used, but there's an AJAX endpoint, `query-attachments`, that makes use of this query, and that's when the problem manifests itself.

Try using the following AJAX call:
```
var selectedIds = a comma-separated list or array of attachment IDs

var formData = new FormData();
formData.append( 'action', 'query-attachments' );
formData.append( 'query[post__in]', selectedIds );
formData.append( 'query[orderby]', 'post__in' );
formData.append( 'query[paged]', 1 );

fetch( ajaxurl, {
	method: 'POST',
	body: formData,
	credentials: 'same-origin'
} )
.then( function( response ) {
	if ( response.ok ) {
		return response.json(); // no errors
	}
	throw new Error( response.status );
} )
.then( function( result ) {
	if ( result.success ) {
		console.log( result );
	}
} )
.catch( function( error ) {
	console.log( error );
} );
```

You will get a 500 error. The problem is not a lack of a nonce, as this call doesn't need a nonce. (Maybe it should, but that's for another day.) The actual problem is that `selectedIds` is always passed as a comma-separated list, even when it's specified as an array.

The fix suggested here checks whether the value of the `post_in` parameter is an array and, if not, it explodes the list into an array. Then the query works as expected.