### PR TITLE
ClassicPress Theme - fix loading of woff2 files in editor

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/editor-style.css
+++ b/src/wp-content/themes/the-classicpress-theme/editor-style.css
@@ -1,50 +1,47 @@
 /* CSS Document */
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Source Sans Pro Regular'), 
-	local('SourceSansPro-Regular'),
-    url('../fonts/source-sans-pro-v12-latin-regular.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: normal;
+	font-weight: 400;
+	src: local("Source Sans Pro Regular"), local("SourceSansPro-Regular"),
+		url("fonts/source-sans-pro-v12-latin-regular.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 600;
-  src: local('Source Sans Pro SemiBold'), 
-	local('SourceSansPro-SemiBold'),
-    url('../fonts/source-sans-pro-v12-latin-600.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: italic;
+	font-weight: 400;
+	src: local("Source Sans Pro Italic"), local("SourceSansPro-Italic"),
+		url("fonts/source-sans-pro-v12-latin-italic.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Source Sans Pro Italic'), 
-	local('SourceSansPro-Italic'),
-    url('../fonts/source-sans-pro-v12-latin-italic.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: normal;
+	font-weight: 600;
+	src: local("Source Sans Pro SemiBold"), local("SourceSansPro-SemiBold"),
+		url("fonts/source-sans-pro-v12-latin-600.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: italic;
-  font-weight: 600;
-  src: local('Source Sans Pro SemiBold Italic'),
-	local('SourceSansPro-SemiBoldItalic'),
-    url('../fonts/source-sans-pro-v12-latin-600italic.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: italic;
+	font-weight: 600;
+	src: local("Source Sans Pro SemiBold Italic"),
+		local("SourceSansPro-SemiBoldItalic"),
+		url("fonts/source-sans-pro-v12-latin-600italic.woff2") format("woff2");
 }
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'),
-    url('../fonts/source-sans-pro-v12-latin-700.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: normal;
+	font-weight: 700;
+	src: local("Source Sans Pro Bold"), local("SourceSansPro-Bold"),
+		url("fonts/source-sans-pro-v12-latin-700.woff2") format("woff2");
 }
+
 @font-face {
-  font-family: 'Source Sans Pro';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Source Sans Pro Bold Italic'), 
-	local('SourceSansPro-BoldItalic'),
-    url('../fonts/source-sans-pro-v12-latin-700italic.woff2') format('woff2');
+	font-family: "Source Sans Pro";
+	font-style: italic;
+	font-weight: 700;
+	src: local("Source Sans Pro Bold Italic"), local("SourceSansPro-BoldItalic"),
+		url("fonts/source-sans-pro-v12-latin-700italic.woff2") format("woff2");
 }
 
 :root {


### PR DESCRIPTION
## Description
Because of moving file `editor-style.css` to main theme folder, the link to the woff2 files should be changed as well.
Copy-pasted whole code block from file `style.css`.
This also changed the indent (from spaces to tabs) and double quotes instead of single quotes.

Props: @citrika

## Screenshots
### Before
![woff2](https://github.com/user-attachments/assets/92dc7095-5319-4824-89e2-05a6598edb15)

## Types of changes
No breaking change