### PR TITLE
Skip recommended installs for apt install commands

### DIFF
--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -66,8 +66,7 @@ jobs:
       - name: Update apt and install libheif-plugin-aomenc
         run: |
             sudo apt-get update
-            sudo apt-get install -y libheif-plugin-aomenc
-            sudo apt-get install -y ghostscript
+            sudo apt-get install -y --no-install-recommends ghostscript libheif-plugin-aomenc
 
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description
In the PHPUnit testing workflow, the step to install `ghostscript` and `libheif-plugin-aomenc` is currently highly variable, is can run and complate in around 20 seconds but is sometimes taking much, much longer.

This PR aims to reduce the excessive run time on the step but combining the installed pacakges into a single commaned and skipping any recommended packacges that a combined in the request.

## Motivation and context
mprove testing speed on some slow tests, if this doesn't help maybe a composite action can be tried too:
https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action#creating-an-action-metadata-file

## How has this been tested?
This PR will test the new changes.

## Screenshots
### Before
<img width="1750" height="82" alt="Screenshot 2026-04-10 at 21 27 36" src="https://github.com/user-attachments/assets/935b2819-8bff-4452-bd72-a7b9175da6da" />

### After
<img width="1768" height="80" alt="Screenshot 2026-04-10 at 21 45 43" src="https://github.com/user-attachments/assets/e34b81d8-2754-4dd3-bc3b-5b5ee449165a" />

## Types of changes
- Enhancement