### PR TITLE
Themes and Plugins page - remove CP update link

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -692,14 +692,6 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 					}
 				} elseif ( ! $compatible_wp ) {
 					$incompatible_notice_message .= __( 'This plugin does not work with your version of ClassicPress.' );
-					if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-						$incompatible_notice_message .= sprintf(
-							/* translators: %s: URL to WordPress Updates screen. */
-							' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-							self_admin_url( 'update-core.php' )
-						);
-						$incompatible_notice_message .= wp_update_php_annotation( '</p><p><em>', '</em>', false );
-					}
 				} elseif ( ! $compatible_php ) {
 					$incompatible_notice_message .= __( 'This plugin does not work with your version of PHP.' );
 					if ( current_user_can( 'update_php' ) ) {

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1314,13 +1314,6 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				}
 			} elseif ( ! $compatible_wp ) {
 				$incompatible_message .= __( 'This plugin does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-					$incompatible_message .= sprintf(
-						/* translators: %s: URL to WordPress Updates screen. */
-						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-						self_admin_url( 'update-core.php' )
-					);
-				}
 			} elseif ( ! $compatible_php ) {
 				$incompatible_message .= __( 'This plugin does not work with your version of PHP.' );
 				if ( current_user_can( 'update_php' ) ) {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -865,14 +865,7 @@ function install_plugin_information() {
 			)
 		);
 	} elseif ( ! $compatible_wp ) {
-		$compatible_wp_notice_message = __( '<strong>Error:</strong> This plugin <strong>requires a newer version of ClassicPress</strong>.' );
-		if ( current_user_can( 'update_core' ) ) {
-			$compatible_wp_notice_message .= sprintf(
-				/* translators: %s: URL to WordPress Updates screen. */
-				' ' . __( '<a href="%s" target="_parent">Click here to update ClassicPress</a>.' ),
-				esc_url( self_admin_url( 'update-core.php' ) )
-			);
-		}
+		$compatible_wp_notice_message = __( '<strong>Error:</strong> This plugin <strong>does not work with your version of ClassicPress</strong>.' );
 
 		wp_admin_notice(
 			$compatible_wp_notice_message,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -985,13 +985,6 @@ function customize_themes_print_templates() {
 							<# } else if ( ! data.compatibleWP ) { #>
 								<?php
 								_e( 'This theme does not work with your version of ClassicPress.' );
-								if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-									printf(
-										/* translators: %s: URL to WordPress Updates screen. */
-										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-										self_admin_url( 'update-core.php' )
-									);
-								}
 								?>
 							<# } else if ( ! data.compatiblePHP ) { #>
 								<?php

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -340,13 +340,6 @@ if ( $tab ) {
 			<# } else if ( ! data.compatible_wp ) { #>
 				<?php
 				_e( 'This theme does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-					printf(
-						/* translators: %s: URL to WordPress Updates screen. */
-						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-						self_admin_url( 'update-core.php' )
-					);
-				}
 				?>
 			<# } else if ( ! data.compatible_php ) { #>
 				<?php
@@ -553,13 +546,6 @@ if ( $tab ) {
 								<# } else if ( ! data.compatible_wp ) { #>
 									<?php
 									_e( 'This theme does not work with your version of ClassicPress.' );
-									if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-										printf(
-											/* translators: %s: URL to WordPress Updates screen. */
-											' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-											self_admin_url( 'update-core.php' )
-										);
-									}
 									?>
 								<# } else if ( ! data.compatible_php ) { #>
 									<?php

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -556,13 +556,6 @@ foreach ( $themes as $theme ) :
 			}
 		} elseif ( ! $theme['compatibleWP'] ) {
 			$message .= __( 'This theme does not work with your version of ClassicPress.' );
-			if ( current_user_can( 'update_core' ) ) {
-				$message .= sprintf(
-					/* translators: %s: URL to WordPress Updates screen. */
-					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-					self_admin_url( 'update-core.php' )
-				);
-			}
 		} elseif ( ! $theme['compatiblePHP'] ) {
 			$message .= __( 'This theme does not work with your version of PHP.' );
 			if ( current_user_can( 'update_php' ) ) {
@@ -943,13 +936,6 @@ function wp_theme_auto_update_setting_template() {
 			<# } else if ( ! data.compatibleWP ) { #>
 				<?php
 				_e( 'This theme does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-					printf(
-						/* translators: %s: URL to WordPress Updates screen. */
-						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-						self_admin_url( 'update-core.php' )
-					);
-				}
 				?>
 			<# } else if ( ! data.compatiblePHP ) { #>
 				<?php
@@ -1112,13 +1098,6 @@ function wp_theme_auto_update_setting_template() {
 						<# } else if ( ! data.compatibleWP ) { #>
 							<?php
 							_e( 'This theme does not work with your version of ClassicPress.' );
-							if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-								printf(
-									/* translators: %s: URL to WordPress Updates screen. */
-									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-									self_admin_url( 'update-core.php' )
-								);
-							}
 							?>
 						<# } else if ( ! data.compatiblePHP ) { #>
 							<?php

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -229,13 +229,6 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 					<# } else if ( ! data.theme.compatibleWP ) { #>
 						<?php
 						_e( 'This theme does not work with your version of ClassicPress.' );
-						if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
-							printf(
-								/* translators: %s: URL to WordPress Updates screen. */
-								' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-								self_admin_url( 'update-core.php' )
-							);
-						}
 						?>
 					<# } else if ( ! data.theme.compatiblePHP ) { #>
 						<?php


### PR DESCRIPTION
## Description
I hereby suggest removing the "Please update ClassicPress" link from the themes and plugins page.
Until CP v3 is released this link does not make sense, because there's nothing to update.
And in case CP v3 becomes available, you may need the migration plugin instead.

Plus updated 1 string to match other strings.

**Update:**
After creating this PR I came up with 1 situation this link is "valid":
- Current CP version is 2.4
- Installed CP version is 2.3
- Theme/plugin says: `Requires CP: 2.4`

But there are not many themes/plugins with that tag.

## Motivation and context
IMO this link causes confusion.

## Screenshots
### Themes page
![Theme not comp](https://github.com/user-attachments/assets/5b2c3f08-4bb6-42aa-9791-b49c6619013e)

### Plugins page
![Plugin not comp 1](https://github.com/user-attachments/assets/0ab74ffb-d1d2-4341-8e22-0d7476e2b4b3)

![Plugin not comp 2](https://github.com/user-attachments/assets/6055ff0f-ec46-4843-b3e7-a8c4b4b5f057)

## Types of changes
- No breaking changes
