### PR TITLE
The ClassicPress Theme - update Cache Buster

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/functions.php
+++ b/src/wp-content/themes/the-classicpress-theme/functions.php
@@ -162,7 +162,7 @@ add_action( 'wp_enqueue_scripts', 'susty_dequeue_dashicons' );
  * Stylesheet version (cache buster)
  */
 function cp_susty_get_asset_version() {
-	return '20250130';
+	return '20250825';
 }
 
 /**


### PR DESCRIPTION
## Description
Forgot to update the Cache Buster `cp_susty_get_asset_version()` in #2029 before the release of 2.5.
As mentioned for a previous release [here](https://github.com/ClassicPress/ClassicPress/pull/1763#issuecomment-2625005385).