### PR TITLE
Implement action to cache apt install step

### DIFF
--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     #
     # Performs the following steps:
     # - Set environment variables.
-    # - Update apt and install libheif-plugin-aomenc and ghostscript.
+    # - Install libheif-plugin-aomenc and ghostscript.
     # - Checkout ClassicPress.
     # - Read .nvmrc.
     # - Installs NodeJS.
@@ -63,10 +63,11 @@ jobs:
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
-      - name: Update apt and install libheif-plugin-aomenc
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y --no-install-recommends ghostscript libheif-plugin-aomenc
+      - name: Install apt packages
+        uses: immoseb/cache-apt-pkgs-action-fork@issue-191-bump-off-of-node-20-actions
+        # Awaiting update to awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libheif-plugin-aomenc ghostscript
 
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Main pacakage is `awalsh128/cache-apt-pkgs-action`, but this is awaiting update for Node so direct fork used for now

## Description
For PHPUnit testing, the GitHub runners need `libheif-plugin-aomenc` and `ghostscript` packages to be instaled for some tests, specifically AVIF write tests and PDF tests.

Installation of these pacakges can, occasionally, take a significant amount of time. A first try at improving this was #2404 but that has not been as successful as hoped.

## Motivation and context
This PR update to using a GitHub action for the package installation step, this not only installs the packages, but it also caches the downloads so the build process can be much faster on subsequent runs of the tests.

The one concern is that the Action, which seeming quite healthy in terms of collaboration and input, is pending a commit at some point to address future Node compatability so this PR uses a fork of the original package (for now) to avoid Node warning in the GitHub Runner.

## How has this been tested?
Private repository testing initially.

## Screenshots
### Before
<img width="1752" height="78" alt="Screenshot 2026-04-18 at 10 55 51" src="https://github.com/user-attachments/assets/8f55c8bb-77df-4899-8c26-ea516b2b722e" />
This step at time can take over 10 minutes.

### After
<img width="1748" height="82" alt="Screenshot 2026-04-18 at 10 58 52" src="https://github.com/user-attachments/assets/70a221e9-34e4-49cb-8e1f-5447ab3c5ddd" />

Examination of this step will show a cache file write is attempted, on many jobs that will fail if they run concurrently. Jobs that run later are much fast when using the cache file:
https://github.com/ClassicPress/ClassicPress/actions/runs/24602212858/job/71942677285
<img width="1746" height="76" alt="Screenshot 2026-04-18 at 11 03 01" src="https://github.com/user-attachments/assets/a7009d72-4428-41cb-baf1-ac19878d1964" />


## Types of changes
- Enhancement

