### PR TITLE
Run APCu install code when `cp_object_cache` option is created

### DIFF
--- a/src/wp-includes/classicpress/class-cp-settings.php
+++ b/src/wp-includes/classicpress/class-cp-settings.php
@@ -10,7 +10,7 @@
 class CP_Settings {
 	public function __construct() {
 		add_action( 'update_option_cp_object_cache', array( $this, 'cp_apcu_cache_option_change' ), 10, 3 );
-		add_action( 'add_option_cp_object_cache', array( $this, 'cp_apcu_cache_option_add' ), 10, 2 );
+		add_action( 'add_option_cp_object_cache', array( $this, 'cp_apcu_cache_option_add' ), 10, 1 );
 	}
 
 	/**
@@ -19,7 +19,7 @@ class CP_Settings {
 	 * @since CP-2.7.0
 	 *
 	 */
-	public function cp_apcu_cache_option_add( $option_name, $value ) {
+	public function cp_apcu_cache_option_add( $option_name ) {
 		if ( $option_name === 'cp_object_cache' ) {
 			$this->_cp_maybe_install_apcu_object_cache();
 		}


### PR DESCRIPTION
`cp_object_cache` option **change** triggers `_cp_maybe_install_apcu_object_cache`.
When the option doesn't exists the checkbox can be checked and settings saved.
Then the setting is **added**, but when the page reloads the checkbox is unchecked as it can't find the `object-cache.php` in place.


## How has this been tested?
Local testing.

## Types of changes
- Bug fix

