### PR TITLE
Grid Attachment details - show category/tag name

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -4041,7 +4041,7 @@ function cp_add_cats_and_tags_to_attachment_for_js( $response, $attachment, $met
 			array(
 				'taxonomy'   => 'media_category',
 				'object_ids' => $attachment->ID,
-				'fields'     => 'slugs',
+				'fields'     => 'names',
 			)
 		);
 	}
@@ -4067,7 +4067,7 @@ function cp_add_cats_and_tags_to_attachment_for_js( $response, $attachment, $met
 			array(
 				'taxonomy'   => 'media_post_tag',
 				'object_ids' => $attachment->ID,
-				'fields'     => 'slugs',
+				'fields'     => 'names',
 			)
 		);
 	}


### PR DESCRIPTION
## Description
This PR fixed issue #2256.
When adding categories and tags, these are auto-saved, but the slug is returned. Doesn't look nice.
At first I was reluctant creating a PR for this, but newly added categories and tags are saved correctly.

## Screenshots
### Before
![Grid modal cats and tags (before)](https://github.com/user-attachments/assets/cda8dea5-7e7f-40d2-9ca4-66534a01d2e1)

### After
![Grid modal cats and tags (after)](https://github.com/user-attachments/assets/64accf03-31c7-4df5-847d-aa71bc83e245)

## Types of changes
- Enhancement