### PR TITLE
Prevent activation of incompatible installed theme

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4092,6 +4092,12 @@ function wp_ajax_query_themes() {
 						$theme_item .= '<button class="button disabled">' . __( 'Preview' ) . '</button>';
 					}
 				}
+			} else {
+				/* translators: %s: Theme name. */
+				$aria_label = sprintf( _x( 'Cannot Activate %s', 'theme' ), $theme->name );
+
+				$theme_item .= '<a class="button button-primary disabled" data-name="' . esc_attr__( $theme->name ) . '" aria-label="' . esc_attr( $aria_label ) . '">' . _x( 'Cannot Activate', 'theme' ) . '</a>';
+				$theme_item .= '<button class="button disabled">' . __( 'Preview' ) . '</button>';
 			}
 		} else {
 			if ( $theme->compatible_wp && $theme->compatible_php && $theme->compatible_cp ) {

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -16,7 +16,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		queryParams = new URLSearchParams( window.location.search ),
 		dialog = document.getElementById( 'theme-modal' ),
 		previewDialog = document.querySelector( '.theme-install-overlay' ),
-		install = previewDialog.querySelector( '.theme-install' ).textContent,
+		install = previewDialog ? previewDialog.querySelector( '.theme-install' ).textContent : '',
 		footer = document.querySelector( '.theme-install-php #wpfooter' ),
 		features = document.querySelectorAll( '.filter-group-feature input' ),
 		tagSearch = document.querySelector( '.theme-install-php #wp-filter-search-input' ),

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -574,8 +574,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				if ( e.target.previousElementSibling.className.includes( 'notice-error' ) ) {
 					if ( previewDialog.querySelector( '.theme-install' ) ) {
 						previewDialog.querySelector( '.theme-install' ).classList.add( 'disabled' );
+						previewDialog.querySelector( '.theme-install' ).setAttribute( 'disabled', true );
+						previewDialog.querySelector( '.theme-install' ).setAttribute( 'inert', true );
+						previewDialog.querySelector( '.theme-install' ).removeAttribute( 'href' );
 					} else if ( previewDialog.querySelector( '.activate' ) ) {
 						previewDialog.querySelector( '.activate' ).classList.add( 'disabled' );
+						previewDialog.querySelector( '.activate' ).setAttribute( 'disabled', true );
+						previewDialog.querySelector( '.activate' ).setAttribute( 'inert', true );
+						previewDialog.querySelector( '.activate' ).removeAttribute( 'href' );
 					}
 				}
 

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -16,6 +16,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		queryParams = new URLSearchParams( window.location.search ),
 		dialog = document.getElementById( 'theme-modal' ),
 		previewDialog = document.querySelector( '.theme-install-overlay' ),
+		install = previewDialog.querySelector( '.theme-install' ).textContent,
 		footer = document.querySelector( '.theme-install-php #wpfooter' ),
 		features = document.querySelectorAll( '.filter-group-feature input' ),
 		tagSearch = document.querySelector( '.theme-install-php #wp-filter-search-input' ),
@@ -550,20 +551,30 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				queryParams.delete( 'search' );
 				queryParams.set( 'theme', theme.id );
 				history.replaceState( null, null, '?' + queryParams.toString() );
-				if ( e.target.parentNode.querySelector( '.theme-actions a' ) && e.target.parentNode.querySelector( '.theme-actions a' ).className.includes( 'disabled' ) ) {
-					previewDialog.querySelector( '.theme-install' ).setAttribute( 'disabled', true );
-					previewDialog.querySelector( '.theme-install' ).setAttribute( 'inert', true );
-					previewDialog.querySelector( '.theme-install' ).removeAttribute( 'href' );
-				} else {
-					previewDialog.querySelector( '.theme-install' ).removeAttribute( 'disabled' );
-					previewDialog.querySelector( '.theme-install' ).removeAttribute( 'inert' );
-					previewDialog.querySelector( '.theme-install' ).href = theme.dataset.installNonce;
+				if ( e.target.parentNode.querySelector( '.theme-actions a' ) ) {
+					previewDialog.querySelector( '.theme-install' ).textContent = install;
+					if ( e.target.parentNode.querySelector( '.theme-actions a' ).className.includes( 'disabled' ) ) {
+						previewDialog.querySelector( '.theme-install' ).setAttribute( 'disabled', true );
+						previewDialog.querySelector( '.theme-install' ).setAttribute( 'inert', true );
+						previewDialog.querySelector( '.theme-install' ).removeAttribute( 'href' );
+					} else {
+						previewDialog.querySelector( '.theme-install' ).removeAttribute( 'disabled' );
+						previewDialog.querySelector( '.theme-install' ).removeAttribute( 'inert' );
+						previewDialog.querySelector( '.theme-install' ).href = theme.dataset.installNonce;
+					}
 				}
 				if ( theme.querySelector( '.notice-success' ) ) {
 					previewDialog.querySelector( '.theme-install' ).href = theme.dataset.activateNonce;
 					previewDialog.querySelector( '.theme-install' ).textContent = _wpThemeSettings.l10n.activate;
 					previewDialog.querySelector( '.theme-install' ).className = 'button button-primary activate';
 					if ( theme.className.includes( 'active' ) ) {
+						previewDialog.querySelector( '.activate' ).classList.add( 'disabled' );
+					}
+				}
+				if ( e.target.previousElementSibling.className.includes( 'notice-error' ) ) {
+					if ( previewDialog.querySelector( '.theme-install' ) ) {
+						previewDialog.querySelector( '.theme-install' ).classList.add( 'disabled' );
+					} else if ( previewDialog.querySelector( '.activate' ) ) {
 						previewDialog.querySelector( '.activate' ).classList.add( 'disabled' );
 					}
 				}


### PR DESCRIPTION
Fixes #2047.

While working on this, I realized that the Activate/Install hyperlink in the modal overlay always shows as "Activate" once an installed them has been selected, even if (while remaining on the same page) that theme is subsequently deselected and another chosen. This PR fixes that issue too.