### PR TITLE
Update PHPUnit test matrix for PHP 8.5

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.5' '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ]
+        php: [ '8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ]
         mysql: [ '5.7', '8.0' ]
         multisite: [ false, true ]
         memcached: [ false ]


### PR DESCRIPTION
## Description
This PR removes the experimantla marker for PHP 8.5 tests.

- Add PHP 8.5 to testing matrix fully
- Bump included tests to newer PHP versions
- Remove experimental jobs

## Motivation and context
Code testing modernisation

## How has this been tested?
Prior work on PHP 8.5 testing and unit tests on this PR.

## Screenshots
### Before
<img width="1836" height="1146" alt="Screenshot 2025-11-15 at 17 00 14" src="https://github.com/user-attachments/assets/1dbebd27-b021-4193-8ff1-ec6f866816f0" />

### After
<img width="1816" height="990" alt="Screenshot 2025-11-15 at 17 01 41" src="https://github.com/user-attachments/assets/41320935-442b-4090-9557-0cc24016bd85" />

## Types of changes
- Enhancement