### PR TITLE
Textual fix in Media library grid view Help tab

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -133,7 +133,7 @@ if ( 'grid' === $mode ) {
 			'content' =>
 				'<p>' . __( 'All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first.' ) . '</p>' .
 				'<p>' . __( 'You can view your media in a simple visual grid or a list with columns. Switch between these views using the icons to the left above the media.' ) . '</p>' .
-				'<p>' . __( 'To delete media items, click the Bulk Select button at the top of the screen. Select any items you wish to delete, then click the Delete Selected button. Clicking the Cancel Selection button takes you back to viewing your media.' ) . '</p>',
+				'<p>' . __( 'To delete media items, click the <strong>Bulk select</strong> button at the top of the screen. Select any items you wish to delete, then click the <strong>Delete permanently</strong> button. Clicking the <strong>Cancel</strong> button takes you back to viewing your media.' ) . '</p>',
 		)
 	);
 


### PR DESCRIPTION
## Description
This PR fixes button names in the Media library grid view Help tab, so they match the ones in the toolbar.
See also [WP trac ticket 64287](https://core.trac.wordpress.org/ticket/64289).

## Screenshots
<img width="1458" height="253" alt="image" src="https://github.com/user-attachments/assets/afe3e571-7dac-4e01-8f0e-c4bc163b0c48" />
