### PR TITLE
Enable attribution of content to a different user when a user is deleted

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -777,11 +777,13 @@ class WP_User_Query {
 		/**
 		 * Enable grouping of users by taxonomy term on 'users.php' page.
 		 *
+		 * Do not run when deleting one or more users.
+		 *
 		 * @since CP-2.1.0
 		 *
 		 */
 		global $pagenow;
-		if ( $pagenow === 'users.php' ) {
+		if ( $pagenow === 'users.php' && ! str_contains( filter_input( INPUT_SERVER, 'QUERY_STRING', FILTER_SANITIZE_STRING ), 'action=delete' ) ) {
 
 			// Get user taxonomies
 			$taxonomies = get_taxonomies(


### PR DESCRIPTION
This PR fixes Issue #1960 . The problem was caused by user taxonomies being invoked on the user delete screen because that is still `users.php`. This PR adds a check for query parameters and prevents the taxonomy-related code being invoked if one of those parameters is `action=delete`.