### PR TITLE
The ClassicPress theme - fix at search results / 404 template

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/404.php
+++ b/src/wp-content/themes/the-classicpress-theme/404.php
@@ -14,41 +14,38 @@ get_header();
 		<main id="main">
 
 			<section>
-				<div>
-					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'the-classicpress-theme' ); ?></p>
+				<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'the-classicpress-theme' ); ?></p>
 
-					<?php
-					get_search_form();
+				<?php
+				get_search_form();
 
-					the_widget( 'WP_Widget_Recent_Posts' );
-					?>
+				the_widget( 'WP_Widget_Recent_Posts' );
+				?>
 
-					<div class="widget widget_categories">
-						<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'the-classicpress-theme' ); ?></h2>
-						<ul>
-							<?php
-							wp_list_categories(
-								array(
-									'orderby'    => 'count',
-									'order'      => 'DESC',
-									'show_count' => 1,
-									'title_li'   => '',
-									'number'     => 10,
-								)
-							);
-							?>
-						</ul>
-					</div><!-- .widget -->
+				<div class="widget widget_categories">
+					<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'the-classicpress-theme' ); ?></h2>
+					<ul>
+						<?php
+						wp_list_categories(
+							array(
+								'orderby'    => 'count',
+								'order'      => 'DESC',
+								'show_count' => 1,
+								'title_li'   => '',
+								'number'     => 10,
+							)
+						);
+						?>
+					</ul>
+				</div><!-- .widget -->
 
-					<?php
-					/* translators: %1$s: smiley */
-					$susty_wp_archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'the-classicpress-theme' ), convert_smilies( ':)' ) ) . '</p>';
-					the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$susty_wp_archive_content" );
+				<?php
+				/* translators: %1$s: smiley */
+				$susty_wp_archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'the-classicpress-theme' ), convert_smilies( ':)' ) ) . '</p>';
+				the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$susty_wp_archive_content" );
 
-					the_widget( 'WP_Widget_Tag_Cloud' );
-					?>
-
-				</div>
+				the_widget( 'WP_Widget_Tag_Cloud' );
+				?>
 			</section>
 
 		</main><!-- #main -->

--- a/src/wp-content/themes/the-classicpress-theme/search.php
+++ b/src/wp-content/themes/the-classicpress-theme/search.php
@@ -16,12 +16,12 @@ get_header();
 		<?php if ( have_posts() ) : ?>
 
 			<header>
-				<h3>
+				<h2>
 					<?php
 					/* translators: %s: search query. */
 					printf( esc_html__( 'Search term: %s', 'the-classicpress-theme' ), '<span>' . get_search_query() . '</span>' );
 					?>
-				</h3>
+				</h2>
 			</header><!-- .page-header -->
 
 			<?php

--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content-none.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content-none.php
@@ -12,7 +12,7 @@
 <section>
 
 	<header>
-		<h1><?php esc_html_e( 'Nothing Found', 'the-classicpress-theme' ); ?></h1>
+		<h3><?php esc_html_e( 'Nothing Found', 'the-classicpress-theme' ); ?></h3>
 	</header><!-- .page-header -->
 
 	<div class="page-content">

--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content-none.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content-none.php
@@ -12,7 +12,7 @@
 <section>
 
 	<header>
-		<h3><?php esc_html_e( 'Nothing Found', 'the-classicpress-theme' ); ?></h3>
+		<h2><?php esc_html_e( 'Nothing Found', 'the-classicpress-theme' ); ?></h2>
 	</header><!-- .page-header -->
 
 	<div class="page-content">

--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content.php
@@ -6,6 +6,7 @@
  *
  * @package Susty
  */
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -32,7 +33,7 @@
 		</header>
 
 	<?php else : ?>
-		<header class="blog">
+		<header>
 			<?php
 			the_title(
 				'<h2><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">',


### PR DESCRIPTION
## Description

- SEO: changed second H1 (Nothing Found) into H3 (same as the "Search term:" heading)
- Removed unused div tag from 404 page
- Not related: removed too general (unused) class name from header tag

## Screenshots
### Before
![Nothing found - before](https://github.com/user-attachments/assets/4286565d-43a9-4353-82b8-3a9b645912cd)

### After
![Nothing found - after](https://github.com/user-attachments/assets/f82629fe-5a7b-494c-bb8f-2499892fa616)

## Types of changes
- Bug fix