### PR TITLE
The ClassicPress Theme - no sidebar template and header section update

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/header.php
+++ b/src/wp-content/themes/the-classicpress-theme/header.php
@@ -34,18 +34,20 @@
 
 	<header id="masthead">
 		<div id="inner-header">
-			<span class="logo" role="banner">
-				
+			<div class="logo" role="banner">
+
 				<?php
 				// Custom logo
 				if ( function_exists( 'the_custom_logo' ) && has_custom_logo() ) {
 					the_custom_logo();
 				} else {
-					echo '<a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
+					echo '<div class="site-title"><a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a></div>';
+					if ( get_bloginfo( 'description' ) ) {
+						echo '<div class="site-description">' . esc_html( get_bloginfo( 'description' ) ) . '</div>';
+					}
 				}
 				?>
-
-			</span>
+			</div>
 
 			<?php if ( has_nav_menu( 'main-menu' ) ) { ?>
 				<nav id="site-navigation" class="main-navigation nav--toggle-sub nav--toggle-small" aria-label="<?php esc_attr_e( 'Main menu', 'the-classicpress-theme' ); ?>">

--- a/src/wp-content/themes/the-classicpress-theme/page-no-sidebar.php
+++ b/src/wp-content/themes/the-classicpress-theme/page-no-sidebar.php
@@ -12,7 +12,7 @@ get_header();
 ?>
 
 	<div id="primary">
-		<main id="main" class="page-main no-sidebar">
+		<main id="main" class="page-main page-no-sidebar">
 
 		<?php
 		susty_wp_post_thumbnail();

--- a/src/wp-content/themes/the-classicpress-theme/page-no-sidebar.php
+++ b/src/wp-content/themes/the-classicpress-theme/page-no-sidebar.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Template Name: No Sidebar
+ * Description: Template without sidebar
+ * Template Post Type: page
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ */
+
+get_header();
+?>
+
+	<div id="primary">
+		<main id="main" class="page-main no-sidebar">
+
+		<?php
+		susty_wp_post_thumbnail();
+
+		while ( have_posts() ) :
+			the_post();
+
+			get_template_part( 'template-parts/content', 'page' );
+
+			// If comments are open or we have at least one comment, load up the comment template.
+			if ( comments_open() || get_comments_number() ) :
+				comments_template();
+			endif;
+
+		endwhile; // End of the loop.
+		?>
+
+		</main><!-- #main -->
+
+	</div><!-- #primary -->
+
+<?php
+get_footer();

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -830,6 +830,7 @@ li.wp-playlist-item .wp-playlist-item-length {
 	padding: 0.75em 0;
 	background: rgba(5, 127, 153, 1);
 	border-bottom: #034a59;
+	color: #fff;
 }
 #masthead h1,
 #masthead p {
@@ -1294,6 +1295,9 @@ img {
 	max-width: 52rem;
 	padding: 0 1em 1em;
 	min-height: 300px;
+}
+#main.no-sidebar {
+	max-width: 72rem;
 }
 #sidebar {
 	width: 100%;
@@ -2001,6 +2005,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		text-align: center;
 	}
 	#main,
+	#main.no-sidebar,
 	#sidebar,
 	.classic {
 		max-width: 600px;

--- a/src/wp-content/themes/the-classicpress-theme/style.css
+++ b/src/wp-content/themes/the-classicpress-theme/style.css
@@ -1296,7 +1296,7 @@ img {
 	padding: 0 1em 1em;
 	min-height: 300px;
 }
-#main.no-sidebar {
+#main.page-no-sidebar {
 	max-width: 72rem;
 }
 #sidebar {
@@ -2005,7 +2005,7 @@ body.page-checkout .woocommerce-form-coupon-toggle {
 		text-align: center;
 	}
 	#main,
-	#main.no-sidebar,
+	#main.page-no-sidebar,
 	#sidebar,
 	.classic {
 		max-width: 600px;


### PR DESCRIPTION
## Description
This PR for The ClassicPress Theme does 3 things:

- Includes the Site Description (tagline) in header
- Updated Customizer: adds pencils to site title and description
- Adds a page template without sidebar (as requested in the forum) 

## Screenshots
### Customizer and header section
<img width="737" height="349" alt="Logo section" src="https://github.com/user-attachments/assets/00c108d4-10a5-4e2e-bd3b-6dc13d8dfc1d" />

### Page without sidebar
<img width="1387" height="792" alt="Page no sidebar" src="https://github.com/user-attachments/assets/2ed44477-2af1-4c69-8b5e-7b666ff03902" />

### Page attributes
<img width="309" height="241" alt="Page attributes" src="https://github.com/user-attachments/assets/aa8585bd-d9c4-44b5-8729-06a5e089e2bd" />

## Types of changes
- Bug fix
- Enhancement
