### PR TITLE
Fix check translation updates issue since cp 2.5

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1092,11 +1092,10 @@ function cp_get_translation_updates() {
 		return;
 	}
 
-	$domains = array( 'admin', 'admin-network', 'continents-cities', 'default' );
 	$po_data = array();
 
-	foreach ( $domains as $domain ) {
-		foreach ( $installed_translations[ $domain ] as $locale => $data ) {
+	foreach ( $installed_translations as $domain ) {
+		foreach ( $domain as $locale => $data ) {
 			if ( ! isset( $po_data[ $locale ] ) ) {
 				$po_data[ $locale ] = strtotime( $data['PO-Revision-Date'] );
 			} else {


### PR DESCRIPTION
## Description

Since classicpress 2.5, users can get undefined array key warnings within the `wp_version_check` cron job in function `cp_get_translation_updates` when the translations for admin, admin-network, ... are not included in the languages dir.

## Motivation and context

#2131 

## How has this been tested?

It was tested in a local copy of classicpress 2.5 by applying the code changes.

## Types of changes

- Bug fix
