### PR TITLE
Update notification for CP plugins: Potentially compatible with ClassicPress

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -347,7 +347,10 @@ function list_plugin_updates() {
 		}
 
 		// Get plugin compat for running version of ClassicPress.
-		if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) ) {
+		if ( isset( $plugin_data->update->requires_cp ) && ! empty( $plugin_data->update->requires_cp ) && ( substr( $plugin_data->update->requires_cp, 0, 1 ) == substr( $cur_cp_version, 0, 1 ) ) && version_compare( $plugin_data->update->requires_cp, $cur_cp_version, '<=' ) ) {
+			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+		} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {
 			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} else {
@@ -356,7 +359,10 @@ function list_plugin_updates() {
 		}
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
-			if ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $core_update_version, '>=' ) ) {
+			if ( isset( $plugin_data->update->requires_cp ) && ! empty( $plugin_data->update->requires_cp ) && ( substr( $plugin_data->update->requires_cp, 0, 1 ) == substr( $core_update_version, 0, 1 ) ) && version_compare( $plugin_data->update->requires_cp, $core_update_version, '<=' ) ) {
+				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
+				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+			} elseif ( isset( $plugin_data->update->tested ) && version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' ) && isset( $plugin_data->RequiresWP ) && version_compare( $plugin_data->RequiresWP, $cur_wp_version, '<=' ) ) {
 				$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $core_update_version );
 				$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 			} else {


### PR DESCRIPTION
## Description
**While cleaning my branches I accidently removed the branch for PR #2034. That's why I created this new PR.**

Recap:
CP plugins: only potentially compatible if plugin has `Requires CP` header between 2 (base version) and current CP version.
Other plugins: only compatible if plugin has `Tested up to` header >= WP 6.2 + `Requires at least` header <= WP 6.2.

## Screenshots
### Before
![Update plugin - before](https://github.com/user-attachments/assets/e64746e8-5986-4852-baa2-b7115e9b5b8b)

### After
![Update plugin - after](https://github.com/user-attachments/assets/cfa8511a-af4a-4be6-bed0-f52e6e72c0a9)

## Types of changes
- Enhancement