### PR TITLE
Add visibility and fix message to WP plugin tagged "ClassicPress"

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -372,6 +372,7 @@ function install_plugins_favorites_form() {
  */
 function display_plugins_categories_list() {
 	$categories = array(
+		'classicpress' => __( 'ClassicPress' ),
 		'form'         => __( 'Forms' ),
 		'widget'       => __( 'Widgets' ),
 		'admin'        => __( 'Admin Utilities' ),

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -307,6 +307,29 @@ function list_plugin_updates() {
 		$auto_update_notice = ' | ' . wp_get_auto_update_message();
 	}
 
+	$tagged_plugins = get_transient( 'tagged_classicpress_plugins' );
+	if ( $tagged_plugins === false ) {
+		$tagged_from_api = plugins_api(
+			'query_plugins',
+			array(
+				'tag'      => 'classicpress',
+				'per_page' => 100,
+				'fields'   => array(
+					'slug'              => true,
+					'short_description' => false,
+					'description'       => false,
+				),
+			)
+		);
+		$tagged_plugins = array();
+		if ( ! is_wp_error( $tagged_from_api ) && is_array( $tagged_from_api->plugins ) ) {
+			foreach ( $tagged_from_api->plugins as $tagged_plugin ) {
+				$tagged_plugins[] = $tagged_plugin['slug'];
+			}
+			set_transient( 'tagged_classicpress_plugins', $tagged_plugins, DAY_IN_SECONDS );
+		}
+	}
+
 	foreach ( (array) $plugins as $plugin_file => $plugin_data ) {
 		$plugin_data = (object) _get_plugin_data_markup_translate( $plugin_file, (array) $plugin_data, false, true );
 
@@ -326,6 +349,15 @@ function list_plugin_updates() {
 			&& version_compare( $plugin_data->update->requires_cp, $cur_cp_version, '<=' )
 		) {
 			$compat  = '<br>' . sprintf( __( 'Potentially compatible with ClassicPress %1$s.' ), $cur_cp_version );
+			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
+		} elseif (
+			isset( $plugin_data->update->tested )
+			&& version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' )
+			&& isset( $plugin_data->update->requires )
+			&& version_compare( $plugin_data->update->requires, $cur_wp_version, '<=' )
+			&& in_array( $plugin_data->update->slug, $tagged_plugins )
+		) {
+			$compat  = '<br>' . sprintf( __( 'Marked as compatible with ClassicPress by the author.' ), $cur_cp_version );
 			$compat .= ' <a href="https://docs.classicpress.net/user-guides/using-classicpress/managing-plugins/#plugin-updates">' . __( 'More info.' ) . '</a>';
 		} elseif (
 			isset( $plugin_data->update->tested )

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -4,6 +4,34 @@
  */
 class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
+	public function test_there_are_less_than_100_tagged_plugins() {
+		$args = array(
+			'tag'      => 'classicpress',
+			'per_page' => 100,
+			'fields'   => array(
+				'slug'              => true,
+				'short_description' => false,
+				'description'      => false,
+			),
+		);
+		$args = (object) $args;
+		$url = 'https://api.wordpress.org/plugins/info/1.2/';
+		$url = add_query_arg(
+			array(
+				'action'  => 'query_plugins',
+				'request' => $args,
+			),
+			$url
+		);
+		$response = json_decode( $this->get_response_body( $url ) );
+
+		$this->assertEquals(
+			1,
+			$response->info->pages,
+			'There are more than 100 plugins tagged ClassicPress (' . $response->info->results . ' now). Please review code in wp-admin/update-core.php.'
+		);
+	}
+
 	public function test_readme_recommended_php_version() {
 		// This test is designed to only run on develop.
 		$this->skipOnAutomatedBranches();


### PR DESCRIPTION
As discussed on the forum and Zulip, some "special" treatment should be reserved to plugin tagged "ClassicPress" on WP repo. 

## Description
- This PR adds "ClassicPress" to the "Categories" tab in "Add Plugins".
- Also, in the Dashboard Updates, changes the message for plugins having the tag.

**Notice that it doesn't allow plugins having `Requires` header > `$wp_version`.**

## How has this been tested?
- Local testing. 
- An external http unit test is added to check that the list of plugins tagged "ClassicPress" is less than 100, allowing to use a single `plugins_api` call.

## Screenshots
### Before
<img width="544" height="271" alt="Schermata 2025-12-31 alle 15 52 00" src="https://github.com/user-attachments/assets/63f380ce-e39a-4650-aff0-28d912d24fb7" />


<img width="606" height="178" alt="Schermata 2025-12-31 alle 15 51 47" src="https://github.com/user-attachments/assets/90be46e7-5834-41fd-a1d5-3c2cd2c4b129" />


### After
<img width="582" height="325" alt="Schermata 2025-12-31 alle 15 52 16" src="https://github.com/user-attachments/assets/d4bd447d-07c6-4bd4-b80e-685dc7efc810" />

<img width="592" height="174" alt="Schermata 2025-12-31 alle 15 51 32" src="https://github.com/user-attachments/assets/e069558f-0379-4d87-9b41-d83ff9f55e05" />


## Types of changes
- New feature

