### PR TITLE
Add polyfill for `do_blocks()`

### DIFF
--- a/src/wp-includes/classicpress/class-wp-compat.php
+++ b/src/wp-includes/classicpress/class-wp-compat.php
@@ -464,6 +464,20 @@ class WP_Compat {
 			}
 		}
 
+		if ( ! function_exists( 'do_blocks' ) ) {
+			/**
+			 * Polyfill for block functions.
+			 *
+			 * @since CP-2.7.0
+			 *
+			 * @return string ''.
+			 */
+			function do_blocks( ...$args ) {
+				WP_Compat::using_block_function();
+				return '';
+			}
+		}
+
 		// Load WP_Block_Type class file as polyfill.
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-type.php';
 		require_once ABSPATH . WPINC . '/classicpress/class-wp-block-template.php';

--- a/tests/phpunit/tests/compat/wordpress.php
+++ b/tests/phpunit/tests/compat/wordpress.php
@@ -46,6 +46,7 @@ class Tests_Compat_wordpress extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'get_block_theme_folders' ) );
 		$this->assertTrue( function_exists( 'register_block_style' ) );
 		$this->assertTrue( function_exists( 'register_block_bindings_source' ) );
+		$this->assertTrue( function_exists( 'do_blocks' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Adds a polyfill for `do_blocks()` function that returns an empty string.

## Motivation and context
Requested by @Guido07111975 on Zulip.

## How has this been tested?
New assertion in place in unit tests.

## Types of changes
- New feature