### PR TITLE
Remove tags from Customizer theme modal for new WP themes

### DIFF
--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -1025,10 +1025,6 @@ function customize_themes_print_templates() {
 					<# } #>
 
 					<p class="theme-description">{{{ data.description }}}</p>
-
-					<# if ( data.tags ) { #>
-						<p class="theme-tags"><span><?php _e( 'Tags:' ); ?></span> {{{ data.tags }}}</p>
-					<# } #>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Description
This PR, as agreed in the weekly core chat, removes the Theme tag listing from the Theme modal displayed when viewing new themes from WordPress.org in the Customizer. This removed 

## Motivation and context
Fixes #1910 

## How has this been tested?
Locally tested, see screen grabs below

## Screenshots
### Before
![Screenshot 2025-05-01 at 18 33 03](https://github.com/user-attachments/assets/005c365d-1de8-4594-8eda-2fc63d6142ec)

### After
![Screenshot 2025-05-01 at 18 33 30](https://github.com/user-attachments/assets/4c1cacde-3876-4014-88fc-b794367b7d7e)

## Types of changes
- Bug fix