### PR TITLE
Add a Fetch priority control to the image details UI

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -1302,6 +1302,7 @@ ul.CodeMirror-hints {
 	max-width: 200px;
 }
 #image-modal-content .column-settings textarea,
+#image-modal-content .column-settings select,
 #image-modal-content .column-settings input:not( #image-details-link-target ) {
 	width: 70%;
 	max-width: 70%;
@@ -1309,12 +1310,14 @@ ul.CodeMirror-hints {
 }
 #image-modal-content .column-settings .setting.size,
 #image-modal-content .column-settings .setting.link-to,
+#image-modal-content .column-settings .setting.fetchpriority,
 #image-modal-content .column-settings .setting.link-target,
 #image-modal-content .column-settings .custom-size-setting {
 	display: block;
 }
 #image-modal-content .column-settings .setting.size label,
 #image-modal-content .column-settings .setting.link-to label,
+#image-modal-content .column-settings .setting.fetchpriority label,
 #image-modal-content .column-settings .setting.link-to-url label,
 #image-modal-content .column-settings .custom-size-setting label {
 	width: 30%;

--- a/src/wp-admin/js/widgets/media-image-widget.js
+++ b/src/wp-admin/js/widgets/media-image-widget.js
@@ -9,6 +9,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		{ FilePond } = window, // import FilePond
 		dialog = document.getElementById( 'widget-modal' );
 
+	function normalizeFetchpriority( value ) {
+		value = ( value || 'auto' ).toLowerCase();
+		if ( value === 'high' || value === 'low' || value === 'auto' ) {
+			return value;
+		}
+		return 'auto';
+	}
+
 	/**
 	 * Update details within modal.
 	 *
@@ -1019,6 +1027,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			linkClasses     = widget.querySelector( '[data-property="link_classes"]' ).value,
 			linkRel         = widget.querySelector( '[data-property="link_rel"]' ).value,
 			linkTargetBlank = widget.querySelector( '[data-property="link_target_blank"]' ).value,
+			fetchpriorityEl = widget.querySelector( '[data-property="fetchpriority"]' ),
+			fetchpriority = fetchpriorityEl ? fetchpriorityEl.value : 'auto',
 			linkImageTitle  = widget.querySelector( '[data-property="link_image_title"]' ).value,
 			attachmentId    = widget.querySelector( '[data-property="attachment_id"]' ).value,
 			url             = widget.querySelector( '[data-property="url"]' ).value,
@@ -1113,7 +1123,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		dialog.querySelector( '#image-details-caption' ).value = caption;
 		dialog.querySelector( '#image-details-title-attribute' ).value = linkImageTitle;
 		dialog.querySelector( '#image-details-css-class' ).value = imageClasses;
-		dialog.querySelector( '#image-details-link-target' ).value = linkTargetBlank;
+		dialog.querySelector( '#image-details-link-target' ).checked = linkTargetBlank === '_blank';
+		dialog.querySelector( '#image-details-fetchpriority' ).value = normalizeFetchpriority( fetchpriority );
 		dialog.querySelector( '#image-details-link-rel' ).value = linkRel;
 		dialog.querySelector( '#image-details-link-css-class' ).value = linkClasses;
 
@@ -1175,6 +1186,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.querySelector( '[data-property="link_url"]' ).value = dialog.querySelector( '#image-details-link-to-custom' ).value,
 		widget.querySelector( '[data-property="image_classes"]' ).value = dialog.querySelector( '#image-details-css-class' ).value,
 		widget.querySelector( '[data-property="link_target_blank"]' ).value = dialog.querySelector( '#image-details-link-target' ).checked ? '_blank' : '',
+		widget.querySelector( '[data-property="fetchpriority"]' ).value = normalizeFetchpriority( dialog.querySelector( '#image-details-fetchpriority' ).value ),
 		widget.querySelector( '[data-property="link_rel"]' ).value = dialog.querySelector( '#image-details-link-rel' ).value,
 		widget.querySelector( '[data-property="link_classes"]' ).value = dialog.querySelector( '#image-details-link-css-class' ).value;
 

--- a/src/wp-admin/js/widgets/text-widgets.js
+++ b/src/wp-admin/js/widgets/text-widgets.js
@@ -15,6 +15,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		parser = new DOMParser(),
 		dialog = document.getElementById( 'widget-modal' );
 
+	function normalizeFetchpriority( value ) {
+		value = ( value || 'auto' ).toLowerCase();
+		if ( value === 'high' || value === 'low' || value === 'auto' ) {
+			return value;
+		}
+		return 'auto';
+	}
+
 	// If in Customizer, remove old-style dialog
 	// Preventing it from opening would be a breaking change, so just remove it asap for now
 	if ( document.body.className.includes( 'wp-customizer' ) ) {
@@ -1774,6 +1782,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			linkClasses     = anchor ? anchor.className : '',
 			linkRel         = anchor ? anchor.getAttribute( 'rel' ) : '',
 			linkTargetBlank = anchor ? anchor.getAttribute( 'target' ) : '',
+			fetchpriorityAttr = normalizeFetchpriority( imgEl.getAttribute( 'fetchpriority' ) ),
 			linkType        = 'none',
 			attachmentPages = false,
 			template        = document.getElementById( 'tmpl-edit-image-modal' ),
@@ -1937,6 +1946,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			if ( linkTargetBlank === '_blank' ) {
 				dialog.querySelector( '#image-details-link-target' ).checked = true;
 			}
+			dialog.querySelector( '#image-details-fetchpriority' ).value = fetchpriorityAttr;
 			dialog.querySelector( '#image-details-link-rel' ).value = linkRel;
 			dialog.querySelector( '#image-details-link-css-class' ).value = linkClasses;
 
@@ -2016,6 +2026,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			title = dialog.querySelector( '#image-details-title-attribute' ).value,
 			rel = dialog.querySelector( '#image-details-link-rel' ).value,
 			linkTarget = dialog.querySelector( '#image-details-link-target' ).checked ? '_blank' : '',
+			fetchpriorityChoice = dialog.querySelector( '#image-details-fetchpriority' ).value,
 			size = dialog.querySelector( '#image-details-size' ),
 			widget = document.getElementById( widgetId );
 
@@ -2080,6 +2091,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					imgEl.setAttribute( 'title', title );
 				}
 				imgEl.className = 'alignnone size-' + size.value + ' wp-image-' + attachmentId + imageClass;
+
+				fetchpriorityChoice = normalizeFetchpriority( fetchpriorityChoice );
+				if ( fetchpriorityChoice === 'auto' ) {
+					imgEl.removeAttribute( 'fetchpriority' );
+				} else {
+					imgEl.setAttribute( 'fetchpriority', fetchpriorityChoice );
+					if ( fetchpriorityChoice === 'high' && imgEl.getAttribute( 'loading' ) === 'lazy' ) {
+						imgEl.setAttribute( 'loading', 'eager' );
+					}
+				}
 
 				// Get hyperlink (if one exists) and modify href attribute
 				if ( imgEl.parentNode && imgEl.parentNode.tagName === 'A' ) {

--- a/src/wp-includes/js/tinymce/plugins/wpeditimage/plugin.js
+++ b/src/wp-includes/js/tinymce/plugins/wpeditimage/plugin.js
@@ -5,6 +5,14 @@ tinymce.PluginManager.add( 'wpeditimage', function( editor ) {
 		trim = tinymce.trim,
 		iOS = tinymce.Env.iOS;
 
+	function normalizeFetchpriority( value ) {
+		value = ( value || 'auto' ).toLowerCase();
+		if ( value === 'high' || value === 'low' || value === 'auto' ) {
+			return value;
+		}
+		return 'auto';
+	}
+
 	function isPlaceholder( node ) {
 		return !! ( editor.dom.getAttrib( node, 'data-mce-placeholder' ) || editor.dom.getAttrib( node, 'data-mce-object' ) );
 	}
@@ -252,12 +260,14 @@ tinymce.PluginManager.add( 'wpeditimage', function( editor ) {
 			linkClassName: '',
 			linkTargetBlank: false,
 			linkRel: '',
-			title: ''
+			title: '',
+			fetchpriority: 'auto'
 		};
 
 		metadata.url = dom.getAttrib( imageNode, 'src' );
 		metadata.alt = dom.getAttrib( imageNode, 'alt' );
 		metadata.title = dom.getAttrib( imageNode, 'title' );
+		metadata.fetchpriority = normalizeFetchpriority( tinymce.trim( dom.getAttrib( imageNode, 'fetchpriority' ) ) );
 
 		width = dom.getAttrib( imageNode, 'width' );
 		height = dom.getAttrib( imageNode, 'height' );
@@ -350,7 +360,7 @@ tinymce.PluginManager.add( 'wpeditimage', function( editor ) {
 	function updateImage( $imageNode, imageData ) {
 		var classes, className, node, html, parent, wrap, linkNode, imageNode,
 			captionNode, dd, dl, id, attrs, linkAttrs, width, height, align,
-			$imageNode, srcset, src,
+			$imageNode, srcset, src, fp,
 			dom = editor.dom;
 
 		if ( ! $imageNode || ! $imageNode.length ) {
@@ -395,6 +405,16 @@ tinymce.PluginManager.add( 'wpeditimage', function( editor ) {
 
 		// Preserve empty alt attributes.
 		$imageNode.attr( 'alt', imageData.alt || '' );
+
+		fp = normalizeFetchpriority( imageData.fetchpriority );
+		if ( fp === 'auto' ) {
+			dom.setAttrib( imageNode, 'fetchpriority', null );
+		} else {
+			dom.setAttrib( imageNode, 'fetchpriority', fp );
+			if ( fp === 'high' && dom.getAttrib( imageNode, 'loading' ) === 'lazy' ) {
+				dom.setAttrib( imageNode, 'loading', 'eager' );
+			}
+		}
 
 		linkAttrs = {
 			href: imageData.linkUrl,

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -1262,6 +1262,7 @@ function wp_print_media_templates() {
 									<label for="image-details-css-class" class="name"><?php _e( 'Image CSS Class' ); ?></label>
 									<input type="text" id="image-details-css-class" data-setting="extraClasses" value="{{ data.model.extraClasses }}">
 								</span>
+								<?php cp_image_details_fetchpriority_field(); ?>
 							</div>
 							<div class="advanced-link">
 								<span class="setting link-target">

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5899,6 +5899,52 @@ function wp_increase_content_media_count( $amount = 1 ) {
 }
 
 /**
+ * Sanitizes a fetchpriority value for use on img elements.
+ *
+ * @since CP-2.7.0
+ *
+ * @param mixed $value Raw value.
+ * @return string One of 'high', 'low', 'auto'.
+ */
+function wp_sanitize_fetchpriority( $value ) {
+	$value = strtolower( (string) $value );
+
+	if ( in_array( $value, array( 'high', 'low', 'auto' ), true ) ) {
+		return $value;
+	}
+
+	return 'auto';
+}
+
+/**
+ * Returns img attribute overrides for a fetchpriority setting.
+ *
+ * Omits fetchpriority when the value is 'auto'. Sets loading to eager when high.
+ *
+ * @since CP-2.7.0
+ *
+ * @param string $fetchpriority Sanitized priority.
+ * @return array Attribute key/value pairs to merge.
+ */
+function wp_get_fetchpriority_img_attributes( $fetchpriority ) {
+	$fetchpriority = wp_sanitize_fetchpriority( $fetchpriority );
+
+	if ( 'auto' === $fetchpriority ) {
+		return array();
+	}
+
+	$attributes = array(
+		'fetchpriority' => $fetchpriority,
+	);
+
+	if ( 'high' === $fetchpriority ) {
+		$attributes['loading'] = 'eager';
+	}
+
+	return $attributes;
+}
+
+/**
  * Determines whether to add `fetchpriority='high'` to loading attributes.
  *
  * @since 6.3.0

--- a/src/wp-includes/widgets/class-wp-widget-media-image.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-image.php
@@ -125,6 +125,15 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 					'description'           => __( 'Open link in a new tab' ),
 					'should_preview_update' => false,
 				),
+				'fetchpriority'     => array(
+					'type'                  => 'string',
+					'enum'                  => array( 'high', 'low', 'auto' ),
+					'default'               => 'auto',
+					'sanitize_callback'     => 'wp_sanitize_fetchpriority',
+					'media_prop'            => 'fetchpriority',
+					'description'           => __( 'Fetch priority' ),
+					'should_preview_update' => false,
+				),
 				'image_title'       => array(
 					'type'                  => 'string',
 					'default'               => '',
@@ -157,6 +166,8 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 	 */
 	public function render_media( $instance ) {
 		$instance = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
+		$this->prepare_fetchpriority_instance( $instance );
+
 		$instance = wp_parse_args(
 			$instance,
 			array(
@@ -190,6 +201,8 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			if ( ! empty( $instance['alt'] ) ) {
 				$image_attributes['alt'] = $instance['alt'];
 			}
+
+			$image_attributes = array_merge( $image_attributes, wp_get_fetchpriority_img_attributes( $instance['fetchpriority'] ) );
 
 			$size = $instance['size'];
 
@@ -237,7 +250,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 				'widget_media_image'
 			);
 
-			$attr = array_merge( $attr, $loading_optimization_attr );
+			$attr = array_merge( $attr, $loading_optimization_attr, wp_get_fetchpriority_img_attributes( $instance['fetchpriority'] ) );
 
 			$attr  = array_map( 'esc_attr', $attr );
 			$image = '<img';
@@ -299,6 +312,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 	 */
 	public function form( $instance ) {
 		$instance = array_merge( wp_list_pluck( $this->get_instance_schema(), 'default' ), $instance );
+		$this->prepare_fetchpriority_instance( $instance );
 
 		$title             = ! empty( $instance['title'] ) ? $instance['title'] : '';
 		$attachment_id     = ! empty( $instance['attachment_id'] ) ? $instance['attachment_id'] : 0;
@@ -314,6 +328,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 		$link_classes      = ! empty( $instance['link_classes'] ) ? $instance['link_classes'] : '';
 		$link_rel          = ! empty( $instance['link_rel'] ) ? $instance['link_rel'] : '';
 		$link_target_blank = ! empty( $instance['link_target_blank'] ) ? '_blank' : '';
+		$fetchpriority     = $instance['fetchpriority'];
 		$link_image_title  = ! empty( $instance['link_image_title'] ) ? $instance['link_image_title'] : '';
 
 		$attributes        = 'alt="' . $alt . '"';
@@ -443,6 +458,7 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			<input id="<?php echo esc_attr( $this->get_field_id( 'link_classes' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'link_classes' ) ); ?>" type="hidden" data-property="link_classes" class="media-widget-instance-property" value="<?php echo esc_attr( $link_classes ); ?>">
 			<input id="<?php echo esc_attr( $this->get_field_id( 'link_rel' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'link_rel' ) ); ?>" type="hidden" data-property="link_rel" class="media-widget-instance-property" value="<?php echo esc_url( $link_rel ); ?>">
 			<input id="<?php echo esc_attr( $this->get_field_id( 'link_target_blank' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'link_target_blank' ) ); ?>" type="hidden" data-property="link_target_blank" class="media-widget-instance-property" value="<?php echo esc_attr( $link_target_blank ); ?>">
+			<input id="<?php echo esc_attr( $this->get_field_id( 'fetchpriority' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'fetchpriority' ) ); ?>" type="hidden" data-property="fetchpriority" class="media-widget-instance-property" value="<?php echo esc_attr( $fetchpriority ); ?>">
 			<input id="<?php echo esc_attr( $this->get_field_id( 'link_image_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'link_image_title' ) ); ?>" type="hidden" data-property="link_image_title" class="media-widget-instance-property" value="<?php echo esc_attr( $link_image_title ); ?>">
 			<input id="<?php echo esc_attr( $this->get_field_id( 'attachment_id' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'attachment_id' ) ); ?>" type="hidden" data-property="attachment_id" class="media-widget-instance-property" value="<?php echo esc_attr( $attachment_id ); ?>">
 			<input id="<?php echo esc_attr( $this->get_field_id( 'url' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'url' ) ); ?>" type="hidden" data-property="url" class="media-widget-instance-property" value="<?php echo esc_url( $url ); ?>">
@@ -524,6 +540,39 @@ class WP_Widget_Media_Image extends WP_Widget_Media {
 			)
 		);
 	}
+
+	/**
+	 * Normalizes fetchpriority on a widget instance before render or form display.
+	 *
+	 * @since CP-2.7.0
+	 *
+	 * @param array $instance Widget instance. Passed by reference.
+	 */
+	private function prepare_fetchpriority_instance( array &$instance ) {
+		if ( ! empty( $instance['fetchpriority_high'] ) ) {
+			$instance['fetchpriority'] = 'high';
+		}
+
+		$instance['fetchpriority'] = wp_sanitize_fetchpriority( $instance['fetchpriority'] ?? 'auto' );
+	}
+}
+
+/**
+ * Outputs the fetchpriority select for image detail modals.
+ *
+ * @since CP-2.7.0
+ */
+function cp_image_details_fetchpriority_field() {
+	?>
+	<span class="setting fetchpriority">
+		<label for="image-details-fetchpriority" class="name"><?php esc_html_e( 'Fetch priority' ); ?></label>
+		<select id="image-details-fetchpriority" data-setting="fetchpriority">
+			<option value="high"><?php esc_html_e( 'High' ); ?></option>
+			<option value="low"><?php esc_html_e( 'Low' ); ?></option>
+			<option value="auto"><?php esc_html_e( 'Auto' ); ?></option>
+		</select>
+	</span>
+	<?php
 }
 
 /**
@@ -614,6 +663,7 @@ function cp_render_media_image_template() {
 										<label for="image-details-css-class" class="name"><?php esc_html_e( 'Image CSS Class' ); ?> </label>
 										<input type="text" id="image-details-css-class" data-setting="extraClasses" value="">
 									</div>
+									<?php cp_image_details_fetchpriority_field(); ?>
 								</div>
 								<div class="advanced-link">
 									<div class="setting link-target">

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3179,6 +3179,62 @@ EOF;
 	}
 
 	/**
+	 * @covers ::wp_sanitize_fetchpriority
+	 * @dataProvider data_wp_sanitize_fetchpriority
+	 */
+	public function test_wp_sanitize_fetchpriority( $input, $expected ) {
+		$this->assertSame( $expected, wp_sanitize_fetchpriority( $input ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_wp_sanitize_fetchpriority() {
+		return array(
+			'high'    => array( 'high', 'high' ),
+			'low'     => array( 'low', 'low' ),
+			'auto'    => array( 'auto', 'auto' ),
+			'upper'   => array( 'HIGH', 'high' ),
+			'invalid' => array( 'urgent', 'auto' ),
+			'empty'   => array( '', 'auto' ),
+		);
+	}
+
+	/**
+	 * @covers ::wp_get_fetchpriority_img_attributes
+	 */
+	public function test_wp_get_fetchpriority_img_attributes_auto() {
+		$this->assertSame( array(), wp_get_fetchpriority_img_attributes( 'auto' ) );
+	}
+
+	/**
+	 * @covers ::wp_get_fetchpriority_img_attributes
+	 */
+	public function test_wp_get_fetchpriority_img_attributes_high() {
+		$this->assertSame(
+			array(
+				'fetchpriority' => 'high',
+				'loading'       => 'eager',
+			),
+			wp_get_fetchpriority_img_attributes( 'high' )
+		);
+	}
+
+	/**
+	 * @covers ::wp_get_fetchpriority_img_attributes
+	 */
+	public function test_wp_get_fetchpriority_img_attributes_low() {
+		$this->assertSame(
+			array(
+				'fetchpriority' => 'low',
+			),
+			wp_get_fetchpriority_img_attributes( 'low' )
+		);
+	}
+
+	/**
 	 * @ticket 57086
 	 *
 	 * @dataProvider data_wp_get_attachment_image_decoding_attr

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3179,62 +3179,6 @@ EOF;
 	}
 
 	/**
-	 * @covers ::wp_sanitize_fetchpriority
-	 * @dataProvider data_wp_sanitize_fetchpriority
-	 */
-	public function test_wp_sanitize_fetchpriority( $input, $expected ) {
-		$this->assertSame( $expected, wp_sanitize_fetchpriority( $input ) );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[]
-	 */
-	public function data_wp_sanitize_fetchpriority() {
-		return array(
-			'high'    => array( 'high', 'high' ),
-			'low'     => array( 'low', 'low' ),
-			'auto'    => array( 'auto', 'auto' ),
-			'upper'   => array( 'HIGH', 'high' ),
-			'invalid' => array( 'urgent', 'auto' ),
-			'empty'   => array( '', 'auto' ),
-		);
-	}
-
-	/**
-	 * @covers ::wp_get_fetchpriority_img_attributes
-	 */
-	public function test_wp_get_fetchpriority_img_attributes_auto() {
-		$this->assertSame( array(), wp_get_fetchpriority_img_attributes( 'auto' ) );
-	}
-
-	/**
-	 * @covers ::wp_get_fetchpriority_img_attributes
-	 */
-	public function test_wp_get_fetchpriority_img_attributes_high() {
-		$this->assertSame(
-			array(
-				'fetchpriority' => 'high',
-				'loading'       => 'eager',
-			),
-			wp_get_fetchpriority_img_attributes( 'high' )
-		);
-	}
-
-	/**
-	 * @covers ::wp_get_fetchpriority_img_attributes
-	 */
-	public function test_wp_get_fetchpriority_img_attributes_low() {
-		$this->assertSame(
-			array(
-				'fetchpriority' => 'low',
-			),
-			wp_get_fetchpriority_img_attributes( 'low' )
-		);
-	}
-
-	/**
 	 * @ticket 57086
 	 *
 	 * @dataProvider data_wp_get_attachment_image_decoding_attr


### PR DESCRIPTION
## Description

Adds a **Fetch priority** control to the image details UI so editors can set `fetchpriority="high"`, `fetchpriority="low"`, or leave the browser default (**Auto**) on individual images.

**Classic Editor (TinyMCE)**

- New dropdown under **Advanced Options** in the image details modal (`tmpl-image-details`), aligned with existing controls such as **Link To**.
- `wpeditimage` reads and writes `fetchpriority` on the `<img>` in post content.
- **Auto** does not output a `fetchpriority` attribute.
- **High** still upgrades `loading="lazy"` to `loading="eager"` when needed (same rule as core).

**Image widget & text widget**

- Same dropdown in the shared image-details modal (`cp_image_details_fetchpriority_field()`).
- Image widget stores `fetchpriority` in instance data and applies it on the frontend.
- Text widget image edit flow updates embedded images in TinyMCE content.

**Core helpers** (`src/wp-includes/media.php`)

- `wp_sanitize_fetchpriority()` — normalizes to `high`, `low`, or `auto`.
- `wp_get_fetchpriority_img_attributes()` — returns attributes to merge on `<img>`; empty for `auto`, includes `loading="eager"` when `high`.

**Other**

- Widget modal CSS updated so the new select lines up with **Link To** / **Size** in the sidebar.

## Motivation and context

Core already supports `fetchpriority` on images (e.g. via `wp_get_loading_optimization_attributes()`), but the Classic Editor image dialog had no way to set it per image. Editors had to edit HTML by hand or rely on automatic heuristics.

This change exposes the attribute in the same place as link target and other advanced image settings, with behavior consistent with core: **Auto** means no explicit attribute, and **high** avoids conflicting with lazy loading.

## How has this been tested?

Manual testing:

1. **Classic Editor** — Insert/edit an image → **Advanced Options** → set Fetch priority to High / Low / Auto → **Update** → confirm HTML:
   - High / Low: `fetchpriority` present with the chosen value
   - Auto: no `fetchpriority` attribute
2. **Existing image** — Image with `fetchpriority="high"` opens with **High** selected; switching to **Auto** removes the attribute.
3. **High + lazy** — Image with `loading="lazy"` and **High** saves as `loading="eager"`.
4. **Image widget** — Edit image in widget modal; save widget; confirm frontend markup matches the selection.
5. **Text widget** — Edit an embedded image in the text widget editor; confirm content updates the same way as in the post editor.

## Screenshots

<img width="1556" height="551" alt="image (3)" src="https://github.com/user-attachments/assets/2321ddd8-5a74-4619-a77c-e7f80ec7eed3" />
<img width="1136" height="857" alt="image (2)" src="https://github.com/user-attachments/assets/b9162677-2517-4e89-9ba6-309cb038065a" />

## Types of changes

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement
- [ ] Breaking change
