### PR TITLE
Separate multisite testing to PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -41,7 +41,7 @@ jobs:
   # - Clone PHP.net if needed for unit tests.
   # - Run PHPUnit Tests.
   test-php:
-    name: "PHP ${{ matrix.php }} on MySQL ${{matrix.mysql}}${{ matrix.memcached && ' with memcached' || '' }}${{ 'xdebug' == matrix.coverage && ' with XDebug' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
+    name: "${{ matrix.multisite && 'Multisite on ' || '' }}PHP ${{ matrix.php }} on MySQL ${{matrix.mysql}}${{ matrix.memcached && ' with memcached' || '' }}${{ 'xdebug' == matrix.coverage && ' with XDebug' || '' }}${{ matrix.experimental && ' - Experimental' || '' }}"
     permissions:
       contents: read
     runs-on: ubuntu-22.04
@@ -51,42 +51,69 @@ jobs:
       matrix:
         php: [ '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ]
         mysql: [ '5.7', '8.0' ]
+        multisite: [ false, true ]
         memcached: [ false ]
         coverage: [ none ]
         experimental: [ false ]
+        # Include jobs that test with memcached.
         include:
           - php: '8.0'
             mysql: '5.7'
+            multisite: false
             memcached: true
             coverage: none
             experimental: false
           - php: '8.2'
             mysql: '5.7'
+            multisite: false
             memcached: true
             coverage: none
             experimental: false
           - php: '8.3'
             mysql: '5.7'
+            multisite: false
             memcached: true
             coverage: none
             experimental: false
           - php: '8.0'
             mysql: '8.0'
+            multisite: false
             memcached: true
             coverage: none
             experimental: false
           - php: '8.2'
             mysql: '8.0'
+            multisite: false
+            memcached: true
+            coverage: none
+            experimental: false
+          - php: '8.2'
+            mysql: '8.0'
+            multisite: true
             memcached: true
             coverage: none
             experimental: false
           - php: '8.3'
             mysql: '8.0'
+            multisite: false
             memcached: true
             coverage: none
             experimental: false
           - php: '8.3'
             mysql: '8.0'
+            multisite: true
+            memcached: true
+            coverage: none
+            experimental: false
+          - php: '8.3'
+            mysql: '8.0'
+            multisite: false
+            memcached: false
+            coverage: xdebug
+            experimental: false
+          - php: '8.3'
+            mysql: '8.0'
+            multisite: true
             memcached: false
             coverage: xdebug
             experimental: false
@@ -226,6 +253,7 @@ jobs:
         uses: niden/actions-memcached@v7
 
       - name: Run PHPUnit default
+        if: ${{ !matrix.multisite }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
         run: grunt phpunit:default
@@ -238,6 +266,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Run PHPUnit multisite
+        if: ${{ matrix.multisite }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
         run: grunt phpunit:multisite


### PR DESCRIPTION
## Description
Introduces a 'multisite' matrix parameter to the GitHub Actions PHPUnit workflow, enabling separate jobs for multisite and non-multisite environments. Updates job naming, matrix includes, and test execution steps to support multisite testing.

## Motivation and context
This PR aims to run `default` and `multisite` PHPUnit tests separately to increase the time for testing on GitHub.
Tests are currently taking 20-25 minutes to complete.

## How has this been tested?
Will need to await testing on this PR.
After PR creation tests are separated and ran in less than 12 minutes.

## Screenshots
### Before
<img width="2448" height="164" alt="Screenshot 2025-08-07 at 17 03 53" src="https://github.com/user-attachments/assets/ad3aa51b-5da7-4a73-9dab-c6cea98d1c45" />

<img width="2446" height="156" alt="Screenshot 2025-08-07 at 17 59 30" src="https://github.com/user-attachments/assets/66992c4f-ac06-46d9-a96d-4d68ee923c43" />

### After
<img width="2450" height="164" alt="Screenshot 2025-08-07 at 19 04 10" src="https://github.com/user-attachments/assets/d3ac344d-46c7-4b42-941e-5bee138b733b" />

## Types of changes
Build / Test Enhancement
