### PR TITLE
Remove orphan $available_updates variable

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1033,7 +1033,6 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
 		$auto_updates      = (array) get_site_option( 'auto_update_plugins', array() );
-		$available_updates = get_site_transient( 'update_plugins' );
 
 		foreach ( $columns as $column_name => $column_display_name ) {
 			$extra_classes = '';


### PR DESCRIPTION
## Description
This minor PR removes an orphan variable called `$available_updates` from file `wp-admin\includes\class-wp-plugins-list-table.php`. 
As you can see it's only being used in 1 file, called `class-wp-ms-themes-list-table.php`.

## Screenshots
![available updates](https://github.com/user-attachments/assets/f648b1fd-4169-4004-a37a-12b96b8c88db)
