### PR TITLE
Theme track length layout adjustments fix

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -762,7 +762,8 @@ object {
 	text-align: center;
 }
 
-div.wp-playlist-item-length {
+/* Playlist caption in CP 2.5+ */
+li.wp-playlist-item .wp-playlist-item-length {
 	top: 3px;
 }
 

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -3023,6 +3023,10 @@ p > object:only-child {
 	background: transparent;
 }
 
+.site-content .wp-playlist-item-length {
+	top: 5px;
+}
+
 /* Playlist Style Overrides for CP 2.5+ */
 
 .wp-playlist-light li.wp-playlist-item {
@@ -3046,6 +3050,10 @@ p > object:only-child {
 .wp-playlist-dark li.wp-playlist-item .wp-playlist-caption,
 .wp-playlist-dark li.wp-playlist-item .wp-playlist-item-length {
 	color: inherit;
+}
+
+li.wp-playlist-item .wp-playlist-item-length {
+	top: 0;
 }
 
 /* SVG Icons base styles */


### PR DESCRIPTION
## Description
This PR reverts the changes from #2021 as they do not take CP 2.4.1 and before into account.
I readded the changes with prefix, so they are only being applied in CP 2.5+.
The playlist in 2.5+ is list based, instead of div based.

See [this comment](https://github.com/ClassicPress/ClassicPress/pull/2021#issuecomment-3088730015).

## How has this been tested?
Local Install.

## Types of changes
- Bug fix
