### PR TITLE
Fix alignment of caret in tags input field

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1418,6 +1418,7 @@ p.description code {
 
 .tagsdiv .newtag {
 	width: 180px;
+	line-height: 1;
 }
 
 .tagsdiv .the-tags {


### PR DESCRIPTION
## Description
A list of available tags appears when hovering/clicking the tags input field.
This PR contains a minor CSS tweak: alignment of the caret. Currently pushed to the bottom of the input field.

## How has this been tested?
Local install (in Edge and Chrome). 
Note: no caret nor hover action in Firefox. Tags list appears when clicking the input twice.

## Screenshots
### Before
![Tags - before](https://github.com/user-attachments/assets/699b2f30-9186-4194-8e7f-b9c27b032b97)

### After
![Tags - after](https://github.com/user-attachments/assets/98871205-6aa6-4380-ba93-66d98644bf1d)
