### PR TITLE
Limit API calls in `class-wp-plugins-list-table.php`

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -27,7 +27,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	/**
 	 * Whether ClassicPress has updates available.
 	 *
-	 * @since 5.5.0
+	 * @since CP-2.5.0
 	 *
 	 * @var bool True if ClassicPress has updates available, false otherwise.
 	 */

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -25,6 +25,15 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	protected $show_autoupdates = true;
 
 	/**
+	 * Whether ClassicPress has updates available.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @var bool True if ClassicPress has updates available, false otherwise.
+	 */
+	protected $cp_has_update = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 3.1.0
@@ -63,6 +72,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			&& current_user_can( 'update_plugins' )
 			&& ( ! is_multisite() || $this->screen->in_admin( 'network' ) )
 			&& ! in_array( $status, array( 'mustuse', 'dropins' ), true );
+
+		$this->cp_has_update = classicpress_has_update();
 	}
 
 	/**
@@ -705,8 +716,6 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	 * @param array $item
 	 */
 	public function single_row( $item ) {
-		$cp_has_update = classicpress_has_update();
-
 		global $status, $page, $s, $totals;
 		static $plugin_id_attrs = array();
 
@@ -1281,7 +1290,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			if ( ! $compatible_php && ! $compatible_wp ) {
 				$incompatible_message .= __( 'This plugin does not work with your versions of ClassicPress and PHP.' );
 				if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-					if ( $cp_has_update ) {
+					if ( $this->cp_has_update ) {
 						$incompatible_message .= sprintf(
 							/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
 							' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
@@ -1312,7 +1321,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				}
 			} elseif ( ! $compatible_wp ) {
 				$incompatible_message .= __( 'This plugin does not work with your version of ClassicPress.' );
-				if ( current_user_can( 'update_core' ) && $cp_has_update ) {
+				if ( current_user_can( 'update_core' ) && $this->cp_has_update ) {
 					$incompatible_message .= sprintf(
 						/* translators: %s: URL to WordPress Updates screen. */
 						' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),


### PR DESCRIPTION
## Description
After #1963 `classicpress_has_update` is called in every plugin row in the installed plugins page.
This PR limits the call at the construction of the class.

## Motivation and context
**In normal conditions this function uses a transient and works well.** But if the API endpoint does not exists, for example for the `dev` version (see https://api-v1.classicpress.net/upgrade/2.4.1+dev.json?version=2.4.1%2Bdev), this transient is not set and so the functions calls `wp_version_check` with the options to force a connection.
In my test setup it ended hitting the API 34 or more times and took 16 seconds to load the page.

## How has this been tested?
Local testing using Query Monitor

## Types of changes
- Enhancement

