### PR TITLE
Exclude legacy certificate file from release checks

### DIFF
--- a/bin/check-release-files.pl
+++ b/bin/check-release-files.pl
@@ -53,6 +53,7 @@ for ( split /\r?\n/, $diff ) {
 		next if $fn =~ /^wp-includes\/js\/jquery\/ui\/.*\.js$/;
 		next if $fn =~ /^wp-includes\/js\/media\/.*\.js$/;
 		next if $fn =~ /^wp-includes\/js\/media\/.*\.ejs$/;
+		next if $fn eq 'wp-includes/certificates/legacy-1024bit.pem';
 	}
 
 	# If we get here, there's a problem


### PR DESCRIPTION
## Description
Added 'wp-includes/certificates/legacy-1024bit.pem' to the exclusion list in check-release-files.pl to prevent it from being flagged during release file validation.

## Motivation and context
As noted during the relase process for ClassicPress `2.6.0` the above file is in `src` but is not required in `build`, as such the file needs excluding from release checks.

## How has this been tested?
Tested during release of `2.6.0` but this fix will apply to future release versions.

## Screenshots
N/A

## Types of changes
- Bug fix