### PR TITLE
WP-r57755: Copy attachment properties on site icon crop

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4426,8 +4426,9 @@ function wp_ajax_crop_image() {
 
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
-			$attachment = $wp_site_icon->create_attachment_object( $cropped, $attachment_id );
-			unset( $attachment['ID'] );
+
+			// Copy attachment properties.
+			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			// Update the attachment.
 			add_filter( 'intermediate_image_sizes_advanced', array( $wp_site_icon, 'additional_sizes' ) );
@@ -4455,46 +4456,8 @@ function wp_ajax_crop_image() {
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-			$parent_url      = wp_get_attachment_url( $attachment_id );
-			$parent_basename = wp_basename( $parent_url );
-			$url             = str_replace( $parent_basename, wp_basename( $cropped ), $parent_url );
-
-			$size       = wp_getimagesize( $cropped );
-			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
-
-			// Get the original image's post to pre-populate the cropped image.
-			$original_attachment  = get_post( $attachment_id );
-			$sanitized_post_title = sanitize_file_name( $original_attachment->post_title );
-			$use_original_title   = (
-				( '' !== trim( $original_attachment->post_title ) ) &&
-				/*
-				 * Check if the original image has a title other than the "filename" default,
-				 * meaning the image had a title when originally uploaded or its title was edited.
-				 */
-				( $parent_basename !== $sanitized_post_title ) &&
-				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
-			);
-			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
-
-			$attachment = array(
-				'post_title'     => $use_original_title ? $original_attachment->post_title : wp_basename( $cropped ),
-				'post_content'   => $use_original_description ? $original_attachment->post_content : $url,
-				'post_mime_type' => $image_type,
-				'guid'           => $url,
-				'context'        => $context,
-			);
-
-			// Copy the image caption attribute (post_excerpt field) from the original image.
-			if ( '' !== trim( $original_attachment->post_excerpt ) ) {
-				$attachment['post_excerpt'] = $original_attachment->post_excerpt;
-			}
-
-			// Copy the image alt text attribute from the original image.
-			if ( '' !== trim( $original_attachment->_wp_attachment_image_alt ) ) {
-				$attachment['meta_input'] = array(
-					'_wp_attachment_image_alt' => wp_slash( $original_attachment->_wp_attachment_image_alt ),
-				);
-			}
+			// Copy attachment properties.
+			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			$attachment_id = wp_insert_attachment( $attachment, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1067,7 +1067,7 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$attachment = $this->create_attachment_object( $cropped, $attachment_id );
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
 
 		if ( ! empty( $_POST['create-new-attachment'] ) ) {
 			unset( $attachment['ID'] );
@@ -1303,12 +1303,14 @@ endif;
 	 * Create an attachment 'object'.
 	 *
 	 * @since 3.9.0
+	 * @deprecated 6.5.0
 	 *
 	 * @param string $cropped              Cropped image URL.
 	 * @param int    $parent_attachment_id Attachment ID of parent image.
 	 * @return array An array with attachment object data.
 	 */
 	final public function create_attachment_object( $cropped, $parent_attachment_id ) {
+		_deprecated_function( __METHOD__, '6.5.0', 'wp_copy_parent_attachment_properties()' );
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
@@ -1410,7 +1412,7 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$attachment = $this->create_attachment_object( $cropped, $attachment_id );
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
 
 		$previous = $this->get_previous_crop( $attachment );
 

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -78,12 +78,15 @@ class WP_Site_Icon {
 	 * Creates an attachment 'object'.
 	 *
 	 * @since 4.3.0
+	 * @deprecated 6.5.0
 	 *
 	 * @param string $cropped              Cropped image URL.
 	 * @param int    $parent_attachment_id Attachment ID of parent image.
 	 * @return array An array with attachment object data.
 	 */
 	public function create_attachment_object( $cropped, $parent_attachment_id ) {
+		_deprecated_function( __METHOD__, '6.5.0', 'wp_copy_parent_attachment_properties()' );
+
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -475,6 +475,62 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 }
 
 /**
+ * Copy parent attachment properties to newly cropped image.
+ *
+ * @since 6.5.0
+ *
+ * @param string $cropped              Path to the cropped image file.
+ * @param int    $parent_attachment_id Parent file Attachment ID.
+ * @param string $context              Control calling the function.
+ * @return array Properties of attachment.
+ */
+function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context = '' ) {
+	$parent          = get_post( $parent_attachment_id );
+	$parent_url      = wp_get_attachment_url( $parent->ID );
+	$parent_basename = wp_basename( $parent_url );
+	$url             = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
+
+	$size       = wp_getimagesize( $cropped );
+	$image_type = $size ? $size['mime'] : 'image/jpeg';
+
+	$sanitized_post_title = sanitize_file_name( $parent->post_title );
+	$use_original_title   = (
+		( '' !== trim( $parent->post_title ) ) &&
+		/*
+		 * Check if the original image has a title other than the "filename" default,
+		 * meaning the image had a title when originally uploaded or its title was edited.
+		 */
+		( $parent_basename !== $sanitized_post_title ) &&
+		( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
+	);
+	$use_original_description = ( '' !== trim( $parent->post_content ) );
+
+	$attachment = array(
+		'post_title'     => $use_original_title ? $parent->post_title : wp_basename( $cropped ),
+		'post_content'   => $use_original_description ? $parent->post_content : $url,
+		'post_mime_type' => $image_type,
+		'guid'           => $url,
+		'context'        => $context,
+	);
+
+	// Copy the image caption attribute (post_excerpt field) from the original image.
+	if ( '' !== trim( $parent->post_excerpt ) ) {
+		$attachment['post_excerpt'] = $parent->post_excerpt;
+	}
+
+	// Copy the image alt text attribute from the original image.
+	if ( '' !== trim( $parent->_wp_attachment_image_alt ) ) {
+		$attachment['meta_input'] = array(
+			'_wp_attachment_image_alt' => wp_slash( $parent->_wp_attachment_image_alt ),
+		);
+	}
+
+	$attachment['post_parent'] = $parent_attachment_id;
+
+	return $attachment;
+}
+
+/**
  * Generates attachment meta data and create image sub-sizes for images.
  *
  * @since 2.1.0

--- a/tests/phpunit/tests/image/header.php
+++ b/tests/phpunit/tests/image/header.php
@@ -108,25 +108,6 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		$this->assertSame( 1200, $dimensions['dst_height'] );
 	}
 
-	public function test_create_attachment_object() {
-		$id = wp_insert_attachment(
-			array(
-				'post_status' => 'publish',
-				'post_title'  => 'foo.png',
-				'post_type'   => 'post',
-				'guid'        => 'http://localhost/foo.png',
-			)
-		);
-
-		$cropped = 'foo-cropped.png';
-
-		$object = $this->custom_image_header->create_attachment_object( $cropped, $id );
-		$this->assertSame( 'foo-cropped.png', $object['post_title'] );
-		$this->assertSame( 'http://localhost/' . $cropped, $object['guid'] );
-		$this->assertSame( 'custom-header', $object['context'] );
-		$this->assertSame( 'image/jpeg', $object['post_mime_type'] );
-	}
-
 	public function test_insert_cropped_attachment() {
 		$id = wp_insert_attachment(
 			array(
@@ -138,7 +119,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		);
 
 		$cropped = 'foo-cropped.png';
-		$object  = $this->custom_image_header->create_attachment_object( $cropped, $id );
+		$object  = wp_copy_parent_attachment_properties( $cropped, $id, 'custom-header' );
 
 		$cropped_id = $this->custom_image_header->insert_attachment( $object, $cropped );
 
@@ -161,7 +142,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 		// Create inital crop object.
 		$cropped_1 = 'foo-cropped-1.png';
-		$object    = $this->custom_image_header->create_attachment_object( $cropped_1, $id );
+		$object    = wp_copy_parent_attachment_properties( $cropped_1, $id, 'custom-header' );
 
 		// Ensure no previous crop exists.
 		$previous = $this->custom_image_header->get_previous_crop( $object );
@@ -175,7 +156,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 		// Create second crop.
 		$cropped_2 = 'foo-cropped-2.png';
-		$object    = $this->custom_image_header->create_attachment_object( $cropped_2, $id );
+		$object    = wp_copy_parent_attachment_properties( $cropped_2, $id );
 
 		// Test that a previous crop is found.
 		$previous = $this->custom_image_header->get_previous_crop( $object );

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -98,26 +98,12 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		unset( $this->wp_site_icon->site_icon_sizes[ array_search( 321, $this->wp_site_icon->site_icon_sizes, true ) ] );
 	}
 
-	public function test_create_attachment_object() {
-		$attachment_id = $this->insert_attachment();
-		$parent_url    = get_post( $attachment_id )->guid;
-		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
-
-		$object = $this->wp_site_icon->create_attachment_object( $cropped, $attachment_id );
-
-		$this->assertSame( $object['post_title'], 'cropped-test-image.jpg' );
-		$this->assertSame( $object['context'], 'site-icon' );
-		$this->assertSame( $object['post_mime_type'], 'image/jpeg' );
-		$this->assertSame( $object['post_content'], $cropped );
-		$this->assertSame( $object['guid'], $cropped );
-	}
-
 	public function test_insert_cropped_attachment() {
 		$attachment_id = $this->insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 
-		$object     = $this->wp_site_icon->create_attachment_object( $cropped, $attachment_id );
+		$object     = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'site-icon' );
 		$cropped_id = $this->wp_site_icon->insert_attachment( $object, $cropped );
 
 		$this->assertIsInt( $cropped_id );

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Tests for the `wp_copy_parent_attachment_properties()` function.
+ *
+ * @group media
+ * @covers ::wp_copy_parent_attachment_properties
+ */
+class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
+
+	public function tear_down() {
+		$this->remove_added_uploads();
+
+		parent::tear_down();
+	}
+
+	public function test_wp_copy_parent_attachment_properties() {
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$parent_url = get_post( $attachment )->guid;
+		// Add alternative text.
+		update_post_meta( $attachment, '_wp_attachment_image_alt', 'Alt text' );
+		// Add image description.
+		wp_update_post(
+			array(
+				'ID'           => $attachment,
+				'post_excerpt' => 'Image description',
+			)
+		);
+		$file = wp_crop_image(
+			DIR_TESTDATA . '/images/canola.jpg',
+			0,
+			0,
+			100,
+			100,
+			100,
+			100
+		);
+
+		$object  = wp_copy_parent_attachment_properties( $file, $attachment );
+		$cropped = str_replace( wp_basename( $parent_url ), 'cropped-canola.jpg', $parent_url );
+
+		$this->assertSame( $object['post_title'], 'cropped-canola.jpg', 'Attachment title is not identical' );
+		$this->assertSame( $object['context'], '', 'Attachment context is not identical' );
+		$this->assertSame( $object['post_mime_type'], 'image/jpeg', 'Attachment mime type is not identical' );
+		$this->assertSame( $object['post_content'], $cropped, 'Attachment content is not identical' );
+		$this->assertSame( $object['guid'], $cropped, 'Attachment GUID is not identical' );
+		$this->assertSame( $object['meta_input']['_wp_attachment_image_alt'], 'Alt text', 'Attachment alt text is not identical' );
+		$this->assertSame( $object['post_excerpt'], 'Image description', 'Attachment description is not identical' );
+
+		unlink( $file );
+	}
+}


### PR DESCRIPTION
## Media: Accessibility: Copy attachment properties on site icon crop.

Add parity between site icon, custom header, and default image crop behaviors. https://core.trac.wordpress.org/changeset/53027 fixed a bug where alt text and caption were not copied on custom headers, but did not apply that change in any other context.

Deprecate the `create_attachment_object` method in the `Wp_Site_Icon` and `Custom_Image_Header` classes and replace that functionality with the new function `wp_copy_parent_attachment_properties()` to improve consistency.

WP:Props afercia, rcreators, jorbin, joedolson, huzaifaalmesbah, shailu25, swissspidy, mukesh27. Fixes https://core.trac.wordpress.org/ticket/60524.

---

Merges https://core.trac.wordpress.org/changeset/57755 / WordPress/wordpress-develop@ee5142efbc to ClassicPress.


## Motivation and context
Attempt to resolve #2053 , although this backport may be interesting in itself.

## How has this been tested?
Local testing and new unit tests.


## Types of changes
- New feature

