### PR TITLE
Improve the semantics of the plugin install page

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1451,6 +1451,7 @@ ul.cat-checklist {
 .plugin-install-php #the-list {
 	display: flex;
 	flex-wrap: wrap;
+	margin-top: -1px;
 }
 
 .plugin-install-php .plugin-card {

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -341,9 +341,9 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 		<?php
 		$this->screen->render_screen_reader_content( 'heading_list' );
 		?>
-	<div id="the-list"<?php echo $data_attr; ?>>
+	<ul id="the-list"<?php echo $data_attr; ?>>
 		<?php $this->display_rows_or_placeholder(); ?>
-	</div>
+	</ul>
 </div>
 		<?php
 		$this->display_tablenav( 'bottom' );
@@ -653,7 +653,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 			$last_updated_timestamp = strtotime( $plugin['last_updated'] );
 			?>
-		<div class="plugin-card plugin-card-<?php echo sanitize_html_class( $plugin['slug'] ); ?>">
+		<li class="plugin-card plugin-card-<?php echo sanitize_html_class( $plugin['slug'] ); ?>">
 			<?php
 			if ( ! $compatible_php || ! $compatible_wp ) {
 				$incompatible_notice_message = '';
@@ -792,7 +792,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 					?>
 				</div>
 			</div>
-		</div>
+		</li>
 			<?php
 		}
 


### PR DESCRIPTION
This PR changes the HTML for the layout of the plugins on the `~/wp-admin/plugin-install.php` page. It changes the container `#the-list` that holds all the plugins from a `div` to a `ul`, and it changes each plugin element from another `div` to a `li`. This change mirrors one made for themes as part of PR #1929.

There's also a minor CSS tweak to prevent the container from dropping down a little.