### PR TITLE
CP Dashboard - several textual changes Help tabs

### DIFF
--- a/src/wp-admin/export-personal-data.php
+++ b/src/wp-admin/export-personal-data.php
@@ -55,7 +55,7 @@ get_current_screen()->add_help_tab(
 		'title'   => __( 'Plugin Data' ),
 		'content' =>
 					'<p>' . __( 'Many plugins may collect or store personal data either in the ClassicPress database or remotely. Any Export Personal Data request should include data from plugins as well.' ) . '</p>' .
-					'<p>' . __( 'Plugin authors can <a href="https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-exporter-to-your-plugin/" target="_blank">learn more about how to add the Personal Data Exporter to a plugin here</a>.' ) . '</p>' .
+					'<p>' . __( 'If you are a plugin author, you can <a href="https://developer.wordpress.org/plugins/privacy/adding-the-personal-data-exporter-to-your-plugin/" target="_blank">learn more about how to add the Personal Data Exporter to a plugin here</a>.' ) . '</p>' .
 					$privacy_policy_guide,
 	)
 );

--- a/src/wp-admin/index.php
+++ b/src/wp-admin/index.php
@@ -73,10 +73,6 @@ $screen->add_help_tab(
 
 $help = '<p>' . __( 'The boxes on your Dashboard screen are:' ) . '</p>';
 
-if ( current_user_can( 'edit_theme_options' ) ) {
-	$help .= '<p>' . __( '<strong>Welcome</strong> &mdash; Shows links for some of the most common tasks when setting up a new site.' ) . '</p>';
-}
-
 if ( current_user_can( 'view_site_health_checks' ) ) {
 	$help .= '<p>' . __( '<strong>Site Health Status</strong> &mdash; Informs you of any potential issues that should be addressed to improve the performance or security of your website.' ) . '</p>';
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -545,6 +545,11 @@ get_current_screen()->add_help_tab(
 				'<p>' . __( 'Plugins extend and expand the functionality of ClassicPress. Once a plugin is installed, you may activate it or deactivate it here.' ) . '</p>' .
 				'<p>' . __( 'The search for installed plugins will search for terms in their name, description, or author.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
 				'<p>' . sprintf(
+					/* translators: %s: link to plugin page in the ClassicPress Directory */
+					__( 'With the <a href="%s"><strong>ClassicPress Directory Integration</strong></a> plugin you get access to plugins that are built for ClassicPress. They will appear in the Plugins > Install CP Plugins screen.' ),
+					__( 'https://directory.classicpress.net/plugins/classicpress-directory-integration/' )
+				) . '</p>' .
+				'<p>' . sprintf(
 					/* translators: %s: WordPress Plugin Directory URL. */
 					__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
 					__( 'https://wordpress.org/plugins/' )

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -149,7 +149,6 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/appearance-themes-screen/#install-themes">Documentation on Adding New Themes</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/documentation/article/block-themes/">Documentation on Block Themes</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -152,6 +152,11 @@ if ( current_user_can( 'install_themes' ) ) {
 		$help_install = '<p>' . __( 'Installing themes on Multisite can only be done from the Network Admin section.' ) . '</p>';
 	} else {
 		$help_install = '<p>' . sprintf(
+			/* translators: %s: link to plugin page in the ClassicPress Directory */
+			__( 'With the <a href="%s"><strong>ClassicPress Directory Integration</strong></a> plugin you get access to themes that are built for ClassicPress. They will appear in the Appearance > Install CP Themes screen.' ),
+			__( 'https://directory.classicpress.net/plugins/classicpress-directory-integration/' )
+		) . '</p>';
+		$help_install .= '<p>' . sprintf(
 			/* translators: %s: https://wordpress.org/themes/ */
 			__( 'If you would like to see more themes to choose from, click on the &#8220;Add New&#8221; button and you will be able to browse or search for additional themes from the <a href="%s">WordPress Theme Directory</a>. Themes in the WordPress Theme Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
 			__( 'https://wordpress.org/themes/' )


### PR DESCRIPTION
## Description
This PR contains a few textual changes for Help tabs throughout the dashboard.

Page `wp-admin/index.php`: removed info about the Welcome dashboard widget, because that widget is removed from CP.
Page `wp-admin/themes.php` > added info about CP Directory (see screenshot).
Page `wp-admin/theme-install.php` > removed link to block themes docs, because not relevant.
Page` wp-admin/plugins.php` > added info about CP Directory (see screenshot).
Page `wp-admin/export-personal-data.php` > make string similar to the one at page Erase Personal Data.

## How has this been tested?
Local install

## Screenshots
### After
![wp-admin-plugins](https://github.com/user-attachments/assets/0d66d11d-9fc6-4b8f-964a-b36ce65e4656)

![wp-admin-themes](https://github.com/user-attachments/assets/313afdad-79c7-4236-8e70-127f6f5f21bf)

## Types of changes
- Enhancement
