### PR TITLE
Extend eslinting to webpack files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -499,7 +499,11 @@ module.exports = function(grunt) {
 		jshint: {
 			options: grunt.file.readJSON('.jshintrc'),
 			grunt: {
-				src: ['Gruntfile.js', 'tools/**/*.js', '!tools/build/grunt-terser.js']
+				src: [
+					'Gruntfile.js',
+					'tools/**/*.js',
+					'!tools/build/grunt-terser.js'
+				]
 			},
 			tests: {
 				src: [
@@ -632,7 +636,9 @@ module.exports = function(grunt) {
 			},
 			grunt: {
 				src: [
-					'Gruntfile.js'
+					'Gruntfile.js',
+					'tools/**/*.js',
+					'!tools/build/grunt-terser.js'
 				]
 			},
 			core: {

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -24,8 +24,8 @@ module.exports = function( env = { environment: 'production', buildTarget: false
 				library: {
 					name: ['wp', camelCaseDash( packageName ) ],
 					type: 'window',
-					export: undefined,
-				},
+					export: undefined
+				}
 			};
 
 			return memo;
@@ -36,9 +36,9 @@ module.exports = function( env = { environment: 'production', buildTarget: false
 			path: normalizeJoin( baseDir, `${ buildTarget }/js/dist` ),
 			environment: {
 				arrowFunction: env.minify,
-				const: env.minify,
+				const: env.minify
 			}
-		},
+		}
 	};
 
 	return config;

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -1,4 +1,5 @@
 /* jshint es3: false, esversion: 9 */
+/* eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }] */
 /* global __dirname*/
 /**
  * External dependencies
@@ -16,7 +17,7 @@ const baseConfig = ( env ) => {
 		target: 'browserslist',
 		mode,
 		plugins: [
-			new StripSourceMapURLPlugin( env.minify ),
+			new StripSourceMapURLPlugin( env.minify )
 		],
 		optimization: {
 			moduleIds: 'deterministic',
@@ -27,16 +28,16 @@ const baseConfig = ( env ) => {
 					terserOptions: {
 						output: {
 							comments: /translators:/i,
-							keep_quoted_props: true,
+							keep_quoted_props: true
 						},
 						compress: {
-							passes: 2,
+							passes: 2
 						},
 						mangle: {
-							reserved: [ '__', '_n', '_nx', '_x' ],
-						},
-					},
-				} ),
+							reserved: [ '__', '_n', '_nx', '_x' ]
+						}
+					}
+				} )
 			]
 		},
 		module: {
@@ -44,17 +45,17 @@ const baseConfig = ( env ) => {
 				{
 					test: /\.js$/,
 					use: [ 'source-map-loader' ],
-					enforce: 'pre',
-				},
-			],
+					enforce: 'pre'
+				}
+			]
 		},
 		resolve: {
 			modules: [
 				baseDir,
-				'node_modules',
-			],
+				'node_modules'
+			]
 		},
-		stats: 'errors-only',
+		stats: 'errors-only'
 	};
 
 	return config;
@@ -70,5 +71,5 @@ module.exports = {
 	baseDir,
 	baseConfig,
 	normalizeJoin,
-	camelCaseDash,
+	camelCaseDash
 };

--- a/tools/webpack/strip-sourcemap.js
+++ b/tools/webpack/strip-sourcemap.js
@@ -12,7 +12,7 @@ class StripSourceMapURLPlugin {
 			compilation.hooks.processAssets.tap(
 				{
 					name: 'StripSourceMapURLPlugin',
-					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE
 				},
 				assets => {
 					const re = /^\/[\/*][#@]\s*sourceMappingURL=.*?\n$/gm;


### PR DESCRIPTION
## Description
The current Gruntfil configuration carries of JSHinting but not ESlinting on the webpack files.

This PR extends ESLinting to include the same files as currently checked in the JSHint configuration.

## Motivation and context
Coding standards and consistency.

## How has this been tested?
Local testing, PR includes coding changes to some existing files.

## Screenshots
N/A

## Types of changes
- Enhancement
