### PR TITLE
Inject meta into wp prepare attachment for js()

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -4084,3 +4084,25 @@ function cp_add_cats_and_tags_to_attachment_for_js( $response, $attachment, $met
 	return $response;
 }
 add_filter( 'wp_prepare_attachment_for_js', 'cp_add_cats_and_tags_to_attachment_for_js', 10, 3 );
+
+/**
+ * Adds metadata to the array of attachment details.
+ *
+ * @since CP-2.5.0
+ *
+ * @return array
+ */
+function cp_add_meta_to_attachment_for_js( $response, $attachment, $meta ) {
+
+	/**
+	 * Filters the metadata included in the array of attachment details.
+	 *
+	 * @since CP-2.5.0
+	 *
+	 * @return array  $meta  Media file metadata
+	 */
+	$response['meta'] = apply_filters( 'cp_media_meta_for_js', $meta );
+
+	return $response;
+}
+add_filter( 'wp_prepare_attachment_for_js', 'cp_add_meta_to_attachment_for_js', 10, 3 );

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -431,7 +431,7 @@ if ( 'grid' === $mode ) {
 					$media_cats   = $data['media_cats'] ? implode( ', ', $data['media_cats'] ) : '';
 					$media_tags   = $data['media_tags'] ? implode( ', ', $data['media_tags'] ) : '';
 					$artist       = $data['meta'] && ! empty( $data['meta']['artist'] ) ? $data['meta']['artist'] : '';
-					$album        = $data['meta'] && ! empty( $data['meta']['artist'] ) ? $data['meta']['album'] : '';
+					$album        = $data['meta'] && ! empty( $data['meta']['album'] ) ? $data['meta']['album'] : '';
 					$update_nonce = $data['nonces']['update'];
 					$delete_nonce = $data['nonces']['delete'];
 					$edit_nonce   = $data['nonces']['edit'];

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -410,29 +410,31 @@ if ( 'grid' === $mode ) {
 
 				<?php
 				foreach ( $attachments->posts as $key => $attachment ) {
-					$meta = wp_prepare_attachment_for_js( $attachment->ID );
-					$date         = $meta['dateFormatted'];
-					$author       = $meta['authorName'];
-					$author_link  = ! empty( $meta['authorLink'] ) ? $meta['authorLink'] : '';
-					$url          = $meta['url'];
-					$width        = ! empty( $meta['width'] ) ? $meta['width'] : '';
-					$height       = ! empty( $meta['height'] ) ? $meta['height'] : '';
-					$file_name    = $meta['filename'];
-					$file_type    = $meta['type'];
-					$subtype      = $meta['subtype'];
-					$mime_type    = $meta['mime'];
-					$size         = ! empty( $meta['filesizeHumanReadable'] ) ? $meta['filesizeHumanReadable'] : '';
-					$alt          = $meta['alt'];
-					$caption      = $meta['caption'];
-					$description  = $meta['description'];
-					$link         = $meta['link'];
-					$orientation  = ! empty( $meta['orientation'] ) ? $meta['orientation'] : 'landscape';
-					$menu_order   = $meta['menuOrder'];
-					$media_cats   = $meta['media_cats'] ? implode( ', ', $meta['media_cats'] ) : '';
-					$media_tags   = $meta['media_tags'] ? implode( ', ', $meta['media_tags'] ) : '';
-					$update_nonce = $meta['nonces']['update'];
-					$delete_nonce = $meta['nonces']['delete'];
-					$edit_nonce   = $meta['nonces']['edit'];
+					$data = wp_prepare_attachment_for_js( $attachment->ID );
+					$date         = $data['dateFormatted'];
+					$author       = $data['authorName'];
+					$author_link  = ! empty( $data['authorLink'] ) ? $data['authorLink'] : '';
+					$url          = $data['url'];
+					$width        = ! empty( $data['width'] ) ? $data['width'] : '';
+					$height       = ! empty( $data['height'] ) ? $data['height'] : '';
+					$file_name    = $data['filename'];
+					$file_type    = $data['type'];
+					$subtype      = $data['subtype'];
+					$mime_type    = $data['mime'];
+					$size         = ! empty( $data['filesizeHumanReadable'] ) ? $data['filesizeHumanReadable'] : '';
+					$alt          = $data['alt'];
+					$caption      = $data['caption'];
+					$description  = $data['description'];
+					$link         = $data['link'];
+					$orientation  = ! empty( $data['orientation'] ) ? $data['orientation'] : 'landscape';
+					$menu_order   = $data['menuOrder'];
+					$media_cats   = $data['media_cats'] ? implode( ', ', $data['media_cats'] ) : '';
+					$media_tags   = $data['media_tags'] ? implode( ', ', $data['media_tags'] ) : '';
+					$artist       = $data['meta'] && ! empty( $data['meta']['artist'] ) ? $data['meta']['artist'] : '';
+					$album        = $data['meta'] && ! empty( $data['meta']['artist'] ) ? $data['meta']['album'] : '';
+					$update_nonce = $data['nonces']['update'];
+					$delete_nonce = $data['nonces']['delete'];
+					$edit_nonce   = $data['nonces']['edit'];
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '">';
 
 					// Use an icon if the file uploaded is not an image
@@ -471,6 +473,8 @@ if ( 'grid' === $mode ) {
 						data-menu-order="<?php echo esc_attr( $menu_order ); ?>"
 						data-taxes="<?php echo esc_attr( $media_cats ); ?>"
 						data-tags="<?php echo esc_attr( $media_tags ); ?>"
+						data-artist="<?php echo esc_attr( $artist ); ?>"
+						data-album="<?php echo esc_attr( $album ); ?>"
 						data-order="<?php echo esc_attr( $key + 1 ); ?>"
 						data-update-nonce="<?php echo $update_nonce; ?>"
 						data-delete-nonce="<?php echo $delete_nonce; ?>"


### PR DESCRIPTION
As discussed on Zulip, this PR makes all media metadata available for use by JavaScript by simply taking the third parameter exposed by the `wp_prepare_attachment_for_js` filter, which is `$meta`, and injecting it through that filter. As the metadata is already exposed by the filter, there is no additional cost to this in terms of trips to the database.

This PR then also makes immediate use of this metadata by including the artist's name and album title (if any) among the data attributes included for audio elements within the media library grid. This can be tested by using the browser inspector to check for the new data attributes, `data-artist` and `data-album` in the media library grid.

![Screenshot at 2025-04-30 11-42-19](https://github.com/user-attachments/assets/acc048fc-8d53-4f42-b6f1-51fc0d6aa9e2)

A further PR will be needed to create the fields where this information can be displayed, though I will will also be able to make immediate use of it as I work towards a PR to rebuild the media audio widget without backbone.