### PR TITLE
Updated Customizer - add CSS class site-tagline to DOM bindings

### DIFF
--- a/src/wp-includes/js/customize-preview.js
+++ b/src/wp-includes/js/customize-preview.js
@@ -770,7 +770,7 @@
 		// Core standard setting → DOM bindings
 		var coreTextBindings = {
 			'blogname':        '.site-title a, .site-title',
-			'blogdescription': '.site-description'
+			'blogdescription': '.site-description, .site-tagline'
 		};
 		Object.keys( coreTextBindings ).forEach( function( id ) {
 			if ( ! api._settings[ id ] ) {
@@ -794,7 +794,7 @@
 				style.id = 'customize-preview-header-textcolor';
 				document.head.appendChild( style );
 			}
-			style.textContent = value === 'blank' ? 'body .site-title a, body .site-description { visibility: hidden; }' : 'body.has-header-image .site-title a, body.has-header-video .site-title a, body .site-title a, body .site-description { color: #' + value.replace( /^#/, '' ) + '; visibility: visible; }';
+			style.textContent = value === 'blank' ? 'body .site-title a, body .site-description, body .site-tagline { visibility: hidden; }' : 'body.has-header-image .site-title a, body.has-header-video .site-title a, body .site-title a, body .site-description, body .site-tagline { color: #' + value.replace( /^#/, '' ) + '; visibility: visible; }';
 		} );
 
 		api.preview.send( 'ready', {


### PR DESCRIPTION
## Description
Besides class `site-description`, class `site-tagline` is also being used as wrapper for the site description/tagline.
So: add class `site-tagline` to DOM bindings as well.

## Motivation and context
Improves preview in Customizer.

## Types of changes
- Bug fix (was working before)
