### PR TITLE
Bump The ClassicPress Theme version to 1.1.1

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -4,7 +4,7 @@ Theme URI: https://directory.classicpress.net/themes/the-classicpress-theme/
 Author: Tim Kaye and ClassicPress contributors
 Author URI: https://www.classicpress.net
 Description: The default theme for ClassicPress.
-Version: 1.1.0
+Version: 1.1.1
 Requires PHP: 8.0
 Requires CP: 2.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Bumping patch version prior to release.

Release will contain:
- Track length layout adjustments for core themes (#2021)
- Fix empty primary menu display in The ClassicPress Theme (#1980)
