### PR TITLE
Twenty Seventeen theme - Fix layout for media playlists

### DIFF
--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -3039,14 +3039,6 @@ ol.wp-playlist-tracks li {
 	padding: 0 0.3125em;
 }
 
-.wp-playlist-light li.wp-playlist-item::marker {
-	color: #222;
-}
-
-.wp-playlist-dark li.wp-playlist-item::marker {
-	color: #fff;
-}
-
 li.wp-playlist-item .wp-playlist-caption {
 	padding: 0.3125em 0;
 }
@@ -3056,6 +3048,7 @@ li.wp-playlist-item .wp-playlist-item-length {
 }
 
 .site-content .wp-playlist-light li.wp-playlist-item,
+.site-content .wp-playlist-light li.wp-playlist-item::marker,
 .site-content .wp-playlist-light li.wp-playlist-item .wp-playlist-caption,
 .site-content .wp-playlist-light li.wp-playlist-item .wp-playlist-item-length {
 	color: #222;
@@ -3071,6 +3064,7 @@ li.wp-playlist-item .wp-playlist-item-length {
 }
 
 .site-content .wp-playlist-dark li.wp-playlist-item,
+.site-content .wp-playlist-dark li.wp-playlist-item::marker,
 .site-content .wp-playlist-dark li.wp-playlist-item .wp-playlist-caption,
 .site-content .wp-playlist-dark li.wp-playlist-item .wp-playlist-item-length {
 	color: #fff;


### PR DESCRIPTION
## Description
In #1979 (2.5 milestone) the Audio and Video playlist are updated. 
The file list now contains `ol` and `li` elements, instead of `div`. 

This PR fixes the broken styling of the file list in Twenty Seventeen. Previous styling is kept in place, for backward compatibility.

**Update: before proceeding with this PR, core styling should be updated. See #2005.**

## How has this been tested?
Local install and different browsers

## Screenshots
### Before
![Playlist - before](https://github.com/user-attachments/assets/0900bcd0-63b5-4d7f-a662-c0da8e61d36a)

### After
![Playlist - after](https://github.com/user-attachments/assets/ffcd569e-613b-4ba2-a487-a8e9ce8c8ea1)

## Types of changes
- Bug fix