### PR TITLE
Refactor title assignment with conditional check

### DIFF
--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -571,7 +571,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					if ( responseText && responseText.length > 2 ) {
 						widget.querySelector( '.widget-content' ).innerHTML = responseText;
 
-						let title = widget.querySelector( 'input[id*="-title"]' ).value || '';
+						let title = widget.querySelector( 'input[id*="-title"]' ) ? widget.querySelector( 'input[id*="-title"]' ).value : '';
 						if ( title ) {
 							title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 						}


### PR DESCRIPTION
If a widget does not have a title field, this throws an error. This PR fixes that and Issue #2099.

Props @rhavin.