### PR TITLE
Add $cp_version for development build check

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -350,7 +350,7 @@ function update_core( $from, $to ) {
 	 * when updating from older WordPress versions, in which case
 	 * the polyfills from wp-includes/compat.php may not be available.
 	 */
-	$development_build = ( false !== strpos( $old_wp_version . $wp_version, '+' ) ); // A plus in the version indicates a development or nightly release.
+	$development_build = ( false !== strpos( $old_wp_version . $wp_version . $cp_version, '+' ) ); // A plus in the version indicates a development or nightly release.
 	$php_compat        = version_compare( $php_version, $required_php_version, '>=' );
 
 	if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && empty( $wpdb->is_mysql ) ) {


### PR DESCRIPTION
## Description
Follow up to #2024, the `$cp_version` string needs adding to the developemnt build check.

## Motivation and context
Should ensure bundled themes and plugins get updated on developmand and nightly builds.

## How has this been tested?
Needs testing in nightly builds

## Screenshots
N/A

## Types of changes
- Bug fix
