### PR TITLE
Remove redundant function from media widgets

### DIFF
--- a/src/wp-includes/widgets/class-wp-widget-custom-html.php
+++ b/src/wp-includes/widgets/class-wp-widget-custom-html.php
@@ -215,8 +215,6 @@ class WP_Widget_Custom_HTML extends WP_Widget {
 	 *
 	 * @since CP-2.3.0
 	 *
-	 * @see WP_Widget_Custom_HTML::render_control_template_scripts()
-	 *
 	 * @param array $instance Current instance.
 	 */
 	public function form( $instance ) {

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -115,10 +115,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_preview_scripts' ) );
 		}
 
-		// Note that the widgets component in the customizer will also do
-		// the 'admin_footer-widgets.php' action in WP_Customize_Widgets::print_footer_scripts().
-		add_action( 'admin_footer-widgets.php', array( $this, 'render_control_template_scripts' ) );
-
 		add_filter( 'display_media_states', array( $this, 'display_media_state' ), 10, 2 );
 	}
 
@@ -328,8 +324,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 * @since 4.8.0
 	 * @since CP-2.5.0 `form` function can be overridden by extending classes
 	 *
-	 * @see \WP_Widget_Media::render_control_template_scripts() Where the JS template is located.
-	 *
 	 * @param array $instance Current settings.
 	 */
 	public function form( $instance ) {
@@ -402,42 +396,6 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 */
 	public function enqueue_admin_scripts() {
 		wp_enqueue_media();
-	}
-
-	/**
-	 * Render form template scripts.
-	 *
-	 * @since 4.8.0
-	 */
-	public function render_control_template_scripts() {
-		?>
-		<script type="text/html" id="tmpl-widget-media-<?php echo esc_attr( $this->id_base ); ?>-control">
-			<# var elementIdPrefix = 'el' + String( Math.random() ) + '_' #>
-			<p>
-				<label for="{{ elementIdPrefix }}title"><?php esc_html_e( 'Title:' ); ?></label>
-				<input id="{{ elementIdPrefix }}title" type="text" class="widefat title">
-			</p>
-			<div class="media-widget-preview <?php echo esc_attr( $this->id_base ); ?>">
-				<div class="attachment-media-view">
-					<button type="button" class="select-media button-add-media not-selected">
-						<?php echo esc_html( $this->l10n['add_media'] ); ?>
-					</button>
-				</div>
-			</div>
-			<p class="media-widget-buttons">
-				<button type="button" class="button edit-media selected">
-					<?php echo esc_html( $this->l10n['edit_media'] ); ?>
-				</button>
-			<?php if ( ! empty( $this->l10n['replace_media'] ) ) : ?>
-				<button type="button" class="button change-media select-media selected">
-					<?php echo esc_html( $this->l10n['replace_media'] ); ?>
-				</button>
-			<?php endif; ?>
-			</p>
-			<div class="media-widget-fields">
-			</div>
-		</script>
-		<?php
 	}
 
 	/**

--- a/tests/phpunit/tests/widgets/wpWidgetMedia.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMedia.php
@@ -79,7 +79,6 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 		$this->assertSame( count( $widget->l10n ), count( array_filter( $widget->l10n ) ), 'Expected all translation strings to be defined.' );
 		$this->assertSame( 10, has_action( 'admin_print_scripts-widgets.php', array( $widget, 'enqueue_admin_scripts' ) ) );
 		$this->assertFalse( has_action( 'wp_enqueue_scripts', array( $widget, 'enqueue_preview_scripts' ) ), 'Did not expect preview scripts to be enqueued when not in customize preview context.' );
-		$this->assertSame( 10, has_action( 'admin_footer-widgets.php', array( $widget, 'render_control_template_scripts' ) ) );
 
 		// With non-default args.
 		$id_base         = 'media_pdf';
@@ -461,21 +460,6 @@ class Tests_Widgets_wpWidgetMedia extends WP_UnitTestCase {
 		$widget->enqueue_admin_scripts();
 
 		$this->assertTrue( wp_script_is( 'wp-mediaelement' ) );
-	}
-
-	/**
-	 * Test render_control_template_scripts method.
-	 *
-	 * @covers WP_Widget_Media::render_control_template_scripts
-	 */
-	public function test_render_control_template_scripts() {
-		$widget = $this->get_mocked_class_instance();
-
-		ob_start();
-		$widget->render_control_template_scripts();
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( '<script type="text/html" id="tmpl-widget-media-mocked-control">', $output );
 	}
 
 	/**


### PR DESCRIPTION
After all the recent updates to media widgets, the function `render_control_template_scripts` no longer does anything. (A quick `grep` confirms this.) This PR removes the function and deletes several references to it in code comments and docblocks.