### PR TITLE
Prevent uploading a file when no media category is selected and yet the storage method is by media category

### DIFF
--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -749,6 +749,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						div.className = 'notice notice-error is-dismissible';
 						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
 						document.querySelector( '.page-title-action' ).after( div );
+						close.click();
 					} else {
 						div = document.createElement( 'div' );
 						div.id = 'message';


### PR DESCRIPTION
Fixes Issue #2058 by ensuring that, if the steps there are followed, the upload dialog will now close.