### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -16,7 +16,7 @@
 
 	<!-- Set the memory limit to 256M.
 		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
-		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
+		 Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
 	-->
 	<ini name="memory_limit" value="256M"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
 
 	<!-- Set the memory limit to 256M.
 		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
-		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
+		 Ref: https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
 	-->
 	<ini name="memory_limit" value="256M"/>
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932