### PR TITLE
Media library - add text file thumbnail and image file title

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -412,7 +412,7 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $data['nonces']['update'];
 					$delete_nonce = $data['nonces']['delete'];
 					$edit_nonce   = $data['nonces']['edit'];
-					$file_title   = strlen( $data['title'] ) > 50 ? substr( $data['title'], 0, 50 ).'&#46;&#46;&#46;' : $data['title'];
+					$file_title   = strlen( $data['title'] ) > 50 ? substr( $data['title'], 0, 50 ) . '&#46;&#46;&#46;' : $data['title'];
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '"><div class="filename"><div>' . esc_html( $file_title ) . '</div></div>';
 
 					// Use an icon if the file uploaded is not an image

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -428,6 +428,8 @@ if ( 'grid' === $mode ) {
 						$image = '<div class="icon"><div class="centered"><img src="' . esc_url( includes_url() . 'images/media/audio.png' ) . '" draggable="false" alt=""></div><div class="filename"><div>' . esc_html( $attachment->post_title ) . '</div></div></div>';
 					} elseif ( $file_type === 'video' ) {
 						$image = '<div class="icon"><div class="centered"><img src="' . esc_url( includes_url() . 'images/media/video.png' ) . '" draggable="false" alt=""></div><div class="filename"><div>' . esc_html( $attachment->post_title ) . '</div></div></div>';
+					} elseif ( $file_type === 'text' ) {
+						$image = '<div class="icon"><div class="centered"><img src="' . esc_url( includes_url() . 'images/media/text.png' ) . '" draggable="false" alt=""></div><div class="filename"><div>' . esc_html( $attachment->post_title ) . '</div></div></div>';
 					}
 					?>
 

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -412,7 +412,8 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $data['nonces']['update'];
 					$delete_nonce = $data['nonces']['delete'];
 					$edit_nonce   = $data['nonces']['edit'];
-					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '">';
+					$file_title   = strlen( $data['title'] ) > 50 ? substr( $data['title'], 0, 50 ).'&#46;&#46;&#46;' : $data['title'];
+					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '"><div class="filename"><div>' . esc_html( $file_title ) . '</div></div>';
 
 					// Use an icon if the file uploaded is not an image
 					if ( $file_type === 'application' ) {

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -412,7 +412,7 @@ if ( 'grid' === $mode ) {
 					$update_nonce = $data['nonces']['update'];
 					$delete_nonce = $data['nonces']['delete'];
 					$edit_nonce   = $data['nonces']['edit'];
-					$file_title   = strlen( $data['title'] ) > 50 ? substr( $data['title'], 0, 50 ) . '&#46;&#46;&#46;' : $data['title'];
+					$file_title   = strlen( $data['title'] ) > 50 ? substr( $data['title'], 0, 50 ) . '...' : $data['title'];
 					$image        = '<img src="' . esc_url( $url ) . '" alt="' . esc_attr( $alt ) . '"><div class="filename"><div>' . esc_html( $file_title ) . '</div></div>';
 
 					// Use an icon if the file uploaded is not an image


### PR DESCRIPTION
## Description
This PR updates page `wp-admin/upload.php` (grid view) and adds the file title to all file types. Improves organizing, especially for sites with many image files.
Also cuts off file title when it's longer than 50 characters.
Plus thumbnail support for text files.

## How has this been tested?
Local install.

## Screenshots
### Before
<img width="637" height="354" alt="Media - Grid View - before" src="https://github.com/user-attachments/assets/840f6922-e2ea-445c-9603-e601f1fea97a" />

### After
<img width="634" height="345" alt="Media - Grid View - after" src="https://github.com/user-attachments/assets/714e3f4d-7f2f-4238-84ba-4723ae82be5b" />

## Types of changes
- Bug fix / Enhancement