### PR TITLE
Delete references to deleted images in gallery widgets

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6094,7 +6094,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 
 				// Remove the deleted image ID from the widget's stored IDs.
 				$instance['ids'] = array_diff( $instance['ids'], array( $post_id ) );
-				$widget_options[$key] = $instance;
+				$widget_options[ $key ] = $instance;
 			}
 		}
 		update_option( 'widget_media_gallery', $widget_options ); // Update widget settings

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6086,6 +6086,20 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 		delete_metadata_by_mid( 'post', $mid );
 	}
 
+	// Delete references to deleted images in gallery widgets.
+	$widget_options = get_option( 'widget_media_gallery' );
+	if ( ! empty( $widget_options ) ) {
+		foreach ( $widget_options as $key => $instance ) {
+			if ( isset( $instance['ids'] ) && is_array( $instance['ids'] ) ) {
+
+				// Remove the deleted image ID from the widget's stored IDs.
+				$instance['ids'] = array_diff( $instance['ids'], array( $post_id ) );
+				$widget_options[$key] = $instance;
+			}
+		}
+		update_option( 'widget_media_gallery', $widget_options ); // Update widget settings
+	}
+
 	/** This action is documented in wp-includes/post.php */
 	do_action( 'delete_post', $post_id, $post );
 	$result = $wpdb->delete( $wpdb->posts, array( 'ID' => $post_id ) );


### PR DESCRIPTION
This PR addresses Issue #1981. It does so by ensuring that, when an image is somehow deleted from the media library, its ID within a gallery widget is also deleted.

This, in turn, avoids confusing the `has_content( $instance )` function within the gallery widget itself. That works by checking for each image and, if it fails to find any of them, it reports that there is nothing to show at all. That's the cause of Issue #1981.

By ensuring that the deleted attachment's ID is deleted from the list contained in a gallery widget, the function `has_content( $instance )` no longer checks for it. Instead, it checks only for images that do exist and so the widget is shown as expected.