### PR TITLE
Update workflow runs to use concurrency

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -10,11 +10,14 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Runs the PHPUnit tests for ClassicPress.
   #
   # Performs the following steps:
-  # - Cancel workflow if PR updated.
   # - Checkout ClassicPress.
   # - Set environment variables.
   # - Read .nvmrc.
@@ -83,12 +86,6 @@ jobs:
             experimental: false
 
     steps:
-      - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: Configure environment variables
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
The PHPUnit tests take the longest time to complete, and we use an action to cancel in progress tests when a new commit is added to an open pull request... only it isn't working, the running process still completes.

On investigating it may be a better option to use the built in [concurrency](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) controls. 

## Motivation and context
More efficient GitHub Action usage.
Stop using outdated and failing GitHub action

## How has this been tested?
Syntax is as recommended here, will be able to test once committed and a PR is rapidly updated with another commit.

## Screenshots
### Before
![Screenshot 2025-05-14 at 17 00 49](https://github.com/user-attachments/assets/d15cc867-a5cc-4863-813e-a2ce43e4da77)

### After
N/A

## Types of changes
- New feature
