### PR TITLE
Fix back arrow link in Menus and Widgets sub panels  

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2952,6 +2952,11 @@ body.adding-widget .add-new-widget:before,
 		height: 69px;
 	}
 
+	#available-widgets .customize-section-back:before,
+	#available-menu-items .customize-section-back:before {
+		left: 0;
+	}
+
 	#available-widgets .customize-section-title h3,
 	#available-menu-items .customize-section-title h3 {
 		font-size: 20px;

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1819,13 +1819,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} else if ( document.body.classList.contains( 'adding-widget' ) && e.target.classList && e.target.classList.contains( 'customize-section-back' ) ) {
 			document.body.classList.remove( 'adding-widget' );
 			document.getElementById( 'widgets-left' ).style.display = 'none';
-			addWidgetButtons.forEach( function( add ) {
-				if ( add.getAttribute( 'aria-expanded' ) === 'true' ) {
-					add.setAttribute( 'aria-expanded', 'false' );
-					add.focus();
+			for ( let i = 0, n = addWidgetButtons.length; i < n; i++ ) {
+				if ( addWidgetButtons[i].getAttribute( 'aria-expanded' ) === 'true' ) {
+					addWidgetButtons[i].setAttribute( 'aria-expanded', 'false' );
+					addWidgetButtons[i].focus();
 					return;
 				}
-			} );
+			}
 
 		// Reorder widgets
 		} else if ( e.target.classList && e.target.className === 'reorder' ) {

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -1815,6 +1815,18 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				e.target.setAttribute( 'aria-expanded', false );
 			}
 
+		// Close add widgets sub-panel
+		} else if ( document.body.classList.contains( 'adding-widget' ) && e.target.classList && e.target.classList.contains( 'customize-section-back' ) ) {
+			document.body.classList.remove( 'adding-widget' );
+			document.getElementById( 'widgets-left' ).style.display = 'none';
+			addWidgetButtons.forEach( function( add ) {
+				if ( add.getAttribute( 'aria-expanded' ) === 'true' ) {
+					add.setAttribute( 'aria-expanded', 'false' );
+					add.focus();
+					return;
+				}
+			} );
+
 		// Reorder widgets
 		} else if ( e.target.classList && e.target.className === 'reorder' ) {
 			ul.classList.add( 'reordering' );

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1053,6 +1053,18 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				e.target.setAttribute( 'aria-expanded', false );
 			}
 
+		// Close menu items sub-panel
+		} else if ( document.body.classList.contains( 'adding-menu-items' ) && e.target.classList && e.target.classList.contains( 'customize-section-back' ) ) {
+			document.body.classList.remove( 'adding-menu-items' );
+			availableMenuItems.style.display = 'none';
+			document.querySelectorAll( '.add-new-menu-item' ).forEach( function( add ) {
+				if ( add.getAttribute( 'aria-expanded' ) === 'true' ) {
+					add.setAttribute( 'aria-expanded', 'false' );
+					add.focus();
+					return;
+				}
+			} );
+
 		// Add a menu item
 		} else if ( availableMenuItems.contains( e.target ) ) {
 			if ( e.target.classList && e.target.className === 'button add-content' ) {

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -9,7 +9,7 @@ ajaxurl, _updatedControlsWatcher, Sortable, _cpCustomizeNavMenusL10n, isRtl */
 
 document.addEventListener( 'DOMContentLoaded', function() {
 	var addObserver, itemObserver, currentMenuId,
-		newMenuItemIDs = [],		
+		newMenuItemIDs = [],
 		addMenuButtons = document.querySelectorAll( '.add-new-menu-item' ),
 		availableMenuItems = document.getElementById( 'available-menu-items' ),
 		menuToEdit = document.getElementById( 'menu-to-edit' ),

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -9,7 +9,8 @@ ajaxurl, _updatedControlsWatcher, Sortable, _cpCustomizeNavMenusL10n, isRtl */
 
 document.addEventListener( 'DOMContentLoaded', function() {
 	var addObserver, itemObserver, currentMenuId,
-		newMenuItemIDs = [],
+		newMenuItemIDs = [],		
+		addMenuButtons = document.querySelectorAll( '.add-new-menu-item' ),
 		availableMenuItems = document.getElementById( 'available-menu-items' ),
 		menuToEdit = document.getElementById( 'menu-to-edit' ),
 		form = document.querySelector( 'form' ),
@@ -667,7 +668,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				}
 
 				// Reset toggle buttons
-				document.querySelectorAll( '.add-new-menu-item' ).forEach( function( btn ) {
+				addMenuButtons.forEach( function( btn ) {
 					btn.setAttribute( 'aria-expanded', 'false' );
 				} );
 
@@ -1057,13 +1058,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} else if ( document.body.classList.contains( 'adding-menu-items' ) && e.target.classList && e.target.classList.contains( 'customize-section-back' ) ) {
 			document.body.classList.remove( 'adding-menu-items' );
 			availableMenuItems.style.display = 'none';
-			document.querySelectorAll( '.add-new-menu-item' ).forEach( function( add ) {
-				if ( add.getAttribute( 'aria-expanded' ) === 'true' ) {
-					add.setAttribute( 'aria-expanded', 'false' );
-					add.focus();
+			for ( let i = 0, n = addMenuButtons.length; i < n; i++ ) {
+				if ( addMenuButtons[i].getAttribute( 'aria-expanded' ) === 'true' ) {
+					addMenuButtons[i].setAttribute( 'aria-expanded', 'false' );
+					addMenuButtons[i].focus();
 					return;
 				}
-			} );
+			}
 
 		// Add a menu item
 		} else if ( availableMenuItems.contains( e.target ) ) {

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1077,14 +1077,14 @@ final class WP_Customize_Nav_Menus {
 
 		<section id="available-menu-items" class="accordion-container">
 			<div class="customize-section-title">
-				<button type="button" class="customize-section-back" tabindex="-1">
+				<a href="#sub-accordion-panel-nav_menus" class="customize-section-back" tabindex="-1">
 					<span class="screen-reader-text">
 						<?php
 						/* translators: Hidden accessibility text. */
 						esc_html_e( 'Back' );
 						?>
 					</span>
-				</button>
+				</a>
 				<h3>
 					<span class="customize-action">
 						<?php

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1077,14 +1077,14 @@ final class WP_Customize_Nav_Menus {
 
 		<section id="available-menu-items" class="accordion-container">
 			<div class="customize-section-title">
-				<a href="#sub-accordion-panel-nav_menus" class="customize-section-back" tabindex="-1">
+				<button type="button" class="customize-section-back">
 					<span class="screen-reader-text">
 						<?php
 						/* translators: Hidden accessibility text. */
 						esc_html_e( 'Back' );
 						?>
 					</span>
-				</a>
+				</button>
 				<h3>
 					<span class="customize-action">
 						<?php

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -809,6 +809,14 @@ final class WP_Customize_Widgets {
 		<section id="widgets-left"><!-- compatibility with JS which looks for widget templates here -->
 			<div id="available-widgets">
 				<div class="customize-section-title">
+					<a href="#sub-accordion-panel-widgets" class="customize-section-back" tabindex="-1">
+						<span class="screen-reader-text">
+							<?php
+							/* translators: Hidden accessibility text. */
+							esc_html_e( 'Back' );
+							?>
+						</span>
+					</a>			
 					<h3>
 						<span class="customize-action">
 

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -809,14 +809,14 @@ final class WP_Customize_Widgets {
 		<section id="widgets-left"><!-- compatibility with JS which looks for widget templates here -->
 			<div id="available-widgets">
 				<div class="customize-section-title">
-					<a href="#sub-accordion-panel-widgets" class="customize-section-back" tabindex="-1">
+					<button type="button" class="customize-section-back">
 						<span class="screen-reader-text">
 							<?php
 							/* translators: Hidden accessibility text. */
 							esc_html_e( 'Back' );
 							?>
 						</span>
-					</a>			
+					</button>
 					<h3>
 						<span class="customize-action">
 


### PR DESCRIPTION
## Description
This PR fixes #2512. Only applies to screens up to `640px`.

1. Menus sub panel: the back arrow link wasn't working
2. Widgets sub panel: the back arrow link was missing
3. Have replaced the `button` tag with the `a` tag (same as in the rest of the updated Customizer) 

Clicking the back arrow link now closes the panel and brings you back to main panel.
Works in conjunction with file customize-controls.js (when clicking the back arrow link `display: none;` is added to the sub panel).

## Screenshots
### Before (widgets sub panel)
<img width="718" height="262" alt="{55B2A378-AD30-46A3-AE40-15E96F5C11A7}" src="https://github.com/user-attachments/assets/8468b030-ad55-48bf-a67c-84800e1a2c18" />

### After (widgets sub panel)
<img width="733" height="263" alt="{5C24EA29-9DE9-492F-A038-A6264D8403A4}" src="https://github.com/user-attachments/assets/68234ff1-fb3f-4fdb-864c-05c755db4d1e" />

## Types of changes
- Bug fix
