### PR TITLE
List distributed dependencies correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,15 @@
         "@wordpress/hooks": "4.26.0",
         "@wordpress/i18n": "5.26.0",
         "@wordpress/url": "4.26.0",
+        "clipboard": "^2.0.11",
+        "lodash": "^4.17.21",
+        "moment": "^2.30.1",
         "sortablejs": "^1.15.6"
       },
       "devDependencies": {
         "@lodder/grunt-postcss": "3.1.1",
         "@rollup/plugin-commonjs": "28.0.6",
         "autoprefixer": "10.4.21",
-        "clipboard": "^2.0.11",
         "grunt": "1.6.1",
         "grunt-banner": "0.6.0",
         "grunt-contrib-clean": "2.0.1",
@@ -42,8 +44,6 @@
         "grunt-webpack": "7.0.0",
         "ink-docstrap": "1.3.2",
         "install-changed": "^1.1.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.29.4",
         "postcss": "8.5.6",
         "qunit": "^2.19.4",
         "rollup": "4.44.2",
@@ -3100,7 +3100,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
       "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -4017,7 +4017,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6433,7 +6433,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delegate": "^3.1.2"
       }
@@ -8868,7 +8868,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -9536,7 +9536,7 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -11804,7 +11804,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "5.7.1",
@@ -13121,7 +13121,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@lodder/grunt-postcss": "3.1.1",
     "@rollup/plugin-commonjs": "28.0.6",
     "autoprefixer": "10.4.21",
-    "clipboard": "^2.0.11",
     "grunt": "1.6.1",
     "grunt-banner": "0.6.0",
     "grunt-contrib-clean": "2.0.1",
@@ -33,8 +32,6 @@
     "grunt-webpack": "7.0.0",
     "ink-docstrap": "1.3.2",
     "install-changed": "^1.1.0",
-    "lodash": "^4.17.21",
-    "moment": "^2.29.4",
     "postcss": "8.5.6",
     "qunit": "^2.19.4",
     "rollup": "4.44.2",
@@ -54,6 +51,9 @@
     "@wordpress/hooks": "4.26.0",
     "@wordpress/i18n": "5.26.0",
     "@wordpress/url": "4.26.0",
+    "clipboard": "^2.0.11",
+    "lodash": "^4.17.21",
+    "moment": "^2.30.1",
     "sortablejs": "^1.15.6"
   },
   "collective": {


### PR DESCRIPTION
## Description
This is a PR to list packages that are distributed with ClassiPress (after build steps) as dependencies, rather thna development depencencies.

## Motivation and context
ClassicPress should correctly differentiate between `npm` packages that are used only in the development of the project and those that contribute files to the final ClassicPress package.

## How has this been tested?
Local testing of npm install and build steps.

## Screenshots
N/A

## Types of changes
- Enhancement
