### PR TITLE
The ClassicPress Theme - minor CSS tweaks

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -2048,7 +2048,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 @media screen and (min-width: 900px) {
 	#inner-header {
 		display: flex;
-		flex-grow: 1;
 		align-items: center;
 		justify-content: space-between;
 		gap: 0.5em;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -826,7 +826,6 @@ li.wp-playlist-item .wp-playlist-item-length {
 #masthead {
 	display: flex;
 	justify-content: space-between;
-	align-items: flex-start;
 	margin: 0;
 	padding: 0.75em 0;
 	background: rgba(5, 127, 153, 1);
@@ -2048,6 +2047,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		display: flex;
 		justify-content: space-between;
 		gap: 0.5em;
+		align-items: center;
 		margin: 0 auto;
 	}
 	#page-title h1 {
@@ -2062,23 +2062,17 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		display: flex;
 		justify-content: space-between;
 		flex-wrap: wrap;
+		gap: 0.2em;
 		padding: 0;
 		margin: 0;
-		gap: 0.2em;
-		line-height: 3.5em;
 	}
 	#primary-menu.menu li a {
-		display: flex;
-		flex-grow: 1;
+		display: block;
 		padding: 0.4em 0.5em;
 	}
 	#primary-menu.menu .sub-menu li a {
 		line-height: 1.4em;
 		padding: 0.55em 0.85em;
-	}
-	#primary-menu.menu ul li {
-		padding: 0;
-		flex-direction: column;
 	}
 	#masthead > div > .get-started {
 		padding: 1em 2em;
@@ -2088,10 +2082,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	#primary-menu.menu ul.sub-menu li:last-child a,
 	#primary-menu.menu li.menu-item-has-children ul.sub-menu li:last-child a {
 		border-radius: 0 0 var(--tcpt-border-radius) var(--tcpt-border-radius);
-	}
-	#primary-menu .menu-item-has-children > a::after {
-		margin-left: 0.12em;
-		margin-top: 0.69em;
 	}
 	.nav--toggle-sub ul ul {
 		width: 180px;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1100,6 +1100,7 @@ img {
 	max-width: 72rem;
 	margin: 0;
 	padding: 0 1em;
+	flex-grow: 1;
 	align-self: start;
 }
 .menu,
@@ -1936,17 +1937,8 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	#primary-menu.menu li.menu-item-has-children ul.sub-menu li a {
 		padding-left: 1.2em;
 	}
-	#masthead .search-form {
-		display: flex;
-		gap: 0.5em;
-	}
-	#masthead .search-field {
-		font-size: 0.9em;
-		width: 100%;
-		max-width: 100%;
-	}
 	#masthead .search-submit {
-		font-size: 0.85em;
+		margin-left: 0.2em;
 	}
 	#main,
 	#sidebar,
@@ -1989,14 +1981,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	}
 	.announcement {
 		flex-direction: column;
-	}
-	.home-hero {
-		padding-bottom: 2em;
-		flex-direction: column;
-	}
-	.home-hero-image {
-		margin: 0 auto 1em;
-		max-width: 600px;
 	}
 	.twocolumn {
 		display: block;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1124,6 +1124,9 @@ img {
 	letter-spacing: 0;
 	margin: 0;
 }
+#primary-menu.menu li a {
+    outline-offset: -1px;
+}
 #primary-menu.menu li a,
 #primary-menu.menu li a:visited {
 	color: rgba(255, 255, 255, 1);

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -825,7 +825,6 @@ li.wp-playlist-item .wp-playlist-item-length {
 --------------------------------------------------------------*/
 #masthead {
 	display: flex;
-	align-items: center;
 	justify-content: space-between;
 	margin: 0;
 	padding: 0.75em 0;
@@ -2048,7 +2047,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 @media screen and (min-width: 900px) {
 	#inner-header {
 		display: flex;
-		align-items: center;
 		justify-content: space-between;
 		gap: 0.5em;
 		margin: 0 auto;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1113,6 +1113,7 @@ img {
 	padding: 0.2em;
 	margin-right: 1em;
 	background: #fff;
+	align-self: start;
 }
 #primary-menu.menu li {
 	letter-spacing: 0.1em;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1188,7 +1188,6 @@ img {
 
 /* PAGE TITLE */
 #page-title {
-	padding: 4.2em 0 1em;
 	background: #006b81;
 	background: -moz-linear-gradient(
 		-135deg,
@@ -1219,7 +1218,7 @@ img {
 	color: #fff;
 	max-width: 72rem;
 	margin: 0 auto;
-	padding: 0.6em 0;
+	padding: 0.6em 15px;
 }
 
 /* PAGE CONTENT STRUCTURE */
@@ -1242,10 +1241,6 @@ img {
 /* body.ie11 class applied in JS */
 body.ie11 #sidebar {
 	max-width: 27rem;
-}
-header#page-title {
-	min-width: 100%;
-	padding: 0 1em;
 }
 
 /* CONTENT */
@@ -1922,7 +1917,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 }
 
 @media screen and (max-width: 899px) {
-	header#page-title h1 {
+	#page-title h1 {
 		max-width: 600px;
 	}
 	#primary {
@@ -2050,9 +2045,6 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		gap: 0.5em;
 		align-items: center;
 		margin: 0 auto;
-	}
-	#page-title h1 {
-		padding: 0.6em 15px;
 	}
 	#primary-menu.menu li {
 		text-transform: uppercase;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1999,8 +1999,8 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	#primary-menu {
 		display: none;
 		flex-direction: column;
-		margin: 1em 0 0 0;
 		gap: 1em;
+		margin: 1em 0;
 	}
 	.petitions-home,
 	.getinvolved,

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1936,7 +1936,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 	#primary-menu.menu li.menu-item-has-children ul.sub-menu li a {
 		padding-left: 1.2em;
 	}
-	#masthead .search-submit {
+	#primary-menu .search-submit {
 		margin-left: 0.2em;
 	}
 	#main,

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -826,6 +826,7 @@ li.wp-playlist-item .wp-playlist-item-length {
 #masthead {
 	display: flex;
 	justify-content: space-between;
+	align-items: flex-start;
 	margin: 0;
 	padding: 0.75em 0;
 	background: rgba(5, 127, 153, 1);
@@ -1100,7 +1101,6 @@ img {
 	margin: 0;
 	padding: 0 1em;
 	flex-grow: 1;
-	align-self: start;
 }
 .menu,
 .menu ul {
@@ -1114,7 +1114,6 @@ img {
 	padding: 0.2em;
 	margin-right: 1em;
 	background: #fff;
-	align-self: start;
 }
 #primary-menu.menu li {
 	letter-spacing: 0.1em;


### PR DESCRIPTION
## Description
This PR adds minor changes to the mobile menu.
The inner-header did not expand to the available space (see screenshots)
The search field in mobile menu was styled with flexbox, not needed, so removed.
Plus some leftover styling removed.

Edit: after creating the PR I added some more menu related fixes. 
For example, removed the enormous `line-height: 3.5em` from `#primary-menu.menu` and fixed elements that were affected by this.
And cleaned styling of the big page title.

## How has this been tested?
Local install (in Edge and Chrome).

## Screenshots
### Before
![Inner-header before](https://github.com/user-attachments/assets/89e30a43-a1ac-48f0-9e74-7cd98a5a7da6)

### After
![Inner-header after](https://github.com/user-attachments/assets/20ecf4f3-3ab4-4abb-8a9f-c532ba3bbfdf)


## Types of changes
- Bug fix
