### PR TITLE
TwentySeventeen theme - add backporting info to readme file

### DIFF
--- a/src/wp-content/themes/twentyseventeen/README.txt
+++ b/src/wp-content/themes/twentyseventeen/README.txt
@@ -63,6 +63,57 @@ Bundled header image, Copyright Alvin Engler
 License: CC0 1.0 Universal (CC0 1.0)
 Source: https://unsplash.com/@englr?photo=bIhpiQA009k
 
+== Backported from WordPress since 1.7 ==
+
+https://github.com/ClassicPress/ClassicPress/pull/2022
+https://github.com/ClassicPress/ClassicPress/pull/1975
+
+= 3.9 =
+* Update .screen-reader-text class, replacing the obsolete clip property with clip-path.
+* https://core.trac.wordpress.org/ticket/62238
+
+= 3.8 =
+* Add spacing between each Reply heading and its Cancel reply link in the comments template.
+* https://core.trac.wordpress.org/ticket/59334
+
+= 3.7 =
+* Improve header image quality with mobile devices and browsers at a narrow width.
+* https://core.trac.wordpress.org/ticket/39253
+
+= 3.2 =
+* Bundle Google Fonts locally.
+* https://core.trac.wordpress.org/ticket/55985
+
+= 3.1 =
+* Remove closing PHP tags.
+* https://core.trac.wordpress.org/ticket/40039
+
+= 2.9 =
+* Post title’s margin-bottom on front page is too large.
+* https://core.trac.wordpress.org/ticket/43628
+
+= 2.4 =
+* Fixes navbar z-index issue by upping the z-index value to 1000 from 7.
+* https://core.trac.wordpress.org/ticket/39384
+
+* Fixes issues where pagination does not work on the page that is set to the home page.
+* https://core.trac.wordpress.org/ticket/39685
+
+= 2.2 =
+* Prevent too-long strings from causing horizontal scrolling.
+* https://core.trac.wordpress.org/ticket/46703
+
+= 2.1 =
+* Add escaping to the pingback URL.
+* https://core.trac.wordpress.org/ticket/43717
+
+* Fix issue with YouTube videos used in the Header Media area displaying offset in Safari.
+* https://core.trac.wordpress.org/ticket/40522
+
+= 1.9 =
+* Remove unneeded ordered list styles from editor styles, which caused issues in starting order.
+* https://core.trac.wordpress.org/ticket/44775
+
 == Changelog ==
 
 = 1.7 =


### PR DESCRIPTION
## Description
This PR adds info to the readme file about all trac tickets that are backported to the TwentySeventeen theme since the theme was added to CP (version 1.7).

This way it becomes clear which fixes and improvements are added so far.