### PR TITLE
Update recommended MySQL version to 8.5

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -35,7 +35,7 @@ jobs:
         os: [ ubuntu-22.04 ]
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0' ]
+        db-version: [ '5.7', '8.4' ]
         multisite: [ false, true ]
         memcached: [ false ]
         coverage: [ none ]
@@ -59,7 +59,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.3'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: false
             memcached: true
@@ -67,7 +67,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.4'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: false
             memcached: true
@@ -91,7 +91,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.3'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: true
             memcached: true
@@ -99,7 +99,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.4'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: true
             memcached: true
@@ -107,7 +107,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.4'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: false
             memcached: false
@@ -115,7 +115,7 @@ jobs:
             experimental: false
           - os: ubuntu-22.04
             php: '8.4'
-            db-version: '8.0'
+            db-version: '8.4'
             db-type: mysql
             multisite: true
             memcached: false

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -144,7 +144,7 @@ jobs:
         os: [ ubuntu-22.04 ]
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         db-type: [ 'mariadb' ]
-        db-version: [ '10.4', '11.4' ]
+        db-version: [ '10.6', '11.4' ]
         multisite: [ false, true ]
         memcached: [ false ]
         coverage: [ none ]

--- a/src/readme.html
+++ b/src/readme.html
@@ -106,7 +106,7 @@
 	<h3>Recommended Setup</h3>
 	<ul>
 		<li><a href="https://secure.php.net/">PHP</a> version <strong>8.4</strong> or greater.</li>
-		<li><a href="https://www.mysql.com/">MySQL</a> version <strong>5.7</strong> or greater, or <a
+		<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.4</strong> or greater, or <a
 				href="https://mariadb.org/">MariaDB</a> version <strong>10.4</strong> or greater.</li>
 		<li><a href="https://httpd.apache.org/">Apache</a> with <code>mod_rewrite</code> module, <a
 				href="https://nginx.org/en/">Nginx</a>, or <a href="https://www.litespeedtech.com/">LiteSpeed</a>

--- a/src/readme.html
+++ b/src/readme.html
@@ -107,7 +107,7 @@
 	<ul>
 		<li><a href="https://secure.php.net/">PHP</a> version <strong>8.4</strong> or greater.</li>
 		<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.4</strong> or greater, or <a
-				href="https://mariadb.org/">MariaDB</a> version <strong>10.4</strong> or greater.</li>
+				href="https://mariadb.org/">MariaDB</a> version <strong>11.4</strong> or greater.</li>
 		<li><a href="https://httpd.apache.org/">Apache</a> with <code>mod_rewrite</code> module, <a
 				href="https://nginx.org/en/">Nginx</a>, or <a href="https://www.litespeedtech.com/">LiteSpeed</a>
 			server.</li>

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -48,21 +48,19 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $matches );
 
-		$response_body = $this->get_response_body( "https://dev.mysql.com/doc/relnotes/mysql/{$matches[1]}/en/" );
+		$response_body = json_decode( $this->get_response_body( 'https://endoflife.date/api/mysql.json' ) );
+		$eol_date      = '';
 
-		preg_match(
-			'#(\d{4}-\d{2}-\d{2}), General Availability#',
-			$response_body,
-			$mysqlmatches
-		);
-		$this->assertNotEmpty( $mysqlmatches );
-
-		// Per https://www.mysql.com/support/, Oracle actively supports MySQL
-		// releases for 5 years from GA release
-		$mysql_eol = strtotime( $mysqlmatches[1] . ' +5 years' );
+		foreach ( $response_body as $version ) {
+			if ( $version->cycle === $matches[1] && false !== $version->eol ) {
+				$eol_date = $version->eol;
+				break;
+			}
+		}
+		$this->assertNotEmpty( $eol_date );
 
 		$this->assertLessThan(
-			$mysql_eol,
+			strtotime( $eol_date ),
 			time(),
 			"readme.html's Recommended MySQL version is too old."
 		);

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -82,7 +82,7 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 
 		$response_body = json_decode( $this->get_response_body( 'https://endoflife.date/api/mariadb.json' ) );
 		$eol_date      = '';
-var_dump( $matches[1] );
+
 		foreach ( $response_body as $version ) {
 			if ( $version->cycle === $matches[1] ) {
 				$eol_date = $version->eol;
@@ -90,7 +90,7 @@ var_dump( $matches[1] );
 			}
 		}
 		$this->assertNotEmpty( $eol_date );
-var_dump( $eol_date );
+
 		$this->assertLessThan(
 			strtotime( $eol_date ),
 			time(),

--- a/tests/phpunit/tests/external-http/basic.php
+++ b/tests/phpunit/tests/external-http/basic.php
@@ -66,6 +66,38 @@ class Tests_External_HTTP_Basic extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_readme_recommended_mariadb_version() {
+		// This test is designed to only run on develop.
+		$this->skipOnAutomatedBranches();
+
+		$readme = file_get_contents( ABSPATH . 'readme.html' );
+
+		preg_match(
+			'#Recommended Setup.*MariaDB</a> version <strong>([0-9.]*)#s',
+			$readme,
+			$matches
+		);
+
+		$this->assertNotEmpty( $matches );
+
+		$response_body = json_decode( $this->get_response_body( 'https://endoflife.date/api/mariadb.json' ) );
+		$eol_date      = '';
+var_dump( $matches[1] );
+		foreach ( $response_body as $version ) {
+			if ( $version->cycle === $matches[1] ) {
+				$eol_date = $version->eol;
+				break;
+			}
+		}
+		$this->assertNotEmpty( $eol_date );
+var_dump( $eol_date );
+		$this->assertLessThan(
+			strtotime( $eol_date ),
+			time(),
+			"readme.html's Recommended MariaDB version is too old."
+		);
+	}
+
 	/**
 	 * Helper function to retrieve the response body or skip the test on HTTP timeout.
 	 *


### PR DESCRIPTION
## Description
While investigating the changes behind #2379 it was noted in an [upstream fix](https://core.trac.wordpress.org/changeset/62170) that there is a json endpoint with EOL data for MySQL versions.

Currently 5.7 is past the EOL support date, 8.4 is in long term support.

## Motivation and context
This PR updates testing to use MySQL 8.4 in place of 8.0, updated the readme to recommend MySQL 8.4 and also updates the unit testing of the readme file for the MySQL recommended version.

## How has this been tested?
Local testing.

## Screenshots
### Before
<img width="1356" height="518" alt="Screenshot 2026-03-28 at 16 29 00" src="https://github.com/user-attachments/assets/de5ad26c-e522-44d9-854c-643b07084349" />

### After
<img width="1316" height="500" alt="Screenshot 2026-03-28 at 16 28 44" src="https://github.com/user-attachments/assets/90ee19da-b0fd-4df4-91ed-afd2255acf87" />

## Types of changes
- Enhancement
