### PR TITLE
Media modal dialog - leave space for prev/next/close buttons

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -641,6 +641,11 @@ border color while dragging a file over the uploader drop area */
 	width: 100%;
 }
 
+.edit-attachment-frame .media-frame-title {
+	left: 0;
+	right: 280px; /* leave space for prev/next/close */
+}
+
 .edit-attachment-frame .edit-media-header {
 	overflow: hidden;
 }


### PR DESCRIPTION
div media-frame-title overlaps dialog buttons so you can't navigate or close the diaolg

## Description
added right margin

## Motivation and context
div media-frame-title overlaps dialog buttons so you can't navigate or close the diaolg

## Types of changes
- Bug fix
