### PR TITLE
Update ramsey/composer-install to v4

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -49,7 +49,7 @@ jobs:
           composer --version
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 
@@ -122,7 +122,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -44,7 +44,7 @@ jobs:
           tools: composer, cs2pr
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 

--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -166,7 +166,7 @@ jobs:
           sudo update-locale LC_ALL="es_ES.UTF-8 fr_FR.UTF-8 ru_RU.UTF-8"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
         with:
           composer-options: "--no-progress --no-ansi --no-interaction"
 


### PR DESCRIPTION
## Description
This PR updates the `ramsey/composer-install` action used in workflows to version 4.

## Motivation and context
The current version, v3, has a dependency on another action that may not work as predicted when Node is updated in GitHub runners, this is according to Warning shown in Action runs on Github. This was corrected in a new version release:
https://github.com/ramsey/composer-install/releases/tag/4.0.0

## How has this been tested?
Actions should run on this PR without logged Warnings.

## Screenshots
<img width="1832" height="506" alt="Screenshot 2026-03-24 at 08 29 07" src="https://github.com/user-attachments/assets/a2741c85-7c73-49eb-a3b4-d361ddbdefff" />

## Types of changes
- Enhancement
