### PR TITLE
Fix: Theme File Editor label

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -230,14 +230,14 @@ if ( ! is_multisite() ) {
 	add_action( 'admin_menu', '_add_themes_utility_last', 101 );
 }
 /**
- * Adds the (theme) 'Editor' link to the bottom of the Appearance menu.
+ * Adds the 'Theme File Editor' link to the bottom of the Appearance menu.
  *
  * @access private
  * @since 3.0.0
  */
 function _add_themes_utility_last() {
 	// Must use API on the admin_menu hook, direct modification is only possible on/before the _admin_menu hook
-	add_submenu_page( 'themes.php', _x( 'Editor', 'theme editor' ), _x( 'Editor', 'theme editor' ), 'edit_themes', 'theme-editor.php' );
+	add_submenu_page( 'themes.php', _x( 'Theme File Editor', 'theme editor' ), _x( 'Theme File Editor', 'theme editor' ), 'edit_themes', 'theme-editor.php' );
 }
 
 $count = '';


### PR DESCRIPTION
## Description
This PR changes the (theme) 'Editor' label into 'Theme File Editor', to avoid translation related confusion with the Editor user role.
In my language Dutch it was wrongly translated.
Besides that, the editor for plugins is called 'Plugin File Editor'.

## Screenshots
![Editor label](https://github.com/user-attachments/assets/31a92a10-e3f5-4910-a7b1-2c7f511c1b69)