### PR TITLE
Remove "wp-pointer" dependency for widgets CSS in script-loader

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1484,7 +1484,7 @@ function wp_default_styles( $styles ) {
 	$styles->add( 'themes', "/wp-admin/css/themes$suffix.css" );
 	$styles->add( 'about', "/wp-admin/css/about$suffix.css" );
 	$styles->add( 'nav-menus', "/wp-admin/css/nav-menus$suffix.css" );
-	$styles->add( 'widgets', "/wp-admin/css/widgets$suffix.css", array( 'wp-pointer' ) );
+	$styles->add( 'widgets', "/wp-admin/css/widgets$suffix.css" );
 	$styles->add( 'site-icon', "/wp-admin/css/site-icon$suffix.css" );
 	$styles->add( 'l10n', "/wp-admin/css/l10n$suffix.css" );
 	$styles->add( 'code-editor', "/wp-admin/css/code-editor$suffix.css", array( 'wp-codemirror' ) );


### PR DESCRIPTION
We will be deprecating the "wp-pointer" stylesheet in CP v2.6.0. But it's still listed as a dependency for the widgets.css stylesheet, which causes a deprecation notice to be displayed on the widgets page. None of the styles in the "wp-pointer" stylesheet is used on that page any more, so this PR removes the dependency and eradicates the notice.