### PR TITLE
Fix nav menu Sortable drag for nested items

### DIFF
--- a/src/wp-admin/js/nav-menu.js
+++ b/src/wp-admin/js/nav-menu.js
@@ -20,6 +20,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	 * Set variables for the whole file
 	 */
 	var column, originalDepth, originalClientX, originalLabel, newClientX, baseClientX, lastInput, lastSelect,
+		lastPointerClient = { x: 0, y: 0 },
+		indentDuringDrag = null,
 		postboxTogs = document.querySelectorAll( '.hide-postbox-tog' ),
 		advancedMenuProperties = document.querySelectorAll( '#adv-settings .hide-column-tog' ),
 		indent = 30,
@@ -215,6 +217,34 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		menuEdge += isRTL ? editMenu.innerWidth : 0;
 
 		/*
+		 * Sortable sometimes omits originalEvent on choose; keep coordinates from the handle press.
+		 */
+		editMenu.addEventListener( 'pointerdown', function( ev ) {
+			if ( ! ev.target.closest( '.item-move' ) ) {
+				return;
+			}
+			if ( typeof ev.clientX === 'number' ) {
+				lastPointerClient.x = ev.clientX;
+				lastPointerClient.y = ev.clientY;
+			}
+		}, true );
+		editMenu.addEventListener( 'mousedown', function( ev ) {
+			if ( ev.target.closest( '.item-move' ) ) {
+				lastPointerClient.x = ev.clientX;
+				lastPointerClient.y = ev.clientY;
+			}
+		}, true );
+		editMenu.addEventListener( 'touchstart', function( ev ) {
+			var t;
+			if ( ! ev.target.closest( '.item-move' ) || ! ev.touches || ! ev.touches[0] ) {
+				return;
+			}
+			t = ev.touches[0];
+			lastPointerClient.x = t.clientX;
+			lastPointerClient.y = t.clientY;
+		}, { capture: true, passive: true } );
+
+		/*
 		* Attach SortableJS to current menu
 		*/
 		Sortable.create( editMenu, {
@@ -223,15 +253,26 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			// Get position of menu item when chosen
 			onChoose: function( e ) {
-				originalClientX = e.originalEvent.clientX;
+				var oe = e.originalEvent, clientX;
+
+				if ( oe && typeof oe.clientX === 'number' ) {
+					clientX = oe.clientX;
+				} else {
+					clientX = lastPointerClient.x;
+				}
+
+				originalClientX = clientX;
+				newClientX = clientX;
 				originalDepth = menuItemDepth( e.item );
-				baseClientX = e.originalEvent.clientX - ( originalDepth * indent );
+				baseClientX = clientX - ( originalDepth * indent );
 
 				// Update aria-label for accessibility
 				refreshAdvancedAccessibilityOfItem( e.item, originalDepth, e.oldIndex );
 
 				// Ensure menu widget is closed before moving
-				e.item.querySelector( 'details' ).removeAttribute( 'open' );
+				if ( e.item.querySelector( 'details' ) ) {
+					e.item.querySelector( 'details' ).removeAttribute( 'open' );
+				}
 			},
 
 			// Style placeholder when element starts to be dragged
@@ -249,42 +290,58 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				originalLabel = e.item.querySelector( '.item-move' ).getAttribute( 'aria-label' ).split( '.' ).join( '' ).replace( 'Menu', 'menu' ).replace( 'Sub', menus.child );
 
 				// Style placeholder
-				details.style.backgroundColor = '#fefefe';
-				details.style.border = '1px dotted #444';
-				details.querySelector( 'summary' ).style.visibility = 'hidden';
-
-				// Continually update horizontal position of current item while dragging
-				editMenu.addEventListener( 'dragover', function( evt ) {
-					var xPos, diff;
-
-					if ( evt.target.closest( 'li' ) === e.item ) {
-						newClientX = evt.clientX;
-
-						// Continually update horizontal position of placeholder
-						xPos = evt.clientX - baseClientX;
-
-						// Get depth of previous item in list
-						prevItem = evt.target.closest( 'li' ).previousElementSibling;
-						if ( prevItem ) {
-							prevDepth = menuItemDepth( prevItem );
-						}
-
-						// Calculate left margin but prevent being indented more than once compared to previous item in list
-						if ( prevItem == null || xPos < 0 ) {
-							menuEdge = 0;
-						} else {
-							diff = Math.floor( xPos / indent );
-							if ( diff > maxDepth ) {
-								diff = maxDepth;
-							}
-							if ( diff > prevDepth + 1 ) {
-								diff = prevDepth + 1;
-							}
-							menuEdge = diff * indent;
-						}
-						document.querySelector( '.sortable-ghost' ).style.marginLeft = menuEdge + 'px';
+				if ( details ) {
+					details.style.backgroundColor = '#fefefe';
+					details.style.border = '1px dotted #444';
+					if ( details.querySelector( 'summary' ) ) {
+						details.querySelector( 'summary' ).style.visibility = 'hidden';
 					}
-				} );
+				}
+
+				/*
+				 * Pointer-driven Sortable often does not emit dragover the way native drag does, and
+				 * hit-testing the dragged row only misses the ghost. Drive indent from pointer position
+				 * and the ghost row's place in the list.
+				 */
+				indentDuringDrag = function( evt ) {
+					var c = evt.touches && evt.touches[0] ? evt.touches[0] : evt,
+						ghost, xPos, diff;
+
+					if ( ! c || typeof c.clientX !== 'number' ) {
+						return;
+					}
+
+					ghost = document.querySelector( '.sortable-ghost' );
+					if ( ! ghost ) {
+						return;
+					}
+
+					newClientX = c.clientX;
+					xPos = c.clientX - baseClientX;
+					prevItem = ghost.previousElementSibling;
+					prevDepth = 0;
+					if ( prevItem ) {
+						prevDepth = menuItemDepth( prevItem );
+					}
+
+					if ( prevItem == null || xPos < 0 ) {
+						menuEdge = 0;
+					} else {
+						diff = Math.floor( xPos / indent );
+						if ( diff > maxDepth ) {
+							diff = maxDepth;
+						}
+						if ( diff > prevDepth + 1 ) {
+							diff = prevDepth + 1;
+						}
+						menuEdge = diff * indent;
+					}
+					ghost.style.marginLeft = menuEdge + 'px';
+				};
+
+				document.addEventListener( 'pointermove', indentDuringDrag, true );
+				document.addEventListener( 'mousemove', indentDuringDrag, true );
+				document.addEventListener( 'dragover', indentDuringDrag, true );
 
 				// Does this menu item have children?
 				children = childMenuItems( e.item );
@@ -298,17 +355,37 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			onEnd: function( e ) {
 				var i, n, diff, prevItem, parent, parentDepth, newLabel,
 					newLabels, positionSpeech,
-					details = e.item.querySelector( 'details' ),
+					details,
 					depth = 0,
 					prevDepth = 0,
-					draggedClasses = e.item.className.split( ' ' );
+					draggedClasses;
+
+				if ( indentDuringDrag ) {
+					document.removeEventListener( 'pointermove', indentDuringDrag, true );
+					document.removeEventListener( 'mousemove', indentDuringDrag, true );
+					document.removeEventListener( 'dragover', indentDuringDrag, true );
+					indentDuringDrag = null;
+				}
+
+				if ( ! e || ! e.item ) {
+					return;
+				}
+
+				details = e.item.querySelector( 'details' );
+				draggedClasses = e.item.className.split( ' ' );
 
 				// Revert styling and set focus on move icon
 				e.item.style.marginLeft = '';
-				details.style.backgroundColor = '#f6f7f7';
-				details.style.border = '1px solid #dcdcde';
-				details.querySelector( 'summary' ).style.visibility = 'visible';
-				details.querySelector( '.dashicons-move' ).focus();
+				if ( details ) {
+					details.style.backgroundColor = '#f6f7f7';
+					details.style.border = '1px solid #dcdcde';
+					if ( details.querySelector( 'summary' ) ) {
+						details.querySelector( 'summary' ).style.visibility = 'visible';
+					}
+					if ( details.querySelector( '.dashicons-move' ) ) {
+						details.querySelector( '.dashicons-move' ).focus();
+					}
+				}
 
 				// Handle drop placement for RTL orientation
 				if ( isRTL ) {


### PR DESCRIPTION
Trying to drag a menu item to create a sub-item (child menu item), errors appear in console -

<img width="1228" height="655" alt="image" src="https://github.com/user-attachments/assets/20da5121-a1af-486f-8361-3b109f06b402" />

Sortable `onChoose` can omit `originalEvent`, which caused `clientX` errors and broken `onEnd`. Cache pointer coordinates from the move handle (`pointerdown`, `mousedown`, `touchstart`).

Horizontal nesting relied on dragover only when the event target was the dragged row; with Sortable's ghost and pointer dragging that rarely matched. Update indent using `pointermove`, `mousemove`, and `dragover` on document, keyed off the sortable-ghost row and its previous sibling.

Also remove document listeners when the drag ends, guard `onEnd` when item is missing, and null-check details styling.

## How has this been tested?

I tested it on a clean `2.7.0` with PHP 8.5 and on `2.7.0+nightly.20260412`

## Screenshots

### Before

Errors:

<img width="1228" height="655" alt="image" src="https://github.com/user-attachments/assets/c38a9532-a0d5-459d-9fe8-a6f2d5a6808f" />

### After

No errors:

<img width="1215" height="665" alt="image" src="https://github.com/user-attachments/assets/8ab015c7-5805-4499-bec6-43d7138a339a" />

## Types of changes

- Bug fix
