### PR TITLE
About screen - condition for displaying notification

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -106,7 +106,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				);
 				?>
 				</p>
-			<?php }; ?>
+			<?php } ?>
 			<h3><?php _e( 'Join our growing community' ); ?></h3>
 			<p>
 				<?php


### PR DESCRIPTION
## Description
This PR adds a condition to info about the ClassicPress Directory Integration plugin, so it's only being displayed:

1. For user roles that have enough permissions
2. If the ClassicPress Directory Integration plugin has not been installed yet 

Condition is copied from #2223.

## Screenshots
![About](https://github.com/user-attachments/assets/590f534f-b997-438b-8e3c-8839ab5f5010)

## Types of changes
- Enhancement