### PR TITLE
Enable deletion of attachment from within Customizer

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1976,7 +1976,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		var items = document.querySelectorAll( '.media-item' ),
 			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
 			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' ),
-			count2 = sign === 'minus' ? parseInt( count[2] - 1, 10 ) : parseInt( count[2] + 1, 10 ),
+			count2 = sign === 'minus' ? parseInt( count[2], 10 ) - 1 : parseInt( count[2], 10 ) + 1,
 			count5 = '';
 
 		items.forEach( function( item, index ) {

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1767,6 +1767,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			// Copy URL
 			} else if ( e.target.className.includes( 'copy-attachment-url' ) ) {
 				copyToClipboard( e.target );
+
+			// Delete media item
+			} else if ( e.target.className.includes( 'delete-attachment' ) ) {
+				id = document.querySelector( '.media-item.selected' ).id;
+				if ( id && window.confirm( _wpCustomizeControlsL10n.confirm_delete ) ) {
+					deleteItem( id );
+				}
 			}
 		}
 	} );
@@ -1899,7 +1906,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					setTimeout( function() {
 						pond.removeFile( file.id );
 					}, 100 );
-					resetDataOrdering();
+					resetDataOrdering( 'plus' );
 				}
 			},
 			onprocessfiles: () => { // Called when all files in the queue have finished uploading
@@ -1920,25 +1927,67 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 	}
 
+	// Delete attachment from within modal
+	function deleteItem( id ) {
+		var mediaItem = document.getElementById( id );
+		if ( ! mediaItem ) {
+			return;
+		}
+		var data = new URLSearchParams( {
+			action: 'delete-post',
+			_ajax_nonce: mediaItem.dataset.deleteNonce,
+			id: id.replace( 'media-', '' )
+		} );
+
+		fetch( ajaxurl, {
+			method: 'POST',
+			body: data,
+			credentials: 'same-origin'
+		} )
+		.then( function( response ) {
+			if ( response.ok ) {
+				return response.json(); // no errors
+			}
+			throw new Error( response.status );
+		} )
+		.then( function( result ) {
+			if ( result === 1 ) { // success
+				if ( mediaItem.previousElementSibling != null ) {
+					document.getElementById( mediaItem.previousElementSibling.id ).focus();
+				} else if ( mediaItem.nextElementSibling != null ) {
+					document.getElementById( mediaItem.nextElementSibling.id ).focus();
+				} else {
+					closeModal();
+				}
+				mediaItem.remove();
+				document.querySelector( '.widget-modal-right-sidebar-info' ).setAttribute( 'hidden', true );
+				resetDataOrdering( 'minus' );
+			} else {
+				console.log( _wpCustomizeControlsL10n.delete_failed );
+			}
+		} )
+		.catch( function( error ) {
+			console.error( _wpCustomizeControlsL10n.error, error );
+		} );
+	}
+
 	// Reset ordering of media items
-	function resetDataOrdering() {
+	function resetDataOrdering( sign ) {
 		var items = document.querySelectorAll( '.media-item' ),
 			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
 			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' ),
-			count5;
+			count2 = sign === 'minus' ? parseInt( count[2] - 1, 10 ) : parseInt( count[2] + 1, 10 ),
+			count5 = '';
 
 		items.forEach( function( item, index ) {
 			item.setAttribute( 'data-order', parseInt( index + 1 ) );
 		} );
 
 		// Reset totals
-		if ( 5 in count ) { // allow for different languages
+		if ( count[5] ) { // allow for different languages
 			count5 = ' ' + count[5];
-		} else {
-			count5 = '';
 		}
-		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + count5;
-
+		document.querySelector( '.load-more-count' ).textContent = items.length + ' ' + count[1] + ' ' + count2 + ' ' + count[4] + count5;
 		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
 	}
 } );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -212,7 +212,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				}
 				mediaItem.remove();
 				closeButton.click();
-				resetDataOrdering();
+				resetDataOrdering( 'minus' );
 			} else {
 				console.log( _wpMediaGridSettings.delete_failed );
 			}
@@ -223,7 +223,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	}
 
 	// Reset ordering of remaining media items after deletion
-	function resetDataOrdering() {
+	function resetDataOrdering( sign ) {
 		var items = document.querySelectorAll( '.media-item' ),
 			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
 			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' ),
@@ -263,7 +263,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		var id = location.search.match( /\d+/g )[0];
 		if ( window.confirm( _wpMediaGridSettings.confirm_delete ) ) {
 			deleteItem( id );
-			resetDataOrdering();
 		}
 	} );
 
@@ -1175,7 +1174,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				setTimeout( function() {
 					pond.removeFile( file.id );
 				}, 100 );
-				resetDataOrdering();
+				resetDataOrdering( 'plus' );
 			}
 		},
 		labelTapToUndo: _wpMediaGridSettings.tap_close,

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -227,6 +227,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		var items = document.querySelectorAll( '.media-item' ),
 			num = document.querySelector( '.displaying-num' ).textContent.split( ' ' ),
 			count = document.querySelector( '.load-more-count' ).textContent.split( ' ' ),
+			count3 = sign === 'minus' ? parseInt( count[3], 10 ) - 1 : parseInt( count[3], 10 ) + 1,
 			count5;
 
 		items.forEach( function( item, index ) {
@@ -234,12 +235,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} );
 
 		// Reset totals
-		if ( 5 in count ) { // allow for different languages
+		if ( count[5] ) { // allow for different languages
 			count5 = ' ' + count[5];
-		} else {
-			count5 = '';
 		}
-		document.querySelector( '.load-more-count' ).textContent = count[0] + ' ' + items.length + ' ' + count[2] + ' ' + items.length + ' ' + count[4] + count5;
+		document.querySelector( '.load-more-count' ).textContent = items.length + ' ' + count[2] + ' ' + count3 + ' ' + count[4] + count5;
 
 		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
 		dialog.querySelector( '#total-media-items' ).textContent = items.length;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1197,6 +1197,9 @@ function wp_default_scripts( $scripts ) {
 			'current'                 => esc_html__( 'Current:' ),
 			'currently'               => __( 'Currently set to:' ),
 			'customizeUrl'            => 'http' . ( ! empty( $_SERVER['HTTPS'] ) ? 's' : '' ) . '://' . $_SERVER['SERVER_NAME'] . $_SERVER['PHP_SELF'],
+			'confirm_delete'          => __( "You are about to permanently delete this item from your site.\nThis action cannot be undone.\n'Cancel' to stop, 'OK' to delete." ),
+			'delete_failed'           => __( 'Failed to delete attachment.' ),
+			'error'                   => __( 'Error:' ),
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'wp-util', 'customize-preview' ), false, 1 );


### PR DESCRIPTION
When choosing an image from within the Customizer, a media modal opens and exposes a function to delete a selected media attachment:

<img width="307" height="184" alt="image" src="https://github.com/user-attachments/assets/cb955d01-2b5d-4a5a-9c19-0782de9d7bfa" />

Currently, clicking on the "Delete permanently" button does nothing. This PR fixes that. It also fixes an issue with the line at the bottom that displays the number of media items available.