### PR TITLE
Add Unit Test for FAIR plugin

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -436,10 +436,6 @@ class WP_Compat {
 			}
 		}
 
-		function wp_print_community_events_markup() {
-			echo 'unuseful';
-		}
-
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -436,6 +436,10 @@ class WP_Compat {
 			}
 		}
 
+		function wp_print_community_events_markup() {
+			echo 'unuseful';
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -47,6 +47,13 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that functions that may cause errors are not polyfilled
+	 */
+	public function test_undefined_polyfills() {
+		$this->assertFalse( function_exists( 'register_block_type' ), 'Do not break FAIR plugin. See https://github.com/fairpm/fair-plugin/pull/65' );
+	}
+
+	/**
 	 * Test the WP_Block_Type class exists
 	 */
 	public function test_class_polyfills() {

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -50,7 +50,7 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 	 * Test that functions that may cause errors are not polyfilled
 	 */
 	public function test_undefined_polyfills() {
-		$this->assertFalse( function_exists( 'register_block_type' ), 'Do not break FAIR plugin. See https://github.com/fairpm/fair-plugin/pull/65' );
+		$this->assertFalse( function_exists( 'wp_print_community_events_markup' ), 'Do not break FAIR plugin. See https://github.com/fairpm/fair-plugin/pull/65' );
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/fairpm/fair-plugin/pull/65

## Description
`wp_print_community_events_markup` will be used in the FAIR - Federated and Independent Repositories to fix an issue with ClassicPress Dashboard.

The test ensures that the function will be not backported or polyfilled (even if there is no reason to do that).

## How has this been tested?
See failing actions for the first commit.

## Types of changes
- New feature

