### PR TITLE
Enable full refresh in the Customizer live preview

### DIFF
--- a/src/wp-admin/js/customize-controls-proxy.js
+++ b/src/wp-admin/js/customize-controls-proxy.js
@@ -386,7 +386,7 @@ window.addEventListener( 'message', function( event ) {
  * Receive postMessages from the preview iframe about menu item updates
  */
 window.addEventListener( 'message', function( event ) {
-	var message, target, src;
+	var message, target, src, url;
 
 	if ( event.origin !== location.origin ) {
 		return;
@@ -409,6 +409,14 @@ window.addEventListener( 'message', function( event ) {
 	}
 
 	src = target.iframe.src;
+	url = new URL( src );
+	url.searchParams.set( 'customized', JSON.stringify( window._cpDirtySettings ) );
+
+	// After the full refresh fires, the iframe will have all current values baked in.
+	// Clear dirty settings so subsequent partial-refresh changes don't re-trigger a full reload.
+	window._cpDirtySettings = {};
+	window._cpPreviewSettings = {};
+
 	target.iframe.src = '';
-	target.iframe.src = src;
+	target.iframe.src = url.toString();
 } );

--- a/src/wp-admin/js/customize-controls-proxy.js
+++ b/src/wp-admin/js/customize-controls-proxy.js
@@ -386,7 +386,7 @@ window.addEventListener( 'message', function( event ) {
  * Receive postMessages from the preview iframe about menu item updates
  */
 window.addEventListener( 'message', function( event ) {
-	var message, target, src, url;
+	var message, target, url;
 
 	if ( event.origin !== location.origin ) {
 		return;
@@ -408,14 +408,8 @@ window.addEventListener( 'message', function( event ) {
 		return;
 	}
 
-	src = target.iframe.src;
-	url = new URL( src );
+	url = new URL( target.iframe.src );
 	url.searchParams.set( 'customized', JSON.stringify( window._cpDirtySettings ) );
-
-	// After the full refresh fires, the iframe will have all current values baked in.
-	// Clear dirty settings so subsequent partial-refresh changes don't re-trigger a full reload.
-	window._cpDirtySettings = {};
-	window._cpPreviewSettings = {};
 
 	target.iframe.src = '';
 	target.iframe.src = url.toString();

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -1833,6 +1833,8 @@ final class WP_Customize_Manager {
 			if ( ! isset( $this->_post_values ) ) {
 				if ( isset( $_POST['customized'] ) ) {
 					$post_values = json_decode( wp_unslash( $_POST['customized'] ), true );
+				} elseif ( isset( $_GET['customized'] ) ) {
+					$post_values = json_decode( wp_unslash( $_GET['customized'] ), true );
 				} else {
 					$post_values = array();
 				}

--- a/src/wp-includes/js/customize-preview.js
+++ b/src/wp-includes/js/customize-preview.js
@@ -622,6 +622,11 @@
 
 			if ( ! handledByPartial ) {
 				setValue( id, value, true );
+
+				// Only do a full refresh if the setting has no live preview binding
+				if ( ! api._settings[ id ] || api._settings[ id ]._handlers.length === 0 ) {
+					wp.customize.selectiveRefresh.requestFullRefresh();
+				}
 			}
 
 			if ( id.startsWith( 'sidebars_widgets[' ) ) {


### PR DESCRIPTION
As @xxsimoxx has explained to me in a DM, sometimes a theme or plugin dev might add an option in the Customizer that is designed to trigger a full refresh rather than a partial refresh. This PR ensures that this option is supported in the new Customizer.

To test, I suggest installing the `twentyseventeen` theme and the `ODAM Legible` plugin by @xxsimoxx himself. Then make a change in the Customizer within the Legible Panel (at the bottom of the list), such as a change to the font. The live preview will refresh as a whole and the new font will be used.