### PR TITLE
Fix category selector in Editor

### DIFF
--- a/src/wp-admin/js/post.js
+++ b/src/wp-admin/js/post.js
@@ -657,7 +657,7 @@ jQuery( function($) {
 			function() {
 				var t = $(this), c = t.is(':checked'), id = t.val();
 				if ( id && t.parents('#taxonomy-'+taxonomy).length ) {
-					$('input[id^="in-' + taxonomy + '-' + id + '"]').prop('checked', c);
+					$('input#in-' + taxonomy + '-' + id + ', input[id^="in-' + taxonomy + '-' + id + '-"]').prop('checked', c);
 					$('input#in-popular-' + taxonomy + '-' + id).prop('checked', c);
 				}
 			}


### PR DESCRIPTION
## Description
Editor: Fix the JS to select, save, and update categories on the old Edit Post screen.

Props: charleslf, im3dabasia1, desrosj, dhruvang21, Zargarov, sainathpoojary, azaozz
Fixes: [#62440](https://core.trac.wordpress.org/ticket/62440)

Editor: Fix selecting/deselecting multiple unwanted categories when clicking on a Category checkbox on the old Edit Post screen.

Props ffffelix, desrosj, ironprogrammer, neotrope, narenin, zaoyao, im3dabasia1, cbravobernal, azaozz.
Fixes [#62504](https://core.trac.wordpress.org/ticket/62504).

## Motivation and context
Fixes #2218

## How has this been tested?
This is a backport of 2 upstream changesets fixing this issue.
Local testing.

## Screenshots
N/A

## Types of changes
- Bug fix