### PR TITLE
Migrate to CP notification at Welcome to CP screen

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -22,27 +22,27 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<p class="about-text">
 			<?php printf( __( 'Version %s' ), classicpress_version() ); ?>
 			<?php classicpress_dev_version_info(); ?>
-			<?php
-			if ( is_multisite() ) {
-				$reinstall_url = network_admin_url( 'update-core.php' );
-			} else {
-				$reinstall_url = admin_url( 'update-core.php' );
-			}
-			if ( strpos( classicpress_version(), 'migration' ) ) {
-				?>
-				<p><strong>
-				<?php
-				printf(
-					/* translators: link to updates page */
-					__( 'You must visit the <a href="%s">Updates Page</a> and Press the Re-Install Now button to complete the migration process!' ),
-					esc_url( $reinstall_url )
-				);
-				?>
-				</strong></p>
-				<?php
-			}
-			?>
 		</p>
+		<?php
+		if ( is_multisite() ) {
+			$reinstall_url = network_admin_url( 'update-core.php' );
+		} else {
+			$reinstall_url = admin_url( 'update-core.php' );
+		}
+		if ( strpos( classicpress_version(), 'migration' ) ) {
+			?>
+			<p><strong>
+			<?php
+			printf(
+				/* translators: link to updates page */
+				__( 'You must visit the <a href="%s">Updates Page</a> and Press the Re-Install Now button to complete the migration process!' ),
+				esc_url( $reinstall_url )
+			);
+			?>
+			</strong></p>
+			<?php
+		}
+		?>
 		<p class="about-text">
 			<?php
 			printf(


### PR DESCRIPTION
## Description
This PR is created as mentioned in the Plugins channel at Zulip.

After migrating from WP to ClassicPress with the Switch to CP plugin, you should re-install CP in order to complete the migration. This is mentioned at the plugin settings page, but after migration you're redirected to the default Welcome to CP screen. So it's not clear.

This PR adds the notification at the Welcome to CP screen as well.
It will display the notification if the version string contains "migration".
I have looked at [the plugin code](https://github.com/ClassicPress/ClassicPress-Migration-Plugin/blob/master/lib/admin-page.php#L322) for this PR.

## How has this been tested?
Local install.

## Screenshots
### After
![Re-install after migrating](https://github.com/user-attachments/assets/10b4ca93-eafe-4794-99bd-07f676c2f893)

## Types of changes
- Enhancement