### PR TITLE
Fix box-shadow at Plugins page

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -406,8 +406,8 @@ table.media .column-title .filename {
 	transition: none;
 }
 
-#the-list tr:last-child td,
-#the-list tr:last-child th {
+#the-list tr:last-of-type td,
+#the-list tr:last-of-type th {
 	border-bottom: none !important;
 	box-shadow: none;
 }


### PR DESCRIPTION
## Description
This minor PR fixes a double box-shadow (border-bottom) when the "block-related functions" notification is displayed as last row at the Plugins page.
For some reason not clear to me the already present styling does not target this notification.
Changing `last-child` into `last-of-type` fixes this.

## How has this been tested?
Local install.

## Screenshots
### Before
![Double box-shadow - border-bottom - before](https://github.com/user-attachments/assets/7b35e759-b366-4197-8beb-9e3d88a1a1d6)

### After
![Double box-shadow - border-bottom - after](https://github.com/user-attachments/assets/ce30561b-8578-4b12-94d4-e4c5437bb975)

## Types of changes
- Bug fix