### PR TITLE
Remove unnecessary ignoreDeps from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,5 @@
 		"### Pre-merge checks",
 		"- [ ] Make sure the GitHub Actions tests are passing.",
 		"- [ ] Run `bin/compare-build-branch.sh` locally on this branch and confirm that this PR is not causing unexpected changes to the build.  Requirements to run this script: `grunt build` and `nvm`."
-	],
-	"ignoreDeps": [
-		"uglify-js"
 	]
 }


### PR DESCRIPTION
## Description
Thsi PR updates the Renovate configuration to remove an unnecessary setting.

## Motivation and context
Uglify-js is set to be ignore for updates due to historical issues with this pacakges, but this was resolved by migrating to `terser` back in PR [608](https://github.com/ClassicPress/ClassicPress/pull/608) so this setting iss no longer required.

## How has this been tested?
Not possible to test but Uglify-js is not a dependency and the PR that removed it has been tracked down as above.

## Screenshots
N/A

## Types of changes
- Enhancement

