### PR TITLE
WP-r61562: Reduce thresholds for object cache threshold tests

### DIFF
--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -474,13 +474,8 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 		return array(
 			array( 'comments_count', 0 ),
 			array( 'posts_count', 0 ),
-<<<<<<< HEAD
-			array( 'terms_count', 1 ),
-			array( 'options_count', 100 ),
-=======
 			array( 'terms_count', 0 ),
 			array( 'options_count', 1 ),
->>>>>>> 13eac41110 (Site Health: Reduce thresholds for object cache threshold tests.)
 			array( 'users_count', 0 ),
 			array( 'alloptions_count', 1 ),
 			array( 'alloptions_bytes', 10 ),


### PR DESCRIPTION
Reduces the object counts required for Site Health to recommend a persistent object cache in the `Tests_Admin_wpSiteHealth::test_object_cache_thresholds()` data provider.

This is to ensure that the number of objects (terms, posts, etc) are certainly below the defaults created by the test suite during set up. The new threasholds are:

- terms count: 0
- alloptions count: 1
- alloptions bytes: 10

This follows the reduction to the options count threshold to 1 in r61438.

WP:Props peterwilsoncc, swissspidy, wildworks.
Fixes https://core.trac.wordpress.org/ticket/60831.

Conflicts:
- tests/phpunit/tests/admin/wpSiteHealth.php

---

Merges https://core.trac.wordpress.org/changeset/61562 / https://github.com/WordPress/wordpress-develop/commit/13eac41110 to ClassicPress.

## Description
It was almost two years that my local installation was not passing unit tests (randomly) as also reported in [this ticket](https://core.trac.wordpress.org/ticket/60831).

**The new thresholds are:**
- terms count: 0
- alloptions count: 1
- alloptions bytes: 10
- options count: 1 (this was introduced in [r61438](https://core.trac.wordpress.org/changeset/61438) and backported manually in the *Fix merge conflicts* commit)

## How has this been tested?
Unit tests.

## Screenshots
### Before
```
There was 1 failure:

1) Tests_Admin_wpSiteHealth::test_object_cache_thresholds with data set #2 ('terms_count', 1)
Failed asserting that false is true.

Tests: 30, Assertions: 136, Failures: 1.
```

### After
`OK (30 tests, 136 assertions)
`
## Types of changes
- Bug fix
