### PR TITLE
Ensure Code Mirror loads in Custom HTML widget

### DIFF
--- a/src/wp-admin/js/widgets/custom-html-widgets.js
+++ b/src/wp-admin/js/widgets/custom-html-widgets.js
@@ -55,4 +55,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	document.addEventListener( 'widget-added', handleWidgetUpdate );
 	document.addEventListener( 'widget-synced', handleWidgetUpdate );
 	document.addEventListener( 'widget-updated', handleWidgetUpdate );
+
+	// Ensure Code Mirror loads on page load
+	document.querySelectorAll( '#widgets-right .id_base' ).forEach( function( base ) {
+		if ( base.value === 'custom_html' ) {
+			initCodeMirror( base.closest ( '.widget' ).querySelector( 'textarea' ) );
+		}
+	} );
 } );


### PR DESCRIPTION
Now that the media widgets open without so-called "just-in-time JavaScript", there is no longer a trigger to have the Code Mirror script run on the Custom HTML widget when the widgets page loads. This PR makes that happen. (We applied a similar fix for the Text widget in PR #1940.)

Before:
![Screenshot at 2025-05-31 10-56-23](https://github.com/user-attachments/assets/26b0d5c2-c7be-4f1b-8e70-9681c39a4229)

After:
![Screenshot at 2025-05-31 10-55-55](https://github.com/user-attachments/assets/e9a246df-7f7a-46e1-a72b-c31f7d856e93)