### PR TITLE
Enable scrolling down via down arrow in the ClassicPress Theme

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/js/menu-resize.js
+++ b/src/wp-content/themes/the-classicpress-theme/js/menu-resize.js
@@ -114,7 +114,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		}, false);
 
 	} else {
-		const menuItems = document.querySelectorAll( '#primary-menu .menu-item a' );
+		const menuItems = [...document.querySelectorAll( '#primary-menu .menu-item a' )];
 
 		/* Show or hide sub-menus by pressing appropriate keys for accessibility */
 		document.addEventListener( 'keydown', function (e) {
@@ -127,7 +127,9 @@ document.addEventListener( 'DOMContentLoaded', function () {
 					}
 				}
 				else if ( e.key === 'ArrowDown' ) {
-					e.preventDefault();
+					if ( menuItems.includes( e.target ) ) {
+						e.preventDefault();
+					}
 					if ( subMenus[i].style.display === 'none' ) {
 						subMenus[i].removeAttribute( 'style' );
 					}


### PR DESCRIPTION
Fixes Issue #2039. As I wrote there, if you're using the keyboard to navigate around the page and didn't have the block of code referred to by @Guido07111975, you would have to tab through every menu item to get through the menu! As regular keyboard navigators expect, this code provides a way of closing each open sub-menu by using the Escape key, so that not every menu item needs to be tabbed through. The down array key can then be used to re-open a sub-menu closed in this manner.

The problem is that the `e.preventDefault();` isn't currently limited to when a user hits the arrow key in the menu. This PR fixes that.