### PR TITLE
Adjust concurrency group

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * 0'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description
Follow up to #1936 
The addition of the concurreny syntax to the PHPUnit tests did result in job cancellation (see screen grabs below) but the `group` definition is cancelling jobs running on `develop` when it should not.

I believe this syntax may be more appropriate:
`${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}`

github.workflow ensure the cancellation applies only to this workflow.
github.event_name limits to pull requests and github.head_ref is the branch name of a PR
If the workflow is not on a PR, github.sha is used instead to avoid erros and that should always be unique.

[I have set the failed job in the image below to run again so anyone investigating the past actions may need to check for the first run]

## Motivation and context
Ensures completion of sequential jobs on the `develop` branch.

## How has this been tested?

## Screenshots
### Before
![Screenshot 2025-05-15 at 19 39 17](https://github.com/user-attachments/assets/388ca30c-5f6e-4f5f-a47a-f51adece5088)

![Screenshot 2025-05-15 at 19 47 29](https://github.com/user-attachments/assets/dbc680b4-7fb6-4fe7-9929-b92e6a92c4a0)

### After
N/A

## Types of changes
- Enhancement