### PR TITLE
Fix at install theme page

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4068,7 +4068,7 @@ function wp_ajax_query_themes() {
 				$aria_label = sprintf( _x( 'Activate %s', 'theme' ), $theme->name );
 				if ( $theme->activate_url ) {
 					if ( $theme->slug !== get_option( 'template' ) ) {
-						$theme_item .= '<a class="button button-primary activate" href="' . esc_url( $theme->activate_url ) . ' aria-label="' . esc_attr( $aria_label ) . '">' . __( 'Activate' ) . '</a>';
+						$theme_item .= '<a class="button button-primary activate" href="' . esc_url( $theme->activate_url ) . '" aria-label="' . esc_attr( $aria_label ) . '">' . __( 'Activate' ) . '</a>';
 					} else {
 						$theme_item .= '<button class="button button-primary disabled">' . _x( 'Activated', 'theme' ) . '</button>';
 					}

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -279,7 +279,7 @@ if ( ! validate_current_theme() || isset( $_GET['broken'] ) ) {
 } elseif ( isset( $_GET['activated'] ) ) {
 	if ( isset( $_GET['previewed'] ) ) {
 		wp_admin_notice(
-			__( 'Settings saved and theme activated.' ) . '<a href="' . esc_url( home_url( '/' ) ) . '">' . __( 'Visit site' ) . '</a>',
+			__( 'Settings saved and theme activated.' ) . ' <a href="' . esc_url( home_url( '/' ) ) . '">' . __( 'Visit site' ) . '</a>',
 			array(
 				'id'                 => 'message2',
 				'additional_classes' => array( 'updated' ),
@@ -288,7 +288,7 @@ if ( ! validate_current_theme() || isset( $_GET['broken'] ) ) {
 		);
 	} else {
 		wp_admin_notice(
-			__( 'New theme activated.' ) . '<a href="' . esc_url( home_url( '/' ) ) . '">' . __( 'Visit site' ) . '</a>',
+			__( 'New theme activated.' ) . ' <a href="' . esc_url( home_url( '/' ) ) . '">' . __( 'Visit site' ) . '</a>',
 			array(
 				'id'                 => 'message2',
 				'additional_classes' => array( 'updated' ),


### PR DESCRIPTION
## Description
This PR fixes the 2 issues mentioned [here](https://github.com/ClassicPress/ClassicPress/pull/2038#issuecomment-3094390798).

- Fixes the activate link at page `wp-admin/theme-install.php`. By accident the aria-label was added to the activate link.
- Adding white space:

![Visit site](https://github.com/user-attachments/assets/ce505cba-16cb-4689-856a-37720f99a0a1)


## Types of changes
- Bug fix
