### PR TITLE
Fix typo in deprecated argument message

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -182,7 +182,7 @@ function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args
 		if ( ! isset( $args['in_footer'] ) ) {
 			$args['in_footer'] = $in_footer;
 		}
-		_deprecated_argument( __FUNCTION__, 'CP3.0.0', __( 'Use the `$args` paramater instead.' ) );
+		_deprecated_argument( __FUNCTION__, 'CP3.0.0', __( 'Use the `$args` parameter instead.' ) );
 	}
 
 	if ( ! is_array( $args ) ) {


### PR DESCRIPTION
## Description
Corrects 'paramater' to 'parameter' in the deprecation notice within wp_register_script for improved clarity.

## Motivation and context
Fixes typographical error

## How has this been tested?
N/A

## Screenshots
N/A

## Types of changes
- Bug fix
- Enhancement