### PR TITLE
Add `get_plugin_data` to filter `get_plugin_data()` result

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -64,7 +64,7 @@
  *     @type string $TextDomain  Plugin textdomain.
  *     @type string $DomainPath  Plugin's relative directory path to .mo files.
  *     @type bool   $Network     Whether the plugin can only be activated network-wide.
- *     @type string $RequiresWP  Minimum required version of ClassicPress.
+ *     @type string $RequiresWP  Minimum required version of WordPress.
  *     @type string $RequiresCP  Minimum required version of ClassicPress.
  *     @type string $RequiresPHP Minimum required version of PHP.
  *     @type string $UpdateURI   ID of the plugin for update purposes, should be a URI.
@@ -126,6 +126,17 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 		$plugin_data['AuthorName'] = $plugin_data['Author'];
 	}
 
+	/**
+	 * Filters the Plugin data returned by get_plugin_data().
+	 *
+	 * @since 2.7.0
+	 *
+	 * @param array  $plugin_data Plugin data.
+	 * @param string $plugin_file Absolute path to the main plugin file.
+	 * @param bool   $markup      If the returned data should have HTML markup applied.
+	 * @param bool   $translate   If the returned data should be translated. Default true.
+	 */
+	$plugin_data = apply_filters( 'get_plugin_data', $plugin_data, $plugin_file, $markup, $translate );
 	return $plugin_data;
 }
 


### PR DESCRIPTION
## Description
This filter allows to change the return value of `get_plugin_data( string $plugin_file, bool $markup = true, bool $translate = true ): array`.

This is similar to the already existent `plugins_api_result` filter.

## Motivation and context
Looking at #2235 in this way we can make plugin installable even if the `Requires` header is > 6.2.

## How has this been tested?
With this code the VS Event list can be installed. The code is not really complete but works.

```php
function trick_api( $res, $action, $args ) {
	$plugins = array(
		'very-simple-event-list',
	);
	if ( $action === 'plugin_information' ) {
		$res->requires = '6.2';
		return $res;
	}
	if ( $action === 'query_plugins' ) {
		foreach ( $res->plugins as $index => $plugin ) {
			$res->plugins[$index]['requires'] = '6.2';
		}
	}
	return $res;
}
add_action('plugins_api_result', 'trick_api', 100, 4 );

function trick_plugin_data( $plugin_data, $plugin_file, $markup, $translate ) {
	$plugin_data['RequiresWP'] = '6.2';
	return $plugin_data;
}
add_filter( 'get_plugin_data', 'trick_plugin_data', 100, 5 );
```

More discussion on how to use this should be done, but this is a starting point.

## Types of changes
- New feature