### PR TITLE
Add condition to Cloudflare bypass step in workflow

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -152,6 +152,7 @@ jobs:
           mysql --version
 
       - name: Bypass Cloudflare for GitHub Action
+        if: ${{ github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) }}
         uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.0.1
         with:
           cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
## Description
The Cloudflare bypass action now runs only for non-pull request events or pull requests from non-forked repositories, improving workflow security and efficiency.

## Motivation and context
Thi recently introduced aciotn uses GutHub secrets. These are protected from being available to PRs run from forks to avoid malicious actos gaining access to secret information.

That means that the step failes from fork PRs though as the required secret informaiton is not available, for now I propose trying to skip this step on fork PRs.

## How has this been tested?
Action will run on this PR.
Once merged a PR with this task failing will need updating to see if the entire job still runs effectively.

## Screenshots
N/A

## Types of changes
- Bug fix