### PR TITLE
Re-enable selection of files in the Customizer

### DIFF
--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -9,7 +9,7 @@
  * @since CP 2.5.0
  */
 document.addEventListener( 'DOMContentLoaded', function() {
-	var observer, addButton, pond, content,
+	var addButton, pond, content,
 		{ FilePond } = window, // import FilePond
 		selectedIds = [],
 		parser = new DOMParser(),


### PR DESCRIPTION
PR #2221 prevented the selection of files in the Customizer. @Guido07111975 identified the offending file. This PR fixes the problem by moving the offending code inside a conditional check.