### PR TITLE
Unify check for `$cp_needs_update` into one function and source of truth

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -425,8 +425,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	}
 
 	public function display_rows() {
-		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+		$cp_needs_update = classicpress_needs_update();
 
 		$plugins_allowedtags = array(
 			'a'       => array(

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -705,9 +705,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 * @param array $item
 	 */
 	public function single_row( $item ) {
-
-		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+		$cp_needs_update = classicpress_needs_update();
 
 		global $status, $page, $s, $totals;
 		static $plugin_id_attrs = array();

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -779,8 +779,7 @@ function wp_prepare_themes_for_js( $themes = null ) {
  * @since 4.2.0
  */
 function customize_themes_print_templates() {
-	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+	$cp_needs_update = classicpress_needs_update();
 
 	?>
 	<script type="text/html" id="tmpl-customize-themes-details-view">

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -641,10 +641,8 @@ function wp_theme_update_rows() {
  * @return void|false
  */
 function wp_theme_update_row( $theme_key, $theme ) {
-
-	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
-	$current          = get_site_transient( 'update_themes' );
+	$cp_needs_update = classicpress_needs_update();
+	$current         = get_site_transient( 'update_themes' );
 
 	if ( ! isset( $current->response[ $theme_key ] ) ) {
 		return false;

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -10,8 +10,7 @@
 require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/theme-install.php';
 
-$updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+$cp_needs_update = classicpress_needs_update();
 
 wp_reset_vars( array( 'tab' ) );
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -417,8 +417,7 @@ if ( ! empty( $_GET['search'] ) ) {
 /*
  * This PHP is synchronized with the tmpl-theme template below!
  */
-$updates_from_api = get_site_transient( 'update_core' );
-$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+$cp_needs_update = classicpress_needs_update();
 
 foreach ( $themes as $theme ) :
 	$aria_action = $theme['id'] . '-action';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -456,9 +456,8 @@ function list_plugin_updates() {
  * @since 2.9.0
  */
 function list_theme_updates() {
-	$updates_from_api = get_site_transient( 'update_core' );
-	$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
-	$themes           = get_theme_updates();
+	$cp_needs_update = classicpress_needs_update();
+	$themes          = get_theme_updates();
 	if ( empty( $themes ) ) {
 		echo '<h2>' . __( 'Themes' ) . '</h2>';
 		echo '<p>' . __( 'Your themes are all up to date.' ) . '</p>';

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -57,8 +57,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 	 * @since 4.2.0
 	 */
 	public function content_template() {
-		$updates_from_api = get_site_transient( 'update_core' );
-		$cp_needs_update  = isset( $updates_from_api->updates ) && is_array( $updates_from_api->updates ) && ! empty( $updates_from_api->updates );
+		$cp_needs_update = classicpress_needs_update();
 		/* translators: %s: Theme name. */
 		$details_label = sprintf( __( 'Details for theme: %s' ), '{{ data.theme.name }}' );
 		/* translators: %s: Theme name. */

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -125,3 +125,17 @@ if ( ! function_exists( 'classicpress_is_dev_install' ) ) {
 		return substr( $cp_version, -4 ) === '+dev';
 	}
 }
+
+/**
+ * Determine whether ClassicPress needs updating
+ *
+ * @since CP-2.5.0
+ *
+ * @return bool Whether the current install needs updating to the latest version of ClassicPress
+ */
+if ( ! function_exists( 'classicpress_needs_update' ) ) {
+	function classicpress_needs_update() {
+		$updates_from_api = get_site_transient( 'update_core' );
+		return empty( $updates_from_api ) || empty( $updates_from_api->version_checked !== $updates_from_api->updates );
+	}
+}


### PR DESCRIPTION
ClassicPress core is littered with checks for `$cp_needs_update`. Unfortunately, these checks do not all use the same code, and the code that some of them use does not work as expected.

This PR creates a function, `classicpress_needs_update`, that runs a check that does work and then has every instance of `$cp_needs_update` use this function. This avoids the current inconsistency by creating one source of truth. It also makes it possible to update the check in future as deemed desirable by just changing the code in one place: in the function.

This PR fixes Issue #1933.