### PR TITLE
Tighten workflow access permissions

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
   # Runs PHP coding standards checks.
   #
@@ -23,6 +27,8 @@ jobs:
   # - Runs PHPCS on the `tests` directory without warnings suppressed.
   phpcs:
     name: PHP coding standards
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 
@@ -76,6 +82,8 @@ jobs:
   #   modifications to generated files).
   precommit:
     name: Pre-commit checks
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     env:

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
   # Runs the QUnit tests for ClassicPress.
   #
@@ -19,6 +23,8 @@ jobs:
   # - Run the ClassicPress QUnit tests.
   test-js:
     name: QUnit Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
 
   # Runs PHP compatibility testing.
@@ -23,6 +27,8 @@ jobs:
   # - Runs the PHP compatibility tests.
   php-comatibility:
     name: Check PHP compatibility
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
   # Runs the PHPUnit tests for ClassicPress.
   #
@@ -38,6 +42,8 @@ jobs:
   # - Run PHPUnit Tests.
   test-php:
     name: "PHP ${{ matrix.php }} on MySQL ${{matrix.mysql}}${{ matrix.memcached && ' with memcached' || '' }}${{ 'xdebug' == matrix.coverage && ' with XDebug' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     if: ${{ github.repository == 'ClassicPress/ClassicPress' || github.event_name == 'pull_request' }}
     strategy:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -4,8 +4,15 @@ on:
   issues:
     types: opened
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
   add_label:
+    name: Triage label
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -4,9 +4,16 @@ on:
   pull_request_target:
     types: [ opened ]
 
+# Disable permissions for all available scopes by default.
+# Required permissions are configured at the job level.
+permissions: {}
+
 jobs:
   # Comments on a pull request when the author is a new contributor.
   post-welcome-message:
+    name: Welcome message
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: wow-actions/welcome@v1


### PR DESCRIPTION
## Description
These changes limit the permissions granted to our workflows. These changes disable all permissions during early confiiguration and then grant jobs the permissions that were required to successfully complete the task.

## Motivation and context
This is good practice and secures the repository during workflow runs.

## How has this been tested?
Tests will run on this workflow covering 4 of the wokflows. The triage and welcome message workflows will need later assessment and checking.

## Screenshots
### Before
![Screenshot 2025-06-08 at 17 19 48](https://github.com/user-attachments/assets/4194a74e-ac75-42de-842b-c3ec3dce1839)

### After
![Screenshot 2025-06-08 at 17 21 21](https://github.com/user-attachments/assets/821ad3f9-b554-4c9c-8794-e541132a963d)

## Types of changes
- Enhancement

