### PR TITLE
Improve SQL query for retrieving custom fields (postmeta) on post edit screen

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -715,15 +715,17 @@ function meta_form( $post = null ) {
 		 */
 		$limit = apply_filters( 'postmeta_form_limit', 30 );
 
+		// Query changed to be routed via $wpdb->posts.
+		// @since CP-2.6.0
 		$keys = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT DISTINCT meta_key
-				FROM $wpdb->postmeta
-				WHERE meta_key NOT BETWEEN '_' AND '_z'
-				HAVING meta_key NOT LIKE %s
-				ORDER BY meta_key
+				FROM $wpdb->posts as p
+				LEFT JOIN $wpdb->postmeta as m ON p.ID = m.post_id
+				WHERE post_type = '$post->post_type'
+				AND SUBSTR(meta_key,1,1) != '_'
+				ORDER BY ID DESC
 				LIMIT %d",
-				$wpdb->esc_like( '_' ) . '%',
 				$limit
 			)
 		);


### PR DESCRIPTION
In the forums at https://forums.classicpress.net/t/slow-query-optimization-in-post-php-inc-solution/6277 a user proposed an improvement to the database query that ClassicPress uses to retrieve custom fields for display on a post's edit page. I have tried it out and this PR is based on that proposal.

I have made a few formatting changes, but these are relatively minor. Most have been made to match a pattern that core already uses; one uses `SELECT DISTINCT` as part of the query instead of using `array_unique` in PHP after the keys have been retrieved.

Research shows that the query in question has been problematic for many years. In fact, a Trac ticket for this was opened in WP ten years ago! https://core.trac.wordpress.org/ticket/33885 The problem is that searching within the `postmeta` table is known to incredibly slow; if the table has a significant number of entries, a post's edit page may take a very long time to load. The irony is that the custom fields form that this query fills is probably ignored or hidden (via Screen Options) by most users, so the load time is lengthy without any offsetting benefit.

The solution proposed (but never adopted) in the Trac ticket was different from that proposed here. It involved changing the length of keys used in the `postmeta` table. This clearly worked for some users but not all, and many were concerned that it could have unforeseen consequences.

This proposal, by contrast, uses the `postmeta` table in precisely the way it is designed to be used: by starting with a post. So the query starts in the `posts` table and searches on the basis of matching the appropriate post type. This not only makes the query significantly faster; it also means that what is retrieved are only those custom fields (postmeta) relevant to that post type. I have tested it out and I am, frankly, quite amazed that instead of seeing rows of custom fields that are completely irrelevant, I am now presented with only those fields that make sense for that post type.

I say "amazed" advisedly; if core had always used this query, I don't think the Advanced Custom Fields plugin would have caught on so much!

Props jujist