### PR TITLE
Prevent duplication of TinyMCE in the text widget in the Customizer

### DIFF
--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -45,7 +45,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function handleWidgetUpdate( event ) {
 		var widget = event.detail.widget;
 		if ( widget.querySelector( '.id_base' ).value === 'text' ) {
-			initTextWidget( widget.querySelector( 'textarea' ) );
+			if ( document.body.className.includes( 'wp-customizer' ) ) {
+				if ( event.type !== 'widget-synced' ) {
+					setTimeout( function() {
+						initTextWidget( widget.querySelector( 'textarea' ) );
+					}, 100);
+				}
+			} else {
+				initTextWidget( widget.querySelector( 'textarea' ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
At the moment, every `keyup` in the Text widget's title or content field causes TinyMCE to duplicate itself within the Text widget in the Customizer. This PR stops that behavior by not re-initializing TinyMCE after the widget syncs its content from within the Customizer.

This PR also uses a `timeout` of `100` before initializing TinyMCE in the Text widget in the Customizer. This follows Tiny's own recommendation to ensure that the content area of the widget can be accessed.

This PR squashes a bug reported on the Forums at https://forums.classicpress.net/t/is-this-a-bug-customizer-widget-duplication-using-twenty-seventeen/6329

Props: [createscape](https://forums.classicpress.net/u/createscape)