### PR TITLE
Update ECMAScript version to 11 in lint configs

### DIFF
--- a/.eslint.config.js
+++ b/.eslint.config.js
@@ -1,7 +1,7 @@
 module.exports = [
 	{
 		"languageOptions": {
-			"ecmaVersion": 6
+			"ecmaVersion": 11
 		},
 		"rules": {
 			"block-scoped-var": "error",

--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
 	"curly": true,
 	"eqeqeq": true,
 	"eqnull": true,
-	"esversion": 6,
+	"esversion": 11,
 	"expr": true,
 	"immed": true,
 	"noarg": true,


### PR DESCRIPTION
## Description
Bump the ECMAScript version from 6 to 11 in both ESLint and JSHint configuration files to support newer JavaScript syntax and features.

## Motivation and context
Fixes #2169

## How has this been tested?
Local testing based on PR #2168, and GitHub tests will need to run.

## Screenshots
N/A

## Types of changes
- Enhancement