### PR TITLE
Update notification for CP plugins

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -374,14 +374,14 @@ function list_plugin_updates() {
 		// Get plugin compat for updated version of ClassicPress.
 		if ( $core_update_version ) {
 			if (
-				// For plugins on the CP Directory
+				// For plugins in the CP Directory
 				isset( $plugin_data->update->requires_cp )
 				&& str_starts_with( $plugin_data->update->requires_cp, $cur_cp_major_version[1] )
 				&& version_compare( $plugin_data->update->requires_cp, $core_update_version, '<=' )
 			) {
 				$compat  = '<br>' . sprintf( __( 'Compatible with ClassicPress %1$s (according to its author).' ), $core_update_version );
 			} elseif (
-				// For plugins on the WP Repository
+				// For plugins in the WP Repository
 				isset( $plugin_data->update->tested )
 				&& version_compare( $plugin_data->update->tested, $cur_wp_version, '>=' )
 			) {


### PR DESCRIPTION
## Description
This is a follow-up on #2034, based on new insights.

In previous PR we've used `$plugin_data->update->requires`. But we don't have to use this, because CP already does this check for us. Updates are not available if the new version of the plugin requires WP 6.3 or higher. This means we can simplify the conditions.
Plus, after having contact with @xxsimoxx I've added an extra check for plugins in the WP Repository that have the `classicpress` tag.

## How has this been tested?
Local install.

## Screenshots
### After
First plugin is hosted at WP Repository and has tag `classicpress`. (Requires WordPress 4.0 or higher)
Second plugin is listed at CP Directory. (Requires CP 2.2)
Third plugin is a random one hosted at WP Repository. (Requires WordPress 5.2 or higher)

![Updates screen](https://github.com/user-attachments/assets/ceb6ade1-5572-4c0b-8178-702eaab7c921)

## Types of changes
- Enhancement