### PR TITLE
Remove locale en_US from core update link

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -118,6 +118,50 @@ function list_core_update( $update ) {
 }
 
 /**
+ * Display dismissed updates.
+ *
+ * @since 2.7.0
+ */
+function dismissed_updates() {
+	$dismissed = get_core_updates(
+		array(
+			'dismissed' => true,
+			'available' => false,
+		)
+	);
+
+	if ( $dismissed ) {
+		$show_text = esc_js( __( 'Show hidden updates' ) );
+		$hide_text = esc_js( __( 'Hide hidden updates' ) );
+		?>
+		<script>
+			jQuery( function( $ ) {
+				$( '#show-dismissed' ).on( 'click', function() {
+					var isExpanded = ( 'true' === $( this ).attr( 'aria-expanded' ) );
+
+					if ( isExpanded ) {
+						$( this ).text( '<?php echo $show_text; ?>' ).attr( 'aria-expanded', 'false' );
+					} else {
+						$( this ).text( '<?php echo $hide_text; ?>' ).attr( 'aria-expanded', 'true' );
+					}
+
+					$( '#dismissed-updates' ).toggle( 'fast' );
+				});
+			});
+		</script>
+		<?php
+		echo '<p class="hide-if-no-js"><button type="button" class="button" id="show-dismissed" aria-expanded="false">' . __( 'Show hidden updates' ) . '</button></p>';
+		echo '<ul id="dismissed-updates" class="core-updates dismissed">';
+		foreach ( (array) $dismissed as $update ) {
+			echo '<li>';
+			list_core_update( $update );
+			echo '</li>';
+		}
+		echo '</ul>';
+	}
+}
+
+/**
  * Display upgrade ClassicPress for downloading latest or upgrading automatically form.
  *
  * @since 2.7.0


### PR DESCRIPTION
## Description
If core update is available you can download it from page `wp-admin/update-core.php`.
When site language is not `en_US`, the locale `en_US` is added to the download link.
This PR removes the locale from the core update link (and everything related).
Even some jQuery is being removed, isn't that nice?!
As mentioned in Issue #2104.

I did not remove `global $wp_local_package, $wpdb;`.
This PR fully removes `$wp_local_package` from the `get_core_updates()` function, but this function is also included in another function in the same file, to list plugin updates.

## Motivation and context
CP does not ship localized versions, only the default `en_US` version.

## How has this been tested?
Local install, page `wp-admin/update-core.php`.

## Screenshots
See Issue #2104

## Types of changes
- Enhancement