### PR TITLE
Fix PHP notices for Comments in inactive Custom Post Types

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -641,7 +641,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$post = get_post( $comment->comment_post_ID );
 		}
 
-		if ( in_array( $post->post_type, get_post_types(), true ) ) {
+		if ( isset( $post->post_type ) && in_array( $post->post_type, get_post_types(), true ) ) {
 			$this->user_can = current_user_can( 'edit_comment', $comment->comment_ID );
 
 			$edit_post_cap = $post ? 'edit_post' : 'edit_posts';

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -522,7 +522,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 					array(
 						'number'    => 1,
 						'type'      => $type,
-						'post_type' => $this->post_type
+						'post_type' => $this->post_type,
 					)
 				) ) {
 					printf(
@@ -1078,7 +1078,6 @@ class WP_Comments_List_Table extends WP_List_Table {
 		$post_type_object = get_post_type_object( $post->post_type );
 		if ( null !== $post_type_object ) {
 			echo "<a href='" . get_permalink( $post->ID ) . "' class='comments-view-item-link'>" . $post_type_object->labels->view_item . '</a>';
-
 
 			echo '<span class="post-com-count-wrapper post-com-count-', $post->ID, '">';
 			$this->comments_bubble( $post->ID, $pending_comments );

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -24,6 +24,8 @@ class WP_Comments_List_Table extends WP_List_Table {
 
 	private $user_can;
 
+	private $post_type;
+
 	/**
 	 * Constructor.
 	 *
@@ -43,6 +45,8 @@ class WP_Comments_List_Table extends WP_List_Table {
 		if ( get_option( 'show_avatars' ) ) {
 			add_filter( 'comment_author', array( $this, 'floated_admin_avatar' ), 10, 2 );
 		}
+
+		$this->post_type = ( isset( $_REQUEST['post_type'] ) ) ? sanitize_key( $_REQUEST['post_type'] ) : get_post_types();
 
 		parent::__construct(
 			array(
@@ -103,8 +107,6 @@ class WP_Comments_List_Table extends WP_List_Table {
 
 		$search = ( isset( $_REQUEST['s'] ) ) ? $_REQUEST['s'] : '';
 
-		$post_type = ( isset( $_REQUEST['post_type'] ) ) ? sanitize_key( $_REQUEST['post_type'] ) : '';
-
 		$user_id = ( isset( $_REQUEST['user_id'] ) ) ? $_REQUEST['user_id'] : '';
 
 		$orderby = ( isset( $_REQUEST['orderby'] ) ) ? $_REQUEST['orderby'] : '';
@@ -149,7 +151,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 			'type'      => $comment_type,
 			'orderby'   => $orderby,
 			'order'     => $order,
-			'post_type' => $post_type,
+			'post_type' => $this->post_type,
 		);
 
 		/**
@@ -294,9 +296,10 @@ class WP_Comments_List_Table extends WP_List_Table {
 				$current_user_id    = get_current_user_id();
 				$num_comments->mine = get_comments(
 					array(
-						'post_id' => $post_id ? $post_id : 0,
-						'user_id' => $current_user_id,
-						'count'   => true,
+						'post_id'   => $post_id ? $post_id : 0,
+						'user_id'   => $current_user_id,
+						'count'     => true,
+						'post_type' => $this->post_type,
 					)
 				);
 				$link               = add_query_arg( 'user_id', $current_user_id, $link );
@@ -517,8 +520,9 @@ class WP_Comments_List_Table extends WP_List_Table {
 			foreach ( $comment_types as $type => $label ) {
 				if ( get_comments(
 					array(
-						'number' => 1,
-						'type'   => $type,
+						'number'    => 1,
+						'type'      => $type,
+						'post_type' => $this->post_type
 					)
 				) ) {
 					printf(
@@ -637,19 +641,21 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$post = get_post( $comment->comment_post_ID );
 		}
 
-		$this->user_can = current_user_can( 'edit_comment', $comment->comment_ID );
+		if ( in_array( $post->post_type, get_post_types(), true ) ) {
+			$this->user_can = current_user_can( 'edit_comment', $comment->comment_ID );
 
-		$edit_post_cap = $post ? 'edit_post' : 'edit_posts';
-		if (
-			current_user_can( $edit_post_cap, $comment->comment_post_ID ) ||
-			(
-				empty( $post->post_password ) &&
-				current_user_can( 'read_post', $comment->comment_post_ID )
-			)
-		) {
-			// The user has access to the post
-		} else {
-			return false;
+			$edit_post_cap = $post ? 'edit_post' : 'edit_posts';
+			if (
+				current_user_can( $edit_post_cap, $comment->comment_post_ID ) ||
+				(
+					empty( $post->post_password ) &&
+					current_user_can( 'read_post', $comment->comment_post_ID )
+				)
+			) {
+				// The user has access to the post
+			} else {
+				return false;
+			}
 		}
 
 		echo "<tr id='comment-$comment->comment_ID' class='$the_comment_class'>";
@@ -1051,7 +1057,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$this->pending_count[ $post->ID ] = $pending_comments;
 		}
 
-		if ( current_user_can( 'edit_post', $post->ID ) ) {
+		if ( in_array( $post->post_type, get_post_types(), true ) && current_user_can( 'edit_post', $post->ID ) ) {
 			$post_link  = "<a href='" . get_edit_post_link( $post->ID ) . "' class='comments-edit-item-link'>";
 			$post_link .= esc_html( get_the_title( $post->ID ) ) . '</a>';
 		} else {
@@ -1070,11 +1076,14 @@ class WP_Comments_List_Table extends WP_List_Table {
 		echo $post_link;
 
 		$post_type_object = get_post_type_object( $post->post_type );
-		echo "<a href='" . get_permalink( $post->ID ) . "' class='comments-view-item-link'>" . $post_type_object->labels->view_item . '</a>';
+		if ( null !== $post_type_object ) {
+			echo "<a href='" . get_permalink( $post->ID ) . "' class='comments-view-item-link'>" . $post_type_object->labels->view_item . '</a>';
 
-		echo '<span class="post-com-count-wrapper post-com-count-', $post->ID, '">';
-		$this->comments_bubble( $post->ID, $pending_comments );
-		echo '</span> ';
+
+			echo '<span class="post-com-count-wrapper post-com-count-', $post->ID, '">';
+			$this->comments_bubble( $post->ID, $pending_comments );
+			echo '</span> ';
+		}
 
 		echo '</div>';
 	}

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -393,9 +393,13 @@ function get_comment_count( $post_id = 0 ) {
 		'all'                 => 0,
 	);
 
+	// Ensure post count reflect comments on available post types or passed URL parameter
+	$post_type = ( isset( $_REQUEST['post_type'] ) ) ? sanitize_key( $_REQUEST['post_type'] ) : get_post_types();
+
 	$args = array(
 		'count'                     => true,
 		'update_comment_meta_cache' => false,
+		'post_type'                 => $post_type,
 	);
 	if ( $post_id > 0 ) {
 		$args['post_id'] = $post_id;

--- a/tests/phpunit/tests/comment/getCommentCount.php
+++ b/tests/phpunit/tests/comment/getCommentCount.php
@@ -6,9 +6,18 @@
  * @covers ::get_comment_count
  */
 class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
+	protected static $comment_post = null;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$comment_post = $factory->post->create_and_get();
+	}
 
 	public function test_get_comment_count() {
-		$count = get_comment_count();
+		$count = get_comment_count(
+			array(
+				'comment_post_ID'  => self::$comment_post->ID,
+			)
+		);
 
 		$this->assertSame( 0, $count['approved'] );
 		$this->assertSame( 0, $count['awaiting_moderation'] );
@@ -23,6 +32,7 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -40,6 +50,7 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 0,
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -57,6 +68,7 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'spam',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -74,6 +86,7 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'trash',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -91,6 +104,7 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'post-trashed',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -111,7 +125,11 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 	 */
 	public function test_get_comment_count_validate_cache_comment_deleted() {
 
-		$comment_id = self::factory()->comment->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$comment_post->ID,
+			)
+		);
 
 		$count = get_comment_count();
 
@@ -156,7 +174,11 @@ class Tests_Comment_GetCommentCount extends WP_UnitTestCase {
 	 * @covers ::get_comment_count
 	 */
 	public function test_get_comment_count_validate_cache_comment_status() {
-		$comment_id = self::factory()->comment->create();
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$comment_post->ID,
+			)
+		);
 
 		$count = get_comment_count();
 

--- a/tests/phpunit/tests/comment/wpCountComments.php
+++ b/tests/phpunit/tests/comment/wpCountComments.php
@@ -6,9 +6,18 @@
  * @covers ::wp_count_comments
  */
 class Tests_Comment_wpCountComments extends WP_UnitTestCase {
+	protected static $comment_post = null;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$comment_post = $factory->post->create_and_get();
+	}
 
 	public function test_wp_count_comments() {
-		$count = wp_count_comments();
+		$count = wp_count_comments(
+			array(
+				'comment_post_ID'  => self::$comment_post->ID,
+			)
+		);
 
 		$this->assertSame( 0, $count->approved );
 		$this->assertSame( 0, $count->moderated );
@@ -23,6 +32,7 @@ class Tests_Comment_wpCountComments extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 1,
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -41,6 +51,7 @@ class Tests_Comment_wpCountComments extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 0,
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -59,6 +70,7 @@ class Tests_Comment_wpCountComments extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'spam',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -77,6 +89,7 @@ class Tests_Comment_wpCountComments extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'trash',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 
@@ -95,6 +108,7 @@ class Tests_Comment_wpCountComments extends WP_UnitTestCase {
 		self::factory()->comment->create(
 			array(
 				'comment_approved' => 'post-trashed',
+				'comment_post_ID'  => self::$comment_post->ID,
 			)
 		);
 


### PR DESCRIPTION
## Description
When Comments have been made on content created for a Custom Post Type and then that CPT is disbaled, Comments may display notices and warning in the Comments page if debug mode is set to true as desribed in #1974 

This  PR aims to resolves those notices and uspate some testing of cmment counting but attaching the comments to a post in order that the tests work successfully.
 
## Motivation and context
Fixes #1974 
Addressed noticed seen when debug is true

## How has this been tested?
Local testing and updated unit tests.

## Screenshots
### Before
![Screenshot 2025-06-05 at 22 02 06](https://github.com/user-attachments/assets/fff10d55-5eb0-4800-a416-e9cb39025c35)

### After
![Screenshot 2025-06-05 at 22 01 51](https://github.com/user-attachments/assets/b3da8609-afaa-463b-a02d-d6c3e974272c)

## Types of changes
- Bug fix