### PR TITLE
Update precommit workflow action

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -151,6 +151,13 @@ jobs:
           grunt --version
           mysql --version
 
+      - name: Bypass Cloudflare for GitHub Action
+        uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.0.1
+        with:
+          cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
+          cf_zone_id: ${{ secrets.CF_ZONE_ID }}
+          cf_api_token: ${{ secrets.CF_API_TOKEN }}
+
       - name: Install dependencies
         run: npx install-changed --install-command="npm ci"
 


### PR DESCRIPTION
## Description
This PR updates the PHP version in use on the Precommit Workflow.
It also implemenets a step to bypass CloudFlare caching so the Workflow still functions so CloudFlare caching can be enabled on the API server.

## Motivation and context
Update to workflow and allow API server caching.

## How has this been tested?
The precommit action working successfully on this PR will be the test.

## Screenshots
### Before
<img width="1030" height="206" alt="Screenshot 2025-11-15 at 12 26 52" src="https://github.com/user-attachments/assets/0b215c09-4ef1-4144-83f5-1472dac74382" />

### After


## Types of changes
- Bug fix / Enhancement