### PR TITLE
Validate element type before initializing MediaElementPlayer

### DIFF
--- a/src/wp-includes/js/mediaelement/wp-mediaelement.js
+++ b/src/wp-includes/js/mediaelement/wp-mediaelement.js
@@ -84,6 +84,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			return;
 		}
 
+		// Skip anything that isn't a true HTMLMediaElement
+		if ( ! ( el instanceof HTMLMediaElement ) ) {
+			return;
+		}
+
 		if ( el.tagName === 'AUDIO' ) {
 			new MediaElementPlayer( el, settings );
 			return;


### PR DESCRIPTION
This PR fixes Issue #2455 by adding a check to ensure the relevant element is an HTMLMediaElement.

