### PR TITLE
Update Admin Bar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -357,9 +357,17 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
 	if ( is_network_admin() || is_user_admin() ) {
 		$title = wp_html_excerpt( $blogname, 40, '&hellip;' );
 	} elseif ( is_admin() ) {
-		$title = wp_html_excerpt( $blogname, 30, '&hellip;' ) . ' | ' . __( 'Visit Site' );
+		$title = sprintf(
+			/* translators: %s: Truncated site title. */
+			__( '%s | Visit Site' ),
+			wp_html_excerpt( $blogname, 30, '&hellip;' )
+		);
 	} else {
-		$title = wp_html_excerpt( $blogname, 30, '&hellip;' ) . ' | ' . __( 'Dashboard' );
+		$title = sprintf(
+			/* translators: %s: Truncated site title. */
+			__( '%s | Dashboard' ),
+			wp_html_excerpt( $blogname, 30, '&hellip;' )
+		);
 	}
 
 	$wp_admin_bar->add_node(


### PR DESCRIPTION
## Description
As suggested by Crystal at [the CP forum](https://forums.classicpress.net/t/feature-suggestions/6330) this PR changes the site name in the Admin Bar into "Dashboard" or "Visit Site".
I did not touch the sub menu, as plugins/themes may target this.
Also did not remove the first item (Dashboard / Visit Site) from the sub menu, because this first item is required to make sub menu look good.

## Motivation and context
More clear to users. 

## How has this been tested?
Local install.

## Screenshots
### After
![Visit dashboard](https://github.com/user-attachments/assets/d9463ed0-5785-4551-bac1-abbd0c25e8c4)

![Visit site](https://github.com/user-attachments/assets/3b05ffa9-11ee-43f1-b617-21674cc1fded)

## Types of changes
- Enhancement