### PR TITLE
Update caniuse-lite in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2825,9 +2825,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001702",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001702.tgz",
-      "integrity": "sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==",
+      "version": "1.0.30001735",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
+      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Description
Bump caniuse-lite from version 1.0.30001702 to 1.0.30001735 to include the latest browser compatibility data.

## Motivation and context
caniuse-lite is a dependency of autoprefixer, package-lock.json is built during `npm install` but needs updating in core for the latest versions of caniuse-lite, the `webpack-dev` grunt task currently shows a warning.

## How has this been tested?
Local testing, requires this PR and then lcoally running `npm i`

## Screenshots
### Before
<img width="1512" height="158" alt="Screenshot 2025-08-19 at 17 03 57" src="https://github.com/user-attachments/assets/14337b36-07f4-4373-b4ce-7c10e1ceb21f" />

### After
<img width="686" height="156" alt="Screenshot 2025-08-19 at 17 06 52" src="https://github.com/user-attachments/assets/b4f8257d-7d05-44e4-b3b5-4b2d705e0af3" />

## Types of changes
- Enhancement
