### PR TITLE
Replace remaining instances of `$cp_needs_update` with `$cp_has_update`

### DIFF
--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -841,7 +841,7 @@ if ( ! is_multisite() && $broken_themes ) {
 						<?php
 						_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
 						if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-							if ( $cp_needs_update ) {
+							if ( $cp_has_update ) {
 								printf(
 									/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
 									' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
@@ -856,7 +856,7 @@ if ( ! is_multisite() && $broken_themes ) {
 								);
 							}
 							wp_update_php_annotation( '</p><p><em>', '</em>' );
-						} elseif ( current_user_can( 'update_core' ) && $cp_needs_update ) {
+						} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
 							printf(
 								/* translators: %s: URL to WordPress Updates screen. */
 								' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
@@ -878,7 +878,7 @@ if ( ! is_multisite() && $broken_themes ) {
 					<p>
 						<?php
 						_e( 'This theme does not work with your version of ClassicPress.' );
-						if ( current_user_can( 'update_core' ) && $cp_needs_update ) {
+						if ( current_user_can( 'update_core' ) && $cp_has_update ) {
 							printf(
 								/* translators: %s: URL to WordPress Updates screen. */
 								' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),


### PR DESCRIPTION
When resolving a code conflict for a previous PR, I missed three instances of `$cp_needs_update` that should have been changed to `$cp_has_update`. This PR rectifies that and prevents the warning "Undefined variable $cp_needs_update in /var/www/html/experimental/wp-admin/themes.php"