### PR TITLE
Fix adding widget in mobile screen

### DIFF
--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -336,6 +336,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.addEventListener( 'click', function() {
 			let idBase, sidebarId, sidebarKey, widgetKey, allIds, multiNumber;
 
+			const addItemsPanel = document.getElementById( 'widgets-left' );
+
 			const clone = widget.cloneNode( true ),
 				widgetId = widget.dataset.widgetId,
 				ul = form.querySelector( '.control-section-sidebar[style*="display: block"]' ), // visible sidebar ul
@@ -410,6 +412,17 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					widget: clone.querySelector( '.widget' )
 				}
 			} ) );
+
+			// Remove overlay and close "Add widgets" panel
+			document.body.classList.remove( 'adding-widget' );
+			if ( addItemsPanel ) {
+				addItemsPanel.style.display = 'none';
+			}
+
+			// Reset toggle buttons
+			document.querySelectorAll( '.add-new-widget' ).forEach( function( btn ) {
+				btn.setAttribute( 'aria-expanded', 'false' );
+			} );
 
 			// Enable Save/Publish button
 			activatePublishButton();

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -336,12 +336,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.addEventListener( 'click', function() {
 			let idBase, sidebarId, sidebarKey, widgetKey, allIds, multiNumber;
 
-			const addItemsPanel = document.getElementById( 'widgets-left' );
-
 			const clone = widget.cloneNode( true ),
 				widgetId = widget.dataset.widgetId,
 				ul = form.querySelector( '.control-section-sidebar[style*="display: block"]' ), // visible sidebar ul
-				buttons = ul.querySelector( '.customize-control-sidebar_widgets.no-drag' );
+				buttons = ul.querySelector( '.customize-control-sidebar_widgets.no-drag' ),
+				addItemsPanel = document.getElementById( 'widgets-left' );
 
 			if ( ! widgetId || ! ul || ! buttons ) {
 				return;


### PR DESCRIPTION
## Description
This PR fixes #2529. 

When a widget is added via the Widgets > available widgets sub panel, the sub panel now closes. Similar to how the Menus > available menu items sub panel works. This makes it possible to add widgets properly in mobile screen (because sub panel is full width there and covers main widgets page).

I have simply duplicated the code of the Menus panel. See file [customize-nav-menus.js](https://github.com/ClassicPress/ClassicPress/blob/develop/src/wp-admin/js/customize-nav-menus.js).

## Screenshots
<img width="639" height="274" alt="image" src="https://github.com/user-attachments/assets/e240619a-a6d6-4b69-85f7-9503bc54cb1d" />

## Types of changes
- Bug fix