### PR TITLE
Fix unwanted button and link styling of playlist and media file

### DIFF
--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -68,9 +68,14 @@
 }
 
 /* Override theme styles that may conflict with controls. */
-.mejs-controls button:hover {
-	border: none;
-	box-shadow: none;
+.mejs-overlay button,
+.mejs-controls button {
+	background:transparent !important;
+}
+
+.mejs-controls a {
+	text-decoration: none !important;
+	box-shadow: none !important;
 }
 
 .mejs-poster {

--- a/src/wp-includes/js/mediaelement/wp-mediaelement.css
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.css
@@ -70,7 +70,7 @@
 /* Override theme styles that may conflict with controls. */
 .mejs-overlay button,
 .mejs-controls button {
-	background:transparent !important;
+	background: transparent !important;
 }
 
 .mejs-controls a {


### PR DESCRIPTION
## Description
This PR fixes unwanted button and link styling of playlist and media file, by adding some extra default styling to file wp-mediaelement.css. 

Because the media element uses buttons and links, in some cases theme styling is also applied, which doesn't always look nice. Screenshot below is with Twenty Seventeen theme installed.

## Screenshots
### Before
<img width="738" height="503" alt="Playlist buttons" src="https://github.com/user-attachments/assets/d8a99877-508d-4918-b6e4-785a29ec0858" />

## Types of changes
- Bug fix