### PR TITLE
Fix theme details modal

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -766,6 +766,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	height: 95%;
 	max-width: 1024px;
 	max-height: 800px;
+	overflow: hidden;
 }
 
 #theme-update-modal iframe {
@@ -773,7 +774,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	top: 49px;
 	left: 0;
 	width: 100%;
-	height: 100%;
+	height: calc(100% - 49px);
 }
 /**
  * Basic Responsive structure...

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -760,6 +760,21 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	position: absolute;
 }
 
+#theme-update-modal {
+	display: flex;
+	width: 90%;
+	height: 95%;
+	max-width: 1024px;
+	max-height: 800px;
+}
+
+#theme-update-modal iframe {
+	position: absolute;
+	top: 49px;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
 /**
  * Basic Responsive structure...
  *
@@ -944,10 +959,11 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.themes-php .wp-filter-search {
 		float: none;
 		clear: both;
-		top: 0;
 		left: 0;
-		margin: 0 0 20px;
+		right: 0;
+		margin: -5px 0 20px;
 		width: 100%;
+		max-width: 280px;
 	}
 
 	.theme-browser .theme.add-new-theme span:after {
@@ -1894,24 +1910,6 @@ body.full-overlay-active {
 
 .customize-loading #customize-container {
 	background-color: #f0f0f1;
-}
-
-#customize-preview.wp-full-overlay-main::before,
-.customize-loading #customize-container::before,
-#customize-controls .notice.notification-overlay.notification-loading::before,
-.theme-install-overlay .wp-full-overlay-main::before {
-	content: "";
-	display: block;
-	width: 20px;
-	height: 20px;
-	position: absolute;
-	left: 50%;
-	top: 50%;
-	z-index: -1;
-	margin: -10px 0 0 -10px;
-	transform: translateZ(0);
-	background: transparent url(../images/spinner.gif) no-repeat center center;
-	background-size: 20px 20px;
 }
 
 #theme-preview-main {

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -776,6 +776,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	width: 100%;
 	height: calc(100% - 49px);
 }
+
 /**
  * Basic Responsive structure...
  *
@@ -960,11 +961,10 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.themes-php .wp-filter-search {
 		float: none;
 		clear: both;
+		top: 0;
 		left: 0;
-		right: 0;
-		margin: -5px 0 20px;
+		margin: 0 0 20px;
 		width: 100%;
-		max-width: 280px;
 	}
 
 	.theme-browser .theme.add-new-theme span:after {
@@ -1911,6 +1911,24 @@ body.full-overlay-active {
 
 .customize-loading #customize-container {
 	background-color: #f0f0f1;
+}
+
+#customize-preview.wp-full-overlay-main::before,
+.customize-loading #customize-container::before,
+#customize-controls .notice.notification-overlay.notification-loading::before,
+.theme-install-overlay .wp-full-overlay-main::before {
+	content: "";
+	display: block;
+	width: 20px;
+	height: 20px;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	z-index: -1;
+	margin: -10px 0 0 -10px;
+	transform: translateZ(0);
+	background: transparent url(../images/spinner.gif) no-repeat center center;
+	background-size: 20px 20px;
 }
 
 #theme-preview-main {

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -112,7 +112,6 @@ function delete_theme( $stylesheet, $redirect = '' ) {
 		foreach ( $translations as $translation => $data ) {
 			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.po' );
 			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.mo' );
-			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.l10n.php' );
 
 			$json_translation_files = glob( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '-*.json' );
 			if ( $json_translation_files ) {
@@ -207,14 +206,6 @@ function get_theme_update_available( $theme ) {
 	if ( isset( $themes_update->response[ $stylesheet ] ) ) {
 		$update      = $themes_update->response[ $stylesheet ];
 		$theme_name  = $theme->display( 'Name' );
-		$details_url = add_query_arg(
-			array(
-				'TB_iframe' => 'true',
-				'width'     => 1024,
-				'height'    => 800,
-			),
-			$update['url']
-		); // Theme browser inside WP? Replace this. Also, theme preview JS will override this on the available list.
 		$update_url  = wp_nonce_url( admin_url( 'update.php?action=upgrade-theme&amp;theme=' . urlencode( $stylesheet ) ), 'upgrade-theme_' . $stylesheet );
 
 		if ( ! is_multisite() ) {
@@ -223,7 +214,7 @@ function get_theme_update_available( $theme ) {
 					/* translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number. */
 					'<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>.' ) . '</strong></p>',
 					$theme_name,
-					esc_url( $details_url ),
+					esc_url( $update['url'] ),
 					sprintf(
 						'class="thickbox open-plugin-details-modal" aria-label="%s"',
 						/* translators: 1: Theme name, 2: Version number. */
@@ -236,7 +227,7 @@ function get_theme_update_available( $theme ) {
 					/* translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number. */
 					'<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a>. <em>Automatic update is unavailable for this theme.</em>' ) . '</strong></p>',
 					$theme_name,
-					esc_url( $details_url ),
+					esc_url( $update['url'] ),
 					sprintf(
 						'class="thickbox open-plugin-details-modal" aria-label="%s"',
 						/* translators: 1: Theme name, 2: Version number. */
@@ -249,7 +240,7 @@ function get_theme_update_available( $theme ) {
 					/* translators: 1: Theme name, 2: Theme details URL, 3: Additional link attributes, 4: Version number, 5: Update URL, 6: Additional link attributes. */
 					'<p><strong>' . __( 'There is a new version of %1$s available. <a href="%2$s" %3$s>View version %4$s details</a> or <a href="%5$s" %6$s>update now</a>.' ) . '</strong></p>',
 					$theme_name,
-					esc_url( $details_url ),
+					esc_url( $update['url'] ),
 					sprintf(
 						'class="thickbox open-plugin-details-modal" aria-label="%s"',
 						/* translators: 1: Theme name, 2: Version number. */
@@ -733,6 +724,7 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			'updateResponse' => array(
 				'compatibleWP'  => is_wp_version_compatible( $update_requires_wp ),
 				'compatiblePHP' => is_php_version_compatible( $update_requires_php ),
+				'compatibleCP'  => ! array_key_exists( 'full-site-editing', $theme->tags ),
 			),
 			'parent'         => $parent,
 			'active'         => $slug === $current_theme,
@@ -781,291 +773,295 @@ function wp_prepare_themes_for_js( $themes = null ) {
  */
 function customize_themes_print_templates() {
 	$cp_has_update = classicpress_has_update();
-
+	ob_start();
 	?>
-	<script type="text/html" id="tmpl-customize-themes-details-view">
-		<div class="theme-backdrop"></div>
-		<div class="theme-wrap wp-clearfix" role="document">
+	<dialog id="theme-modal" class="theme-overlay" aria-label="<?php esc_html_e( 'Theme Details' ); ?>" data-highlighted-theme="">
+		<div class="theme-wrap wp-clearfix">
 			<div class="theme-header">
-				<button type="button" class="left dashicons dashicons-no"><span class="screen-reader-text">
-					<?php
-					/* translators: Hidden accessibility text. */
-					_e( 'Show previous theme' );
-					?>
-				</span></button>
-				<button type="button" class="right dashicons dashicons-no"><span class="screen-reader-text">
-					<?php
-					/* translators: Hidden accessibility text. */
-					_e( 'Show next theme' );
-					?>
-				</span></button>
-				<button type="button" class="close dashicons dashicons-no"><span class="screen-reader-text">
-					<?php
-					/* translators: Hidden accessibility text. */
-					_e( 'Close details dialog' );
-					?>
-				</span></button>
+				<button type="button" class="left dashicons dashicons-no">
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						esc_html_e( 'Show previous theme' );
+						?>
+					</span>
+				</button>
+				<button type="button" class="right dashicons dashicons-no">
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						esc_html_e( 'Show next theme' );
+						?>
+					</span>
+				</button>
+				<button type="button" class="close dashicons dashicons-no">
+					<span class="screen-reader-text">
+						<?php
+						/* translators: Hidden accessibility text. */
+						esc_html_e( 'Close details dialog' );
+						?>
+					</span>
+				</button>
 			</div>
+		</div>
+	</dialog>
+
+	<template id="theme-modal-insert">
+		<div id="theme-modal-insert-container">
 			<div class="theme-about wp-clearfix">
 				<div class="theme-screenshots">
-				<# if ( data.screenshot && data.screenshot[0] ) { #>
-					<div class="screenshot"><img src="{{ data.screenshot[0] }}?ver={{ data.version }}" alt=""></div>
-				<# } else { #>
-					<div class="screenshot blank"></div>
-				<# } #>
+					<div class="screenshot"></div>
 				</div>
 
 				<div class="theme-info">
-					<# if ( data.active ) { #>
-						<span class="current-label"><?php _e( 'Active Theme' ); ?></span>
-					<# } #>
-					<h2 class="theme-name">{{{ data.name }}}<span class="theme-version">
-						<?php
-						/* translators: %s: Theme version. */
-						printf( __( 'Version: %s' ), '{{ data.version }}' );
-						?>
-					</span></h2>
-					<h3 class="theme-author">
-						<?php
-						/* translators: %s: Theme author link. */
-						printf( __( 'By %s' ), '{{{ data.authorAndUri }}}' );
-						?>
-					</h3>
+					<span class="current-label" hidden><?php esc_html_e( 'Active Theme' ); ?></span>
+					<h2>
+						<span class="theme-name"></span>
+						<span class="theme-version"></span>
+					</h2>
+					<p class="theme-author"></p>
 
-					<# if ( data.stars && 0 != data.num_ratings ) { #>
-						<div class="theme-rating">
-							{{{ data.stars }}}
-							<a class="num-ratings" target="_blank" href="{{ data.reviews_url }}">
-								<?php
-								printf(
-									'%1$s <span class="screen-reader-text">%2$s</span>',
-									/* translators: %s: Number of ratings. */
-									sprintf( __( '(%s ratings)' ), '{{ data.num_ratings }}' ),
-									/* translators: Hidden accessibility text. */
-									__( '(opens in a new tab)' )
-								);
-								?>
-							</a>
-						</div>
-					<# } #>
-
-					<# if ( data.hasUpdate ) { #>
-						<# if ( data.updateResponse.compatibleWP && data.updateResponse.compatiblePHP ) { #>
-							<div class="notice notice-warning notice-alt notice-large" data-slug="{{ data.id }}">
-								<h3 class="notice-title"><?php _e( 'Update Available' ); ?></h3>
-								{{{ data.update }}}
-							</div>
-						<# } else { #>
-							<div class="notice notice-error notice-alt notice-large" data-slug="{{ data.id }}">
-								<h3 class="notice-title"><?php _e( 'Update Incompatible' ); ?></h3>
-								<p>
-									<# if ( ! data.updateResponse.compatibleWP && ! data.updateResponse.compatiblePHP ) { #>
-										<?php
-										printf(
-											/* translators: %s: Theme name. */
-											__( 'There is a new version of %s available, but it does not work with your versions of ClassicPress and PHP.' ),
-											'{{{ data.name }}}'
-										);
-										if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-											if ( $cp_has_update ) {
-												printf(
-													/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-													' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-													self_admin_url( 'update-core.php' ),
-													esc_url( wp_get_update_php_url() )
-												);
-											} else {
-												printf(
-													/* translators: %s: URL to Update PHP page. */
-													' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-													esc_url( wp_get_update_php_url() )
-												);
-											}
-											wp_update_php_annotation( '</p><p><em>', '</em>' );
-										} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
-											printf(
-												/* translators: %s: URL to WordPress Updates screen. */
-												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-												self_admin_url( 'update-core.php' )
-											);
-										} elseif ( current_user_can( 'update_php' ) ) {
-											printf(
-												/* translators: %s: URL to Update PHP page. */
-												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-												esc_url( wp_get_update_php_url() )
-											);
-											wp_update_php_annotation( '</p><p><em>', '</em>' );
-										}
-										?>
-									<# } else if ( ! data.updateResponse.compatibleWP ) { #>
-										<?php
-										printf(
-											/* translators: %s: Theme name. */
-											__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
-											'{{{ data.name }}}'
-										);
-										if ( current_user_can( 'update_core' ) && $cp_has_update ) {
-											printf(
-												/* translators: %s: URL to WordPress Updates screen. */
-												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-												self_admin_url( 'update-core.php' )
-											);
-										}
-										?>
-									<# } else if ( ! data.updateResponse.compatiblePHP ) { #>
-										<?php
-										printf(
-											/* translators: %s: Theme name. */
-											__( 'There is a new version of %s available, but it does not work with your version of PHP.' ),
-											'{{{ data.name }}}'
-										);
-										if ( current_user_can( 'update_php' ) ) {
-											printf(
-												/* translators: %s: URL to Update PHP page. */
-												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-												esc_url( wp_get_update_php_url() )
-											);
-											wp_update_php_annotation( '</p><p><em>', '</em>' );
-										}
-										?>
-									<# } #>
-								</p>
-							</div>
-						<# } #>
-					<# } #>
-
-					<# if ( data.parent ) { #>
-						<p class="parent-theme">
+					<div class="notice inline notice-error notice-alt notice-large no-wp-php" hidden>
+						<p>
 							<?php
-							printf(
-								/* translators: %s: Theme name. */
-								__( 'This is a child theme of %s.' ),
-								'<strong>{{{ data.parent }}}</strong>'
-							);
+							_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
+							if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+								if ( $cp_has_update ) {
+									printf(
+										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+										self_admin_url( 'update-core.php' ),
+										esc_url( wp_get_update_php_url() )
+									);
+								} else {
+									printf(
+										/* translators: %s: URL to Update PHP page. */
+										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+										esc_url( wp_get_update_php_url() )
+									);
+								}
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
+								printf(
+									/* translators: %s: URL to WordPress Updates screen. */
+									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+									self_admin_url( 'update-core.php' )
+								);
+							} elseif ( current_user_can( 'update_php' ) ) {
+								printf(
+									/* translators: %s: URL to Update PHP page. */
+									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+									esc_url( wp_get_update_php_url() )
+								);
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							}
 							?>
 						</p>
-					<# } #>
+					</div>
 
-					<# if ( ! data.compatibleWP || ! data.compatiblePHP ) { #>
-						<div class="notice notice-error notice-alt notice-large"><p>
-							<# if ( ! data.compatibleWP && ! data.compatiblePHP ) { #>
-								<?php
-								_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
-								if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-									if ( $cp_has_update ) {
-										printf(
-											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-											self_admin_url( 'update-core.php' ),
-											esc_url( wp_get_update_php_url() )
-										);
-									} else {
-										printf(
-											/* translators: %s: URL to Update PHP page. */
-											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-											esc_url( wp_get_update_php_url() )
-										);
-									}
-									wp_update_php_annotation( '</p><p><em>', '</em>' );
-								} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
-									printf(
-										/* translators: %s: URL to WordPress Updates screen. */
-										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-										self_admin_url( 'update-core.php' )
-									);
-								} elseif ( current_user_can( 'update_php' ) ) {
-									printf(
-										/* translators: %s: URL to Update PHP page. */
-										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-										esc_url( wp_get_update_php_url() )
-									);
-									wp_update_php_annotation( '</p><p><em>', '</em>' );
-								}
-								?>
-							<# } else if ( ! data.compatibleWP ) { #>
-								<?php
-								_e( 'This theme does not work with your version of ClassicPress.' );
-								if ( current_user_can( 'update_core' ) && $cp_has_update ) {
-									printf(
-										/* translators: %s: URL to WordPress Updates screen. */
-										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-										self_admin_url( 'update-core.php' )
-									);
-								}
-								?>
-							<# } else if ( ! data.compatiblePHP ) { #>
-								<?php
-								_e( 'This theme does not work with your version of PHP.' );
-								if ( current_user_can( 'update_php' ) ) {
-									printf(
-										/* translators: %s: URL to Update PHP page. */
-										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-										esc_url( wp_get_update_php_url() )
-									);
-									wp_update_php_annotation( '</p><p><em>', '</em>' );
-								}
-								?>
-							<# } #>
-						</p></div>
-					<# } else if ( ! data.active && data.blockTheme ) { #>
-						<div class="notice notice-error notice-alt notice-large"><p>
-						<?php
-							_e( 'This theme doesn\'t support Customizer.' );
-						?>
-						<# if ( data.actions.activate ) { #>
+					<div class="notice inline notice-error notice-alt notice-large no-wp" hidden>
+						<p>
 							<?php
-							printf(
-								/* translators: %s: URL to the themes page (also it activates the theme). */
-								' ' . __( 'However, you can still <a href="%s">activate this theme</a>, and use the Site Editor to customize it.' ),
-								'{{{ data.actions.activate }}}'
-							);
+							_e( 'This theme does not work with your version of ClassicPress.' );
+							if ( current_user_can( 'update_core' ) && $cp_has_update ) {
+								printf(
+									/* translators: %s: URL to WordPress Updates screen. */
+									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+									self_admin_url( 'update-core.php' )
+								);
+							}
 							?>
-						<# } #>
-						</p></div>
-					<# } #>
+						</p>
+					</div>
 
-					<p class="theme-description">{{{ data.description }}}</p>
+					<div class="notice inline notice-error notice-alt notice-large no-php" hidden>
+						<p>
+							<?php
+							_e( 'This theme does not work with your version of PHP.' );
+							if ( current_user_can( 'update_php' ) ) {
+								printf(
+									/* translators: %s: URL to Update PHP page. */
+									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+									esc_url( wp_get_update_php_url() )
+								);
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							}
+							?>
+						</p>
+					</div>
+
+					<div class="notice inline notice-warning notice-alt notice-large has-update" hidden>
+						<h3 class="notice-title"><?php esc_html_e( 'Update Available' ); ?></h3>
+						<span></span>
+					</div>
+
+					<div class="notice inline notice-error notice-alt notice-large incompat-update" hidden>
+						<h3 class="notice-title"><?php esc_html_e( 'Update Incompatible' ); ?></h3>
+						<p class="no-wp-php" hidden>
+							<?php
+							esc_html_e( 'There is a new version of this theme available, but it does not work with your versions of ClassicPress and PHP.' );
+							if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+								if ( $cp_has_update ) {
+									printf(
+										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+										self_admin_url( 'update-core.php' ),
+										esc_url( wp_get_update_php_url() )
+									);
+								} else {
+									printf(
+										/* translators: %s: URL to Update PHP page. */
+										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+										esc_url( wp_get_update_php_url() )
+									);
+								}
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
+								printf(
+									/* translators: %s: URL to WordPress Updates screen. */
+									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+									self_admin_url( 'update-core.php' )
+								);
+							} elseif ( current_user_can( 'update_php' ) ) {
+								printf(
+									/* translators: %s: URL to Update PHP page. */
+									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+									esc_url( wp_get_update_php_url() )
+								);
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							}
+							?>
+						</p>
+
+						<p class="no-wp" hidden>
+							<?php
+							esc_html_e( 'There is a new version of this theme available, but it does not work with your version of ClassicPress.' );
+							if ( current_user_can( 'update_core' ) && $cp_has_update ) {
+								printf(
+									/* translators: %s: URL to WordPress Updates screen. */
+									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+									self_admin_url( 'update-core.php' )
+								);
+							}
+							?>
+						</p>
+
+						<p class="no-php" hidden>
+							<?php
+							esc_html_e( 'There is a new version of this theme available, but it does not work with your version of PHP.' );
+							if ( current_user_can( 'update_php' ) ) {
+								printf(
+									/* translators: %s: URL to Update PHP page. */
+									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+									esc_url( wp_get_update_php_url() )
+								);
+								wp_update_php_annotation( '</p><p><em>', '</em>' );
+							}
+							?>
+						</p>
+					</div>
+
+					<div class="theme-autoupdate" style="margin-top:1em;" hidden>
+						<span class="forced" hidden><?php esc_html_e( 'Auto-updates enabled' ); ?></span>
+						<span class="not-forced" hidden><?php esc_html_e( 'Auto-updates disabled' ); ?></span>
+
+						<?php
+						if ( current_user_can( 'edit_theme_options' ) ) {
+							?>
+
+							<button type="button" class="toggle-auto-update button-link enabled" data-slug="" data-wp-action="disable" hidden>
+								<span class="dashicons dashicons-update spin hidden" aria-hidden="true"></span><span class="label"><?php esc_html_e( 'Disable auto-updates' ); ?></span>
+							</button>
+							<button type="button" class="toggle-auto-update button-link no-auto" data-slug="" data-wp-action="enable" hidden>
+								<span class="dashicons dashicons-update spin hidden" aria-hidden="true"></span><span class="label"><?php esc_html_e( 'Enable auto-updates' ); ?></span>
+							</button>
+
+							<?php
+						}
+						?>
+
+						<span class="auto-update-time" hidden>
+							<br><?php wp_get_auto_update_message(); ?>
+						</span>
+
+						<?php
+						wp_get_admin_notice(
+							'',
+							array(
+								'type'               => 'error',
+								'additional_classes' => array( 'notice-alt', 'inline', 'hidden' ),
+							)
+						);
+						?>
+
+					</div>
+
+					<p class="theme-description"></p>
+
+					<p class="parent-theme" hidden><span><?php esc_html_e( 'This is a child theme of:' ); ?></span> <strong></strong></p>
+
+					<p class="theme-tags" hidden>
+						<span><?php esc_html_e( 'Tags:' ); ?></span>
+						<span class="theme-tags-span" style="font-weight:normal;"></span>
+					</p>
 				</div>
 			</div>
 
 			<div class="theme-actions">
-				<# if ( data.active ) { #>
-					<button type="button" class="button button-primary customize-theme"><?php _e( 'Customize' ); ?></button>
-				<# } else if ( 'installed' === data.type ) { #>
-					<?php if ( current_user_can( 'delete_themes' ) ) { ?>
-						<# if ( data.actions && data.actions['delete'] ) { #>
-							<a href="{{{ data.actions['delete'] }}}" data-slug="{{ data.id }}" class="button button-secondary delete-theme"><?php _e( 'Delete' ); ?></a>
-						<# } #>
-					<?php } ?>
+				<div class="active-theme" hidden>
 
-					<# if ( data.blockTheme ) { #>
-						<?php
-							/* translators: %s: Theme name. */
-							$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
+					<?php
+					if ( current_user_can( 'edit_theme_options' ) ) {
+						if ( current_user_can( 'customize' ) ) {
+							?>
+
+							<a href="" class="button button-primary customize load-customize hide-if-no-customize">
+								<?php esc_html_e( 'Customize' ); ?>
+							</a>
+
+							<?php
+						}
+					}
+					?>
+
+				</div>
+				<div class="inactive-theme" hidden>
+					<a href="" class="button" aria-label="">
+						<?php esc_html_e( 'Activate' ); ?>
+					</a>
+
+					<?php
+					if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
 						?>
-						<# if ( data.compatibleWP && data.compatiblePHP && data.actions.activate && data.compatibleCP !== false ) { #>
-							<a href="{{{ data.actions.activate }}}" class="button button-primary activate" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
-						<# } #>
-					<# } else { #>
-						<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
-							<button type="button" class="button button-primary preview-theme" data-slug="{{ data.id }}"><?php _e( 'Live Preview' ); ?></button>
-						<# } else { #>
-							<button class="button button-primary disabled"><?php _e( 'Live Preview' ); ?></button>
-						<# } #>
-					<# } #>
-				<# } else { #>
-					<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
-						<button type="button" class="button theme-install" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></button>
-						<button type="button" class="button button-primary theme-install preview" data-slug="{{ data.id }}"><?php _e( 'Install &amp; Preview' ); ?></button>
-					<# } else { #>
-						<button type="button" class="button disabled"><?php _ex( 'Cannot Install', 'theme' ); ?></button>
-						<button type="button" class="button button-primary disabled"><?php _e( 'Install &amp; Preview' ); ?></button>
-					<# } #>
-				<# } #>
+
+						<a href="" class="button button-primary load-customize hide-if-no-customize">
+							<?php esc_html_e( 'Live Preview' ); ?>
+						</a>
+
+						<?php
+					}
+					?>
+
+				</div>
+
+				<?php
+				if ( current_user_can( 'delete_themes' ) ) {
+					?>
+
+					<a href="" class="button delete-theme" aria-label="" hidden>
+						<?php esc_html_e( 'Delete' ); ?>
+					</a>
+
+					<?php
+				}
+				?>
+
 			</div>
 		</div>
-	</script>
+	</template>
+
 	<?php
+	echo ob_get_clean();
 }
 
 /**

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -112,6 +112,7 @@ function delete_theme( $stylesheet, $redirect = '' ) {
 		foreach ( $translations as $translation => $data ) {
 			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.po' );
 			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.mo' );
+			$wp_filesystem->delete( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '.l10n.php' );
 
 			$json_translation_files = glob( WP_LANG_DIR . '/themes/' . $stylesheet . '-' . $translation . '-*.json' );
 			if ( $json_translation_files ) {
@@ -724,7 +725,6 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			'updateResponse' => array(
 				'compatibleWP'  => is_wp_version_compatible( $update_requires_wp ),
 				'compatiblePHP' => is_php_version_compatible( $update_requires_php ),
-				'compatibleCP'  => ! array_key_exists( 'full-site-editing', $theme->tags ),
 			),
 			'parent'         => $parent,
 			'active'         => $slug === $current_theme,
@@ -773,295 +773,291 @@ function wp_prepare_themes_for_js( $themes = null ) {
  */
 function customize_themes_print_templates() {
 	$cp_has_update = classicpress_has_update();
-	ob_start();
-	?>
-	<dialog id="theme-modal" class="theme-overlay" aria-label="<?php esc_html_e( 'Theme Details' ); ?>" data-highlighted-theme="">
-		<div class="theme-wrap wp-clearfix">
-			<div class="theme-header">
-				<button type="button" class="left dashicons dashicons-no">
-					<span class="screen-reader-text">
-						<?php
-						/* translators: Hidden accessibility text. */
-						esc_html_e( 'Show previous theme' );
-						?>
-					</span>
-				</button>
-				<button type="button" class="right dashicons dashicons-no">
-					<span class="screen-reader-text">
-						<?php
-						/* translators: Hidden accessibility text. */
-						esc_html_e( 'Show next theme' );
-						?>
-					</span>
-				</button>
-				<button type="button" class="close dashicons dashicons-no">
-					<span class="screen-reader-text">
-						<?php
-						/* translators: Hidden accessibility text. */
-						esc_html_e( 'Close details dialog' );
-						?>
-					</span>
-				</button>
-			</div>
-		</div>
-	</dialog>
 
-	<template id="theme-modal-insert">
-		<div id="theme-modal-insert-container">
+	?>
+	<script type="text/html" id="tmpl-customize-themes-details-view">
+		<div class="theme-backdrop"></div>
+		<div class="theme-wrap wp-clearfix" role="document">
+			<div class="theme-header">
+				<button type="button" class="left dashicons dashicons-no"><span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Show previous theme' );
+					?>
+				</span></button>
+				<button type="button" class="right dashicons dashicons-no"><span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Show next theme' );
+					?>
+				</span></button>
+				<button type="button" class="close dashicons dashicons-no"><span class="screen-reader-text">
+					<?php
+					/* translators: Hidden accessibility text. */
+					_e( 'Close details dialog' );
+					?>
+				</span></button>
+			</div>
 			<div class="theme-about wp-clearfix">
 				<div class="theme-screenshots">
-					<div class="screenshot"></div>
+				<# if ( data.screenshot && data.screenshot[0] ) { #>
+					<div class="screenshot"><img src="{{ data.screenshot[0] }}?ver={{ data.version }}" alt=""></div>
+				<# } else { #>
+					<div class="screenshot blank"></div>
+				<# } #>
 				</div>
 
 				<div class="theme-info">
-					<span class="current-label" hidden><?php esc_html_e( 'Active Theme' ); ?></span>
-					<h2>
-						<span class="theme-name"></span>
-						<span class="theme-version"></span>
-					</h2>
-					<p class="theme-author"></p>
+					<# if ( data.active ) { #>
+						<span class="current-label"><?php _e( 'Active Theme' ); ?></span>
+					<# } #>
+					<h2 class="theme-name">{{{ data.name }}}<span class="theme-version">
+						<?php
+						/* translators: %s: Theme version. */
+						printf( __( 'Version: %s' ), '{{ data.version }}' );
+						?>
+					</span></h2>
+					<h3 class="theme-author">
+						<?php
+						/* translators: %s: Theme author link. */
+						printf( __( 'By %s' ), '{{{ data.authorAndUri }}}' );
+						?>
+					</h3>
 
-					<div class="notice inline notice-error notice-alt notice-large no-wp-php" hidden>
-						<p>
+					<# if ( data.stars && 0 != data.num_ratings ) { #>
+						<div class="theme-rating">
+							{{{ data.stars }}}
+							<a class="num-ratings" target="_blank" href="{{ data.reviews_url }}">
+								<?php
+								printf(
+									'%1$s <span class="screen-reader-text">%2$s</span>',
+									/* translators: %s: Number of ratings. */
+									sprintf( __( '(%s ratings)' ), '{{ data.num_ratings }}' ),
+									/* translators: Hidden accessibility text. */
+									__( '(opens in a new tab)' )
+								);
+								?>
+							</a>
+						</div>
+					<# } #>
+
+					<# if ( data.hasUpdate ) { #>
+						<# if ( data.updateResponse.compatibleWP && data.updateResponse.compatiblePHP ) { #>
+							<div class="notice notice-warning notice-alt notice-large" data-slug="{{ data.id }}">
+								<h3 class="notice-title"><?php _e( 'Update Available' ); ?></h3>
+								{{{ data.update }}}
+							</div>
+						<# } else { #>
+							<div class="notice notice-error notice-alt notice-large" data-slug="{{ data.id }}">
+								<h3 class="notice-title"><?php _e( 'Update Incompatible' ); ?></h3>
+								<p>
+									<# if ( ! data.updateResponse.compatibleWP && ! data.updateResponse.compatiblePHP ) { #>
+										<?php
+										printf(
+											/* translators: %s: Theme name. */
+											__( 'There is a new version of %s available, but it does not work with your versions of ClassicPress and PHP.' ),
+											'{{{ data.name }}}'
+										);
+										if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+											if ( $cp_has_update ) {
+												printf(
+													/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+													' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+													self_admin_url( 'update-core.php' ),
+													esc_url( wp_get_update_php_url() )
+												);
+											} else {
+												printf(
+													/* translators: %s: URL to Update PHP page. */
+													' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+													esc_url( wp_get_update_php_url() )
+												);
+											}
+											wp_update_php_annotation( '</p><p><em>', '</em>' );
+										} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
+											printf(
+												/* translators: %s: URL to WordPress Updates screen. */
+												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+												self_admin_url( 'update-core.php' )
+											);
+										} elseif ( current_user_can( 'update_php' ) ) {
+											printf(
+												/* translators: %s: URL to Update PHP page. */
+												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+												esc_url( wp_get_update_php_url() )
+											);
+											wp_update_php_annotation( '</p><p><em>', '</em>' );
+										}
+										?>
+									<# } else if ( ! data.updateResponse.compatibleWP ) { #>
+										<?php
+										printf(
+											/* translators: %s: Theme name. */
+											__( 'There is a new version of %s available, but it does not work with your version of ClassicPress.' ),
+											'{{{ data.name }}}'
+										);
+										if ( current_user_can( 'update_core' ) && $cp_has_update ) {
+											printf(
+												/* translators: %s: URL to WordPress Updates screen. */
+												' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+												self_admin_url( 'update-core.php' )
+											);
+										}
+										?>
+									<# } else if ( ! data.updateResponse.compatiblePHP ) { #>
+										<?php
+										printf(
+											/* translators: %s: Theme name. */
+											__( 'There is a new version of %s available, but it does not work with your version of PHP.' ),
+											'{{{ data.name }}}'
+										);
+										if ( current_user_can( 'update_php' ) ) {
+											printf(
+												/* translators: %s: URL to Update PHP page. */
+												' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+												esc_url( wp_get_update_php_url() )
+											);
+											wp_update_php_annotation( '</p><p><em>', '</em>' );
+										}
+										?>
+									<# } #>
+								</p>
+							</div>
+						<# } #>
+					<# } #>
+
+					<# if ( data.parent ) { #>
+						<p class="parent-theme">
 							<?php
-							_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
-							if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-								if ( $cp_has_update ) {
+							printf(
+								/* translators: %s: Theme name. */
+								__( 'This is a child theme of %s.' ),
+								'<strong>{{{ data.parent }}}</strong>'
+							);
+							?>
+						</p>
+					<# } #>
+
+					<# if ( ! data.compatibleWP || ! data.compatiblePHP ) { #>
+						<div class="notice notice-error notice-alt notice-large"><p>
+							<# if ( ! data.compatibleWP && ! data.compatiblePHP ) { #>
+								<?php
+								_e( 'This theme does not work with your versions of ClassicPress and PHP.' );
+								if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
+									if ( $cp_has_update ) {
+										printf(
+											/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
+											' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
+											self_admin_url( 'update-core.php' ),
+											esc_url( wp_get_update_php_url() )
+										);
+									} else {
+										printf(
+											/* translators: %s: URL to Update PHP page. */
+											' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
+											esc_url( wp_get_update_php_url() )
+										);
+									}
+									wp_update_php_annotation( '</p><p><em>', '</em>' );
+								} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
 									printf(
-										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-										self_admin_url( 'update-core.php' ),
-										esc_url( wp_get_update_php_url() )
+										/* translators: %s: URL to WordPress Updates screen. */
+										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+										self_admin_url( 'update-core.php' )
 									);
-								} else {
+								} elseif ( current_user_can( 'update_php' ) ) {
 									printf(
 										/* translators: %s: URL to Update PHP page. */
 										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 										esc_url( wp_get_update_php_url() )
 									);
+									wp_update_php_annotation( '</p><p><em>', '</em>' );
 								}
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
-								printf(
-									/* translators: %s: URL to WordPress Updates screen. */
-									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-									self_admin_url( 'update-core.php' )
-								);
-							} elseif ( current_user_can( 'update_php' ) ) {
-								printf(
-									/* translators: %s: URL to Update PHP page. */
-									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-									esc_url( wp_get_update_php_url() )
-								);
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							}
-							?>
-						</p>
-					</div>
-
-					<div class="notice inline notice-error notice-alt notice-large no-wp" hidden>
-						<p>
-							<?php
-							_e( 'This theme does not work with your version of ClassicPress.' );
-							if ( current_user_can( 'update_core' ) && $cp_has_update ) {
-								printf(
-									/* translators: %s: URL to WordPress Updates screen. */
-									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-									self_admin_url( 'update-core.php' )
-								);
-							}
-							?>
-						</p>
-					</div>
-
-					<div class="notice inline notice-error notice-alt notice-large no-php" hidden>
-						<p>
-							<?php
-							_e( 'This theme does not work with your version of PHP.' );
-							if ( current_user_can( 'update_php' ) ) {
-								printf(
-									/* translators: %s: URL to Update PHP page. */
-									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-									esc_url( wp_get_update_php_url() )
-								);
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							}
-							?>
-						</p>
-					</div>
-
-					<div class="notice inline notice-warning notice-alt notice-large has-update" hidden>
-						<h3 class="notice-title"><?php esc_html_e( 'Update Available' ); ?></h3>
-						<span></span>
-					</div>
-
-					<div class="notice inline notice-error notice-alt notice-large incompat-update" hidden>
-						<h3 class="notice-title"><?php esc_html_e( 'Update Incompatible' ); ?></h3>
-						<p class="no-wp-php" hidden>
-							<?php
-							esc_html_e( 'There is a new version of this theme available, but it does not work with your versions of ClassicPress and PHP.' );
-							if ( current_user_can( 'update_core' ) && current_user_can( 'update_php' ) ) {
-								if ( $cp_has_update ) {
+								?>
+							<# } else if ( ! data.compatibleWP ) { #>
+								<?php
+								_e( 'This theme does not work with your version of ClassicPress.' );
+								if ( current_user_can( 'update_core' ) && $cp_has_update ) {
 									printf(
-										/* translators: 1: URL to WordPress Updates screen, 2: URL to Update PHP page. */
-										' ' . __( '<a href="%1$s">Please update ClassicPress</a>, and then <a href="%2$s">learn more about updating PHP</a>.' ),
-										self_admin_url( 'update-core.php' ),
-										esc_url( wp_get_update_php_url() )
+										/* translators: %s: URL to WordPress Updates screen. */
+										' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
+										self_admin_url( 'update-core.php' )
 									);
-								} else {
+								}
+								?>
+							<# } else if ( ! data.compatiblePHP ) { #>
+								<?php
+								_e( 'This theme does not work with your version of PHP.' );
+								if ( current_user_can( 'update_php' ) ) {
 									printf(
 										/* translators: %s: URL to Update PHP page. */
 										' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
 										esc_url( wp_get_update_php_url() )
 									);
+									wp_update_php_annotation( '</p><p><em>', '</em>' );
 								}
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							} elseif ( current_user_can( 'update_core' ) && $cp_has_update ) {
-								printf(
-									/* translators: %s: URL to WordPress Updates screen. */
-									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-									self_admin_url( 'update-core.php' )
-								);
-							} elseif ( current_user_can( 'update_php' ) ) {
-								printf(
-									/* translators: %s: URL to Update PHP page. */
-									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-									esc_url( wp_get_update_php_url() )
-								);
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							}
-							?>
-						</p>
-
-						<p class="no-wp" hidden>
-							<?php
-							esc_html_e( 'There is a new version of this theme available, but it does not work with your version of ClassicPress.' );
-							if ( current_user_can( 'update_core' ) && $cp_has_update ) {
-								printf(
-									/* translators: %s: URL to WordPress Updates screen. */
-									' ' . __( '<a href="%s">Please update ClassicPress</a>.' ),
-									self_admin_url( 'update-core.php' )
-								);
-							}
-							?>
-						</p>
-
-						<p class="no-php" hidden>
-							<?php
-							esc_html_e( 'There is a new version of this theme available, but it does not work with your version of PHP.' );
-							if ( current_user_can( 'update_php' ) ) {
-								printf(
-									/* translators: %s: URL to Update PHP page. */
-									' ' . __( '<a href="%s">Learn more about updating PHP</a>.' ),
-									esc_url( wp_get_update_php_url() )
-								);
-								wp_update_php_annotation( '</p><p><em>', '</em>' );
-							}
-							?>
-						</p>
-					</div>
-
-					<div class="theme-autoupdate" style="margin-top:1em;" hidden>
-						<span class="forced" hidden><?php esc_html_e( 'Auto-updates enabled' ); ?></span>
-						<span class="not-forced" hidden><?php esc_html_e( 'Auto-updates disabled' ); ?></span>
-
+								?>
+							<# } #>
+						</p></div>
+					<# } else if ( ! data.active && data.blockTheme ) { #>
+						<div class="notice notice-error notice-alt notice-large"><p>
 						<?php
-						if ( current_user_can( 'edit_theme_options' ) ) {
-							?>
-
-							<button type="button" class="toggle-auto-update button-link enabled" data-slug="" data-wp-action="disable" hidden>
-								<span class="dashicons dashicons-update spin hidden" aria-hidden="true"></span><span class="label"><?php esc_html_e( 'Disable auto-updates' ); ?></span>
-							</button>
-							<button type="button" class="toggle-auto-update button-link no-auto" data-slug="" data-wp-action="enable" hidden>
-								<span class="dashicons dashicons-update spin hidden" aria-hidden="true"></span><span class="label"><?php esc_html_e( 'Enable auto-updates' ); ?></span>
-							</button>
-
+							_e( 'This theme doesn\'t support Customizer.' );
+						?>
+						<# if ( data.actions.activate ) { #>
 							<?php
-						}
-						?>
+							printf(
+								/* translators: %s: URL to the themes page (also it activates the theme). */
+								' ' . __( 'However, you can still <a href="%s">activate this theme</a>, and use the Site Editor to customize it.' ),
+								'{{{ data.actions.activate }}}'
+							);
+							?>
+						<# } #>
+						</p></div>
+					<# } #>
 
-						<span class="auto-update-time" hidden>
-							<br><?php wp_get_auto_update_message(); ?>
-						</span>
-
-						<?php
-						wp_get_admin_notice(
-							'',
-							array(
-								'type'               => 'error',
-								'additional_classes' => array( 'notice-alt', 'inline', 'hidden' ),
-							)
-						);
-						?>
-
-					</div>
-
-					<p class="theme-description"></p>
-
-					<p class="parent-theme" hidden><span><?php esc_html_e( 'This is a child theme of:' ); ?></span> <strong></strong></p>
-
-					<p class="theme-tags" hidden>
-						<span><?php esc_html_e( 'Tags:' ); ?></span>
-						<span class="theme-tags-span" style="font-weight:normal;"></span>
-					</p>
+					<p class="theme-description">{{{ data.description }}}</p>
 				</div>
 			</div>
 
 			<div class="theme-actions">
-				<div class="active-theme" hidden>
+				<# if ( data.active ) { #>
+					<button type="button" class="button button-primary customize-theme"><?php _e( 'Customize' ); ?></button>
+				<# } else if ( 'installed' === data.type ) { #>
+					<?php if ( current_user_can( 'delete_themes' ) ) { ?>
+						<# if ( data.actions && data.actions['delete'] ) { #>
+							<a href="{{{ data.actions['delete'] }}}" data-slug="{{ data.id }}" class="button button-secondary delete-theme"><?php _e( 'Delete' ); ?></a>
+						<# } #>
+					<?php } ?>
 
-					<?php
-					if ( current_user_can( 'edit_theme_options' ) ) {
-						if ( current_user_can( 'customize' ) ) {
-							?>
-
-							<a href="" class="button button-primary customize load-customize hide-if-no-customize">
-								<?php esc_html_e( 'Customize' ); ?>
-							</a>
-
-							<?php
-						}
-					}
-					?>
-
-				</div>
-				<div class="inactive-theme" hidden>
-					<a href="" class="button" aria-label="">
-						<?php esc_html_e( 'Activate' ); ?>
-					</a>
-
-					<?php
-					if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
-						?>
-
-						<a href="" class="button button-primary load-customize hide-if-no-customize">
-							<?php esc_html_e( 'Live Preview' ); ?>
-						</a>
-
+					<# if ( data.blockTheme ) { #>
 						<?php
-					}
-					?>
-
-				</div>
-
-				<?php
-				if ( current_user_can( 'delete_themes' ) ) {
-					?>
-
-					<a href="" class="button delete-theme" aria-label="" hidden>
-						<?php esc_html_e( 'Delete' ); ?>
-					</a>
-
-					<?php
-				}
-				?>
-
+							/* translators: %s: Theme name. */
+							$aria_label = sprintf( _x( 'Activate %s', 'theme' ), '{{ data.name }}' );
+						?>
+						<# if ( data.compatibleWP && data.compatiblePHP && data.actions.activate && data.compatibleCP !== false ) { #>
+							<a href="{{{ data.actions.activate }}}" class="button button-primary activate" aria-label="<?php echo esc_attr( $aria_label ); ?>"><?php _e( 'Activate' ); ?></a>
+						<# } #>
+					<# } else { #>
+						<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
+							<button type="button" class="button button-primary preview-theme" data-slug="{{ data.id }}"><?php _e( 'Live Preview' ); ?></button>
+						<# } else { #>
+							<button class="button button-primary disabled"><?php _e( 'Live Preview' ); ?></button>
+						<# } #>
+					<# } #>
+				<# } else { #>
+					<# if ( data.compatibleWP && data.compatiblePHP && data.compatibleCP !== false ) { #>
+						<button type="button" class="button theme-install" data-slug="{{ data.id }}"><?php _e( 'Install' ); ?></button>
+						<button type="button" class="button button-primary theme-install preview" data-slug="{{ data.id }}"><?php _e( 'Install &amp; Preview' ); ?></button>
+					<# } else { #>
+						<button type="button" class="button disabled"><?php _ex( 'Cannot Install', 'theme' ); ?></button>
+						<button type="button" class="button button-primary disabled"><?php _e( 'Install &amp; Preview' ); ?></button>
+					<# } #>
+				<# } #>
 			</div>
 		</div>
-	</template>
-
+	</script>
 	<?php
-	echo ob_get_clean();
 }
 
 /**

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	// Close modal and set focus on theme
 	function closeModal() {
 		dialog.close();
-		document.getElementById( dialog.dataset.highlightedTheme )?.focus();
+		document.getElementById( dialog.dataset.highlightedTheme ).focus();
 		dialog.querySelector( '.left.dashicons.dashicons-no' ).disabled = false;
 		dialog.querySelector( '.right.dashicons.dashicons-no' ).disabled = false;
 		cleanup();
@@ -74,7 +74,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Reset the dialog element to its default state
 	function cleanup() {
-		dialog.querySelector( '#theme-modal-insert-container' )?.remove();
+		dialog.querySelector( '#theme-modal-insert-container' ).remove();
 		dialog.dataset.highlightedTheme = '';
 
 		// Reset URL params
@@ -176,7 +176,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function() {
-			var theme = document.getElementById( slug ) || document.getElementById( 'customize-control-installed_theme_' + slug ),
+			var theme = document.getElementById( slug ),
 				notice = theme.querySelector( '.update-message' );
 
 			notice.innerHTML = '<p>' + _wpThemeSettings.l10n.updated + '</p>';
@@ -312,7 +312,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	// Open the modal or perform other operations
 	document.addEventListener( 'click', function( e ) {
 		var img, template, clone, response, span, topModal,
-			customizer = document.body.className.includes( 'wp-customizer' ) ? true : false,
 			theme = e.target.closest( '.theme' ),
 			allThemes = document.querySelectorAll( '.themes li:not( .add-new-theme )' ),
 			firstElement = document.querySelector( '.themes li' ),
@@ -328,17 +327,17 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				dialog.querySelector( '.theme-wrap' ).append( clone );
 
 				// Set URL
-				queryParams.set( 'theme', customizer ? theme.dataset.id : theme.id );
+				queryParams.set( 'theme', theme.id );
 				history.replaceState( null, null, '?' + queryParams.toString() );
 
 				// Set theme ID and previous and next themes
-				dialog.dataset.highlightedTheme = customizer ? theme.dataset.id : theme.id;
-				prevElement = document.getElementById( theme.id ).previousElementSibling;
+				dialog.dataset.highlightedTheme = theme.id;
+				prevElement = document.getElementById( dialog.dataset.highlightedTheme ).previousElementSibling;
 				if ( prevElement == null ) { // first theme
 					dialog.querySelector( '.left.dashicons.dashicons-no' ).disabled = true;
 				}
 
-				nextElement = document.getElementById( theme.id ).nextElementSibling;
+				nextElement = document.getElementById( dialog.dataset.highlightedTheme ).nextElementSibling;
 				if ( nextElement == null ) { // last theme
 					dialog.querySelector( '.right.dashicons.dashicons-no' ).disabled = true;
 				}
@@ -501,12 +500,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 
 		// Update a theme
-		} else if ( e.target.className.includes( 'update-button-link' ) ) { // themes.php
+		} else if ( e.target.className.includes( 'update-button-link' ) ) {
 			e.target.closest( '.update-message' ).classList.add( 'updating-message' );
 			updateIndividualTheme( e.target.closest( 'li' ).id );
-		} else if ( e.target.className.includes( 'update-theme' ) ) { // Customizer
-			e.target.closest( '.update-message' ).classList.add( 'updating-message' );
-			updateIndividualTheme( e.target.closest( 'li' ).dataset.id );
 
 		// Get further details about a theme when it has an update
 		} else if ( e.target.className.includes( 'open-plugin-details-modal' ) ) {

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -66,7 +66,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	// Close modal and set focus on theme
 	function closeModal() {
 		dialog.close();
-		document.getElementById( dialog.dataset.highlightedTheme ).focus();
+		document.getElementById( dialog.dataset.highlightedTheme )?.focus();
 		dialog.querySelector( '.left.dashicons.dashicons-no' ).disabled = false;
 		dialog.querySelector( '.right.dashicons.dashicons-no' ).disabled = false;
 		cleanup();
@@ -74,7 +74,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Reset the dialog element to its default state
 	function cleanup() {
-		dialog.querySelector( '#theme-modal-insert-container' ).remove();
+		dialog.querySelector( '#theme-modal-insert-container' )?.remove();
 		dialog.dataset.highlightedTheme = '';
 
 		// Reset URL params
@@ -176,7 +176,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function() {
-			var theme = document.getElementById( slug ),
+			var theme = document.getElementById( slug ) || document.getElementById( 'customize-control-installed_theme_' + slug ),
 				notice = theme.querySelector( '.update-message' );
 
 			notice.innerHTML = '<p>' + _wpThemeSettings.l10n.updated + '</p>';
@@ -281,8 +281,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Navigate the modals by using the keyboard
 	document.addEventListener( 'keydown', function( e ) {
+		const topModal = document.getElementById( 'theme-update-modal' );
 		if ( dialog && dialog.open ) {
 			if ( e.key === 'Escape' ) {
+				topModal?.close();
+				topModal?.remove();
 				closeModal();
 			} else if ( e.key === 'ArrowLeft' || e.key === 'ArrowUp' ) {
 				e.preventDefault();
@@ -293,6 +296,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 		} else if ( previewDialog && previewDialog.open ) {
 			if ( e.key === 'Escape' ) {
+				topModal?.close();
+				topModal?.remove();
 				closePreviewDialog();
 			} else if ( e.key === 'ArrowLeft' || e.key === 'ArrowUp' ) {
 				e.preventDefault();
@@ -306,7 +311,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Open the modal or perform other operations
 	document.addEventListener( 'click', function( e ) {
-		var img, template, clone, response, span,
+		var img, template, clone, response, span, topModal,
+			customizer = document.body.className.includes( 'wp-customizer' ) ? true : false,
 			theme = e.target.closest( '.theme' ),
 			allThemes = document.querySelectorAll( '.themes li:not( .add-new-theme )' ),
 			firstElement = document.querySelector( '.themes li' ),
@@ -322,17 +328,17 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				dialog.querySelector( '.theme-wrap' ).append( clone );
 
 				// Set URL
-				queryParams.set( 'theme', theme.id );
+				queryParams.set( 'theme', customizer ? theme.dataset.id : theme.id );
 				history.replaceState( null, null, '?' + queryParams.toString() );
 
 				// Set theme ID and previous and next themes
-				dialog.dataset.highlightedTheme = theme.id;
-				prevElement = document.getElementById( dialog.dataset.highlightedTheme ).previousElementSibling;
+				dialog.dataset.highlightedTheme = customizer ? theme.dataset.id : theme.id;
+				prevElement = document.getElementById( theme.id ).previousElementSibling;
 				if ( prevElement == null ) { // first theme
 					dialog.querySelector( '.left.dashicons.dashicons-no' ).disabled = true;
 				}
 
-				nextElement = document.getElementById( dialog.dataset.highlightedTheme ).nextElementSibling;
+				nextElement = document.getElementById( theme.id ).nextElementSibling;
 				if ( nextElement == null ) { // last theme
 					dialog.querySelector( '.right.dashicons.dashicons-no' ).disabled = true;
 				}
@@ -494,14 +500,42 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				e.target.disabled = true;
 			}
 
-		// Close modal
-		} else if ( e.target.className === 'close dashicons dashicons-no' ) {
-			closeModal();
-
 		// Update a theme
-		} else if ( e.target.className.includes( 'update-button-link' ) ) {
+		} else if ( e.target.className.includes( 'update-button-link' ) ) { // themes.php
 			e.target.closest( '.update-message' ).classList.add( 'updating-message' );
 			updateIndividualTheme( e.target.closest( 'li' ).id );
+		} else if ( e.target.className.includes( 'update-theme' ) ) { // Customizer
+			e.target.closest( '.update-message' ).classList.add( 'updating-message' );
+			updateIndividualTheme( e.target.closest( 'li' ).dataset.id );
+
+		// Get further details about a theme when it has an update
+		} else if ( e.target.className.includes( 'open-plugin-details-modal' ) ) {
+			e.preventDefault();
+			topModal = document.createElement( 'dialog' );
+			topModal.id = 'theme-update-modal';
+			topModal.className = 'theme-overlay';
+			topModal.setAttribute( 'aria-label', e.target.getAttribute( 'aria-label' ) );
+			topModal.innerHTML = '<div class="theme-overlay">' +
+				'<div class="wp-clearfix">' +
+					'<div class="theme-header">' +
+						'<button id="theme-update-modal-close" class="close dashicons dashicons-no" autofocus>' +
+							'<span class="screen-reader-text">' + dialog.querySelector( '.close .screen-reader-text' ).textContent + '</span>' +
+						'</button>' +
+					'</div>' +
+					'<iframe src="' + e.target.href + '">' +
+					'</iframe>' +
+				'</div>';
+			document.body.append( topModal );
+			topModal.showModal();
+
+		// Close update modal
+		} else if ( e.target.id === 'theme-update-modal-close' ) {
+			document.getElementById( 'theme-update-modal' ).close();
+			document.getElementById( 'theme-update-modal' ).remove();
+
+		// Close other modal
+		} else if ( e.target.className === 'close dashicons dashicons-no' ) {
+			closeModal();
 
 		// Search for popular or latest themes at wordpress.org
 		} else if ( document.body.className.includes( 'theme-install-php' ) ) {


### PR DESCRIPTION
This PR fixes Issue #2383 by reinstating previous functionality so that, when clicking on the link for more details about a theme update, it opens a modal (above the current modal) that holds an iframe of the appropriate information. I have also cleaned up the hyperlink to remove the now-redundant `query_arg`.