### PR TITLE
Replace an empty `foreach` loop in `wp_replace_in_html_tags()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -758,8 +758,8 @@ function wp_replace_in_html_tags( $haystack, $replace_pairs ) {
 	// Optimize when searching for one item.
 	if ( 1 === count( $replace_pairs ) ) {
 		// Extract $needle and $replace.
-		foreach ( $replace_pairs as $needle => $replace ) {
-		}
+		$needle  = array_key_first( $replace_pairs );
+		$replace = $replace_pairs[ $needle ];
 
 		// Loop through delimiters (elements) only.
 		for ( $i = 1, $c = count( $textarr ); $i < $c; $i += 2 ) {


### PR DESCRIPTION
## Description
While investigating a different issue, I stumbled across an empty `foreach` loop and found that there is an upstream fix available to backport.

WP-r58889: Coding Standards: Replace an empty `foreach` loop in `wp_replace_in_html_tags()`.

This aims to clarify the intention of the code and improve readability.

Follow-up to https://core.trac.wordpress.org/changeset/33359.

WP:Props jrf, TobiasBg, mi5t4n, dhruvang21, mayura8991, nadimcse, Presskopp, SergeyBiryukov. Fixes https://core.trac.wordpress.org/ticket/61860.

---

Merges https://core.trac.wordpress.org/changeset/58889 / WordPress/wordpress-develop@3476790c2e to ClassicPress.

## Motivation and context
Fix for some poor code layout.

## How has this been tested?
This is a backport.

## Screenshots
N/A

## Types of changes
- Code enhancement
