### PR TITLE
Update Site Health page with info about Blocks Compatibility 

### DIFF
--- a/src/wp-includes/classicpress/class-cp-debug-compat.php
+++ b/src/wp-includes/classicpress/class-cp-debug-compat.php
@@ -84,6 +84,14 @@ class CP_Debug_Compat {
 		}
 		$action  = esc_html__( 'Plugins on this list may have issues.' );
 		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
+		$action .= sprintf(
+			'<p>%s</p>',
+			sprintf(
+				/* translators: %s: URL to Settings > General > Blocks Compatibility. */
+				__( 'You can reset this list by switching the <a href="%s">Blocks Compatibility</a> to "On" and back to "Troubleshooting" again.' ),
+				esc_url( admin_url( 'options-general.php#blocks_compatibility_level' ) )
+			)
+		);	
 		$result = array(
 			'label'       => __( 'Plugins using block functions' ),
 			'status'      => 'recommended',
@@ -120,6 +128,14 @@ class CP_Debug_Compat {
 		}
 		$action  = esc_html__( 'Themes on this list may have issues.' );
 		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
+		$action .= sprintf(
+			'<p>%s</p>',
+			sprintf(
+				/* translators: %s: URL to Settings > General > Blocks Compatibility. */
+				__( 'You can reset this list by switching the <a href="%s">Blocks Compatibility</a> to "On" and back to "Troubleshooting" again.' ),
+				esc_url( admin_url( 'options-general.php#blocks_compatibility_level' ) )
+			)
+		);
 		$result = array(
 			'label'       => __( 'Themes using block functions' ),
 			'status'      => 'recommended',

--- a/src/wp-includes/classicpress/class-cp-debug-compat.php
+++ b/src/wp-includes/classicpress/class-cp-debug-compat.php
@@ -91,7 +91,7 @@ class CP_Debug_Compat {
 				__( 'You can reset this list by switching the <a href="%s">Blocks Compatibility</a> to "On" and back to "Troubleshooting" again.' ),
 				esc_url( admin_url( 'options-general.php#blocks_compatibility_level' ) )
 			)
-		);	
+		);
 		$result = array(
 			'label'       => __( 'Plugins using block functions' ),
 			'status'      => 'recommended',

--- a/src/wp-includes/classicpress/class-cp-debug-compat.php
+++ b/src/wp-includes/classicpress/class-cp-debug-compat.php
@@ -83,7 +83,7 @@ class CP_Debug_Compat {
 			return $result;
 		}
 		$action  = esc_html__( 'Plugins on this list may have issues.' );
-		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
+		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
 		$action .= sprintf(
 			'<p>%s</p>',
 			sprintf(
@@ -127,7 +127,7 @@ class CP_Debug_Compat {
 			return $result;
 		}
 		$action  = esc_html__( 'Themes on this list may have issues.' );
-		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/site-health-screen/#block-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
+		$action .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility">' . esc_html__( 'Learn more.' ) . '</a>';
 		$action .= sprintf(
 			'<p>%s</p>',
 			sprintf(


### PR DESCRIPTION
## Description
Update Site Health page with info about Blocks Compatibility and link to the associated setting.
As mentioned in Zulip [and here](https://github.com/ClassicPress/ClassicPress/issues/1872).

## Motivation and context
I did not understand why the list wasn't auto-updating after adding/removing themes/plugins.
Then I heard at Zulip you can force an update.

## Screenshots
### Before
![Block Compatibility - before](https://github.com/user-attachments/assets/1ec7cc8d-4913-4718-94ab-83e87219f0ef)

### After
![Block Compatibility](https://github.com/user-attachments/assets/bd4b0eb1-c08a-4d79-952a-8bff9141633a)

## Types of changes
- No breaking change