### PR TITLE
Add focus check before hiding theme actions

### DIFF
--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -245,6 +245,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
+			theme.addEventListener( 'focusin', function() {
+				themes.forEach( function( other ) {
+					other.querySelector( '.more-details' ).style.opacity = '0';
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
+				} );
+				theme.querySelector( '.more-details' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.display = 'block';
+			} );
 			theme.addEventListener( 'touchenter', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';


### PR DESCRIPTION
This PR is designed to fix Issue #2251 by ensuring that the Installing... and Activate buttons do not disappear when the mouse no longer hovers over the theme, provided that the theme continues to have focus.