### PR TITLE
Media Grid View upload - fix infinite loop

### DIFF
--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -1166,7 +1166,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		},
 		labelTapToUndo: _wpMediaGridSettings.tap_close,
 		fileRenameFunction: ( file ) =>
-			new Promise( ( resolve ) => {
+			new Promise( function( resolve ) {
 				const newName = window.prompt(
 					_wpMediaGridSettings.new_filename,
 					file.name


### PR DESCRIPTION
## Description
This PR fixes Issue #2143.
If cancel is clicked in the file rename modal, an infinite loop occurs (first screenshot).
After this fix the file is uploaded with its original name.

Props @rikschennink

## How has this been tested?
Local install.

## Screenshots
### Before
![File rename cancel - before](https://github.com/user-attachments/assets/618d4e54-6379-42fe-a002-e57cd6d53a9d)

### After
![File rename cancel - after](https://github.com/user-attachments/assets/9c47b794-3c2a-4362-9e2a-02d6e0a43de8)

## Types of changes
- Bug fix
