### PR TITLE
Add further PHP 8.5 tests to CI workflow

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -141,7 +141,7 @@ jobs:
             memcached: false
             coverage: none
             experimental: true
-           php: '8.5'
+          - php: '8.5'
             mysql: '8.0'
             multisite: false
             memcached: true


### PR DESCRIPTION
## Description
Introduces new test configurations for PHP 8.5 with various MySQL, multisite, and memcached settings to expand coverage for upcoming PHP versions.

## Motivation and context
PHP 8.5 is now in release candidate phase of developement. This PR extends experimental PHPUnit testing for PHP 8.5 to include Multisite and memcached testing.

## How has this been tested?
This PR will introduce new testing workflows, initially just default tests.

## Screenshots
N/A

## Types of changes
- Enhancement
