### PR TITLE
Add polyfills for two block-related functions

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -436,6 +436,34 @@ class WP_Compat {
 			}
 		}
 
+		if ( ! function_exists( 'register_block_style' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.7.0
+			 *
+			 * @return bool False.
+			 */
+			function register_block_style( ...$args ) {
+				WP_Compat::using_block_function();
+				return false;
+			}
+		}
+
+		if ( ! function_exists( 'register_block_bindings_source' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.7.0
+			 *
+			 * @return bool False.
+			 */
+			function register_block_bindings_source( ...$args ) {
+				WP_Compat::using_block_function();
+				return false;
+			}
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -44,6 +44,8 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'parse_blocks' ) );
 		$this->assertTrue( function_exists( 'get_dynamic_block_names' ) );
 		$this->assertTrue( function_exists( 'get_block_theme_folders' ) );
+		$this->assertTrue( function_exists( 'register_block_style' ) );
+		$this->assertTrue( function_exists( 'register_block_bindings_source' ) );
 	}
 
 	/**


### PR DESCRIPTION
Add polyfills for:
- `register_block_style `
- `register_block_bindings_source `

## Motivation and context
Among other things, it allows migrating to ClassicPress with Twenty TwentyFive without a WSOD in the backend.

## How has this been tested?
Migrating with Twenty TwentyFive theme active.
Also adds unit tests.

## Types of changes
- New feature

