### PR TITLE
Ensure Update URI is not bypassed

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -409,7 +409,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 
 	// Support updates for any plugins using the `Update URI` header field.
 	foreach ( $plugins as $plugin_file => $plugin_data ) {
-		if ( ! $plugin_data['UpdateURI'] || isset( $updates->response[ $plugin_file ] ) ) {
+		if ( ! $plugin_data['UpdateURI'] ) {
 			continue;
 		}
 
@@ -689,7 +689,7 @@ function wp_update_themes( $extra_stats = array() ) {
 
 	// Support updates for any themes using the `Update URI` header field.
 	foreach ( $themes as $theme_stylesheet => $theme_data ) {
-		if ( ! $theme_data['UpdateURI'] || isset( $new_update->response[ $theme_stylesheet ] ) ) {
+		if ( ! $theme_data['UpdateURI'] ) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #2213.

## Description
As reported in this [comment](https://github.com/ClassicPress/ClassicPress/issues/2167#issuecomment-3566449394) by @sybrew the `Update URI` could be bypassed in both plugin and theme updates.
**This is not happening now**, as WordPress API honor that field and sends back no update information.

## Motivation and context
Make sure this can't happen.

## How has this been tested?
- [X] Updates from ClassicPress Directory are working
- [X] Updates from WordPress repo are working
- [X] Updates from WordPress repo are not working if the plugin uses `Update URI: false`
- [X] Updates from WordPress repo are working if the plugin uses `Update URI: w.org/plugin/{$slug}`

## Types of changes
- Bug fix
I'm considering this as a bug fix because the `Update URI` is documented as a header that prevents accidental updates.

