### PR TITLE
Fix deprecated warning at settings page and in editor

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4868,8 +4868,6 @@ function wp_enqueue_media( $args = array() ) {
 
 	$strings['settings'] = $settings;
 
-	wp_enqueue_script( 'jquery-ui-sortable' );
-
 	// Ensure we enqueue media-editor first, that way media-views
 	// is registered internally before we try to localize it. See #24724.
 	wp_enqueue_script( 'media-editor' );


### PR DESCRIPTION
## Description
With debugging `true` there's a deprecated warning at page Settings > General and in the Post and Page editor.
Related to media handling.

```
Deprecated: Function wp_enqueue_script was called with an argument that is deprecated since version CP-2.2.0! The enqueued script jquery-ui-core has been deprecated.
Deprecated: Function wp_enqueue_script was called with an argument that is deprecated since version CP-2.2.0! The enqueued script jquery-ui-mouse has been deprecated.
Deprecated: Function wp_enqueue_script was called with an argument that is deprecated since version CP-2.2.0! The enqueued script jquery-ui-sortable has been deprecated.
```
Fixed it by removing `wp_enqueue_script( 'jquery-ui-sortable' );` from file `wp-includes/media.php`.

Strangely enough this string is not present in WP 6.2.3 nor in [current](https://github.com/WordPress/WordPress/blob/master/wp-includes/media.php#L5109) WP version.

Also mentioned in [this post](https://forums.classicpress.net/t/deprecated-warning-at-settings-page/6145) at the CP forum.

## How has this been tested?
Local install.
After removing the string I can still insert files, images, site icon, etc.

## Types of changes
- No breaking change