### PR TITLE
Add missing options in `schema.php`

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -585,6 +585,12 @@ function populate_options( array $options = array() ) {
 		'cp_db_version'                   => $cp_db_version,
 		'disable_emojis'                  => 0,
 		'disable_xml_rpc'                 => 0,
+
+		// CP-2.4.0
+		'link_manager_enabled'            => 0,
+
+		// CP-2.7.0
+		'cp_object_cache'                 => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -54,7 +54,7 @@ $wp_db_version = 56657;
  *
  * @global int $cp_db_version
  */
-$cp_db_version = 1446;
+$cp_db_version = 2275;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
Add missing options in `schema.php`:
- `link_manager_enabled` introduced in 2.4 (#1697)
- `cp_object_cache` introduced in 2.7 (#2199)

This also need a bump of `$cp_db_version`

## How has this been tested?
Local testing.

## Types of changes
- Bug fix

## What to check
Please check that I didn't miss other new options.