### PR TITLE
Update coding standards workflow to use Composer dependencies

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -118,11 +118,8 @@ jobs:
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 
-      - name: Install PHPUnit
-        run: |
-          wget -O phpunit https://phar.phpunit.de/phpunit-8.phar
-          chmod +x phpunit
-          sudo mv phpunit /usr/bin/
+      - name: Make Composer packages available globally
+        run: echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 
       - name: Enable, start and initialise MySQL
         run: |


### PR DESCRIPTION
## Description
Pre-commit checks in the Coding Standards workflow are currently failing because the PHPUnit.de site has an invalid SSL certificate.

![Screenshot 2025-05-24 at 11 51 06](https://github.com/user-attachments/assets/20900031-5781-434f-b1da-2e7ecdc3b2e5)

On reviewing the workflow configuration, PHPUnit 8 is manually installed, but the composer.json configuration uses PHPunit 9 which should work fine, thus avoiding a manual installation step.

## Motivation and context
Simplyify workflow and reduce dependency range.

## How has this been tested?
GitHub actions on this branch should confirm this PR is a solution.

## Screenshots
### Before
![Screenshot 2025-05-24 at 11 54 14](https://github.com/user-attachments/assets/82c1260d-16c2-4c5d-825f-cc9f40952ce3)

### After
![Screenshot 2025-05-24 at 11 56 17](https://github.com/user-attachments/assets/eb7febcf-ee18-4818-ac6f-0061565ec647)

## Types of changes
- Bug fix