### PR TITLE
Remove backbone.js from the updates process

### DIFF
--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -872,151 +872,61 @@ function maintenance_nag() {
 }
 
 /**
- * Prints the JavaScript templates for update admin notices.
+ * Prints the templates for update admin notices.
  *
  * @since 4.6.0
  *
- * Template takes one argument with four values:
- *
- *     param {object} data {
- *         Arguments for admin notice.
- *
- *         @type string id        ID of the notice.
- *         @type string className Class names for the notice.
- *         @type string message   The notice's message.
- *         @type string type      The type of update the notice is for. Either 'plugin' or 'theme'.
- *     }
+ * @since CP-2.8.0
+ * No longer uses backbone.js
  */
 function wp_print_admin_notice_templates() {
-	?>
-	<script id="tmpl-wp-updates-admin-notice" type="text/html">
-		<div <# if ( data.id ) { #>id="{{ data.id }}"<# } #> class="notice {{ data.className }}"><p>{{{ data.message }}}</p></div>
-	</script>
-	<script id="tmpl-wp-bulk-updates-admin-notice" type="text/html">
-		<div id="{{ data.id }}" class="{{ data.className }} notice <# if ( data.errors ) { #>notice-error<# } else { #>notice-success<# } #>">
-			<p>
-				<# if ( data.successes ) { #>
-					<# if ( 1 === data.successes ) { #>
-						<# if ( 'plugin' === data.type ) { #>
-							<?php
-							/* translators: %s: Number of plugins. */
-							printf( __( '%s plugin successfully updated.' ), '{{ data.successes }}' );
-							?>
-						<# } else { #>
-							<?php
-							/* translators: %s: Number of themes. */
-							printf( __( '%s theme successfully updated.' ), '{{ data.successes }}' );
-							?>
-						<# } #>
-					<# } else { #>
-						<# if ( 'plugin' === data.type ) { #>
-							<?php
-							/* translators: %s: Number of plugins. */
-							printf( __( '%s plugins successfully updated.' ), '{{ data.successes }}' );
-							?>
-						<# } else { #>
-							<?php
-							/* translators: %s: Number of themes. */
-							printf( __( '%s themes successfully updated.' ), '{{ data.successes }}' );
-							?>
-						<# } #>
-					<# } #>
-				<# } #>
-				<# if ( data.errors ) { #>
-					<button class="button-link bulk-action-errors-collapsed" aria-expanded="false">
-						<# if ( 1 === data.errors ) { #>
-							<?php
-							/* translators: %s: Number of failed updates. */
-							printf( __( '%s update failed.' ), '{{ data.errors }}' );
-							?>
-						<# } else { #>
-							<?php
-							/* translators: %s: Number of failed updates. */
-							printf( __( '%s updates failed.' ), '{{ data.errors }}' );
-							?>
-						<# } #>
-						<span class="screen-reader-text">
-							<?php
-							/* translators: Hidden accessibility text. */
-							_e( 'Show more details' );
-							?>
-						</span>
-						<span class="toggle-indicator" aria-hidden="true"></span>
-					</button>
-				<# } #>
-			</p>
-			<# if ( data.errors ) { #>
-				<ul class="bulk-action-errors hidden">
-					<# _.each( data.errorMessages, function( errorMessage ) { #>
-						<li>{{ errorMessage }}</li>
-					<# } ); #>
-				</ul>
-			<# } #>
+    ?>
+    <template id="tmpl-wp-updates-admin-notice">
+        <div class="notice">
+			<p></p>
 		</div>
-	</script>
-	<?php
+    </template>
+
+    <template id="tmpl-wp-bulk-updates-admin-notice">
+        <div class="notice">
+            <p>
+                <span class="bulk-updates-success-count"></span>
+                <button class="button-link bulk-action-errors-collapsed" aria-expanded="false" hidden>
+                    <span class="bulk-updates-error-count"></span>
+                    <span class="screen-reader-text"><?php _e( 'Show more details' ); ?></span>
+                    <span class="toggle-indicator" aria-hidden="true"></span>
+                </button>
+            </p>
+            <ul class="bulk-action-errors hidden"></ul>
+        </div>
+    </template>
+    <?php
 }
 
 /**
- * Prints the JavaScript templates for update and deletion rows in list tables.
+ * Prints the templates for update and deletion rows in list tables.
  *
  * @since 4.6.0
  *
- * The update template takes one argument with four values:
- *
- *     param {object} data {
- *         Arguments for the update row
- *
- *         @type string slug    Plugin slug.
- *         @type string plugin  Plugin base name.
- *         @type string colspan The number of table columns this row spans.
- *         @type string content The row content.
- *     }
- *
- * The delete template takes one argument with four values:
- *
- *     param {object} data {
- *         Arguments for the update row
- *
- *         @type string slug    Plugin slug.
- *         @type string plugin  Plugin base name.
- *         @type string name    Plugin name.
- *         @type string colspan The number of table columns this row spans.
- *     }
+ * @since CP-2.8.0
+ * No longer uses backbone.js
  */
 function wp_print_update_row_templates() {
-	?>
-	<script id="tmpl-item-update-row" type="text/template">
-		<tr class="plugin-update-tr update" id="{{ data.slug }}-update" data-slug="{{ data.slug }}" <# if ( data.plugin ) { #>data-plugin="{{ data.plugin }}"<# } #>>
-			<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
-				{{{ data.content }}}
+    ?>
+    <template id="tmpl-item-update-row">
+        <tr class="plugin-update-tr update">
+            <td class="plugin-update colspanchange"></td>
+        </tr>
+    </template>
+
+    <template id="tmpl-item-deleted-row">
+        <tr class="plugin-deleted-tr inactive deleted">
+            <td class="plugin-update colspanchange">
+				<p></p>
 			</td>
-		</tr>
-	</script>
-	<script id="tmpl-item-deleted-row" type="text/template">
-		<tr class="plugin-deleted-tr inactive deleted" id="{{ data.slug }}-deleted" data-slug="{{ data.slug }}" <# if ( data.plugin ) { #>data-plugin="{{ data.plugin }}"<# } #>>
-			<td colspan="{{ data.colspan }}" class="plugin-update colspanchange">
-				<# if ( data.plugin ) { #>
-					<?php
-					printf(
-						/* translators: %s: Plugin name. */
-						_x( '%s was successfully deleted.', 'plugin' ),
-						'<strong>{{{ data.name }}}</strong>'
-					);
-					?>
-				<# } else { #>
-					<?php
-					printf(
-						/* translators: %s: Theme name. */
-						_x( '%s was successfully deleted.', 'theme' ),
-						'<strong>{{{ data.name }}}</strong>'
-					);
-					?>
-				<# } #>
-			</td>
-		</tr>
-	</script>
-	<?php
+        </tr>
+    </template>
+    <?php
 }
 
 /**

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -880,27 +880,27 @@ function maintenance_nag() {
  * No longer uses backbone.js
  */
 function wp_print_admin_notice_templates() {
-    ?>
-    <template id="tmpl-wp-updates-admin-notice">
-        <div class="notice">
+	?>
+	<template id="tmpl-wp-updates-admin-notice">
+		<div class="notice">
 			<p></p>
 		</div>
-    </template>
+	</template>
 
-    <template id="tmpl-wp-bulk-updates-admin-notice">
-        <div class="notice">
-            <p>
-                <span class="bulk-updates-success-count"></span>
-                <button class="button-link bulk-action-errors-collapsed" aria-expanded="false" hidden>
-                    <span class="bulk-updates-error-count"></span>
-                    <span class="screen-reader-text"><?php _e( 'Show more details' ); ?></span>
-                    <span class="toggle-indicator" aria-hidden="true"></span>
-                </button>
-            </p>
-            <ul class="bulk-action-errors hidden"></ul>
-        </div>
-    </template>
-    <?php
+	<template id="tmpl-wp-bulk-updates-admin-notice">
+		<div class="notice">
+			<p>
+				<span class="bulk-updates-success-count"></span>
+				<button class="button-link bulk-action-errors-collapsed" aria-expanded="false" hidden>
+					<span class="bulk-updates-error-count"></span>
+					<span class="screen-reader-text"><?php _e( 'Show more details' ); ?></span>
+					<span class="toggle-indicator" aria-hidden="true"></span>
+				</button>
+			</p>
+			<ul class="bulk-action-errors hidden"></ul>
+		</div>
+	</template>
+	<?php
 }
 
 /**
@@ -912,21 +912,21 @@ function wp_print_admin_notice_templates() {
  * No longer uses backbone.js
  */
 function wp_print_update_row_templates() {
-    ?>
-    <template id="tmpl-item-update-row">
-        <tr class="plugin-update-tr update">
-            <td class="plugin-update colspanchange"></td>
-        </tr>
-    </template>
+	?>
+	<template id="tmpl-item-update-row">
+		<tr class="plugin-update-tr update">
+			<td class="plugin-update colspanchange"></td>
+		</tr>
+	</template>
 
-    <template id="tmpl-item-deleted-row">
-        <tr class="plugin-deleted-tr inactive deleted">
-            <td class="plugin-update colspanchange">
+	<template id="tmpl-item-deleted-row">
+		<tr class="plugin-deleted-tr inactive deleted">
+			<td class="plugin-update colspanchange">
 				<p></p>
 			</td>
-        </tr>
-    </template>
-    <?php
+		</tr>
+	</template>
+	<?php
 }
 
 /**

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -1216,7 +1216,7 @@
 		// Add a plugin update row if it doesn't exist yet.
 		if ( ! $pluginUpdateRow.length ) {
 			$plugin.addClass( 'update' ).after(
-				pluginUpdateRow( {
+				fillUpdateRow( {
 					slug:    response.slug,
 					plugin:  response.plugin || response.slug,
 					colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -202,7 +202,107 @@
 	 *
 	 * @type {function}
 	 */
-	wp.updates.adminNotice = wp.template( 'wp-updates-admin-notice' );
+	wp.updates.adminNotice = fillAdminNotice;
+
+	/**
+	 * Template helpers.
+	 * Each function clones an HTML <template> element and populates it with
+	 * the provided data, replacing the former wp.template() / Backbone pattern.
+	 */
+	function fillAdminNotice( data ) {
+		const tmpl = document.getElementById( 'tmpl-wp-updates-admin-notice' ),
+			el = tmpl.content.cloneNode( true ).firstElementChild;
+
+		if ( data.id ) {
+			el.id = data.id;
+		}
+		el.classList.add( ...data.className.split( ' ' ) );
+		el.querySelector( 'p' ).innerHTML = data.message;
+
+		return el;
+	}
+
+	function fillBulkUpdatesAdminNotice( data ) {
+		const tmpl = document.getElementById( 'tmpl-wp-bulk-updates-admin-notice' ),
+			el = tmpl.content.cloneNode( true ).firstElementChild,
+			successSpan = el.querySelector( '.bulk-updates-success-count' ),
+			errorBtn = el.querySelector( '.bulk-action-errors-collapsed' ),
+			errorList = el.querySelector( '.bulk-action-errors' );
+
+		el.id = data.id;
+		el.classList.add( ...data.className.split( ' ' ) );
+		el.classList.add( data.errors ? 'notice-error' : 'notice-success' );
+
+		// Success count sentence
+		if ( data.successes ) {
+			if ( data.type === 'plugin' ) {
+				successSpan.textContent = data.successes === 1 ? settings.pluginUpdatedSingular.replace( '%s', data.successes ) : settings.pluginUpdatedPlural.replace( '%s', data.successes );
+			} else {
+				successSpan.textContent = data.successes === 1 ? settings.themeUpdatedSingular.replace( '%s', data.successes ) : settings.themeUpdatedPlural.replace( '%s', data.successes );
+			}
+		}
+
+		// Error button
+		if ( data.errors ) {
+			errorBtn.hidden = false;
+			el.querySelector( '.bulk-updates-error-count' ).textContent = data.errors === 1 ? settings.updateFailedSingular.replace( '%s', data.errors ) : settings.updateFailedPlural.replace( '%s', data.errors );
+		}
+
+		// Error list
+		if ( data.errors && data.errorMessages && data.errorMessages.length ) {
+			data.errorMessages.forEach( function( msg ) {
+				const li = document.createElement( 'li' );
+				li.textContent = msg;
+				errorList.appendChild( li );
+			} );
+		}
+
+		return el;
+	}
+
+	function fillUpdateRow( data ) {
+		const tmpl = document.getElementById( 'tmpl-item-update-row' ),
+			el = tmpl.content.cloneNode( true ).firstElementChild,
+			td = el.querySelector( 'td' );
+
+		el.id = data.slug + '-update';
+		el.dataset.slug = data.slug;
+		if ( data.plugin ) {
+			el.dataset.plugin = data.plugin;
+		}
+
+		td.colSpan = data.colspan;
+		td.innerHTML = data.content;
+
+		return el;
+	}
+
+	function fillDeletedRow( data ) {
+		const tmpl = document.getElementById( 'tmpl-item-deleted-row' ),
+			el = tmpl.content.cloneNode( true ).firstElementChild,
+			td = el.querySelector( 'td' ),
+			strong = document.createElement( 'strong' ),
+			context = data.plugin ? 'plugin' : 'theme',
+			parts = ( context === 'plugin' ? settings.pluginDeletedSuccess : settings.themeDeletedSuccess ).split( '%s' );
+
+		el.id = data.slug + '-deleted';
+		el.dataset.slug = data.slug;
+		if ( data.plugin ) {
+			el.dataset.plugin = data.plugin;
+		}
+
+		td.colSpan = data.colspan;
+
+		// Build "<strong>Name</strong> was successfully deleted."
+		strong.textContent = data.name;
+		td.querySelector( 'p' ).replaceWith(
+			document.createTextNode( parts[0] ),
+			strong,
+			document.createTextNode( parts[1] || '' )
+		);
+
+		return el;
+	}
 
 	/**
 	 * Update queue.
@@ -974,7 +1074,6 @@
 				$currentView     = $views.find( '[aria-current="page"]' ),
 				$itemsCount      = $( '.displaying-num' ),
 				columnCount      = $form.find( 'thead th:not(.hidden), thead td' ).length,
-				pluginDeletedRow = wp.template( 'item-deleted-row' ),
 				/**
 				 * Plugins Base names of plugins in their different states.
 				 *
@@ -986,7 +1085,7 @@
 			// Add a success message after deleting a plugin.
 			if ( ! $pluginRow.hasClass( 'plugin-update-tr' ) ) {
 				$pluginRow.after(
-					pluginDeletedRow( {
+					fillDeletedRow( {
 						slug:    response.slug,
 						plugin:  response.plugin,
 						colspan: columnCount,
@@ -1093,7 +1192,6 @@
 	 */
 	wp.updates.deletePluginError = function( response ) {
 		var $plugin, $pluginUpdateRow,
-			pluginUpdateRow  = wp.template( 'item-update-row' ),
 			noticeContent    = wp.updates.adminNotice( {
 				className: 'update-message notice-error notice-alt',
 				message:   response.errorMessage
@@ -1558,12 +1656,11 @@
 			$themeRows.css( { backgroundColor: '#faafaa' } ).fadeOut( 350, function() {
 				var $views     = $( '.subsubsub' ),
 					$themeRow  = $( this ),
-					themes     = settings.themes,
-					deletedRow = wp.template( 'item-deleted-row' );
+					themes     = settings.themes;
 
 				if ( ! $themeRow.hasClass( 'plugin-update-tr' ) ) {
 					$themeRow.after(
-						deletedRow( {
+						fillDeletedRow( {
 							slug:    response.slug,
 							colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
 							name:    $themeRow.find( '.theme-title strong' ).text()
@@ -1640,7 +1737,6 @@
 	wp.updates.deleteThemeError = function( response ) {
 		var $themeRow    = $( 'tr.inactive[data-slug="' + response.slug + '"]' ),
 			$button      = $( '.theme-actions .delete-theme' ),
-			updateRow    = wp.template( 'item-update-row' ),
 			$updateRow   = $themeRow.siblings( '#' + response.slug + '-update' ),
 			errorMessage = sprintf(
 				/* translators: %s: Error string for a failed deletion. */
@@ -1659,7 +1755,7 @@
 		if ( 'themes-network' === pagenow ) {
 			if ( ! $updateRow.length ) {
 				$themeRow.addClass( 'update' ).after(
-					updateRow( {
+					fillUpdateRow( {
 						slug: response.slug,
 						colspan: $( '#bulk-action-form' ).find( 'thead th:not(.hidden), thead td' ).length,
 						content: $message
@@ -2494,7 +2590,7 @@
 
 				$itemRow.find( 'input[name="checked[]"]:checked' ).prop( 'checked', false );
 
-				wp.updates.adminNotice = wp.template( 'wp-bulk-updates-admin-notice' );
+				wp.updates.adminNotice = fillBulkUpdatesAdminNotice;
 
 				wp.updates.addAdminNotice( {
 					id:            'bulk-action-notice',
@@ -2521,7 +2617,7 @@
 
 			// Reset admin notice template after #bulk-action-notice was added.
 			$document.on( 'wp-updates-notice-added', function() {
-				wp.updates.adminNotice = wp.template( 'wp-updates-admin-notice' );
+				wp.updates.adminNotice = fillAdminNotice;
 			} );
 
 			// Check the queue, now that the event handlers have been added.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1353,6 +1353,15 @@ function wp_default_scripts( $scripts ) {
 			'_wpUpdatesSettings',
 			array(
 				'ajax_nonce' => wp_installing() ? '' : wp_create_nonce( 'updates' ),
+				'pluginUpdatedSingular' => __( '%s plugin successfully updated.' ),
+				'pluginUpdatedPlural'   => __( '%s plugins successfully updated.' ),
+				'themeUpdatedSingular'  => __( '%s theme successfully updated.' ),
+				'themeUpdatedPlural'    => __( '%s themes successfully updated.' ),
+				'updateFailedSingular'  => __( '%s update failed.' ),
+				'updateFailedPlural'    => __( '%s updates failed.' ),
+				'showMoreDetails'       => __( 'Show more details' ),
+				'pluginDeletedSuccess'  => _x( '%s was successfully deleted.', 'plugin' ),
+				'themeDeletedSuccess'   => _x( '%s was successfully deleted.', 'theme' ),
 			)
 		);
 


### PR DESCRIPTION
This PR removes backbone.js from the process by which success or failure messages are generated after something is updated or deleted in ClassicPress. It converts what were formerly JS templates into regular HTML `<template>`s and then adds four new JS functions to connect things up.

To test, try updating or deleting a theme or plugin, whether individually or in bulk.