### PR TITLE
Add visibility to WP plugins tagged "ClassicPress"

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -377,7 +377,7 @@ function display_plugins_categories_list() {
 		'widget'       => __( 'Widgets' ),
 		'admin'        => __( 'Admin Utilities' ),
 		'page-builder' => __( 'Page Builders' ),
-		'e-commerce'   => __( 'eCommerce' ),
+		'ecommerce'    => __( 'eCommerce' ),
 		'media'        => __( 'Media' ),
 		'seo'          => __( 'SEO' ),
 		'social'       => __( 'Social Networking' ),


### PR DESCRIPTION
This PR adds "ClassicPress" to the "Categories" tab in "Add Plugins" and remove the "Advertising" category.

This change was in #2258 that is closed in favor of #2262.

## How has this been tested?
Local testing.

## Screenshots
### Before

<img width="1167" height="391" alt="Schermata 2026-01-08 alle 10 19 12" src="https://github.com/user-attachments/assets/7a8bfec8-bb3d-4e32-8ed2-a67c7c0bdd26" />


### After
<img width="1160" height="387" alt="Schermata 2026-01-08 alle 10 11 21" src="https://github.com/user-attachments/assets/e5578836-ec19-4e2e-b773-24d601459e81" />


## Types of changes
- Enhancement

