### PR TITLE
Fix CP version in load.php

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -139,10 +139,10 @@ function wp_populate_basic_auth_from_authorization_header() {
  * @access private
  *
  * @global string $required_php_version The required PHP version string.
- * @global string $wp_version           The WordPress version string.
+ * @global string $cp_version           The ClassicPress version string.
  */
 function wp_check_php_mysql_versions() {
-	global $required_php_version, $wp_version;
+	global $required_php_version, $cp_version;
 	$php_version = PHP_VERSION;
 
 	if ( version_compare( $required_php_version, $php_version, '>' ) ) {
@@ -152,7 +152,7 @@ function wp_check_php_mysql_versions() {
 		printf(
 			'Your server is running PHP version %1$s but ClassicPress %2$s requires at least %3$s.',
 			$php_version,
-			$wp_version,
+			$cp_version,
 			$required_php_version
 		);
 		exit( 1 );


### PR DESCRIPTION
## Description
This PR fixes the wrong CP version number in the notification when PHP version is < 7.4 

Before: 
`Your server is running PHP version 7.3.33 but ClassicPress 6.2.9 requires at least 7.4.0.`

After: 
`Your server is running PHP version 7.3.33 but ClassicPress 2.7.0 requires at least 7.4.0.`

As mentioned [here](https://github.com/ClassicPress/ClassicPress/pull/2373#issuecomment-4178264993) by @joyously.

## How has this been tested?
Local install.

## Types of changes
- Bug fix