### PR TITLE
Add data ID to li elements in media grid

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -455,6 +455,7 @@ if ( 'grid' === $mode ) {
 
 					<li class="media-item" id="media-<?php echo esc_attr( $attachment->ID ); ?>" tabindex="0" role="checkbox" aria-checked="false"
 						aria-label="<?php echo esc_attr( $attachment->post_title ); ?>"
+						data-id ="<?php echo esc_attr( $attachment->ID ); ?>"
 						data-date="<?php echo esc_attr( $date ); ?>"
 						data-url="<?php echo esc_url( $url ); ?>"
 						data-filename="<?php echo esc_attr( $file_name ); ?>"

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -268,7 +268,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Open modal
 	function openModalDialog( item ) {
-		var id = item.id.replace( 'media-', '' ),
+		var id = item.dataset.id,
 			title = item.getAttribute( 'aria-label' ),
 			date = item.dataset.date,
 			filename = item.dataset.filename,


### PR DESCRIPTION
In PR #1873 I attempted to eliminate the need to use `replace()` in order to obtain an attachment's ID from the list element in the HTML. This caused a problem because there was no `data-id` attribute for the element. This PR adds that `data-id` attribute without causing extra queries because the information is already held within the `$attachment` variable.