### PR TITLE
Check for development builds the ClassicPress way

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -350,7 +350,7 @@ function update_core( $from, $to ) {
 	 * when updating from older WordPress versions, in which case
 	 * the polyfills from wp-includes/compat.php may not be available.
 	 */
-	$development_build = ( false !== strpos( $old_wp_version . $wp_version, '-' ) ); // A dash in the version indicates a development release.
+	$development_build = ( false !== strpos( $old_wp_version . $wp_version, '+' ) ); // A plus in the version indicates a development or nightly release.
 	$php_compat        = version_compare( $php_version, $required_php_version, '>=' );
 
 	if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {


### PR DESCRIPTION
## Description
At the core meeting on the 10th July, it was noted that nightly build updates do not update core plugins and themes reliably.

A previous [PR](https://github.com/ClassicPress/ClassicPress/pull/1584) has forced updates to the Pepper plugin 

## Motivation and context
Nightly testing of bundled plugins and themes should ensure updates are installed after changes are made in core.

## How has this been tested?
Nightly testing after merging will be required because `wp-admin/includes/update-core.php` is copied and used from the updated version that has been downloaded for the local update process.

## Screenshots
N/A

## Types of changes
- Bug fix