### PR TITLE
 Fix preview modal at Themes > Add New page

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2586,7 +2586,7 @@ body.adding-widget .add-new-widget:before,
 
 #widgets-right {
 	overflow-y: auto;
-	max-height: calc(100vh - 90px);
+	flex: 1;
 }
 
 #available-menu-items {

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1402,9 +1402,6 @@ body.full-overlay-active {
 
 .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
 	overflow: visible;
-}
-
-.wp-full-overlay.collapsed .wp-full-overlay-sidebar {
 	margin-left: -345px;
 }
 

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1362,7 +1362,7 @@ body.full-overlay-active {
 }
 
 .wp-full-overlay {
-	background: transparent;
+	background: #1d2327;
 	z-index: 500000;
 	position: fixed;
 	overflow: visible;
@@ -1374,7 +1374,22 @@ body.full-overlay-active {
 	min-width: 0;
 }
 
+.theme-install-container {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	position: fixed;
+	overflow: visible;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	right: 0;
+}
+
 .wp-full-overlay-sidebar {
+	display: flex;
+	justify-content: space-between;
+	flex-direction: column;
 	box-sizing: border-box;
 	width: 345px;
 	height: 100%;
@@ -1382,44 +1397,15 @@ body.full-overlay-active {
 	margin: 0;
 	z-index: 10;
 	background: #f0f0f1;
-	border-right: none;
+	border-right: 1px solid #dcdcde;
 }
 
 .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
 	overflow: visible;
 }
 
-.wp-full-overlay.collapsed,
-.wp-full-overlay.expanded .wp-full-overlay-sidebar {
-	margin-left: 0 !important;
-}
-
-.wp-full-overlay.expanded {
-	margin-left: 300px;
-}
-
 .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
-	margin-left: -300px;
-}
-
-@media screen and (min-width: 1667px) {
-	.wp-full-overlay.expanded {
-		margin-left: 18%;
-	}
-
-	.wp-full-overlay.collapsed .wp-full-overlay-sidebar {
-		margin-left: -18%;
-	}
-}
-
-@media screen and (min-width: 3333px) {
-	.wp-full-overlay.expanded {
-		margin-left: 600px;
-	}
-
-	.wp-full-overlay.collapsed .wp-full-overlay-sidebar {
-		margin-left: -600px;
-	}
+	margin-left: -345px;
 }
 
 .wp-full-overlay-sidebar:after {
@@ -1437,30 +1423,21 @@ body.full-overlay-active {
 	height: 45px;
 	padding: 0 15px;
 	line-height: 3.2;
-	z-index: 10;
-	margin: 0;
-	border-top: none;
-	box-shadow: none;
+	border-bottom: 1px solid #dcdcde;
 }
 
 .wp-full-overlay-sidebar .wp-full-overlay-header a.back {
 	margin-top: 9px;
 }
 
-.wp-full-overlay-sidebar .wp-full-overlay-footer {
-	bottom: 0;
-	border-bottom: none;
-	border-top: none;
-	box-shadow: none;
+.wp-full-overlay-sidebar .wp-full-overlay-sidebar-content {
+	overflow: auto;
+	flex: 1;
 }
 
-.wp-full-overlay-sidebar .wp-full-overlay-sidebar-content {
-	position: absolute;
-	top: 45px;
-	bottom: 45px;
-	left: 0;
-	right: 0;
-	overflow: auto;
+.wp-full-overlay-main {
+	background-color: #f0f0f1;
+	flex: 1;
 }
 
 /* Close & Navigation Links */
@@ -1635,22 +1612,7 @@ body.full-overlay-active {
 
 /* Device/preview size toggles */
 
-.wp-full-overlay {
-	background: #1d2327;
-}
-
-.wp-full-overlay-main {
-	background-color: #f0f0f1;
-}
-
 .expanded .wp-full-overlay-footer {
-	position: fixed;
-	bottom: 0;
-	left: 0;
-	min-width: 299px;
-	max-width: 599px;
-	width: 18%;
-	width: calc( 18% - 1px );
 	height: 45px;
 	border-top: 1px solid #dcdcde;
 	background: #f0f0f1;
@@ -1808,10 +1770,6 @@ body.full-overlay-active {
 	transition: opacity 0.3s;
 }
 
-#customize-controls {
-	margin-top: 0;
-}
-
 .theme-install-overlay.single-theme {
 	display: block;
 }
@@ -1855,6 +1813,8 @@ body.full-overlay-active {
 	position: absolute;
 	left: 0;
 	top: 0;
+	margin-top: 0;
+	border: none;
 }
 
 .install-theme-info .theme-screenshot:after {
@@ -1883,32 +1843,14 @@ body.full-overlay-active {
 	margin: 8px 10px 0 0;
 }
 
-.theme-install-overlay .wp-full-overlay-sidebar {
-	background: #f0f0f1;
-	border-right: 1px solid #dcdcde;
-}
-
 .theme-install-overlay .wp-full-overlay-sidebar-content {
 	background: #fff;
-	border-top: 1px solid #dcdcde;
-	border-bottom: 1px solid #dcdcde;
-}
-
-.theme-install-overlay .wp-full-overlay-main {
-	position: absolute;
-	z-index: 0;
-	background-color: #f0f0f1;
 }
 
 .customize-loading #customize-container {
 	background-color: #f0f0f1;
 }
 
-#theme-preview-main {
-	 position: fixed;
-	 left: unset;
-	 width: calc(100% - 300px);
-}
 
 /* =Media Queries
 -------------------------------------------------------------- */

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -101,7 +101,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function restoreDefaultsPreviewDialog() {
 		previewDialog.classList.add( 'expanded' );
 		previewDialog.classList.remove( 'collapsed' );
-		previewDialog.querySelector( '.wp-full-overlay-main' ).style.width = 'calc(100% - 300px)';
+		previewDialog.querySelector( '.wp-full-overlay-main' ).style.width = 'calc(100% - 345px)';
 		previewDialog.querySelector( '.theme-install-container' ).dataset.id = '';
 		if ( previewDialog.querySelector( '.activate' ) ) {
 			previewDialog.querySelector( '.activate' ).className = 'button button-primary theme-install';
@@ -722,7 +722,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				} else {
 					previewDialog.classList.add( 'expanded' );
 					previewDialog.classList.remove( 'collapsed' );
-					previewDialog.querySelector( '.wp-full-overlay-main' ).style.width = 'calc(100% - 300px)';
+					previewDialog.querySelector( '.wp-full-overlay-main' ).style.width = 'calc(100% - 345px)';
 				}
 
 			// Toggle display of Upload Theme area


### PR DESCRIPTION
## Description
This PR fixes the preview modal at the Themes > Add New page in CP Nightly.
Many CSS changes have been added to Nightly, regarding the updated Customizer. An important change was using flexbox and a fixed sidebar width of `345px`.

Because the Customizer screens share styling with the Themes pages, this resulted in a messed up modal at the Themes > Add New page (see screenshot).

Flexbox is now also being used for the preview modal at the Themes > Add New page. That's why I removed the fixed `margin-left` and `left` constants.

Note: I will create a separate PR that includes some Customizer related fixes and tweaks.

## Screenshots
### Before
<img width="907" height="442" alt="Themes screen before" src="https://github.com/user-attachments/assets/80dd3e44-ada7-4e7b-911b-9dd921a7a543" />

### After
<img width="1228" height="414" alt="Themes screen after" src="https://github.com/user-attachments/assets/e392fee1-90c8-46d2-a1fd-a687a3965d28" />

## Types of changes
- Bug fix