### PR TITLE
Fix layout for media playlists

### DIFF
--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -181,10 +181,11 @@ video.wp-video-shortcode,
 }
 
 .wp-playlist-item .wp-playlist-caption {
-	overflow: visible;
-	white-space: normal;
-	max-width: -webkit-calc(100% - 40px);
-	max-width: calc(100% - 40px);
+	display: inline-block;
+	width: 100%;
+	max-width: -webkit-calc(100% - 60px);
+	max-width: calc(100% - 60px);
+	vertical-align: bottom;
 }
 
 .wp-playlist-item-meta {
@@ -200,6 +201,9 @@ video.wp-video-shortcode,
 
 .wp-playlist-item-album {
 	font-style: italic;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .wp-playlist-item-artist {
@@ -229,6 +233,7 @@ video.wp-video-shortcode,
 	cursor: pointer;
 	padding: 0 3px;
 	border-bottom: 1px solid #ccc;
+	list-style-position: inside;
 }
 
 .wp-playlist-item:last-child {
@@ -272,7 +277,6 @@ video.wp-video-shortcode,
 }
 
 .wp-playlist-current-item .wp-playlist-item-title,
-.wp-playlist-current-item .wp-playlist-item-album,
 .wp-playlist-current-item .wp-playlist-item-artist {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -240,6 +240,14 @@ video.wp-video-shortcode,
 	border-bottom: 0;
 }
 
+.wp-playlist-light .wp-playlist-caption {
+	color: #333;
+}
+
+.wp-playlist-dark .wp-playlist-caption {
+	color: #ddd;
+}
+
 .wp-playlist-playing {
 	font-weight: bold;
 	background: #f7f7f7;

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -181,8 +181,8 @@ video.wp-video-shortcode,
 }
 
 .wp-playlist-item .wp-playlist-caption {
-	text-decoration: none;
-	color: #000;
+	overflow: visible;
+	white-space: normal;
 	max-width: -webkit-calc(100% - 40px);
 	max-width: calc(100% - 40px);
 }
@@ -200,9 +200,6 @@ video.wp-video-shortcode,
 
 .wp-playlist-item-album {
 	font-style: italic;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .wp-playlist-item-artist {
@@ -236,14 +233,6 @@ video.wp-video-shortcode,
 
 .wp-playlist-item:last-child {
 	border-bottom: 0;
-}
-
-.wp-playlist-light .wp-playlist-caption {
-	color: #333;
-}
-
-.wp-playlist-dark .wp-playlist-caption {
-	color: #ddd;
 }
 
 .wp-playlist-playing {
@@ -283,6 +272,7 @@ video.wp-video-shortcode,
 }
 
 .wp-playlist-current-item .wp-playlist-item-title,
+.wp-playlist-current-item .wp-playlist-item-album,
 .wp-playlist-current-item .wp-playlist-item-artist {
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -50,7 +50,6 @@
 /* Override theme styles that may conflict with controls. */
 .mejs-controls button:hover {
 	border: none;
-	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 
@@ -183,7 +182,6 @@ video.wp-video-shortcode,
 .wp-playlist-item .wp-playlist-caption {
 	display: inline-block;
 	width: 100%;
-	max-width: -webkit-calc(100% - 60px);
 	max-width: calc(100% - 60px);
 	vertical-align: bottom;
 }


### PR DESCRIPTION
## Description
As discussed in #1997 core playlist styling needs an update, because playlist items are wrapped in list elements from CP 2.5.

We found out **list numbers are not being displayed in Safari**, because `overflow: hidden;` is added to the `.wp-playlist-caption` element. It's added to clip long file/artist names nicely (check screenshot before). This will happen mostly in small (widget) areas and in mobile screens.

I could not find a simple fix. So I suggest removing the overflow from the `ol` playlist. 
IMO it still looks fine (check screenshot after).


There's also margin/padding that is often added by themes to the `ol` / `li` tags. 
We could add a reset (example below). Or we could decide this is theme territory. Feedback requested..

```
ol.wp-playlist-tracks {
	margin-left: 1em;
	padding-left: 0;
}

li.wp-playlist-item {
	margin-left: 0;
	padding-left: 0;
}
```

## How has this been tested?
Different browsers: Safari, Chrome, Edge

## Screenshots
### Before
![Playlist - before](https://github.com/user-attachments/assets/0187cf69-6b97-42b3-8eaa-e8a0bf94399f)

### After
![Playlist - after](https://github.com/user-attachments/assets/25c4ac2d-fa74-4f9e-bfb9-7c23b87abe59)

## Types of changes
- Bug fix