### PR TITLE
CP dashboard - fix comments in Activity widget

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1082,6 +1082,7 @@ function wp_dashboard_recent_comments( $total_items = 5 ) {
 	$comments_query = array(
 		'number' => $total_items * 5,
 		'offset' => 0,
+		'post_type' => 'post',
 	);
 
 	if ( ! current_user_can( 'edit_posts' ) ) {


### PR DESCRIPTION
## Description
In some cases the Activity widget returns a warning:
`Notice: map_meta_cap was called <strong>incorrectly</strong>. The post type shop_order is not registered
`
In my case because ClassicCommerce was deactivated. 
Same issue in WP, reported years ago but still not fixed. Check for example [this PR](https://github.com/WordPress/wordpress-develop/pull/3045).

My PR fixes this, by listing comments for posts only. Because this is what the [Activity widget](https://docs.classicpress.net/user-guides/using-classicpress/dashboard-screen/#activity) should list.

## How has this been tested?
- Local install.

## Screenshots
### Before
![Activity widget - before 1](https://github.com/user-attachments/assets/dc46de55-1b46-4514-9a1a-6e9b88e57034)

![Activity widget - before 2](https://github.com/user-attachments/assets/4dc62fed-56b1-45e4-9684-b62911c5b896)

### After
![Activity widget - after](https://github.com/user-attachments/assets/fc9547b9-55ca-4efe-911d-77c63e2b57ab)

## Types of changes
- Bug fix
