### PR TITLE
Add PHP 8.5 experimental test jobs

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -117,6 +117,18 @@ jobs:
             memcached: false
             coverage: xdebug
             experimental: false
+          - php: '8.5'
+            mysql: '5.7'
+            multisite: false
+            memcached: false
+            coverage: none
+            experimental: true
+          - php: '8.5'
+            mysql: '8.0'
+            multisite: false
+            memcached: false
+            coverage: none
+            experimental: true
 
     steps:
       - name: Configure environment variables


### PR DESCRIPTION
## Description
Introduces two new experimental jobs for PHP 8.5 with MySQL 5.7 and 8.0 to the PHPUnit workflow matrix. These jobs run without coverage and multisite, helping to test compatibility with upcoming PHP versions.

## Motivation and context
PHP 8.5 is now in release candidate phase of developement. As discussed at the core meeting on 8th October, this PR enables experimental PHPUnit testing for PHP 8.5 so we can indentify and fix any issues.

## How has this been tested?
This PR will introduce new testing workflows, initially just default tests.

## Screenshots
N/A

## Types of changes
- Enhancement