### PR TITLE
add grid to primary

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -2100,6 +2100,18 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 }
 
 @media screen and (min-width: 900px) {
+	#primary{
+		display: grid;
+		grid-template-columns: 3fr 1fr;
+	}
+	#main{
+		display: flex;
+		padding: 1.78em 1em;
+	}
+	#sidebar{
+	  display: initial;
+		padding: 1.14em .444em
+	}	
 	#inner-header {
 		display: flex;
 		flex-grow: 1;


### PR DESCRIPTION
Contain main and sidebar inside three quarter and one quarter **grid** column to have defined widths of page.

## Description
After using default CP theme for several sites, it appears as if there is not a stable container for the content and sidebar to live in. The 'primary' div could be changed to reflect a grid layout so that the child divs are set by the browser width which should help between various browser width. This will also help with the padding that is somewhat uneven on the main contenet as compared to the sidebar and other surrounding divs.
## Motivation and context
May help to allow new them,e users to understand the grid property and bring the theme up to date

## How has this been tested?
Testing was done with a branch and on local https://github.com/tradesouthwest/ClassicPress
## Screenshots
@ >900px

### Before

![Screenshot_2025-04-20_14-00-39](https://github.com/user-attachments/assets/c8f98919-6bf4-4768-ad98-918d0488371e)

### After
![Screenshot_2025-04-20_14-00-13](https://github.com/user-attachments/assets/9d8814d5-80f5-46c3-a5b2-50950b996e49)
## Types of changes

What types of changes does your code introduce?  Most PRs are one of the following:
- Bug fix
