### PR TITLE
Add coverage check to external-http PHPUnit job

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -279,6 +279,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Run PHPUnit external-http
+        if: ${{ matrix.coverage != 'none' }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
         run: grunt phpunit:external-http


### PR DESCRIPTION
## Description
The external-http PHPUnit job now only runs when code coverage is enabled in the matrix, preventing unnecessary runs when coverage is set to 'none'.


## Motivation and context
The external-http PHPUnit tests connect to an external API so multiple instances of this test can cause timeouts on the API and multiplied testing is probably not necessary.

## How has this been tested?
Tests will rin on this PR and the external-http PHPUnit should only run on the PHPUnit test that also tests using XDebug now.

## Screenshots
Example none XDeug test
<img width="694" height="246" alt="Screenshot 2025-08-17 at 10 14 40" src="https://github.com/user-attachments/assets/7445fb61-b8a1-4368-8445-dac9e875e754" />

XDeug test
<img width="604" height="250" alt="Screenshot 2025-08-17 at 10 17 13" src="https://github.com/user-attachments/assets/ebedb2af-9c16-4bb4-bcdd-7250239025ec" />

## Types of changes
- Enhancement
