### PR TITLE
Ensure TinyMCE is always displayed in Text widget

### DIFF
--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -72,4 +72,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	document.addEventListener( 'widget-added', handleWidgetUpdate );
 	document.addEventListener( 'widget-synced', handleWidgetUpdate );
 	document.addEventListener( 'widget-updated', handleWidgetUpdate );
+
+	// Ensure TinyMCE loads on page load
+	document.querySelectorAll( '#widgets-right .id_base' ).forEach( function( base ) {
+		if ( base.value === 'text' ) {
+			initTextWidget( base.closest ( '.widget' ).querySelector( 'textarea' ) );
+		}
+	} );
 } );


### PR DESCRIPTION
In the core meeting today, there was some discussion about the Text widget not always displaying the TinyMCE editor. I have had a further look since then, and it seems to be an issue of when the relevant scripts load. This PR addresses that problem by making an explicit call to initialize TinyMCE for each text widget on page load.