### PR TITLE
CP admin - updated About and Freedoms screen

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -91,9 +91,9 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			<p>
 				<?php
 				printf(
-					/* translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum */
-					__( 'If you need help with something else, please see our <a href="%1$s"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
-					'https://www.classicpress.net/faq/',
+					/* translators: 1: link to ClassicPress docs, 2: link to ClassicPress support forum */
+					__( 'If you need help with something else, please see our <a href="%1$s"><strong>documentation</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
+					'https://docs.classicpress.net/',
 					'https://forums.classicpress.net/c/support/'
 				);
 				?>
@@ -113,8 +113,8 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			<p>
 				<?php
 				printf(
-					/* translators: link to ClassicPress 1.0.0 changelog */
-					__( 'For a list of new features and other changes from WordPress %1$s, see the <a href="%2$s"><strong>ClassicPress 2.0.0 (Bella) release notes</strong></a>.' ),
+					/* translators: link to ClassicPress 2.0.0 changelog */
+					__( 'ClassicPress 2.0.0 is a fork of the WordPress %1$s branch. See the <a href="%2$s"><strong>ClassicPress 2.0.0 (Bella) release notes</strong></a>.' ),
 					'6.2.x',
 					'https://forums.classicpress.net/t/classicpress-2-0-0-bella-release-notes/5099'
 				);
@@ -133,7 +133,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<?php
 				printf(
 					/* translators: link to ClassicPress release announcements subforum */
-					__( 'The changes and new features included in recent versions of ClassicPress can be found in our <a href="%s"><strong>Release Notes subforum</strong></a>.' ),
+					__( 'The changes and new features included in current and previous versions of ClassicPress can be found in our <a href="%s"><strong>Release Notes subforum</strong></a>.' ),
 					'https://forums.classicpress.net/c/announcements/release-notes'
 				);
 				?>
@@ -143,7 +143,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<?php
 				printf(
 					/* translators: link to ClassicPress 1.0.0 changelog */
-					__( 'For a list of new features and other changes in WordPress %1$s, see the <a href="%2$s"><strong>ClassicPress 1.0.0 (Aurora) release notes</strong></a>.' ),
+					__( 'ClassicPress 1.0.0 is a fork of the WordPress %1$s branch. See the <a href="%2$s"><strong>ClassicPress 1.0.0 (Aurora) release notes</strong></a>.' ),
 					'4.9.x',
 					'https://forums.classicpress.net/t/classicpress-1-0-0-aurora-release-notes/910'
 				);

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -72,7 +72,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	$themes_url  = current_user_can( 'switch_themes' ) ? admin_url( 'themes.php' ) : __( 'https://wordpress.org/themes/' );
 	$plugins_url = current_user_can( 'activate_plugins' ) ? admin_url( 'plugins.php' ) : __( 'https://wordpress.org/plugins/' );
 
-	printf( __( 'WordPress <a href="%2$s">themes</a> and <a href="%1$s">plugins</a> fall under the GPL or a similarly free and compatible license as well. If you get a theme or plugin from another source, make sure it has the right license. If it does not respect the ClassicPress license, we do not recommend it.' ), $themes_url, $plugins_url );
+	printf( __( 'WordPress <a href="%1$s">themes</a> and <a href="%2$s">plugins</a> fall under the GPL or a similarly free and compatible license as well. If you get a theme or plugin from another source, make sure it has the right license. If it does not respect the ClassicPress license, we do not recommend it.' ), $themes_url, $plugins_url );
 
 	?>
 	</p>

--- a/src/wp-admin/freedoms.php
+++ b/src/wp-admin/freedoms.php
@@ -58,11 +58,22 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	<p>
 	<?php
 
-	$plugins_url = current_user_can( 'activate_plugins' ) ? admin_url( 'plugins.php' ) : __( 'https://wordpress.org/plugins/' );
-	$themes_url  = current_user_can( 'switch_themes' ) ? admin_url( 'themes.php' ) : __( 'https://wordpress.org/themes/' );
+	$cp_directory = 'https://directory.classicpress.net/';
 	$license_url = 'https://opensource.org/licenses/gpl-license';
+	$cp_directory_plugin = 'https://directory.classicpress.net/plugins/classicpress-directory-integration/';
 
-	printf( __( 'Every plugin and theme in ClassicPress.net&#8217;s directory is 100%% GPL or a similarly free and compatible license, so you can feel safe finding <a href="%1$s">plugins</a> and <a href="%2$s">themes</a> there. If you get a plugin or theme from another source, make sure to ask them if it&#8217;s <a href="%3$s">GPL</a> first. If they don&#8217;t respect the ClassicPress license, we don&#8217;t recommend them.' ), $plugins_url, $themes_url, $license_url );
+	printf( __( 'Every theme and plugin in the <a href="%1$s">ClassicPress Directory</a> falls under the <a href="%2$s">GPL</a> or a similarly free and compatible license. With the <a href="%3$s">ClassicPress Directory Integration</a> plugin you get access to themes and plugins that are built for ClassicPress. They will appear in the Appearance > Install CP Themes or Plugins > Install CP Plugins screen.' ), $cp_directory, $license_url, $cp_directory_plugin );
+
+	?>
+	</p>
+	<p>
+	<?php
+
+	$themes_url  = current_user_can( 'switch_themes' ) ? admin_url( 'themes.php' ) : __( 'https://wordpress.org/themes/' );
+	$plugins_url = current_user_can( 'activate_plugins' ) ? admin_url( 'plugins.php' ) : __( 'https://wordpress.org/plugins/' );
+
+	printf( __( 'WordPress <a href="%2$s">themes</a> and <a href="%1$s">plugins</a> fall under the GPL or a similarly free and compatible license as well. If you get a theme or plugin from another source, make sure it has the right license. If it does not respect the ClassicPress license, we do not recommend it.' ), $themes_url, $plugins_url );
+
 	?>
 	</p>
 


### PR DESCRIPTION
## Description
This PR updates the info at dashboard pages `wp-admin/about.php` and `wp-admin/freedoms.php`.

## Motivation and context
IMO the info at both pages wasn't very clear for new users.
- Page About: Added a link to the docs instead of the FAQ page.
- Page About: Better description of the various versions in the changelog.
- Page Freedoms: Added info about the use of themes and plugins from the CP Directory.

## Screenshots
### After
![About](https://github.com/user-attachments/assets/52ce6298-8c60-4a89-8525-d67820ae68b9)

![Freedoms](https://github.com/user-attachments/assets/1d98ace1-4889-4b9a-beac-3adac73514b4)