### PR TITLE
Edit Media modal - show category/tag name

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -1868,7 +1868,7 @@ function get_compat_media_markup( $attachment_id, $args = null ) {
 			$values = array();
 
 			foreach ( $terms as $term ) {
-				$values[] = $term->slug;
+				$values[] = $term->name;
 			}
 
 			$t['value']    = implode( ', ', $values );


### PR DESCRIPTION
## Description
Follow-up on #2292. Now for the media modal in Post and Page editor, while adding media file.
For categories and tags the slug is returned. Doesn't look nice.

## How has this been tested?
Local install.

## Screenshots
### Before
<img width="452" height="357" alt="Cats and Tags before" src="https://github.com/user-attachments/assets/60bbe970-bfdb-45ce-a131-6e6e98f0a56b" />

### After
<img width="452" height="361" alt="Cats and Tags after" src="https://github.com/user-attachments/assets/99949e96-cc2b-4e2f-8cc4-94c46e40684d" />

## Types of changes
- Enhancement