### PR TITLE
Update and fix color picker slider in Customizer

### DIFF
--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -240,10 +240,8 @@ input+.iris-picker {
 .iris-picker .iris-slider-offset {
 	position:absolute;
 	top:0;
-	left:-86px;
 	right:0;
 	bottom:0;
-	width:200px !important;
 	height:auto;
 	background:transparent;
 	border:0;

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -248,7 +248,6 @@ input+.iris-picker {
 	background:transparent;
 	border:0;
 	border-radius:0;
-	transform:rotate(270deg);
 }
 .iris-strip-horiz .iris-slider-offset {
 	top:0;

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -252,7 +252,7 @@ input+.iris-picker {
 	bottom:0;
 	right:0;
 	left:0;
-	width:auto !important;
+	width:auto;
 }
 .iris-picker .iris-square-handle {
 	background:transparent;

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -253,7 +253,8 @@ input+.iris-picker {
 	top:0;
 	bottom:0;
 	right:11px;
-	left:-3px;
+	left:0;
+	width:255px !important;
 }
 .iris-picker .iris-square-handle {
 	background:transparent;

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -239,14 +239,16 @@ input+.iris-picker {
 }
 .iris-picker .iris-slider-offset {
 	position:absolute;
-	top:11px;
-	left:0;
+	top:0;
+	left:-86px;
 	right:0;
-	bottom:-3px;
-	width:auto;
+	bottom:0;
+	width:200px !important;
 	height:auto;
 	background:transparent;
-	border:0;border-radius:0;
+	border:0;
+	border-radius:0;
+	transform:rotate(270deg);
 }
 .iris-strip-horiz .iris-slider-offset {
 	top:0;

--- a/src/wp-admin/css/color-picker.css
+++ b/src/wp-admin/css/color-picker.css
@@ -252,9 +252,9 @@ input+.iris-picker {
 .iris-strip-horiz .iris-slider-offset {
 	top:0;
 	bottom:0;
-	right:11px;
+	right:0;
 	left:0;
-	width:255px !important;
+	width:auto !important;
 }
 .iris-picker .iris-square-handle {
 	background:transparent;

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -11,8 +11,7 @@
 	position: relative;
 	min-height: 50px;
 }
-.sliders-control input[type="range"],
-.wp-picker-holder input[type="range"] {
+.sliders-control input[type="range"] {
 	-moz-appearance: none;
 	appearance: none;
 	height: 4px;
@@ -21,12 +20,10 @@
 	background-color: #00b3bc;
 	pointer-events: none;
 }
-.sliders-control input[type="range"]:focus,
-.wp-picker-holder input[type="range"]:focus {
+.sliders-control input[type="range"]:focus {
 	outline: 0;
 }
-.sliders-control input[type="range"]::-webkit-slider-thumb,
-.wp-picker-holder input[type="range"]::-webkit-slider-thumb {
+.sliders-control input[type="range"]::-webkit-slider-thumb {
 	appearance: none;
 	pointer-events: all;
 	width: 30px;
@@ -37,8 +34,7 @@
 	cursor: pointer;
 	margin-top: -1.2em;
 }
-.sliders-control input[type="range"]::-moz-range-thumb,
-.wp-picker-holder input[type="range"]::-moz-range-thumb {
+.sliders-control input[type="range"]::-moz-range-thumb {
 	border: none;
 	pointer-events: all;
 	width: 30px;
@@ -48,26 +44,22 @@
 	box-shadow: 0 0 0 1px #C6C6C6;
 	cursor: pointer;
 }
-.sliders-control input[type="range"]:hover::-webkit-slider-thumb,
-.wp-picker-holder input[type="range"]:hover::-webkit-slider-thumb {
+.sliders-control input[type="range"]:hover::-webkit-slider-thumb {
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-.sliders-control input[type="range"]:hover::-moz-range-thumb,
-.wp-picker-holder input[type="range"]:hover::-moz-range-thumb {
+.sliders-control input[type="range"]:hover::-moz-range-thumb {
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-.sliders-control input[type="range"]:focus::-webkit-slider-thumb,
-.wp-picker-holder input[type="range"]:focus::-webkit-slider-thumb {
+.sliders-control input[type="range"]:focus::-webkit-slider-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1; 
 	border: 1px solid #053a5f;
 	outline: 3px solid #053a5f;
 	outline-offset: 0.125rem; 
 }
-.sliders-control input[type="range"]:focus::-moz-range-thumb,
-.wp-picker-holder input[type="range"]:focus::-moz-range-thumb {
+.sliders-control input[type="range"]:focus::-moz-range-thumb {
 	background-color: red;
 	box-shadow: 0 0 0 1px #2271b1;
 	border: 1px solid #053a5f;

--- a/src/wp-admin/js/iris.js
+++ b/src/wp-admin/js/iris.js
@@ -592,13 +592,10 @@
 				stripOrientation = self.horizontalSlider ? 'horizontal' : 'vertical';
 
 			if ( stripOrientation === 'vertical' ) {
-				// Use non-standard attribute to ensure Firefox doesn't reverse the scale
-				if ( userAgent.match( /firefox|fxios/i ) ) {
-					controls.stripSlider[0].setAttribute( 'orient', 'vertical' );
-				} else {
-					controls.stripSlider[0].style.writingMode = 'vertical-rl'; // scale runs from bottom to top
-					controls.stripSlider[0].style.webkitAppearance = 'slider-vertical'; // for Safari
-				}
+				controls.stripSlider[0].setAttribute( 'writing-mode', 'vertical-lr' );
+				controls.stripSlider[0].setAttribute( 'appearance', 'slider-vertical' );
+				controls.stripSlider[0].setAttribute( 'direction', 'rtl' );
+				controls.stripSlider[0].setAttribute( 'vertical-align', 'bottom' );
 			}
 
 			controls.stripSlider[0].setAttribute( 'min', '0' );
@@ -606,7 +603,7 @@
 
 			controls.stripSlider.on( 'input', function( e ) {
 				self.active = 'strip';
-				self._color[controlOpts.strip]( e.currentTarget.value );
+				self._color[controlOpts.strip]( e.target.value );
 				self._change.apply( self, arguments );
 			} );
 

--- a/src/wp-admin/js/iris.js
+++ b/src/wp-admin/js/iris.js
@@ -592,10 +592,10 @@
 				stripOrientation = self.horizontalSlider ? 'horizontal' : 'vertical';
 
 			if ( stripOrientation === 'vertical' ) {
-				controls.stripSlider[0].setAttribute( 'writing-mode', 'vertical-lr' );
-				controls.stripSlider[0].setAttribute( 'appearance', 'slider-vertical' );
-				controls.stripSlider[0].setAttribute( 'direction', 'rtl' );
-				controls.stripSlider[0].setAttribute( 'vertical-align', 'bottom' );
+				controls.stripSlider[0].style.writingMode = 'vertical-lr';
+				controls.stripSlider[0].style.appearance = 'slider-vertical';
+				controls.stripSlider[0].style.direction = 'rtl';
+				controls.stripSlider[0].style.verticalAlign = 'bottom';
 			}
 
 			controls.stripSlider[0].setAttribute( 'min', '0' );


### PR DESCRIPTION
At the moment, the slider in the color picker in the Customizer won't slide. (If it gets focus, it can still be used to change the color values using the arrow keys, but the slider itself won't move.) This is because the browsers have not, until recently, agreed on how a vertical slider should work, and so each did it differently, and our code made allowances for those differences.

But now there is a shared spec, and our code no longer works properly. This PR fixes that.

A welcome by-product of this is that we can let the browsers handle the precise way that the slider gets displayed instead of needing to take over control ourselves.

## How to reproduce the current issue
To see the current problem, open the Customizer with a theme (like CP TwentyFifteen) that supports changing colors. Go to the Colors panel and attempt to make the slider move. It won't, though the track pad to the left works, and the slider itself works to change values if it gains focus and the arrow keys are used.

When the PR is applied, the slider will slide as expected.

## How has this been tested?
Tested on localhost in Firefox, Chrome and Web (Safari-style browser for Linux).
