### PR TITLE
Update Regex for recommended MySQL version in readme

### DIFF
--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -51,7 +51,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		$response_body = $this->get_response_body( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
 
 		preg_match(
-			'#(\d{4}-\d{2}-\d{2}), General Availability#',
+			'#(\d{4}-\d{2}-\d{2})#',
 			$response_body,
 			$mysqlmatches
 		);


### PR DESCRIPTION
## Description
MySQL documentation pages no longer indicates the 'General Availability' version resulting in test failures.

https://dev.mysql.com/doc/relnotes/mysql/5.7/en/

## Motivation and context
ThisPR still ensure the a MySQL version up to 5 years old maximum is recommended, and restores passing tests.

## How has this been tested?
Local Testing

## Screenshots
### Before
<img width="1472" height="346" alt="Screenshot 2026-03-27 at 18 56 48" src="https://github.com/user-attachments/assets/98f6bee5-4603-4282-ab9e-59279e558611" />

### After
<img width="1464" height="770" alt="Screenshot 2026-03-27 at 18 58 20" src="https://github.com/user-attachments/assets/342bfc79-0c68-46d4-a208-d39d256687b7" />

## Types of changes
- Bug fix