### PR TITLE
Set default max_upload_size to 2MB

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -183,8 +183,8 @@ if ( 'grid' === $mode ) {
 
 	// Get the maximum upload size.
 	$max_upload_size = wp_max_upload_size();
-	if ( ! $max_upload_size ) {
-		$max_upload_size = 0;
+	if ( empty( $max_upload_size ) ) {
+		$max_upload_size = 2097152;
 	}
 
 	// Get a list of allowed mime types.


### PR DESCRIPTION
There is a bug with the way we set the default file upload size. Go to Media, choose the Grid View, and click Add New. The maximum file upload size will be shown there. The problem is twofold:

1. The check for what is returned by `wp_max_upload_size()` is done with `if ( ! $max_upload_size ) {` and this doesn't perform as expected. So this often returns false even when `wp_max_upload_size()` has a value. Changing the check to `if ( empty( $max_upload_size ) ) {` makes this work as expected.
2. If `wp_max_upload_size()` returns nothing, we currently set the default to zero. But this is not what pretty much every host does; they set it to 2MB. So this PR changes the default value to match that.