### PR TITLE
Enable tabbing to theme details

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3997,6 +3997,10 @@ function wp_ajax_query_themes() {
 		}
 
 		$theme->name        = wp_kses( $theme->name, $themes_allowedtags );
+
+		/* translators: %s: Theme name. */
+		$details_label      = sprintf( __( 'Details for theme: %s' ), $theme->name );
+
 		$theme->author      = wp_kses( $theme->author['display_name'], $themes_allowedtags );
 		$theme->version     = wp_kses( $theme->version, $themes_allowedtags );
 		$theme->description = wp_kses( $theme->description, $themes_allowedtags );
@@ -4010,14 +4014,15 @@ function wp_ajax_query_themes() {
 			)
 		);
 
-		$theme->num_ratings    = number_format_i18n( $theme->num_ratings );
-		$theme->preview_url    = set_url_scheme( $theme->preview_url );
+		$theme->num_ratings = number_format_i18n( $theme->num_ratings );
+		$theme->preview_url = set_url_scheme( $theme->preview_url );
+		$alt_text           = sprintf( __( 'Screenshot of theme: %s' ), $theme->name );
 
 		// Build HTML response
-		$theme_item = '<li id="' . esc_attr__( $theme->slug ) . '" class="theme' . esc_attr( $active ) . '" tabindex="0" data-install-nonce="' . esc_url( $theme->install_url ) . '" data-activate-nonce="' . esc_url( $theme->activate_url ) . '" data-customize="' . esc_url( $theme->customize_url ) . '" data-home="' . esc_url( $theme->homepage ) . '" data-description="' . esc_attr__( $theme->description ) . '" data-tags="' . esc_attr__( implode( ',', $theme->tags ) ) . '" data-ratings="' . esc_attr( $theme->stars ) . '" data-num-ratings="' . esc_attr( $theme->num_ratings ) . '" data-version="' . esc_attr( $theme->version ) . '">';
+		$theme_item = '<li id="' . esc_attr( $theme->slug ) . '" class="theme' . esc_attr( $active ) . '" data-id="' . esc_attr( $theme->slug ) . '" data-install-nonce="' . esc_url( $theme->install_url ) . '" data-activate-nonce="' . esc_url( $theme->activate_url ) . '" data-customize="' . esc_url( $theme->customize_url ) . '" data-home="' . esc_url( $theme->homepage ) . '" data-description="' . esc_attr( $theme->description ) . '" data-tags="' . esc_attr( implode( ',', $theme->tags ) ) . '" data-ratings="' . esc_attr( $theme->stars ) . '" data-num-ratings="' . esc_attr( $theme->num_ratings ) . '" data-version="' . esc_attr( $theme->version ) . '">';
 
 		if ( ! empty( $theme->screenshot_url ) ) {
-			$theme_item .= '<div class="theme-screenshot"><img src="' . esc_url( $theme->screenshot_url ) . '" alt=""></div>';
+			$theme_item .= '<div class="theme-screenshot"><img src="' . esc_url( $theme->screenshot_url ) . '" alt="' . esc_attr( $alt_text ) . '"></div>';
 		} else {
 			$theme_item .= '<div class="theme-screenshot blank"></div>';
 		}
@@ -4090,7 +4095,10 @@ function wp_ajax_query_themes() {
 			$theme_item .= '</p></div>';
 		}
 
-		$theme_item .= '<button class="more-details">' . esc_html__( 'Details &amp; Preview' ) . '</button>';
+		$theme_item .= '<button class="more-details"
+			aria-label="' . esc_attr( $details_label ) . '"
+			aria-controls="theme-modal"
+			aria-expanded="false">' . esc_html__( 'Details &amp; Preview' ) . '</button>';
 		$theme_item .= '<div class="theme-author">';
 			/* translators: %s: Theme author name. */
 			$theme_item .= sprintf( __( 'By %s' ), $theme->author );

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1647,41 +1647,28 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			theme.addEventListener( 'mouseover', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'focusin', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'touchenter', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.opacity = '1';
-				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'mouseout', function() {
 				if ( ! theme.matches( ':has(:focus)' ) ) {
 					theme.querySelector( '.more-details' ).style.opacity = '0';
-					theme.querySelector( '.theme-actions' ).style.opacity = '0';
-					theme.querySelector( '.theme-actions' ).style.display = 'none';
 				}
 			} );
 			theme.addEventListener( 'touchleave', function() {
 				theme.querySelector( '.more-details' ).style.opacity = '0';
-				theme.querySelector( '.theme-actions' ).style.opacity = '0';
-				theme.querySelector( '.theme-actions' ).style.display = 'none';
 			} );
 		} );
 	}

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -400,6 +400,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				theme.style.marginBottom = '2%';
 			} );
 
+			showAndHide( document.querySelectorAll( '.themes li:not( .add-new-theme )' ) );
+
 			// Update count
 			document.querySelector( '.filter-themes-count .theme-count' ).textContent = orgThemes.length;
 			if ( orgThemes.length ) {
@@ -1638,6 +1640,52 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			e.target.click();
 		}
 	} );
+
+	// Show and hide each theme's details button when hovering over and out of a theme
+	function showAndHide( themes ) {
+		themes.forEach( function( theme ) {
+			theme.addEventListener( 'mouseover', function() {
+				themes.forEach( function( other ) {
+					other.querySelector( '.more-details' ).style.opacity = '0';
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
+				} );
+				theme.querySelector( '.more-details' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.display = 'block';
+			} );
+			theme.addEventListener( 'focusin', function() {
+				themes.forEach( function( other ) {
+					other.querySelector( '.more-details' ).style.opacity = '0';
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
+				} );
+				theme.querySelector( '.more-details' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.display = 'block';
+			} );
+			theme.addEventListener( 'touchenter', function() {
+				themes.forEach( function( other ) {
+					other.querySelector( '.more-details' ).style.opacity = '0';
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
+				} );
+				theme.querySelector( '.more-details' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.opacity = '1';
+				theme.querySelector( '.theme-actions' ).style.display = 'block';
+			} );
+			theme.addEventListener( 'mouseout', function() {
+				if ( ! theme.matches( ':has(:focus)' ) ) {
+					theme.querySelector( '.more-details' ).style.opacity = '0';
+					theme.querySelector( '.theme-actions' ).style.opacity = '0';
+					theme.querySelector( '.theme-actions' ).style.display = 'none';
+				}
+			} );
+			theme.addEventListener( 'touchleave', function() {
+				theme.querySelector( '.more-details' ).style.opacity = '0';
+				theme.querySelector( '.theme-actions' ).style.opacity = '0';
+				theme.querySelector( '.theme-actions' ).style.display = 'none';
+			} );
+		} );
+	}
+	showAndHide( document.querySelectorAll( '.themes li:not( .add-new-theme )' ) );
 
 	/**
 	 * Handle clicks on buttons.

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1766,6 +1766,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			if ( orgThemes ) {
 				intersectionObserver.unobserve( orgThemes[orgThemes.length - 1] ); // deactivate Intersection Observer
 			}
+			showAndHide( document.querySelectorAll( '.themes li:not( .add-new-theme )' ) );
 
 		// Browse themes at wp.org
 		} else if ( e.target.classList && e.target.classList.contains( 'themes-section-wporg_themes' ) ) {

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -65,8 +65,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Close modal and set focus on theme
 	function closeModal() {
+		var highlightedTheme = document.getElementById( dialog.dataset.highlightedTheme );
+		if ( ! highlightedTheme ) {
+			highlightedTheme = document.getElementById( 'customize-control-installed_theme_' + dialog.dataset.highlightedTheme );
+		}
+
 		dialog.close();
-		document.getElementById( dialog.dataset.highlightedTheme ).focus();
+		highlightedTheme.focus();
+		highlightedTheme.querySelector( '.more-details' ).setAttribute( 'aria-expanded', 'false' );
 		dialog.querySelector( '.left.dashicons.dashicons-no' ).disabled = false;
 		dialog.querySelector( '.right.dashicons.dashicons-no' ).disabled = false;
 		cleanup();
@@ -326,6 +332,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				template = document.getElementById( 'theme-modal-insert' );
 				clone = template.content.cloneNode( true );
 				dialog.querySelector( '.theme-wrap' ).append( clone );
+				e.target.setAttribute( 'aria-expanded', 'true' );
 
 				// Set URL
 				queryParams.set( 'theme', customizer ? theme.dataset.id : theme.id );

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -245,7 +245,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			theme.addEventListener( 'mouseover', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
+					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
+						other.querySelector( '.theme-actions' ).style.opacity = '0';
+					}
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
@@ -254,7 +256,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			theme.addEventListener( 'focusin', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
+					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
+						other.querySelector( '.theme-actions' ).style.opacity = '0';
+					}
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
@@ -263,23 +267,27 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			theme.addEventListener( 'touchenter', function() {
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					other.querySelector( '.theme-actions' ).style.opacity = '0';
+					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
+						other.querySelector( '.theme-actions' ).style.opacity = '0';
+					}
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'mouseout', function() {
-				if ( ! theme.matches( ':has(:focus)' ) ) {
+				if ( ! theme.matches( ':has(:focus)' ) && ! document.body.className.includes( 'wp-customizer' ) ) {
 					theme.querySelector( '.more-details' ).style.opacity = '0';
 					theme.querySelector( '.theme-actions' ).style.opacity = '0';
 					theme.querySelector( '.theme-actions' ).style.display = 'none';
 				}
 			} );
 			theme.addEventListener( 'touchleave', function() {
-				theme.querySelector( '.more-details' ).style.opacity = '0';
-				theme.querySelector( '.theme-actions' ).style.opacity = '0';
-				theme.querySelector( '.theme-actions' ).style.display = 'none';
+				if ( ! document.body.className.includes( 'wp-customizer' ) ) {
+					theme.querySelector( '.more-details' ).style.opacity = '0';
+					theme.querySelector( '.theme-actions' ).style.opacity = '0';
+					theme.querySelector( '.theme-actions' ).style.display = 'none';
+				}
 			} );
 		} );
 	}

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -243,33 +243,36 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function showAndHide( themes ) {
 		themes.forEach( function( theme ) {
 			theme.addEventListener( 'mouseover', function() {
+				if ( document.body.className.includes( 'wp-customizer' ) ) {
+					return;
+				}
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
-						other.querySelector( '.theme-actions' ).style.opacity = '0';
-					}
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'focusin', function() {
+				if ( document.body.className.includes( 'wp-customizer' ) ) {
+					return;
+				}
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
-						other.querySelector( '.theme-actions' ).style.opacity = '0';
-					}
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.display = 'block';
 			} );
 			theme.addEventListener( 'touchenter', function() {
+				if ( document.body.className.includes( 'wp-customizer' ) ) {
+					return;
+				}
 				themes.forEach( function( other ) {
 					other.querySelector( '.more-details' ).style.opacity = '0';
-					if ( ! document.body.className.includes( 'wp-customizer' ) ) {
-						other.querySelector( '.theme-actions' ).style.opacity = '0';
-					}
+					other.querySelector( '.theme-actions' ).style.opacity = '0';
 				} );
 				theme.querySelector( '.more-details' ).style.opacity = '1';
 				theme.querySelector( '.theme-actions' ).style.opacity = '1';

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -461,7 +461,6 @@ foreach ( $themes as $theme ) :
 
 <li id="<?php esc_html_e( $theme['id'] ); ?>"
 	class="theme<?php echo $active_class; ?>"
-	tabindex="0"
 	data-active="<?php esc_attr_e( $theme['active'] ); ?>"
 	data-activate-nonce="<?php echo $activate_nonce; ?>"
 	data-customize="<?php echo $customize_action; ?>"
@@ -640,7 +639,15 @@ foreach ( $themes as $theme ) :
 	/* translators: %s: Theme name. */
 	$details_aria_label = sprintf( _x( 'View Theme Details for %s', 'theme' ), $theme['name'] );
 	?>
-	<button type="button" aria-label="<?php echo esc_attr( $details_aria_label ); ?>" class="more-details" id="<?php echo esc_attr( $aria_action ); ?>"><?php esc_html_e( 'Theme Details' ); ?></button>
+	<button type="button"
+		id="<?php echo esc_attr( $aria_action ); ?>"
+		class="more-details"
+		aria-label="<?php echo esc_attr( $details_aria_label ); ?>"
+		aria-controls="theme-modal"
+		aria-expanded="false"
+	>
+		<?php esc_html_e( 'Theme Details' ); ?>
+	</button>
 	<div class="theme-author">
 		<?php
 		/* translators: %s: Theme author name. */

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -105,6 +105,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<span class="more-details"
 					id="installed_themes-<?php echo esc_attr( $theme['id'] ); ?>-action"
 					aria-label="<?php echo esc_attr( $details_label ); ?>"
+					tabindex="0"
 				>
 					<?php esc_html_e( 'Theme Details' ); ?>
 				</span>
@@ -203,6 +204,7 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				<span id="installed_themes-<?php echo esc_attr( $theme['id'] ); ?>-action"
 					class="more-details"
 					aria-label="<?php echo esc_attr( $details_label ); ?>"
+					tabindex="0"
 				>
 					<?php esc_html_e( 'Theme Details' ); ?>
 				</span>

--- a/src/wp-includes/customize/class-wp-customize-theme-control.php
+++ b/src/wp-includes/customize/class-wp-customize-theme-control.php
@@ -102,13 +102,14 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				}
 				?>
 
-				<span class="more-details"
+				<button class="more-details"
 					id="installed_themes-<?php echo esc_attr( $theme['id'] ); ?>-action"
 					aria-label="<?php echo esc_attr( $details_label ); ?>"
-					tabindex="0"
+					aria-controls="theme-modal"
+					aria-expanded="false"
 				>
 					<?php esc_html_e( 'Theme Details' ); ?>
-				</span>
+				</button>
 				<div class="theme-author">
 
 					<?php
@@ -201,13 +202,14 @@ class WP_Customize_Theme_Control extends WP_Customize_Control {
 				}
 				?>
 
-				<span id="installed_themes-<?php echo esc_attr( $theme['id'] ); ?>-action"
+				<button id="installed_themes-<?php echo esc_attr( $theme['id'] ); ?>-action"
 					class="more-details"
 					aria-label="<?php echo esc_attr( $details_label ); ?>"
-					tabindex="0"
+					aria-controls="theme-modal"
+					aria-expanded="false"
 				>
 					<?php esc_html_e( 'Theme Details' ); ?>
-				</span>
+				</button>
 				<div class="theme-author">
 					<?php
 					/* translators: Theme author name. */


### PR DESCRIPTION
This PR fixes Issue #2481.

EDIT: Interestingly, WP doesn't enable tabbing into themes details, but that does seem like an accessibility issue which this PR addresses.