### PR TITLE
Replace click event listener cleanup strategy in Quick Edit

### DIFF
--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -602,7 +602,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 									document.body.append( quickEdit );
 								}, 100 );
 							}
-						} );
+						}, { once: true } );
 					} else {
 						document.querySelectorAll( 'tr' ).forEach( function( item ) {
 							if ( item.style.display === 'none' ) {


### PR DESCRIPTION
The "options.once" parameter was removed when resolving merge conflicts after merging #1837 and #1887
It prevents multiple AJAX submissions in Quick Edit.

Edit: The click event listener cleanup strategy needed to be replaced to support HTML5 validation.
