### PR TITLE
Update to supported welcome action

### DIFF
--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -2,7 +2,11 @@ name: Welcome New Contributors
 
 on:
   pull_request_target:
-    types: [ opened ]
+    types:
+      opened
+  issues:
+    types:
+      opened
 
 # Disable permissions for all available scopes by default.
 # Required permissions are configured at the job level.
@@ -14,12 +18,24 @@ jobs:
     name: Welcome message
     permissions:
       pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: wow-actions/welcome@v1
+      - uses: actions/first-interaction@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FIRST_PR_COMMENT: >
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
+            Hi @{{ author }}! 👋
+
+            Thank you for opening an issue at ClassicPress! 💖
+
+            It looks like this is your first issue. We appreciate and value your time!
+
+            If you haven't already, please give us as much information about the issue. If you can include steps on how to re-create the issue, that would be really helpful.
+
+            Thank you,
+            ClassicPress Core Team.
+          pr_message: |
             Hi @{{ author }}! 👋
 
             Thank you for your contribution to ClassicPress! 💖


### PR DESCRIPTION
## Description
The [wow-actions/welcome](https://github.com/wow-actions/welcome) action is currently use to welcome new PR contributors to the repository and direct them to the contributing guide. This action was last update in October 2024, and is currently showing a warning in action runs as it relies on Node 20.

This PR migrates to an alternative solution that seems to be under more active support and development - [actions/first-interaction](https://github.com/actions/first-interaction).

## Motivation and context
This will hopefully remove the warning when the action runs, and also allows anyone newly opening an Issue to get a welcome as well.

## How has this been tested?
AI has been use to check the update yml file for compatibility.

## Screenshots
### Before
<img width="1824" height="326" alt="Screenshot 2026-04-03 at 16 27 05" src="https://github.com/user-attachments/assets/148e6bac-999b-4290-845d-645980839f82" />

### After


## Types of changes
- Enhancement