### PR TITLE
WP-r61131: Mail: reset `Encoding` to 8-bit in `wp_mail()`.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -381,6 +381,15 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$phpmailer->Body    = '';
 		$phpmailer->AltBody = '';
 
+		/*
+		 * Reset encoding to 8-bit, as it may have been automatically downgraded
+		 * to 7-bit by PHPMailer (based on the body contents) in a previous call
+		 * to wp_mail().
+		 *
+		 * See https://core.trac.wordpress.org/ticket/33972
+		 */
+		$phpmailer->Encoding = PHPMailer\PHPMailer\PHPMailer::ENCODING_8BIT;
+
 		// Set "From" name and email.
 
 		// If we don't have a name from the input headers.

--- a/tests/phpunit/includes/mock-mailer.php
+++ b/tests/phpunit/includes/mock-mailer.php
@@ -6,7 +6,6 @@ class MockPHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	public $mock_sent = array();
 
 	public function preSend() {
-		$this->Encoding = '8bit';
 		return parent::preSend();
 	}
 

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -657,4 +657,22 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'cid:' . $key, $mailer->get_sent()->body, 'The cid ' . $key . ' is not referenced in the mail body.' );
 		}
 	}
+
+	/**
+	 * Test that the encoding of the email does not bleed between long and short emails.
+	 *
+	 * @ticket 33972
+	 */
+	public function test_wp_mail_encoding_does_not_bleed() {
+		$content = str_repeat( 'A', 1000 );
+		wp_mail( WP_TESTS_EMAIL, 'Looong line testing', $content );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertEquals( 'quoted-printable', $mailer->Encoding );
+
+		wp_mail( WP_TESTS_EMAIL, 'A follow up short email', 'Short email' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertEquals( '7bit', $mailer->Encoding );
+	}
 }


### PR DESCRIPTION
## Description
The PHPMailer library may automatically switch its encoding based on various internal factors.

This commit fixes a bug where the `$phpmailer` global was unintentionally persisting its `Encoding` property from the first `wp_mail()` call to all subsequent calls.

This includes unit tests to verify the fix is accurate, and a change to the mock-mailer helper that worked around this bug just-in-time when running the test suite.

WP:Props codebuddy, dilip2615, rishabhwp, sajjad67, sirlouen, stephenharris.

Fixes https://core.trac.wordpress.org/ticket/33972.

---

Merges https://core.trac.wordpress.org/changeset/61131 / WordPress/wordpress-develop@1187abf11e to ClassicPress.


## Motivation and context
Fixes possible issue in static use of PHPMailer.

## How has this been tested?
This is a backport and includes a unit test.

## Screenshots
N/A

## Types of changes
- Bug fix
