### PR TITLE
Move .mejs-overlay-button padding to wp-mediaelement.css

### DIFF
--- a/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
+++ b/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css
@@ -154,7 +154,6 @@ Reference: http://blog.rrwd.nl/2015/04/04/the-screen-reader-text-class-why-and-h
 .mejs-overlay-button {
     background: transparent;
     border: 0;
-	padding: 0;
 }
 
 .mejs-overlay:hover .mejs-overlay-button svg {

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -63,6 +63,10 @@
 	max-width: 100%;
 }
 
+.mejs-overlay-button {
+	padding: 0;
+}
+
 /* Override theme styles that may conflict with controls. */
 .mejs-controls button:hover {
 	border: none;


### PR DESCRIPTION
## Description
Removed the padding property from .mejs-overlay-button in mediaelementplayer-legacy.css and added it to wp-mediaelement.css to centralize style definitions and avoid redundancy.

As noted by @Guido07111975, the CSS fix we made here:
https://github.com/ClassicPress/ClassicPress/blob/develop/src/wp-includes/js/mediaelement/mediaelementplayer-legacy.css#L157

Is not being retained in the nightly builds:
https://github.com/ClassyBot/ClassicPress-v2-nightly/blob/519ff4a51286b86dd664d09dc53bbbd24acc9b4f/wp-includes/js/mediaelement/mediaelementplayer-legacy.css#L157

This is becuase the `mediaelementplayer-legacy.css` file is part of the MediaElement dependency and is over-written from source on each build. So the CSS rule needs moving to a file under our direct control rather than a dependency.

## Motivation and context
Correctly implement CSS chane to fix issue.

## How has this been tested?
Local testing.

## Screenshots
N/A

## Types of changes
- Bug fix