### PR TITLE
Use Filepond as plugin zip uploader

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -385,7 +385,6 @@
 }
 
 @media screen and (max-width: 660px) {
-
 	.find-box {
 		top: 0;
 		bottom: 0;
@@ -394,7 +393,6 @@
 		margin: 0;
 		width: 100%;
 	}
-
 }
 
 .ui-find-overlay {
@@ -444,6 +442,12 @@
 
 #plupload-upload-ui {
 	position: relative;
+}
+
+.upload-plugin .drag-drop #drag-drop-area,
+.upload-theme .drag-drop #drag-drop-area {
+	height: auto;
+	padding: 1em 0 2em;
 }
 
 /**
@@ -664,7 +668,7 @@
 
 .upload-php .media-modal-close {
 	position: absolute;
-	top: 0;	
+	top: 0;
 	right: 0;
 }
 

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -326,18 +326,22 @@ function install_search_form( $deprecated = true ) {
 function install_plugins_upload() {
 	?>
 <div class="upload-plugin">
-	<p class="install-help"><?php _e( 'If you have a plugin in a .zip format, you may install or update it by uploading it here.' ); ?></p>
-	<form method="post" enctype="multipart/form-data" class="wp-upload-form" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-plugin' ) ); ?>">
-		<?php wp_nonce_field( 'plugin-upload' ); ?>
-		<label class="screen-reader-text" for="pluginzip">
-			<?php
-			/* translators: Hidden accessibility text. */
-			_e( 'Plugin zip file' );
-			?>
-		</label>
-		<input type="file" id="pluginzip" name="pluginzip" accept=".zip">
-		<?php submit_button( __( 'Install Now' ), '', 'install-plugin-submit', false ); ?>
-	</form>
+	<div id="plupload-upload-ui" class="hide-if-no-js drag-drop">
+		<div id="drag-drop-area">
+			<p class="install-help"><?php _e( 'If you have a plugin in a .zip format, you may install or update it by uploading it here.' ); ?></p>
+			<form method="post" enctype="multipart/form-data" id="filepond" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-plugin' ) ); ?>">
+				<?php wp_nonce_field( 'plugin-upload' ); ?>
+				<label class="screen-reader-text" for="pluginzip">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Plugin zip file' );
+					?>
+				</label>
+				<input type="file" id="pluginzip" name="pluginzip" accept=".zip">
+				<?php submit_button( __( 'Install Now' ), '', 'install-plugin-submit', false, array( 'disabled' => 'disabled' ) ); ?>
+			</form>
+		</div>
+	</div>
 </div>
 	<?php
 }

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -322,13 +322,14 @@ function install_search_form( $deprecated = true ) {
  * Displays a form to upload plugins from zip files.
  *
  * @since 2.8.0
+ * @since CP-2.8.0 JavaScript uploader used with browser fallback alternative
  */
 function install_plugins_upload() {
 	?>
 <div class="upload-plugin">
+	<p class="install-help"><?php _e( 'If you have a plugin in a .zip format, you may install or update it by uploading it here.' ); ?></p>
 	<div id="plupload-upload-ui" class="hide-if-no-js drag-drop">
 		<div id="drag-drop-area">
-			<p class="install-help"><?php _e( 'If you have a plugin in a .zip format, you may install or update it by uploading it here.' ); ?></p>
 			<form method="post" enctype="multipart/form-data" id="filepond" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-plugin' ) ); ?>">
 				<?php wp_nonce_field( 'plugin-upload' ); ?>
 				<label class="screen-reader-text" for="pluginzip">
@@ -342,6 +343,19 @@ function install_plugins_upload() {
 			</form>
 		</div>
 	</div>
+	<noscript>
+		<form method="post" enctype="multipart/form-data" class="wp-upload-form" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-plugin' ) ); ?>">
+			<?php wp_nonce_field( 'plugin-upload' ); ?>
+			<label class="screen-reader-text" for="pluginzip">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( 'Plugin zip file' );
+				?>
+			</label>
+			<input type="file" id="pluginzip" name="pluginzip" accept=".zip">
+			<?php submit_button( __( 'Install Now' ), '', 'install-plugin-submit', false ); ?>
+		</form>
+	</noscript>
 </div>
 	<?php
 }

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -338,7 +338,7 @@ function install_plugins_upload() {
 					_e( 'Plugin zip file' );
 					?>
 				</label>
-				<input type="file" id="pluginzip" name="pluginzip" accept=".zip">
+				<input type="file" id="pluginzip" name="pluginzip">
 				<?php submit_button( __( 'Install Now' ), '', 'install-plugin-submit', false, array( 'disabled' => 'disabled' ) ); ?>
 			</form>
 		</div>

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -226,20 +226,19 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	var filepond = document.querySelector( 'input[type="file"][name="pluginzip"]' );
 	var button   = document.getElementById( 'install-plugin-submit' );
 	var options = {
-		name:               'pluginzip',
-		storeAsFile:         true,
-		allowMultiple:       false,
-		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
-		dropOnPage:          true,
-		dropOnElement:       false,
-		labelIdle:           _cpFilepondLabels.labelPluginIdle,
-		credits:             false,
-		onaddfile:           function( error ) { if ( button && ! error ) { button.disabled = false; } },
-		onremovefile:        function() { if ( button ) { button.disabled = true; } },
+		name:                   'pluginzip',
+		storeAsFile:             true,
+		allowMultiple:           false,
+		allowFileTypeValidation: true,
+		acceptedFileTypes:       [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
+		dropOnPage:              true,
+		dropOnElement:           false,
+		labelIdle:               _cpFilepondLabels.labelPluginIdle,
+		credits:                 false,
+		onaddfile:               function( error, fileItem ) { if ( button && ! error ) { button.disabled = false; } },
+		onremovefile:            function() { if ( button ) { button.disabled = true; } },
 	};
-	FilePond.registerPlugin(
-		FilePondPluginFileValidateType
-	);
+	FilePond.registerPlugin( FilePondPluginFileValidateType );
 	FilePond.create( filepond, options );
 } );
 </script>

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -51,6 +51,7 @@ if ( $pagenum > $total_pages && $total_pages > 0 ) {
 $title       = __( 'Add Plugins' );
 $parent_file = 'plugins.php';
 
+wp_enqueue_script( 'cp-filepond-file-validate-type' );
 wp_enqueue_script( 'cp-filepond' );
 wp_enqueue_style( 'cp-filepond' );
 wp_enqueue_script( 'plugin-install' );
@@ -225,17 +226,20 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	var filepond = document.querySelector( 'input[type="file"][name="pluginzip"]' );
 	var button   = document.getElementById( 'install-plugin-submit' );
 	var options = {
-		name:               'filepond',
+		name:               'pluginzip',
 		storeAsFile:         true,
 		allowMultiple:       false,
-		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed' ],
+		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
 		dropOnPage:          true,
 		dropOnElement:       false,
 		labelIdle:           _cpFilepondLabels.labelPluginIdle,
 		credits:             false,
-		onaddfile:           function() { if ( button ) { button.disabled = false; } },
+		onaddfile:           function( error ) { if ( button && ! error ) { button.disabled = false; } },
 		onremovefile:        function() { if ( button ) { button.disabled = true; } },
 	};
+	FilePond.registerPlugin(
+		FilePondPluginFileValidateType
+	);
 	FilePond.create( filepond, options );
 } );
 </script>

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -233,10 +233,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		acceptedFileTypes:       [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
 		dropOnPage:              true,
 		dropOnElement:           false,
-		labelIdle:               _cpFilepondLabels.labelPluginIdle,
+		labelIdle:               _cpFilepondLabels.labelZipIdle,
 		credits:                 false,
 		onaddfile:               function( error, fileItem ) { if ( button && ! error ) { button.disabled = false; } },
-		onremovefile:            function() { if ( button ) { button.disabled = true; } },
+		onremovefile:            function() { if ( button ) { button.disabled = true; } }
 	};
 	FilePond.registerPlugin( FilePondPluginFileValidateType );
 	FilePond.create( filepond, options );

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -51,6 +51,8 @@ if ( $pagenum > $total_pages && $total_pages > 0 ) {
 $title       = __( 'Add Plugins' );
 $parent_file = 'plugins.php';
 
+wp_enqueue_script( 'cp-filepond' );
+wp_enqueue_style( 'cp-filepond' );
 wp_enqueue_script( 'plugin-install' );
 
 $body_id = $tab;
@@ -217,6 +219,28 @@ do_action( "install_plugins_{$tab}", $paged );
 <?php
 wp_print_request_filesystem_credentials_modal();
 wp_print_admin_notice_templates();
+?>
+<script>
+document.addEventListener( 'DOMContentLoaded', function () {
+	var filepond = document.querySelector( 'input[type="file"][name="pluginzip"]' );
+	var button   = document.getElementById( 'install-plugin-submit' );
+	var options = {
+		name:               'filepond',
+		storeAsFile:         true,
+		allowMultiple:       false,
+		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed' ],
+		dropOnPage:          true,
+		dropOnElement:       false,
+		labelIdle:           _cpFilepondLabels.labelPluginIdle,
+		credits:             false,
+		onaddfile:           function() { if ( button ) { button.disabled = false; } },
+		onremovefile:        function() { if ( button ) { button.disabled = true; } },
+	};
+	FilePond.create( filepond, options );
+} );
+</script>
+<?php
+
 
 /**
  * ClassicPress Administration Template Footer.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -825,7 +825,7 @@ function wp_default_scripts( $scripts ) {
 		'_cpFilepondLabels',
 		array(
 			'labelIdle'                      => __( 'Drag & Drop your files or <span class="filepond--label-action">Browse</span>' ),
-			'labelPluginIdle'                => __( 'Drag & Drop your plugin zip file or <span class="filepond--label-action">Browse</span>' ),
+			'labelZipIdle'                   => __( 'Drag & Drop your zip file or <span class="filepond--label-action">Browse</span>' ),
 			'labelInvalidField'              => __( 'Field contains invalid files' ),
 			'labelFileWaitingForSize'        => __( 'Waiting for size' ),
 			'labelFileSizeNotAvailable'      => __( 'Size not available' ),

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -825,6 +825,7 @@ function wp_default_scripts( $scripts ) {
 		'_cpFilepondLabels',
 		array(
 			'labelIdle'                      => __( 'Drag & Drop your files or <span class="filepond--label-action">Browse</span>' ),
+			'labelPluginIdle'                => __( 'Drag & Drop your plugin zip file or <span class="filepond--label-action">Browse</span>' ),
 			'labelInvalidField'              => __( 'Field contains invalid files' ),
 			'labelFileWaitingForSize'        => __( 'Waiting for size' ),
 			'labelFileSizeNotAvailable'      => __( 'Size not available' ),


### PR DESCRIPTION
## Description
This PR address #2355

Currently the plugin file uploads uses basic HTML, as a reuslt some of the strings presented to end users are translated via the Browser rather than by ClassicPress. Further, changing these string is not a simple process.

The proposed solution is to deploy Filepond (the ClassicPress preferred uploaded) to hand zip file uploading. A proof of concept plugin is already attched to the open issue.

In this change I have found a way to enable file dropping to the full browser screen, and have also added a new string for use on this page in `script-loader.php` the is used via local string over-writing.

## Motivation and context
This PR provides better localisation for end users, core code control over translations for zip file uploading and a more consistent upload inderface for users.

## How has this been tested?
Local testing.

## Screenshots
### Before
<img width="1586" height="404" alt="Screenshot 2026-03-07 at 16 29 02" src="https://github.com/user-attachments/assets/9e1bf4fc-61d9-457e-8489-71251218363f" />

### After
<img width="2734" height="534" alt="Screenshot 2026-03-07 at 16 29 37" src="https://github.com/user-attachments/assets/a7d9e522-0d31-4e46-acd6-fa9a35325d23" />

## Types of changes
- Bug fix
- Enhancement
