### PR TITLE
Fix workflow input key name for first-interaction

### DIFF
--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
-            Hi @{{ github.actor }}! 👋
+            Hi @${{ github.actor }}! 👋
 
             Thank you for opening an issue at ClassicPress! 💖
 
@@ -36,7 +36,7 @@ jobs:
             Thank you,
             ClassicPress Core Team.
           pr_message: |
-            Hi @{{ github.actor }}! 👋
+            Hi @${{ github.actor }}! 👋
 
             Thank you for your contribution to ClassicPress! 💖
 

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
             Hi @{{ author }}! 👋
 

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
-            Hi @{{ author }}! 👋
+            Hi @{{ github.actor }}! 👋
 
             Thank you for opening an issue at ClassicPress! 💖
 
@@ -36,7 +36,7 @@ jobs:
             Thank you,
             ClassicPress Core Team.
           pr_message: |
-            Hi @{{ author }}! 👋
+            Hi @{{ github.actor }}! 👋
 
             Thank you for your contribution to ClassicPress! 💖
 


### PR DESCRIPTION
## Description
There is a parameter typo in the new GitHub welcome action. `repo-token` is in use when it should be `repo_token`, so an underscore rather then a hyphen.

## Motivation and context
Action is working as this parameter seems to be optional, but it's worth fixing to resolve a warning message.

## How has this been tested?
Will be able to check after merge.

## Screenshots
### Before
<img width="1826" height="304" alt="Screenshot 2026-04-09 at 15-14-37 Undeprecate deprecated warning for HTML5 · ClassicPress_ClassicPress@95c9d84" src="https://github.com/user-attachments/assets/3c5e42f4-c560-432d-8931-0935d1bf6f74" />

### After
N/A

## Types of changes
- Bug fix