### PR TITLE
Media category dropdown

### DIFF
--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -222,7 +222,7 @@ class WP_Media_List_Table extends WP_List_Table {
 		}
 
 		$media_category = get_taxonomy( 'media_category' );
-		if ( is_object_in_taxonomy( 'attachment', 'media_category' ) ) {
+		if ( is_object_in_taxonomy( 'attachment', 'media_category' ) && has_term( '', 'media_category' ) ) {
 			$dropdown_options = array(
 				'show_option_all' => $media_category->labels->all_items,
 				'hide_empty'      => 0,


### PR DESCRIPTION
This fixes Issue #2017 so that the media categories dropdown box doesn't cause an ugly artefact when there are no such categories.