### PR TITLE
The ClassicPress Theme - menu fix

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/header.php
+++ b/src/wp-content/themes/the-classicpress-theme/header.php
@@ -47,20 +47,21 @@
 
 			</span>
 
-			<nav id="site-navigation" class="main-navigation nav--toggle-sub nav--toggle-small" aria-label="<?php esc_attr_e( 'Main menu', 'the-classicpress-theme' ); ?>">
-
-				<?php
-				wp_nav_menu(
-					array(
-						'theme_location' => 'main-menu',
-						'depth'          => 2,
-						'menu_id'        => 'primary-menu', /*keeping original id so nav css and js still works*/
-					)
-				);
-				?>
-
-			</nav><!-- #site-navigation -->
-
+			<?php if ( has_nav_menu( 'main-menu' ) ) { ?>
+				<nav id="site-navigation" class="main-navigation nav--toggle-sub nav--toggle-small" aria-label="<?php esc_attr_e( 'Main menu', 'the-classicpress-theme' ); ?>">
+	
+					<?php
+					wp_nav_menu(
+						array(
+							'theme_location' => 'main-menu',
+							'depth'          => 2,
+							'menu_id'        => 'primary-menu', /*keeping original id so nav css and js still works*/
+						)
+					);
+					?>
+	
+				</nav><!-- #site-navigation -->
+			<?php } ?>
 		</div>
 
 		<button id="menu-toggle" class="menu-toggle" type="button" aria-haspopup="true" aria-controls="site-navigation" aria-expanded="false" tabindex="0">


### PR DESCRIPTION
## Description
This PR fixes a minor display issue with the primary menu.
If no menu is set at the Menus page, the `ul` is missing the `#primary` ID, which messes up the layout.
I have added a check: if no menu is set, no menu is displayed. Same approach as footer menu.

![Menu](https://github.com/user-attachments/assets/44cb6b64-2a2b-473f-8974-978521e699e9)

## Motivation and context
A messed up layout may cause confusion. "How can this happen?"

## How has this been tested?
Local install.

## Screenshots
### Before
Menu items listed underneath each other.
![Menu before](https://github.com/user-attachments/assets/5fc76262-5dc0-4923-8ec0-487239c60dff)

### After
No menu displayed.
![Menu after](https://github.com/user-attachments/assets/e1b851cf-98e4-4f67-956a-0ae5f5b71124)

## Types of changes
- Bug fix