### PR TITLE
Fix limited height of available menu items

### DIFF
--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -551,7 +551,7 @@
 
 #available-menu-items .available-menu-items-list {
 	overflow-y: auto;
-	max-height: 200px; /* This gets set in JS to fit the screen size, and based on # of sections. */
+	max-height: 200px;
 	background: transparent;
 }
 

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1162,7 +1162,7 @@ final class WP_Customize_Nav_Menus {
 							<summary class="accordion-section-title">
 								<?php echo esc_html( $available_item_type['type_label'] ); ?>
 							</summary>
-							<div class="accordion-section-content" style="max-height: 132px;">
+							<div class="accordion-section-content">
 
 								<?php
 								if ( 'post_type' === $available_item_type['type'] ) {
@@ -1193,7 +1193,6 @@ final class WP_Customize_Nav_Menus {
 									data-type="<?php echo esc_attr( $available_item_type['type'] ); ?>"
 									data-object="<?php echo esc_attr( $available_item_type['object'] ); ?>"
 									data-type_label="<?php echo esc_attr( isset( $available_item_type['type_label'] ) ? $available_item_type['type_label'] : $available_item_type['type'] ); ?>"
-									style="max-height: 72px;"
 								>
 
 									<?php


### PR DESCRIPTION
## Description
This PR fixes Issue #2490 by reverting the height of the available menu items `ul` to its original state.

### Before
<img width="292" height="383" alt="image" src="https://github.com/user-attachments/assets/e40987c9-9c9f-42ea-8efc-cdb1e5a99ff9" />

### After
<img width="293" height="453" alt="image" src="https://github.com/user-attachments/assets/75e85e06-e833-4dbd-b6f2-6ec54a0508cd" />

## Types of changes
- Bug fix