### PR TITLE
TwentySeventeen theme - playlist hover in CP 2.5+

### DIFF
--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -3023,6 +3023,31 @@ p > object:only-child {
 	background: transparent;
 }
 
+/* Playlist Style Overrides for CP 2.5+ */
+
+.wp-playlist-light li.wp-playlist-item {
+	color: #222;
+}
+
+.wp-playlist-light li.wp-playlist-item:hover {
+	color: #fff;
+}
+
+.wp-playlist-dark li.wp-playlist-item {
+	color: #fff;
+}
+
+.wp-playlist-dark li.wp-playlist-item:hover {
+	color: #222;
+}
+
+.wp-playlist-light li.wp-playlist-item .wp-playlist-caption,
+.wp-playlist-light li.wp-playlist-item .wp-playlist-item-length,
+.wp-playlist-dark li.wp-playlist-item .wp-playlist-caption,
+.wp-playlist-dark li.wp-playlist-item .wp-playlist-item-length {
+	color: inherit;
+}
+
 /* SVG Icons base styles */
 
 .icon {


### PR DESCRIPTION
## Description
This PR fixes the hover styling of the playlist item in CP 2.5+.

## How has this been tested?
Local install.

## Screenshots
### Before
![Playlist - before](https://github.com/user-attachments/assets/44ff0548-dd72-412b-9c44-03ae2de20e52)

### After
![Playlist - after](https://github.com/user-attachments/assets/e5b25a08-9443-411b-b05b-620eb5b83090)


## Types of changes
- Bug fix
