### PR TITLE
WP-r60678: Fix playlist shortcodes if the first playlist is broken

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2798,6 +2798,8 @@ function wp_playlist_shortcode( $attr ) {
 	static $instance = 0;
 	$instance++;
 
+	static $is_loaded = false;
+
 	if ( ! empty( $attr['ids'] ) ) {
 		// 'ids' is explicitly ordered, unless you specify otherwise.
 		if ( empty( $attr['orderby'] ) ) {
@@ -2979,7 +2981,7 @@ function wp_playlist_shortcode( $attr ) {
 
 	ob_start();
 
-	if ( 1 === $instance ) {
+	if ( ! $is_loaded ) {
 		/**
 		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
 		 *
@@ -2989,6 +2991,7 @@ function wp_playlist_shortcode( $attr ) {
 		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
 		 */
 		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
+		$is_loaded = true;
 	}
 	?>
 <div class="wp-playlist wp-<?php echo $safe_type; ?>-playlist wp-playlist-<?php echo $safe_style; ?>">

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @group media
+ * @covers ::wp_playlist_shortcode
+ */
+class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 63583
+	 */
+	public function test_should_load_scripts_exactly_once_when_first_playlist_is_invalid() {
+		global $wp_scripts;
+
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/uploads/small-audio.mp3'
+		);
+
+		wp_playlist_shortcode( array( 'ids' => '999999' ) );
+		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
+		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
+
+		$queue_count = array_count_values( $wp_scripts->queue );
+
+		$this->assertArrayHasKey( 'wp-playlist', $queue_count, 'wp-playlist handle should be in the queue.' );
+		$this->assertSame( 1, $queue_count['wp-playlist'], 'The wp-playlist script handle should appear exactly once in the queue.' );
+	}
+}


### PR DESCRIPTION
**WP-r60678: Media: Fix playlist shortcodes not rendering correctly if the first playlist is broken.**

The playlist shortcode has a base set of JavaScript that should only be loaded once. Previously, this JS was only loaded the first time a playlist shortcode was processed. If the first playlist was broken, because the media file was missing for instance, this would break all other playlists on the page.

This commit introduces a new static variable to keep track of whether the necessary JavaScript has been loaded instead.

WP:Props iamadisingh, abcd95, justlevine, jorbin, rollybueno, Guido07111975. 

Fixes https://core.trac.wordpress.org/ticket/63583.

---

Merges https://core.trac.wordpress.org/changeset/60678 / WordPress/wordpress-develop@f40b60d4b2 to ClassicPress.

## Motivation and context
#2094 also address the issue well, but backporting the change also brings in unit tests.

## How has this been tested?
Local testing and unit tests.

## Types of changes
- Bug fix

