### PR TITLE
Correct custom media tag autocomplete

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -587,29 +587,19 @@ function post_tags_meta_box( $post, $box ) {
 	if ( $user_can_assign_terms ) :
 
 		/**
-		 * Check if this is a media post tag taxonomy.
-		 *
-		 * @since CP-2.1.0
+		 * @since CP-2.5.0
 		 */
-		$object_types = $taxonomy->object_type;
-		if ( $object_types[0] === 'attachment' ) {
-			$tags = get_terms(
-				array(
-					'taxonomy'   => $taxonomy->name,
-					'hide_empty' => false,
-					'fields'     => 'names',
-				)
-			);
-		} else {
-			$tags = get_tags(
-				array(
-					'hide_empty' => false,
-					'fields'     => 'names',
-				)
-			);
-		}
+		$tags = get_terms(
+			array(
+				'taxonomy'   => $tax_name,
+				'hide_empty' => false,
+				'fields'     => 'names',
+			)
+		);
 
-		$tags_list = '<datalist id="tags-list">';
+		$datalist_id = 'datalist-' . $tax_name;
+
+		$tags_list = sprintf( '<datalist id="%s" autocomplete="off">', $datalist_id );
 		if ( ! empty( $tags ) ) {
 			foreach ( $tags as $tag ) {
 				$tags_list .= '<option>' . esc_html( $tag ) . '</option>';


### PR DESCRIPTION
This PR fixes the issue reported at https://forums.classicpress.net/t/custom-taxonomy-autocomplete-issue/6238. The problem there was caused by the `datalist` always having the same ID. This PR ensures that each tag has its own `datalist` ID.

Note that, in order for the "Choose from the most used" button to produce the intended tag cloud, the custom taxonomy should be registered by including the line
```
'update_count_callback' => '_update_generic_term_count',
```
within the `$args` array.