### PR TITLE
Backport of fixes from WordPress 6.8.3

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -111,36 +111,10 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			<p>
 				<?php
 				printf(
-<<<<<<< HEAD
 					/* translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum */
 					__( 'If you need help with something else, please see our <a href="%1$s"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
 					'https://www.classicpress.net/faq/',
 					'https://forums.classicpress.net/c/support/'
-=======
-					/* translators: %s: WordPress version. */
-					__( '<strong>Version %s</strong> addressed some security issues.' ),
-					'6.2.8'
-				);
-				?>
-				<?php
-				printf(
-					/* translators: %s: HelpHub URL. */
-					__( 'For more information, see <a href="%s">the release notes</a>.' ),
-					sprintf(
-						/* translators: %s: WordPress version. */
-						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
-						sanitize_title( '6.2.8' )
-					)
-				);
-				?>
-			</p>
-				<p>
-					<?php
-					printf(
-						/* translators: %s: WordPress version number. */
-						__( '<strong>Version %s</strong> addressed one security issue.' ),
-						'6.2.7'
->>>>>>> 2fd458e9fc (WordPress 6.2.8.)
 				);
 				?>
 			</p>
@@ -201,6 +175,26 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				_e(
 					'This version of ClassicPress includes all changes from the following versions of WordPress:'
 				);
+				?>
+			</p>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: WordPress version. */
+					__( '<strong>WordPress version %s</strong> addressed some security issues.' ),
+					'6.2.8'
+				);
+				?>
+				<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '6.2.8' )
+						)
+					);
 				?>
 			</p>
 			<p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -186,15 +186,15 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 				<?php
-					printf(
-						/* translators: %s: HelpHub URL. */
-						__( 'For more information, see <a href="%s">the release notes</a>.' ),
-						sprintf(
-							/* translators: %s: WordPress version. */
-							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
-							sanitize_title( '6.2.8' )
-						)
-					);
+				printf(
+					/* translators: %s: HelpHub URL. */
+					__( 'For more information, see <a href="%s">the release notes</a>.' ),
+					sprintf(
+						/* translators: %s: WordPress version. */
+						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+						sanitize_title( '6.2.8' )
+					)
+				);
 				?>
 			</p>
 			<p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -111,10 +111,36 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			<p>
 				<?php
 				printf(
+<<<<<<< HEAD
 					/* translators: 1: link to ClassicPress FAQs page, 2: link to ClassicPress support forum */
 					__( 'If you need help with something else, please see our <a href="%1$s"><strong>FAQs page</strong></a>. If your question is not answered there, you can make a new post on our <a href="%2$s"><strong>support forum</strong></a>.' ),
 					'https://www.classicpress.net/faq/',
 					'https://forums.classicpress.net/c/support/'
+=======
+					/* translators: %s: WordPress version. */
+					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					'6.2.8'
+				);
+				?>
+				<?php
+				printf(
+					/* translators: %s: HelpHub URL. */
+					__( 'For more information, see <a href="%s">the release notes</a>.' ),
+					sprintf(
+						/* translators: %s: WordPress version. */
+						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+						sanitize_title( '6.2.8' )
+					)
+				);
+				?>
+			</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: WordPress version number. */
+						__( '<strong>Version %s</strong> addressed one security issue.' ),
+						'6.2.7'
+>>>>>>> 2fd458e9fc (WordPress 6.2.8.)
 				);
 				?>
 			</p>

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -842,7 +842,13 @@
 				return;
 			}
 
-			this.currentMenuControl.addItemToMenu( menu_item.attributes );
+			// Leave the title as empty to reuse the original title as a placeholder if set.
+			var nav_menu_item = Object.assign( {}, menu_item.attributes );
+			if ( nav_menu_item.title === nav_menu_item.original_title ) {
+				nav_menu_item.title = '';
+			}
+
+			this.currentMenuControl.addItemToMenu( nav_menu_item );
 
 			$( menuitemTpl ).find( '.menu-item-handle' ).addClass( 'item-added' );
 		},
@@ -3310,7 +3316,6 @@
 				item,
 				{
 					nav_menu_term_id: menuControl.params.menu_id,
-					original_title: item.title,
 					position: position
 				}
 			);

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -191,9 +191,11 @@ final class WP_Customize_Nav_Menus {
 				}
 			} elseif ( 'post' !== $object_name && 0 === $page && $post_type->has_archive ) {
 				// Add a post type archive link.
+				$title   = $post_type->labels->archives;
 				$items[] = array(
 					'id'         => $object_name . '-archive',
-					'title'      => $post_type->labels->archives,
+					'title'          => $title,
+					'original_title' => $title,
 					'type'       => 'post_type_archive',
 					'type_label' => __( 'Post Type Archive' ),
 					'object'     => $object_name,
@@ -244,9 +246,11 @@ final class WP_Customize_Nav_Menus {
 					$post_type_label = implode( ',', $post_states );
 				}
 
+				$title   = html_entity_decode( $post_title, ENT_QUOTES, get_bloginfo( 'charset' ) );
 				$items[] = array(
 					'id'         => "post-{$post->ID}",
-					'title'      => html_entity_decode( $post_title, ENT_QUOTES, get_bloginfo( 'charset' ) ),
+					'title'          => $title,
+					'original_title' => $title,
 					'type'       => 'post_type',
 					'type_label' => $post_type_label,
 					'object'     => $post->post_type,
@@ -276,9 +280,11 @@ final class WP_Customize_Nav_Menus {
 			}
 
 			foreach ( $terms as $term ) {
+				$title   = html_entity_decode( $term->name, ENT_QUOTES, get_bloginfo( 'charset' ) );
 				$items[] = array(
 					'id'         => "term-{$term->term_id}",
-					'title'      => html_entity_decode( $term->name, ENT_QUOTES, get_bloginfo( 'charset' ) ),
+					'title'          => $title,
+					'original_title' => $title,
 					'type'       => 'taxonomy',
 					'type_label' => get_taxonomy( $term->taxonomy )->labels->singular_name,
 					'object'     => $term->taxonomy,

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -56,7 +56,6 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 		'classes'          => '',
 		'xfn'              => '',
 		'status'           => 'publish',
-		'original_title'   => '',
 		'nav_menu_term_id' => 0, // This will be supplied as the $menu_id arg for wp_update_nav_menu_item().
 		'_invalid'         => false,
 	);
@@ -210,6 +209,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 * @return array|false Instance data array, or false if the item is marked for deletion.
 	 */
 	public function value() {
+		$type_label = null;
 		if ( $this->is_previewed && get_current_blog_id() === $this->_previewed_blog_id ) {
 			$undefined  = new stdClass(); // Symbol.
 			$post_value = $this->post_value( $undefined );
@@ -218,9 +218,6 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				$value = $this->_original_value;
 			} else {
 				$value = $post_value;
-			}
-			if ( ! empty( $value ) && empty( $value['original_title'] ) ) {
-				$value['original_title'] = $this->get_original_title( (object) $value );
 			}
 		} elseif ( isset( $this->value ) ) {
 			$value = $this->value;
@@ -233,6 +230,9 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				if ( $post && self::POST_TYPE === $post->post_type ) {
 					$is_title_empty = empty( $post->post_title );
 					$value          = (array) wp_setup_nav_menu_item( $post );
+					if ( isset( $value['type_label'] ) ) {
+						$type_label = $value['type_label'];
+					}
 					if ( $is_title_empty ) {
 						$value['title'] = '';
 					}
@@ -249,10 +249,29 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 			$value = $this->value;
 		}
 
-		if ( ! empty( $value ) && empty( $value['type_label'] ) ) {
-			$value['type_label'] = $this->get_type_label( (object) $value );
+		// These properties are read-only and are part of the setting for use in the Customizer UI.
+		if ( is_array( $value ) ) {
+			$value_obj               = (object) $value;
+			$value['type_label']     = isset( $type_label ) ? $type_label : $this->get_type_label( $value_obj );
+			$value['original_title'] = $this->get_original_title( $value_obj );
 		}
 
+		return $value;
+	}
+
+	/**
+	 * Prepares the value for editing on the client.
+	 *
+	 * @since 6.8.3
+	 *
+	 * @return array|false Value prepared for the client.
+	 */
+	public function js_value() {
+		$value = parent::js_value();
+		if ( is_array( $value ) && isset( $value['original_title'] ) ) {
+			// Decode entities for the sake of displaying the original title as a placeholder.
+			$value['original_title'] = html_entity_decode( $value['original_title'], ENT_QUOTES, get_bloginfo( 'charset' ) );
+		}
 		return $value;
 	}
 
@@ -262,7 +281,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 * @since 4.7.0
 	 *
 	 * @param object $item Nav menu item.
-	 * @return string The original title.
+	 * @return string The original title, without entity decoding.
 	 */
 	protected function get_original_title( $item ) {
 		$original_title = '';
@@ -288,7 +307,6 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				$original_title = $original_object->labels->archives;
 			}
 		}
-		$original_title = html_entity_decode( $original_title, ENT_QUOTES, get_bloginfo( 'charset' ) );
 		return $original_title;
 	}
 
@@ -344,10 +362,6 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 		if ( isset( $this->value['post_status'] ) ) {
 			$this->value['status'] = $this->value['post_status'];
 			unset( $this->value['post_status'] );
-		}
-
-		if ( ! isset( $this->value['original_title'] ) ) {
-			$this->value['original_title'] = $this->get_original_title( (object) $this->value );
 		}
 
 		if ( ! isset( $this->value['nav_menu_term_id'] ) && $this->post_id > 0 ) {
@@ -594,11 +608,8 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 		$item->menu_order = $item->position;
 		unset( $item->position );
 
-		if ( empty( $item->original_title ) ) {
-			$item->original_title = $this->get_original_title( $item );
-		}
 		if ( empty( $item->title ) && ! empty( $item->original_title ) ) {
-			$item->title = $item->original_title;
+			$item->title = $item->original_title; // This is NOT entity-decoded. It comes from self::get_original_title().
 		}
 		if ( $item->title ) {
 			$item->post_title = $item->title;
@@ -654,7 +665,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 * @since 4.3.0
 	 * @since 5.9.0 Renamed `$menu_item_value` to `$value` for PHP 8 named parameter support.
 	 *
-	 * @param array $value The menu item value to sanitize.
+	 * @param array|false $value The menu item value to sanitize.
 	 * @return array|false|null|WP_Error Null or WP_Error if an input isn't valid. False if it is marked for deletion.
 	 *                                   Otherwise the sanitized value.
 	 */
@@ -710,8 +721,6 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 			}
 			$menu_item_value[ $key ] = implode( ' ', array_map( 'sanitize_html_class', $value ) );
 		}
-
-		$menu_item_value['original_title'] = sanitize_text_field( $menu_item_value['original_title'] );
 
 		// Apply the same filters as when calling wp_insert_post().
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -378,7 +378,13 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		foreach ( $query_result as $post ) {
-			if ( ! $this->check_read_permission( $post ) ) {
+			if ( 'edit' === $request['context'] ) {
+				$permission = $this->check_update_permission( $post );
+			} else {
+				$permission = $this->check_read_permission( $post );
+			}
+
+			if ( ! $permission ) {
 				continue;
 			}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -340,6 +340,10 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		$response = array();
 
 		foreach ( $query_result as $term ) {
+			if ( 'edit' === $request['context'] && ! current_user_can( 'edit_term', $term->term_id ) ) {
+				continue;
+			}
+
 			$data       = $this->prepare_item_for_response( $term, $request );
 			$response[] = $this->prepare_response_for_collection( $data );
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -339,15 +339,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$users = array();
 
-<<<<<<< HEAD
 		foreach ( $query->get_results() as $user ) {
-=======
-		foreach ( $query->results as $user ) {
 			if ( 'edit' === $request['context'] && ! current_user_can( 'edit_user', $user->ID ) ) {
 				continue;
 			}
 
->>>>>>> d157ce3b88 (Grouped backports for the 6.2 branch.)
 			$data    = $this->prepare_item_for_response( $user, $request );
 			$users[] = $this->prepare_response_for_collection( $data );
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -210,7 +210,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		if ( 'edit' === $request['context'] && ! current_user_can( 'list_users' ) ) {
 			return new WP_Error(
 				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to list users.' ),
+				__( 'Sorry, you are not allowed to edit users.' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
@@ -339,7 +339,15 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$users = array();
 
+<<<<<<< HEAD
 		foreach ( $query->get_results() as $user ) {
+=======
+		foreach ( $query->results as $user ) {
+			if ( 'edit' === $request['context'] && ! current_user_can( 'edit_user', $user->ID ) ) {
+				continue;
+			}
+
+>>>>>>> d157ce3b88 (Grouped backports for the 6.2 branch.)
 			$data    = $this->prepare_item_for_response( $user, $request );
 			$users[] = $this->prepare_response_for_collection( $data );
 		}
@@ -439,13 +447,15 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return true;
 		}
 
-		if ( 'edit' === $request['context'] && ! current_user_can( 'list_users' ) ) {
+		if ( 'edit' === $request['context'] && ! current_user_can( 'edit_user', $user->ID ) ) {
 			return new WP_Error(
-				'rest_user_cannot_view',
-				__( 'Sorry, you are not allowed to list users.' ),
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to edit this user.' ),
 				array( 'status' => rest_authorization_required_code() )
 			);
-		} elseif ( ! count_user_posts( $user->ID, $types ) && ! current_user_can( 'edit_user', $user->ID ) && ! current_user_can( 'list_users' ) ) {
+		}
+
+		if ( ! current_user_can( 'edit_user', $user->ID ) && ! current_user_can( 'list_users' ) && ! count_user_posts( $user->ID, $types ) ) {
 			return new WP_Error(
 				'rest_user_cannot_view',
 				__( 'Sorry, you are not allowed to list users.' ),
@@ -1037,7 +1047,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			$data['slug'] = $user->user_nicename;
 		}
 
-		if ( in_array( 'roles', $fields, true ) ) {
+		if ( in_array( 'roles', $fields, true ) && ( current_user_can( 'list_users' ) || current_user_can( 'edit_user', $user->ID ) ) ) {
 			// Defensively call array_values() to ensure an array is returned.
 			$data['roles'] = array_values( $user->roles );
 		}

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -39,11 +39,7 @@ $cp_version = '2.5.0+dev';
  *
  * @global string $wp_version
  */
-<<<<<<< HEAD
-$wp_version = '6.2.6';
-=======
-$wp_version = '6.2.8-src';
->>>>>>> 2fd458e9fc (WordPress 6.2.8.)
+$wp_version = '6.2.8';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -39,7 +39,11 @@ $cp_version = '2.5.0+dev';
  *
  * @global string $wp_version
  */
+<<<<<<< HEAD
 $wp_version = '6.2.6';
+=======
+$wp_version = '6.2.8-src';
+>>>>>>> 2fd458e9fc (WordPress 6.2.8.)
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.

--- a/tests/phpunit/tests/customize/nav-menu-item-setting.php
+++ b/tests/phpunit/tests/customize/nav-menu-item-setting.php
@@ -89,7 +89,6 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 			'classes'          => '',
 			'xfn'              => '',
 			'status'           => 'publish',
-			'original_title'   => '',
 			'nav_menu_term_id' => 0,
 			'_invalid'         => false,
 		);
@@ -581,7 +580,8 @@ class Test_WP_Customize_Nav_Menu_Item_Setting extends WP_UnitTestCase {
 			'classes'          => 'hello  inject',
 			'xfn'              => 'hello  inject',
 			'status'           => 'draft',
-			'original_title'   => 'Hi',
+			'original_title'   => 'Hi<script>unfilteredHtml()</script>',
+
 			'nav_menu_term_id' => 0,
 		);
 

--- a/tests/phpunit/tests/customize/nav-menus.php
+++ b/tests/phpunit/tests/customize/nav-menus.php
@@ -170,6 +170,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$expected = array(
 			'id'         => "post-{$post_id}",
 			'title'      => 'Post Title',
+			'original_title' => 'Post Title',
 			'type'       => 'post_type',
 			'type_label' => 'Post',
 			'object'     => 'post',
@@ -202,6 +203,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$expected = array(
 			'id'         => "post-{$page_id}",
 			'title'      => 'Page Title',
+			'original_title' => 'Page Title',
 			'type'       => 'post_type',
 			'type_label' => 'Page',
 			'object'     => 'page',
@@ -228,6 +230,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$expected = array(
 			'id'         => "post-{$post_id}",
 			'title'      => 'Post Title',
+			'original_title' => 'Post Title',
 			'type'       => 'post_type',
 			'type_label' => 'Post',
 			'object'     => 'post',
@@ -254,6 +257,7 @@ class Test_WP_Customize_Nav_Menus extends WP_UnitTestCase {
 		$expected = array(
 			'id'         => "term-{$term_id}",
 			'title'      => 'Term Title',
+			'original_title' => 'Term Title',
 			'type'       => 'taxonomy',
 			'type_label' => 'Category',
 			'object'     => 'category',

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1187,7 +1187,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/users/%d', $author_id ) );
 		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_user_cannot_view', $response, 401 );
+		$this->assertErrorResponse( 'rest_forbidden_context', $response, 401 );
 	}
 
 	public function test_get_current_user() {


### PR DESCRIPTION
## Description
This is a backport of two upstream security fixes:
https://wordpress.org/news/2025/09/wordpress-6-8-3-release/

- A data exposure issue where authenticated users could access some restricted content. Independently reported by [Mike Nelson](https://hackerone.com/mnelson4), [Abu Hurayra](https://hackerone.com/hurayraiit), [Timothy Jacobs](https://profiles.wordpress.org/timothyblynjacobs/), and [Peter Wilson](https://profiles.wordpress.org/peterwilsoncc/).
- A cross-site scripting (XSS) vulnerability requiring an authenticated user role that affects the nav menus. Reported by [Phill Savage](https://x.com/Savphill).

This PR aso updates the `about.php` page and bumps the core `$wp_version` variable.
## Motivation and context
Security fix.

## How has this been tested?
Backport

## Screenshots
N/A

## Types of changes
- Bug fix