### PR TITLE
Plugins page - block notification fix

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -58,7 +58,7 @@ class WP_Compat {
 
 		$wp_list_table = _get_list_table( 'WP_Plugins_List_Table' );
 		$active        = is_plugin_active( $plugin_file ) ? 'active' : '';
-		$shadow        = isset( $plugin_data['new_version'] ) ? 'style="box-shadow: none;"' : '';
+		$shadow        = isset( $plugin_data['update'] ) ? 'style="box-shadow: none;"' : '';
 		// Translators: %1$s is the plugin name.
 		$notice_msg    = sprintf( esc_html__( '%1$s uses block-related functions and may have issues.' ), $plugin_data['Name'] );
 		$notice_msg   .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/settings-general-screen/#blocks-compatibility">' . __( 'Learn more' ) . '</a> | ';


### PR DESCRIPTION
## Description
A notification at plugins page is displayed if CP detects a plugin using block releated features.
This notification does not have a border-bottom (box-shadow) if there's a plugin update notification displayed as well.

But the condition to set border fails for WP-plugins.
Somehow `$plugin_data['new_version']` is always set for WP-plugins.
Replacing this with `$plugin_data['update']` fixes this. This variable is only available in case of a plugin update (also for CP plugins).

Note: this notification is not always displayed at Plugins page. Cache-related perhaps. While creating the PR and the screenshots I've changed some conditions to force the display.

## How has this been tested?
Local install with WP and CP plugins.

## Screenshots
### WP plugin with blocks and no update - before
![Plugin with blocks and no update - before](https://github.com/user-attachments/assets/587078bf-a71e-4511-b736-303c03a05bd1)

### WP plugin with blocks and no update - after
![Plugin with blocks and no update - after](https://github.com/user-attachments/assets/6770eaff-5b87-4829-8127-e785333d0520)

### WP plugin with blocks and update - after
![Plugin with blocks and update - after](https://github.com/user-attachments/assets/e162b9ce-e6aa-47e1-a793-4ef81e4c4865)


## Types of changes
- Bug fix
