### PR TITLE
Fix: playlist shortcodes

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2798,6 +2798,8 @@ function wp_playlist_shortcode( $attr ) {
 	static $instance = 0;
 	$instance++;
 
+	static $is_loaded = false;
+
 	if ( ! empty( $attr['ids'] ) ) {
 		// 'ids' is explicitly ordered, unless you specify otherwise.
 		if ( empty( $attr['orderby'] ) ) {
@@ -2979,7 +2981,7 @@ function wp_playlist_shortcode( $attr ) {
 
 	ob_start();
 
-	if ( 1 === $instance ) {
+	if ( ! $is_loaded ) {
 		/**
 		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
 		 *
@@ -2989,6 +2991,7 @@ function wp_playlist_shortcode( $attr ) {
 		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
 		 */
 		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
+		$is_loaded = true;
 	}
 	?>
 <div class="wp-playlist wp-<?php echo $safe_type; ?>-playlist wp-playlist-<?php echo $safe_style; ?>">


### PR DESCRIPTION
## Description
Fix playlist shortcodes not rendering correctly if the first playlist is broken.
Backported from WP, see Issue #1987 and [this trac ticket](https://core.trac.wordpress.org/ticket/63583).

## How has this been tested?
Local install

## Types of changes
- Bug fix