### PR TITLE
Update copyright years in license.txt

### DIFF
--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018-2025 ClassicPress and contributors
+Copyright © 2018-2026 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2025 by the WordPress contributors
+  Copyright 2003-2026 by the WordPress contributors
 
   WordPress is released under the GPL
 


### PR DESCRIPTION
## Description

Extended the copyright years for ClassicPress and WordPress in the license.txt file to 2026.

## Motivation and context
Update copyright message and will address a PHPUnit test failure.

## How has this been tested?
Locally test using:
`composer run phpunit -- --group basic`

## Screenshots
### Before
<img width="1812" height="402" alt="Screenshot 2026-01-01 at 10 51 13" src="https://github.com/user-attachments/assets/2e5148e7-75b8-4080-aa06-84f93d826456" />

### After
<img width="1476" height="390" alt="Screenshot 2026-01-01 at 10 51 22" src="https://github.com/user-attachments/assets/5dd64c5d-3344-4118-a1c0-b73720a0ae54" />

## Types of changes
- Bug fix
