### PR TITLE
Clean legacy entries from Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -588,9 +588,7 @@ module.exports = function(grunt) {
 				cwd: `${SOURCE_DIR}wp-content/themes`,
 				src: [
 					'twenty*/**/*.js',
-					'!twenty{eleven,twelve,thirteen}/**',
 					// Third party scripts
-					'!twenty{fourteen,fifteen,sixteen}/js/html5.js',
 					'!twentyseventeen/assets/js/html5.js',
 					'!twentyseventeen/assets/js/jquery.scrollTo.js'
 				]
@@ -625,7 +623,6 @@ module.exports = function(grunt) {
 					'!wp-admin/js/iris.js',
 					'!wp-includes/js/backbone*.js',
 					'!wp-includes/js/clipboard.js',
-					'!wp-includes/js/swfobject.js',
 					'!wp-includes/js/underscore*.js',
 					'!wp-includes/js/colorpicker.js',
 					'!wp-includes/js/hoverIntent.js',
@@ -739,7 +736,6 @@ module.exports = function(grunt) {
 					'!src/wp-admin/js/iris.js',
 					'!src/wp-includes/js/backbone*.js',
 					'!src/wp-includes/js/clipboard.js',
-					'!src/wp-includes/js/swfobject.js',
 					'!src/wp-includes/js/underscore*.js',
 					'!src/wp-includes/js/colorpicker.js',
 					'!src/wp-includes/js/hoverIntent.js',
@@ -852,7 +848,6 @@ module.exports = function(grunt) {
 					'!wp-admin/js/iris.min.js',
 					'!wp-includes/js/backbone.*',
 					'!wp-includes/js/masonry.min.js',
-					'!wp-includes/js/swfobject.js',
 					'!wp-includes/js/underscore.*',
 					'!wp-includes/js/zxcvbn.min.js',
 					'!wp-includes/js/wp-embed.js' // We have extra options for this, see terser:embed

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -589,7 +589,6 @@ module.exports = function(grunt) {
 				src: [
 					'twenty*/**/*.js',
 					// Third party scripts
-					'!twentyseventeen/assets/js/html5.js',
 					'!twentyseventeen/assets/js/jquery.scrollTo.js'
 				]
 			},


### PR DESCRIPTION
## Description
This PR cleans up `Gruntfile.js` to remove some unnecessary entries, for example relating to legacy themes not part of ClassicPress and Flash files that have been removed from core.

## Motivation and context
Keep Gruntfile cleaner.

## How has this been tested?
Local runs of `grunt jshint:grunt` and `grunt eslint:grunt` are still passing.

## Screenshots
N/A

## Types of changes
- Enhancement