### PR TITLE
Playlist without backbone

### DIFF
--- a/src/wp-includes/js/mediaelement/mediaelement-and-player.js
+++ b/src/wp-includes/js/mediaelement/mediaelement-and-player.js
@@ -4378,7 +4378,7 @@ var MediaElementPlayer = function () {
 					if (t.hasFluidMode() === true) {
 						t.setResponsiveMode();
 					} else {
-						t.setDimensions(t.width, t.height);
+						t.setResponsiveMode();
 					}
 					break;
 			}

--- a/src/wp-includes/js/mediaelement/mediaelement-and-player.js
+++ b/src/wp-includes/js/mediaelement/mediaelement-and-player.js
@@ -3602,7 +3602,7 @@ var config = exports.config = {
 
 	stretching: 'auto',
 
-	classPrefix: 'mejs__',
+	classPrefix: 'mejs-',
 
 	enableKeyboard: true,
 

--- a/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
+++ b/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
@@ -149,6 +149,7 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 
 .mejs-overlay-play {
 	cursor: pointer;
+	max-width: 100%;
 }
 
 .mejs-overlay-button {

--- a/src/wp-includes/js/mediaelement/wp-playlist.js
+++ b/src/wp-includes/js/mediaelement/wp-playlist.js
@@ -1,6 +1,3 @@
-/* global _wpmejsSettings, MediaElementPlayer, ajaxurl */
-
-//document.addEventListener( 'DOMContentLoaded', function() {
 jQuery( function( $ ) {
 
 	var playlists = document.querySelectorAll( '.wp-playlist-script' );
@@ -28,7 +25,7 @@ jQuery( function( $ ) {
 
 		ol.className = 'wp-playlist-tracks';
 		if ( playlistEl.parentNode.className === 'textwidget' ) {
-			ol.style='margin-left:-1em';
+			ol.style = 'margin-left:-1em';
 		}
 
 		tracks.forEach( function( track ) {
@@ -60,28 +57,25 @@ jQuery( function( $ ) {
 
 		// Play next item in playlist
 		playlistEl.querySelector( type ).addEventListener( 'ended', function( e ) {
-			var item = ol.querySelector( '.wp-playlist-playing' ),
+			var item = playlistEl.querySelector( '.wp-playlist-playing' ),
 				index = [...item.parentNode.children].indexOf( item );
+
+			playlistEl.querySelector( '.wp-playlist-playing' ).classList.remove( 'wp-playlist-playing' );
 
 			index++;
 			if ( index === tracks.length ) {
-				index = 0;				
-				ol.querySelector( '.wp-playlist-playing' ).classList.remove( 'wp-playlist-playing' );
-				ol.querySelector( '.wp-playlist-item' ).classList.add( 'wp-playlist-playing' );
-			} else {
-				ol.querySelector( '.wp-playlist-playing' ).nextElementSibling.classList.add( 'wp-playlist-playing' );
-				ol.querySelector( '.wp-playlist-playing' ).classList.remove( 'wp-playlist-playing' );
+				index = 0;
 			}
-			item = ol.querySelector( '.wp-playlist-playing' );
+			playlistEl.querySelectorAll( '.wp-playlist-item' )[ index ].classList.add( 'wp-playlist-playing' );
+			item = playlistEl.querySelector( '.wp-playlist-playing' );
 
 			playlistEl.querySelector( type ).src = item.dataset.src;
-
 			if ( type === 'audio' ) {
 				playlistEl.querySelector( 'img' ).src = item.dataset.img;
+				playlistEl.querySelector( '.wp-playlist-item-title' ).textContent = item.dataset.title;
 				playlistEl.querySelector( '.wp-playlist-item-album' ).textContent = item.dataset.album;
+				playlistEl.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
-			playlistEl.querySelector( '.wp-playlist-item-title' ).textContent = item.dataset.title;
-			playlistEl.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 
 			setTimeout( function() {
 				playlistEl.querySelector( type ).play();
@@ -100,21 +94,21 @@ jQuery( function( $ ) {
 			item = e.target.closest( '.wp-playlist-item' );
 			item.classList.add( 'wp-playlist-playing' );
 
-			type = playlist.className.split( ' ' );
-			type = type[1].split( '-' )[1];
+			type = playlist.className.split( ' ' )[1];
+			type = type.split( '-' )[1];
 			playlist.querySelector( type ).src = item.dataset.src;
 
 			if ( type === 'audio' ) {
 				playlist.querySelector( 'img' ).src = item.dataset.img;
+				playlist.querySelector( '.wp-playlist-item-title' ).textContent = item.dataset.title;
 				playlist.querySelector( '.wp-playlist-item-album' ).textContent = item.dataset.album;
+				playlist.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
-			playlist.querySelector( '.wp-playlist-item-title' ).textContent = item.dataset.title;
-			playlist.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 
 			setTimeout( function() {
 				playlist.querySelector( type ).play();
 			}, 200 );
-		} else if ( e.target.closest( '.mejs-play' ) ) {
+		} else if ( e.target.closest( '.mejs-play' ) || e.target.closest( '.mejs-overlay-play' ) ) {
 			playlist = e.target.closest( '.wp-playlist' );
 			if ( ! playlist.querySelector( '.wp-playlist-playing' ) ) {
 				e.target.closest( '.wp-playlist' ).querySelector( '.wp-playlist-item ' ).classList.add( 'wp-playlist-playing' );

--- a/src/wp-includes/js/mediaelement/wp-playlist.js
+++ b/src/wp-includes/js/mediaelement/wp-playlist.js
@@ -79,7 +79,7 @@ jQuery( function( $ ) {
 				playlistEl.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
 
-			// Timeout require for promise
+			// Timeout required for promise
 			setTimeout( function() {
 				playlistEl.querySelector( type ).play();
 			}, 200 );
@@ -109,7 +109,7 @@ jQuery( function( $ ) {
 				playlist.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
 
-			// Timeout require for promise
+			// Timeout required for promise
 			setTimeout( function() {
 				playlist.querySelector( type ).play();
 			}, 200 );

--- a/src/wp-includes/js/mediaelement/wp-playlist.js
+++ b/src/wp-includes/js/mediaelement/wp-playlist.js
@@ -1,7 +1,9 @@
 jQuery( function( $ ) {
 
+	// Script set by wp_playlist_shortcode function in wp-includes/media.php
 	var playlists = document.querySelectorAll( '.wp-playlist-script' );
 
+	// Set up playlists when page loads
 	playlists.forEach( function( playlist ) {
 		var playlistData = JSON.parse( playlist.innerHTML ),
 			type = playlistData.type,
@@ -77,12 +79,14 @@ jQuery( function( $ ) {
 				playlistEl.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
 
+			// Timeout require for promise
 			setTimeout( function() {
 				playlistEl.querySelector( type ).play();
 			}, 200 );
 		} );
 	} );
 
+	// Pay track when clicking on it
 	document.addEventListener( 'click', function( e ) {
 		var item, playlist, type;
 		if ( e.target.closest( '.wp-playlist-caption' ) ) {
@@ -105,9 +109,12 @@ jQuery( function( $ ) {
 				playlist.querySelector( '.wp-playlist-item-artist' ).textContent = item.dataset.artist;
 			}
 
+			// Timeout require for promise
 			setTimeout( function() {
 				playlist.querySelector( type ).play();
 			}, 200 );
+
+		// Ensure that current track shows in boldface
 		} else if ( e.target.closest( '.mejs-play' ) || e.target.closest( '.mejs-overlay-play' ) ) {
 			playlist = e.target.closest( '.wp-playlist' );
 			if ( ! playlist.querySelector( '.wp-playlist-playing' ) ) {

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2741,60 +2741,6 @@ function gallery_shortcode( $attr ) {
 }
 
 /**
- * Outputs the templates used by playlists.
- *
- * @since 3.9.0
- */
-function wp_underscore_playlist_templates() {
-	?>
-<script type="text/html" id="tmpl-wp-playlist-current-item">
-	<# if ( data.thumb && data.thumb.src ) { #>
-		<img src="{{ data.thumb.src }}" alt="">
-	<# } #>
-	<div class="wp-playlist-caption">
-		<span class="wp-playlist-item-meta wp-playlist-item-title">
-			<# if ( data.meta.album || data.meta.artist ) { #>
-				<?php
-				/* translators: %s: Playlist item title. */
-				printf( _x( '&#8220;%s&#8221;', 'playlist item title' ), '{{ data.title }}' );
-				?>
-			<# } else { #>
-				{{ data.title }}
-			<# } #>
-		</span>
-		<# if ( data.meta.album ) { #><span class="wp-playlist-item-meta wp-playlist-item-album">{{ data.meta.album }}</span><# } #>
-		<# if ( data.meta.artist ) { #><span class="wp-playlist-item-meta wp-playlist-item-artist">{{ data.meta.artist }}</span><# } #>
-	</div>
-</script>
-<script type="text/html" id="tmpl-wp-playlist-item">
-	<div class="wp-playlist-item">
-		<a class="wp-playlist-caption" href="{{ data.src }}">
-			{{ data.index ? ( data.index + '. ' ) : '' }}
-			<# if ( data.caption ) { #>
-				{{ data.caption }}
-			<# } else { #>
-				<# if ( data.artists && data.meta.artist ) { #>
-					<span class="wp-playlist-item-title">
-						<?php
-						/* translators: %s: Playlist item title. */
-						printf( _x( '&#8220;%s&#8221;', 'playlist item title' ), '{{{ data.title }}}' );
-						?>
-					</span>
-					<span class="wp-playlist-item-artist"> &mdash; {{ data.meta.artist }}</span>
-				<# } else { #>
-					<span class="wp-playlist-item-title">{{{ data.title }}}</span>
-				<# } #>
-			<# } #>
-		</a>
-		<# if ( data.meta.length_formatted ) { #>
-		<div class="wp-playlist-item-length">{{ data.meta.length_formatted }}</div>
-		<# } #>
-	</div>
-</script>
-	<?php
-}
-
-/**
  * Outputs and enqueues default scripts and styles for playlists.
  *
  * @since 3.9.0
@@ -2807,8 +2753,6 @@ function wp_playlist_scripts( $type ) {
 	?>
 <!--[if lt IE 9]><script>document.createElement('<?php echo esc_js( $type ); ?>');</script><![endif]-->
 	<?php
-	add_action( 'wp_footer', 'wp_underscore_playlist_templates', 0 );
-	add_action( 'admin_footer', 'wp_underscore_playlist_templates', 0 );
 }
 
 /**


### PR DESCRIPTION
I had said that I was having a break from killing off `backbone.js`, but something else got delayed, so I thought I'd tackle this one. Playlists (of audio or video files) are created either in the text widget or in the main post/page editor by clicking on the Add Media button and then choosing one of the playlist options.

This PR should leave the functionality unchanged but without the overhead of `backbone.js`.