### PR TITLE
Protect comments in editor content when switching tabs

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -75,6 +75,14 @@
 	pointer-events: none;
 }
 
+#titlewrap .skiplink:focus {
+	clip: inherit;
+	clip-path: inherit;
+	right: 4px;
+	top: 4px;
+	width: auto;
+}
+
 input#link_description,
 input#link_url {
 	width: 100%;
@@ -1045,6 +1053,14 @@ form#tags-filter {
 	.wp-core-ui button.privacy-text-copy {
 		white-space: normal;
 		line-height: 1.8;
+	}
+
+	#edit-slug-box {
+		padding: 0;
+	}
+
+	#titlewrap .skiplink:focus {
+		top: 5px;
 	}
 }
 

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -575,12 +575,8 @@ do_action( 'edit_form_top', $post );
 	$title_placeholder = apply_filters( 'enter_title_here', __( 'Add title' ), $post );
 	?>
 	<label class="screen-reader-text" id="title-prompt-text" for="title"><?php echo $title_placeholder; ?></label>
-<<<<<<< HEAD
 	<input type="text" name="post_title" size="30" value="<?php echo esc_attr( $post->post_title ); ?>" id="title" spellcheck="true" autocomplete="off">
-=======
-	<input type="text" name="post_title" size="30" value="<?php echo esc_attr( $post->post_title ); ?>" id="title" spellcheck="true" autocomplete="off" />
 	<a href="#content" class="button-secondary screen-reader-text skiplink" onclick="if (tinymce) { tinymce.execCommand( 'mceFocus', false, 'content' ); }"><?php esc_html_e( 'Skip to Editor' ); ?></a>
->>>>>>> 4c1898dad2 (Editor: A11y: Fix tab order, state, and focus in classic editor.)
 </div>
 	<?php
 	/**

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -575,7 +575,12 @@ do_action( 'edit_form_top', $post );
 	$title_placeholder = apply_filters( 'enter_title_here', __( 'Add title' ), $post );
 	?>
 	<label class="screen-reader-text" id="title-prompt-text" for="title"><?php echo $title_placeholder; ?></label>
+<<<<<<< HEAD
 	<input type="text" name="post_title" size="30" value="<?php echo esc_attr( $post->post_title ); ?>" id="title" spellcheck="true" autocomplete="off">
+=======
+	<input type="text" name="post_title" size="30" value="<?php echo esc_attr( $post->post_title ); ?>" id="title" spellcheck="true" autocomplete="off" />
+	<a href="#content" class="button-secondary screen-reader-text skiplink" onclick="if (tinymce) { tinymce.execCommand( 'mceFocus', false, 'content' ); }"><?php esc_html_e( 'Skip to Editor' ); ?></a>
+>>>>>>> 4c1898dad2 (Editor: A11y: Fix tab order, state, and focus in classic editor.)
 </div>
 	<?php
 	/**
@@ -651,18 +656,16 @@ if ( post_type_supports( $post_type, 'editor' ) ) {
 		array(
 			'_content_editor_dfw' => $_content_editor_dfw,
 			'drag_drop_upload'    => true,
-			'tabfocus_elements'   => 'content-html,save-post',
 			'editor_height'       => 300,
 			'tinymce'             => array(
 				'resize'                  => false,
 				'wp_autoresize_on'        => $_wp_editor_expand,
 				'add_unload_trigger'      => false,
-				'wp_keep_scroll_position' => ! $is_IE,
 			),
 		)
 	);
 	?>
-<table id="post-status-info"><tbody><tr>
+<table id="post-status-info" role="presentation"><tbody><tr>
 	<td id="wp-word-count" class="hide-if-no-js">
 	<?php
 	printf(

--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -654,9 +654,9 @@ if ( post_type_supports( $post_type, 'editor' ) ) {
 			'drag_drop_upload'    => true,
 			'editor_height'       => 300,
 			'tinymce'             => array(
-				'resize'                  => false,
-				'wp_autoresize_on'        => $_wp_editor_expand,
-				'add_unload_trigger'      => false,
+				'resize'             => false,
+				'wp_autoresize_on'   => $_wp_editor_expand,
+				'add_unload_trigger' => false,
 			),
 		)
 	);

--- a/src/wp-admin/js/editor.js
+++ b/src/wp-admin/js/editor.js
@@ -79,6 +79,8 @@ window.wp = window.wp || {};
 			var editorHeight, toolbarHeight, iframe,
 				editor = tinymce.get( id ),
 				wrap = $$( '#wp-' + id + '-wrap' ),
+				htmlSwitch = wrap.find( '.switch-tmce' ),
+				tmceSwitch = wrap.find( '.switch-html' ),
 				$textarea = $$( '#' + id ),
 				textarea = $textarea[0];
 
@@ -103,18 +105,7 @@ window.wp = window.wp || {};
 
 				editorHeight = parseInt( textarea.style.height, 10 ) || 0;
 
-				var keepSelection = false;
-				if ( editor ) {
-					keepSelection = editor.getParam( 'wp_keep_scroll_position' );
-				} else {
-					keepSelection = window.tinyMCEPreInit.mceInit[ id ] &&
-									window.tinyMCEPreInit.mceInit[ id ].wp_keep_scroll_position;
-				}
-
-				if ( keepSelection ) {
-					// Save the selection.
 					addHTMLBookmarkInTextAreaContent( $textarea );
-				}
 
 				if ( editor ) {
 					editor.show();
@@ -130,15 +121,14 @@ window.wp = window.wp || {};
 						}
 					}
 
-					if ( editor.getParam( 'wp_keep_scroll_position' ) ) {
-						// Restore the selection.
 						focusHTMLBookmarkInVisualEditor( editor );
-					}
 				} else {
 					tinymce.init( window.tinyMCEPreInit.mceInit[ id ] );
 				}
 
 				wrap.removeClass( 'html-active' ).addClass( 'tmce-active' );
+				tmceSwitch.attr( 'aria-pressed', false );
+				htmlSwitch.attr( 'aria-pressed', true );
 				$textarea.attr( 'aria-hidden', true );
 				window.setUserSetting( 'editor', 'tinymce' );
 
@@ -168,9 +158,7 @@ window.wp = window.wp || {};
 
 					var selectionRange = null;
 
-					if ( editor.getParam( 'wp_keep_scroll_position' ) ) {
 						selectionRange = findBookmarkedPosition( editor );
-					}
 
 					editor.hide();
 
@@ -184,6 +172,8 @@ window.wp = window.wp || {};
 				}
 
 				wrap.removeClass( 'tmce-active' ).addClass( 'html-active' );
+				tmceSwitch.attr( 'aria-pressed', true );
+				htmlSwitch.attr( 'aria-pressed', false );
 				$textarea.attr( 'aria-hidden', false );
 				window.setUserSetting( 'editor', 'html' );
 			}
@@ -520,7 +510,7 @@ window.wp = window.wp || {};
 		 * Focuses the selection markers in Visual mode.
 		 *
 		 * The method checks for existing selection markers inside the editor DOM (Visual mode)
-		 * and create a selection between the two nodes using the DOM `createRange` selection API
+		 * and create a selection between the two nodes using the DOM `createRange` selection API.
 		 *
 		 * If there is only a single node, select only the single node through TinyMCE's selection API
 		 *
@@ -545,9 +535,7 @@ window.wp = window.wp || {};
 				}
 			}
 
-			if ( editor.getParam( 'wp_keep_scroll_position' ) ) {
 				scrollVisualModeToStartElement( editor, startNode );
-			}
 
 			removeSelectionMarker( startNode );
 			removeSelectionMarker( endNode );

--- a/src/wp-admin/js/post.js
+++ b/src/wp-admin/js/post.js
@@ -431,25 +431,6 @@ jQuery( function($) {
 		$previewField.val('');
 	});
 
-	// This code is meant to allow tabbing from Title to Post content.
-	$('#title').on( 'keydown.editor-focus', function( event ) {
-		var editor;
-
-		if ( event.keyCode === 9 && ! event.ctrlKey && ! event.altKey && ! event.shiftKey ) {
-			editor = typeof tinymce != 'undefined' && tinymce.get('content');
-
-			if ( editor && ! editor.isHidden() ) {
-				editor.focus();
-			} else if ( $textarea.length ) {
-				$textarea.trigger( 'focus' );
-			} else {
-				return;
-			}
-
-			event.preventDefault();
-		}
-	});
-
 	// Auto save new posts after a title is typed.
 	if ( $( '#auto_draft' ).val() ) {
 		$( '#title' ).on( 'blur', function() {

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -82,10 +82,18 @@ final class _WP_Editors {
 		 */
 		$settings = apply_filters( 'wp_editor_settings', $settings, $editor_id );
 
+		$wp_post = get_post();
+		if ( ! $wp_post instanceof WP_Post ) {
+			$has_blocks = false;
+		} else {
+			$post = $wp_post->post_content;
+			$has_blocks = str_contains( (string) $post, '<!-- wp:' );
+		}
+
 		$set = wp_parse_args(
 			$settings,
 			array(
-				'wpautop'             => true,
+				'wpautop'             => $has_blocks,
 				'media_buttons'       => true,
 				'default_editor'      => '',
 				'drag_drop_upload'    => false,

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -82,10 +82,10 @@ final class _WP_Editors {
 		 */
 		$settings = apply_filters( 'wp_editor_settings', $settings, $editor_id );
 
-		$wp_post = get_post();
-		if ( ! $wp_post instanceof WP_Post ) {
-			$has_blocks = false;
-		} else {
+		$wp_post    = get_post();
+		$has_blocks = false;
+
+		if ( $wp_post instanceof WP_Post ) {
 			$post = $wp_post->post_content;
 			$has_blocks = str_contains( (string) $post, '<!--' );
 		}

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -93,7 +93,7 @@ final class _WP_Editors {
 		$set = wp_parse_args(
 			$settings,
 			array(
-				'wpautop'             => $has_blocks,
+				'wpautop'             => ! $has_blocks,
 				'media_buttons'       => true,
 				'default_editor'      => '',
 				'drag_drop_upload'    => false,

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -87,7 +87,7 @@ final class _WP_Editors {
 			$has_blocks = false;
 		} else {
 			$post = $wp_post->post_content;
-			$has_blocks = str_contains( (string) $post, '<!-- wp:' );
+			$has_blocks = str_contains( (string) $post, '<!--' );
 		}
 
 		$set = wp_parse_args(

--- a/src/wp-includes/class-wp-editor.php
+++ b/src/wp-includes/class-wp-editor.php
@@ -185,10 +185,12 @@ final class _WP_Editors {
 				if ( 'html' !== $default_editor ) {
 					$default_editor = 'tinymce';
 				}
+				$tmce_active = ( 'html' === $default_editor ) ? ' aria-pressed="true"' : '';
+				$html_active = ( 'html' === $default_editor ) ? '' : ' aria-pressed="true"';
 
-				$buttons .= '<button type="button" id="' . $editor_id_attr . '-tmce" class="wp-switch-editor switch-tmce"' .
+				$buttons .= '<button type="button" id="' . $editor_id_attr . '-tmce"' . $html_active . ' class="wp-switch-editor switch-tmce"' .
 					' data-wp-editor-id="' . $editor_id_attr . '">' . _x( 'Visual', 'Name for the Visual editor tab' ) . "</button>\n";
-				$buttons .= '<button type="button" id="' . $editor_id_attr . '-html" class="wp-switch-editor switch-html"' .
+				$buttons .= '<button type="button" id="' . $editor_id_attr . '-html"' . $tmce_active . ' class="wp-switch-editor switch-html"' .
 					' data-wp-editor-id="' . $editor_id_attr . '">' . _x( 'Text', 'Name for the Text editor tab (formerly HTML)' ) . "</button>\n";
 			} else {
 				$default_editor = 'tinymce';
@@ -1107,7 +1109,6 @@ final class _WP_Editors {
 			'end_container_on_empty_block' => true,
 			'wpeditimage_html5_captions'   => true,
 			'wp_lang_attr'                 => get_bloginfo( 'language' ),
-			'wp_keep_scroll_position'      => false,
 			'wp_shortcut_labels'           => wp_json_encode( $shortcut_labels ),
 		);
 

--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -1139,12 +1139,6 @@ i.mce-i-wp_code:before {
 	color: #1d2327;
 }
 
-.wp-switch-editor:active,
-.html-active .switch-html:focus,
-.tmce-active .switch-tmce:focus {
-	box-shadow: none;
-}
-
 .wp-switch-editor:active {
 	background-color: #f6f7f7;
 	box-shadow: none;


### PR DESCRIPTION
## Description
For some time I have known that any comments within the editor content can get stripped out when switching between visual and text tabs in the editor.

I had presumed that this was linked to some JavaScript but I now think it is linked to the initiation of the Editor.

Upstream `wpautop` is configure to false if Block content is detected within post content. This PR applies simple post content check for blocks to ensure post content data is not destroyed by swapping tabs when content is migrated from WordPress.

Additionally, this PR includes an A11Y backport (https://core.trac.wordpress.org/changeset/59188) for the editor and a subsequent layout correction (https://core.trac.wordpress.org/changeset/60043).

## Motivation and context
Ensures that post content integrity is respected on site migration.

## How has this been tested?
Local testing, see screen grabs.

## Screenshots
Original content as seen in 'Text' tab of the visual editor:
![Screenshot 2025-04-21 at 15 56 38](https://github.com/user-attachments/assets/013c30d8-8a3a-457b-b993-e48f98ab79c1)

### Before
Toggling to Visual and back again on `develop`:
![Screenshot 2025-04-21 at 15 57 02](https://github.com/user-attachments/assets/f3190995-843f-4fc4-9c26-ea00ed5fd2f9)


### After
Toggling to Visual and back again on this PR:
![Screenshot 2025-04-21 at 15 56 38](https://github.com/user-attachments/assets/641a8708-19f0-410c-8598-e4f1aa61eba4)


## Types of changes
- Bug fix
