### PR TITLE
Improve display of warnings for incompatible theme updates

### DIFF
--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -40,6 +40,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 	}
 
+	// Enable legible display of multiple error messages
+	document.querySelectorAll( 'li' ).forEach( function( item ) {
+		var secondError;
+		if ( item.querySelectorAll( '.notice-error' ).length > 1 ) {
+			secondError = item.querySelectorAll( '.notice-error' )[1];
+			item.querySelector( '.notice-error' ).insertAdjacentHTML( 'beforeend', secondError.innerHTML );
+			secondError.remove();
+		}
+	} );
+
 	// Reload the list of themes from wordpress.org using Intersection Observer
 	if ( footer ) {
 		observer = new IntersectionObserver( function( entries ) {
@@ -347,7 +357,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						dialog.querySelector( '.has-update span' ).innerHTML = theme.dataset.update;
 						dialog.querySelector( '.has-update' ).removeAttribute( 'hidden' );
 					} else {
-						dialog.querySelector( '.incompat-update span' ).innerHTML = theme.dataset.update;
 						dialog.querySelector( '.incompat-update' ).removeAttribute( 'hidden' );
 						response = theme.dataset.updateResponse.split( '-' );
 						if ( response[0] !== '1' && response[1] !== '1' ) {

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -580,7 +580,7 @@ foreach ( $themes as $theme ) :
 			}
 		} elseif ( ! $theme['compatibleWP'] ) {
 			$message .= __( 'This theme does not work with your version of ClassicPress.' );
-			if ( current_user_can( 'update_core' ) ) {
+			if ( current_user_can( 'update_core' ) && $cp_has_update ) {
 				$message .= sprintf(
 					/* translators: %s: URL to WordPress Updates screen. */
 					' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),


### PR DESCRIPTION
This PR addresses an issue that arises where an incompatible them is already installed in a CP instance and then gets an update. To test, download the Kadence theme from [wordpress.org](https://wordpress.org/themes/kadence/) and then upload it manually to a test site while downgrading the version number in its `style.css` file, so that it appears to be an old version.

On the `Appearance -> Themes` page, you will see something like this, where two warning messages overlap each other:

<img width="401" height="348" alt="Screenshot at 2025-08-18 19-47-29" src="https://github.com/user-attachments/assets/fdd7ec67-6e04-4ec8-896f-098a42eeabf2" />

This PR corrects that so that the two can now both be read easily, like this:

<img width="396" height="347" alt="Screenshot at 2025-08-18 19-46-28" src="https://github.com/user-attachments/assets/1ad55c02-c83e-4213-8243-c8a234f01a1a" />

Another current problem is that, when clicking on the `Theme Details` button that appears when hovering over the theme, an error is shown in the browser console:

<img width="1927" height="152" alt="Screenshot at 2025-08-18 19-47-55" src="https://github.com/user-attachments/assets/e945e494-6379-4e82-bc91-a57cd87e0d3a" />

This PR addresses that and allows the modal to open as intended, like this:

<img width="1778" height="880" alt="Screenshot at 2025-08-18 19-46-58" src="https://github.com/user-attachments/assets/200ceb41-0d45-4d19-9fec-6a8d03d22695" />