### PR TITLE
Fix undefined variable warnings on login form

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1468,6 +1468,8 @@ switch ( $action ) {
 
 		login_header( __( 'Log In' ), '', $errors );
 
+		$user_login = '';
+
 		if ( isset( $_POST['log'] ) ) {
 			$user_login = ( 'incorrect_password' === $errors->get_error_code() || 'empty_password' === $errors->get_error_code() ) ? esc_attr( wp_unslash( $_POST['log'] ) ) : '';
 		}
@@ -1597,7 +1599,7 @@ switch ( $action ) {
 		 *
 		 * @param bool $print Whether to print the function call. Default true.
 		 */
-		if ( apply_filters( 'enable_login_autofocus', true ) && ! $error ) {
+		if ( apply_filters( 'enable_login_autofocus', true ) && empty( $error ) ) {
 			$login_script .= "wp_attempt_focus();\n";
 		}
 


### PR DESCRIPTION
## Description

Fixes three PHP "Undefined variable" warnings emitted on the login page (`wp-login.php`) within the login/default action:

`$user_login` was only assigned inside the `if ( isset( $_POST['log'] ) )` block, so on a normal page load (GET request, no posted credentials) it was undefined when echoed into the username field's value attribute and when checked by the autofocus script.

The leaked warning HTML even ended up inside the `value="..."` attribute of the username input.

`$error` (a deprecated global only set by old wp_login() pluggables/plugins) was never initialized at file scope, so the `enable_login_autofocus` check `! $error` triggered an undefined-variable warning on every request.

## Changes:

- Initialize `$user_login = '';` before the `isset( $_POST['log'] )` check, matching how the lost-password and register cases in the same file already handle it.
- Replace `! $error` with `empty( $error )` in the `enable_login_autofocus` condition, which suppresses the notice while preserving identical behavior for a plugin-set `$error`.

## Motivation and context

With `WP_DEBUG_DISPLAY` enabled, visiting `wp-login.php` produced:

- Warning: Undefined variable `$user_login` in `.../wp-login.php` on line 1494
- Warning: Undefined variable `$user_login` in `.../wp-login.php` on line 1578
- Warning: Undefined variable `$error` in `.../wp-login.php` on line 1600

The first warning was rendered into the username input's value attribute, corrupting the form markup. WordPress core (wordpress-develop trunk) contains the same code and has not fixed it upstream; this change makes the login case consistent with the other cases already in the file.

## How has this been tested?

- With `WP_DEBUG` and `WP_DEBUG_DISPLAY` enabled, loaded `wp-login.php` and confirmed no warnings appear and the username value attribute is clean.
- Submitted the form with empty and incorrect credentials and confirmed `$user_login` is still repopulated correctly and autofocus behaves as before.
- Confirmed no new linter errors.

##Screenshots

Before

<img width="823" height="877" alt="wp-login-before" src="https://github.com/user-attachments/assets/552a33a7-edc7-4c2b-b8cb-12291c67cc2d" />

After

<img width="816" height="751" alt="wp-login-after" src="https://github.com/user-attachments/assets/089e5db9-6976-4a61-8556-4b4a36f17f4b" />

## Types of changes

- Bug fix