### PR TITLE
Add check for empty content in revision before displaying diff

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3792,7 +3792,9 @@ function wp_ajax_get_revision_diffs() {
 		$diffs_array[ $diff['id'] ]['author_right'] = $author_right;
 
 		$diffs_string  = '<h3>' . esc_html__( 'Title' ) . '</h3>' . $diff['fields'][0]['diff'];
-		$diffs_string .= '<h3>' . esc_html__( 'Content' ) . '</h3>' . $diff['fields'][1]['diff'];
+		if ( ! empty( $diff['fields'][1] ) ) {
+			$diffs_string .= '<h3>' . esc_html__( 'Content' ) . '</h3>' . $diff['fields'][1]['diff'];
+		}
 		$diffs_array[ $diff['id'] ]['diffs'] = $diffs_string;
 	}
 


### PR DESCRIPTION
This is a fix for Issue #2140 reported by @8ctopus. It adds a check to ensure an array key exists before attempting to show the content of the diff on the post revisions screen.