### PR TITLE
Use Filepond as theme zip uploader

### DIFF
--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -191,7 +191,7 @@ function install_themes_dashboard() {
  * Displays a form to upload themes from zip files.
  *
  * @since 2.8.0
- * @since CP-2.8.0 JavaScript uploader used with browser fallback alternative
+ * @since CP-2.8.0 JavaScript uploader used
  */
 function install_themes_upload() {
 	?>

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -206,7 +206,7 @@ function install_themes_upload() {
 					_e( 'Theme zip file' );
 					?>
 				</label>
-				<input type="file" id="themezip" name="themezip" accept=".zip">
+				<input type="file" id="themezip" name="themezip">
 				<?php submit_button( __( 'Install Now' ), '', 'install-theme-submit', false, array( 'disabled' => 'disabled' ) ); ?>
 			</form>
 		</div>

--- a/src/wp-admin/includes/theme-install.php
+++ b/src/wp-admin/includes/theme-install.php
@@ -191,21 +191,26 @@ function install_themes_dashboard() {
  * Displays a form to upload themes from zip files.
  *
  * @since 2.8.0
+ * @since CP-2.8.0 JavaScript uploader used with browser fallback alternative
  */
 function install_themes_upload() {
 	?>
-<p class="install-help"><?php _e( 'If you have a theme in a .zip format, you may install or update it by uploading it here.' ); ?></p>
-<form method="post" enctype="multipart/form-data" class="wp-upload-form" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-theme' ) ); ?>">
-	<?php wp_nonce_field( 'theme-upload' ); ?>
-	<label class="screen-reader-text" for="themezip">
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Theme zip file' );
-		?>
-	</label>
-	<input type="file" id="themezip" name="themezip" accept=".zip">
-	<?php submit_button( __( 'Install Now' ), '', 'install-theme-submit', false ); ?>
-</form>
+	<p class="install-help"><?php _e( 'If you have a theme in a .zip format, you may install or update it by uploading it here.' ); ?></p>
+	<div id="plupload-upload-ui" class="hide-if-no-js drag-drop">
+		<div id="drag-drop-area">
+			<form method="post" enctype="multipart/form-data" id="filepond" action="<?php echo esc_url( self_admin_url( 'update.php?action=upload-theme' ) ); ?>">
+				<?php wp_nonce_field( 'theme-upload' ); ?>
+				<label class="screen-reader-text" for="themezip">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Theme zip file' );
+					?>
+				</label>
+				<input type="file" id="themezip" name="themezip" accept=".zip">
+				<?php submit_button( __( 'Install Now' ), '', 'install-theme-submit', false, array( 'disabled' => 'disabled' ) ); ?>
+			</form>
+		</div>
+	</div>
 	<?php
 }
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -396,9 +396,10 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		acceptedFileTypes:       [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
 		dropOnPage:              true,
 		dropOnElement:           false,
+		labelIdle:               _cpFilepondLabels.labelZipIdle,
 		credits:                 false,
 		onaddfile:               function( error ) { if ( button && ! error ) { button.disabled = false; } },
-		onremovefile:            function() { if ( button ) { button.disabled = true; } },
+		onremovefile:            function() { if ( button ) { button.disabled = true; } }
 	};
 	FilePond.registerPlugin( FilePondPluginFileValidateType );
 	FilePond.create( filepond, options );

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -88,6 +88,8 @@ wp_localize_script(
 
 wp_enqueue_script( 'theme' );
 wp_enqueue_script( 'updates' );
+wp_enqueue_script( 'cp-filepond' );
+wp_enqueue_style( 'cp-filepond' );
 
 if ( $tab ) {
 	/**
@@ -379,5 +381,26 @@ if ( $tab ) {
 <?php
 wp_print_request_filesystem_credentials_modal();
 wp_print_admin_notice_templates();
+
+?>
+<script>
+document.addEventListener( 'DOMContentLoaded', function () {
+	var filepond = document.querySelector( 'input[type="file"][name="themezip"]' );
+	var button   = document.getElementById( 'install-theme-submit' );
+	var options = {
+		name:               'filepond',
+		storeAsFile:         true,
+		allowMultiple:       false,
+		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed' ],
+		dropOnPage:          true,
+		dropOnElement:       false,
+		credits:             false,
+		onaddfile:           function() { if ( button ) { button.disabled = false; } },
+		onremovefile:        function() { if ( button ) { button.disabled = true; } },
+	};
+	FilePond.create( filepond, options );
+} );
+</script>
+<?php
 
 require_once ABSPATH . 'wp-admin/admin-footer.php';

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -389,19 +389,18 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	var filepond = document.querySelector( 'input[type="file"][name="themezip"]' );
 	var button   = document.getElementById( 'install-theme-submit' );
 	var options = {
-		name:               'themezip',
-		storeAsFile:         true,
-		allowMultiple:       false,
-		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
-		dropOnPage:          true,
-		dropOnElement:       false,
-		credits:             false,
-		onaddfile:           function( error ) { if ( button && ! error ) { button.disabled = false; } },
-		onremovefile:        function() { if ( button ) { button.disabled = true; } },
+		name:                    'themezip',
+		storeAsFile:             true,
+		allowMultiple:           false,
+		allowFileTypeValidation: true,
+		acceptedFileTypes:       [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
+		dropOnPage:              true,
+		dropOnElement:           false,
+		credits:                 false,
+		onaddfile:               function( error ) { if ( button && ! error ) { button.disabled = false; } },
+		onremovefile:            function() { if ( button ) { button.disabled = true; } },
 	};
-	FilePond.registerPlugin(
-		FilePondPluginFileValidateType
-	);
+	FilePond.registerPlugin( FilePondPluginFileValidateType );
 	FilePond.create( filepond, options );
 } );
 </script>

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -88,6 +88,7 @@ wp_localize_script(
 
 wp_enqueue_script( 'theme' );
 wp_enqueue_script( 'updates' );
+wp_enqueue_script( 'cp-filepond-file-validate-type' );
 wp_enqueue_script( 'cp-filepond' );
 wp_enqueue_style( 'cp-filepond' );
 
@@ -388,16 +389,19 @@ document.addEventListener( 'DOMContentLoaded', function () {
 	var filepond = document.querySelector( 'input[type="file"][name="themezip"]' );
 	var button   = document.getElementById( 'install-theme-submit' );
 	var options = {
-		name:               'filepond',
+		name:               'themezip',
 		storeAsFile:         true,
 		allowMultiple:       false,
-		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed' ],
+		acceptedFileTypes:   [ 'application/zip', 'application/x-zip-compressed', 'application/x-zip' ],
 		dropOnPage:          true,
 		dropOnElement:       false,
 		credits:             false,
-		onaddfile:           function() { if ( button ) { button.disabled = false; } },
+		onaddfile:           function( error ) { if ( button && ! error ) { button.disabled = false; } },
 		onremovefile:        function() { if ( button ) { button.disabled = true; } },
 	};
+	FilePond.registerPlugin(
+		FilePondPluginFileValidateType
+	);
 	FilePond.create( filepond, options );
 } );
 </script>


### PR DESCRIPTION
## Description
Based on a comment on PR #2360 this PR extends Filepond use to the Theme zip uploader.

Currently the plugin file uploads uses a basic HTML form element, as a result some of the strings presented to end users are translated via the Browser rather than by ClassicPress. Further, changing these string is not a simple process.

The proposed solution is to deploy Filepond (the ClassicPress preferred uploaded) to hand zip file uploading. There is no need for a `<noscript>` fallback as the button and form are already hidden in this scenario, Theme zip processing requires AJAX handling.

Currently I have not added or amnded the Uploader string but that could be considered.

## Motivation and context
UX consistency and as per comment as stated above.

## How has this been tested?
Local testing.

## Screenshots
### Before
<img width="2704" height="914" alt="Screenshot 2026-03-11 at 18 19 35" src="https://github.com/user-attachments/assets/b8755335-f94f-4fe8-9147-45b5df524d05" />

### After
<img width="2728" height="972" alt="Screenshot 2026-03-11 at 18 19 16" src="https://github.com/user-attachments/assets/d991a6a7-66ba-4456-87ec-a93b59a88532" />

## Types of changes
- Bug fix
- Enhancement
