### PR TITLE
The CP Theme - menu related error

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/functions.php
+++ b/src/wp-content/themes/the-classicpress-theme/functions.php
@@ -46,7 +46,7 @@ if ( ! function_exists( 'susty_setup' ) ) :
 
 		/**
 		 * This theme uses wp_nav_menu() in two locations.
-   		 *
+		 *
 		 * @link https://developer.wordpress.org/themes/functionality/navigation-menus/
 		 */
 		register_nav_menus(
@@ -74,7 +74,7 @@ if ( ! function_exists( 'susty_setup' ) ) :
 
 		/**
 		 * Add theme support for selective refresh for widgets.
-		 */	
+		 */
 		add_theme_support( 'customize-selective-refresh-widgets' );
 
 		/**


### PR DESCRIPTION
## Description
This PR fixes a menu related error, as mentioned in [this post](https://forums.classicpress.net/t/the-classic-press-theme-gives-a-warning-in-logs/6315) at the CP Forum. File `menu.php` did not exist but was called.

Also changed several comment tags in the same file, for consistency.

I have created this PR after having contact with Elisabetta.
Props [nootkan](https://forums.classicpress.net/u/nootkan) / Paul.

## Types of changes
- Bug fix