### PR TITLE
Update notification for CP plugins: Potentially compatible with ClassicPress

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,7 +347,7 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && ( substr( $plugin_data->RequiresCP, 0, 1 ) == substr( $cur_cp_version, 0, 1 ) ) && version_compare( $plugin_data->RequiresCP, $cur_cp_version, '<=' ) ) {
+		if ( isset( $plugin_data->update->requires_cp ) && ! empty( $plugin_data->update->requires_cp ) && ( substr( $plugin_data->update->requires_cp, 0, 1 ) == substr( $cur_cp_version, 0, 1 ) ) && version_compare( $plugin_data->update->requires_cp, $cur_cp_version, '<=' ) ) {
 			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {
@@ -359,7 +359,7 @@ function list_plugin_updates() {
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && ( substr( $plugin_data->RequiresCP, 0, 1 ) == substr( $core_update_version, 0, 1 ) ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
+			if ( isset( $plugin_data->update->requires_cp ) && ! empty( $plugin_data->update->requires_cp ) && ( substr( $plugin_data->update->requires_cp, 0, 1 ) == substr( $core_update_version, 0, 1 ) ) && version_compare( $plugin_data->update->requires_cp, $core_update_version, '<=' ) ) {
 				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,7 +347,10 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
+		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
+			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+		} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
 			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} else {
@@ -356,7 +359,10 @@ function list_plugin_updates() {
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $core_update_version, '>=' ) ) {
+			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
 				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			} else {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,28 +347,24 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
-			if ( version_compare( substr( $plugin_data->RequiresCP, 0, 1 ), substr( $cur_cp_version, 0, 1 ), '==' ) && version_compare( $plugin_data->RequiresCP, $cur_cp_version, '<=' ) ) {
-				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
-				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-			} else {
-				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $cur_cp_version );
-				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-			}
+		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && ( substr( $plugin_data->RequiresCP, 0, 1 ) == substr( $cur_cp_version, 0, 1 ) ) && version_compare( $plugin_data->RequiresCP, $cur_cp_version, '<=' ) ) {
+			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+		} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {
+			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} else {
 			$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
-				if ( version_compare( substr( $plugin_data->RequiresCP, 0, 1 ), substr( $core_update_version, 0, 1 ), '==' ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
-					$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
-					$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-				} else {
-					$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
-					$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-				}
+			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && ( substr( $plugin_data->RequiresCP, 0, 1 ) == substr( $core_update_version, 0, 1 ) ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			} else {
 				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,18 +347,22 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) || ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) ) {
-			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
-			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
+			if ( version_compare( substr( $plugin_data->RequiresCP, 0, 3 ), substr( $cur_cp_version, 0, 3 ) ) != 0 ) {
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			}
 		} else {
 			$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $core_update_version, '>=' ) ) || ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) ) {
-				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
-				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
+				if ( version_compare( substr( $plugin_data->RequiresCP, 0, 3 ), substr( $core_update_version, 0, 3 ) ) != 0 ) {
+					$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+					$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+				}
 			} else {
 				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,10 +347,7 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
-			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
-			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-		} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
+		if ( ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) || ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) ) {
 			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} else {
@@ -359,10 +356,7 @@ function list_plugin_updates() {
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
-				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
-				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-			} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
+			if ( ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $core_update_version, '>=' ) ) || ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) ) {
 				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			} else {

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -348,8 +348,11 @@ function list_plugin_updates() {
 
 		// Get plugin compat for running version of ClassicPress.
 		if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
-			if ( version_compare( substr( $plugin_data->RequiresCP, 0, 3 ), substr( $cur_cp_version, 0, 3 ) ) != 0 ) {
+			if ( version_compare( substr( $plugin_data->RequiresCP, 0, 1 ), substr( $cur_cp_version, 0, 1 ), '==' ) && version_compare( $plugin_data->RequiresCP, $cur_cp_version, '<=' ) ) {
 				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			} else {
+				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $cur_cp_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			}
 		} else {
@@ -359,14 +362,17 @@ function list_plugin_updates() {
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
 			if ( isset( $plugin_data->RequiresCP ) && ! empty( $plugin_data->RequiresCP ) ) {
-				if ( version_compare( substr( $plugin_data->RequiresCP, 0, 3 ), substr( $core_update_version, 0, 3 ) ) != 0 ) {
+				if ( version_compare( substr( $plugin_data->RequiresCP, 0, 1 ), substr( $core_update_version, 0, 1 ), '==' ) && version_compare( $plugin_data->RequiresCP, $core_update_version, '<=' ) ) {
 					$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+					$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+				} else {
+					$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 					$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 				}
 			} else {
 				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-			}
+			}	
 		}
 
 		$requires_php   = isset( $plugin_data->update->requires_php ) ? $plugin_data->update->requires_php : null;

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -372,7 +372,7 @@ function list_plugin_updates() {
 			} else {
 				$compat  = '<br>' . sprintf( __( 'Expected compatibility with ClassicPress %1$s: Unknown.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
-			}	
+			}
 		}
 
 		$requires_php   = isset( $plugin_data->update->requires_php ) ? $plugin_data->update->requires_php : null;


### PR DESCRIPTION
## Description
Follow-up of #2002 and mentioned in Zulip Core channel yesterday.

At page `wp-admin/update-core.php` all CP plugins that have update available return:
`Expected compatibility with ClassicPress 2.4.1: Unknown.
`

While all WP plugins with the `Tested up to` header up to WP 6.2+ return:
`Potentially compatible with ClassicPress 2.4.1.
`

This is not good. CP plugins should pass or at least return potentially compatibility.

In Zulip Core channel there was no support for a `Tested up to` header for CP plugins.
That's why this PR suggests returning this notification for all CP plugins (same as WP plugins):
`Potentially compatible with ClassicPress 2.4.1.
`

## How has this been tested?
Local install.

## Screenshots
### Before
![Update plugin - before](https://github.com/user-attachments/assets/e64746e8-5986-4852-baa2-b7115e9b5b8b)

### After
![Update plugin - after](https://github.com/user-attachments/assets/cfa8511a-af4a-4be6-bed0-f52e6e72c0a9)


## Types of changes
- Enhancement
