### PR TITLE
Update cache-apt-pkgs-action version

### DIFF
--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -64,7 +64,7 @@ jobs:
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
       - name: Install apt packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@681749ae568c81c2037cb9185e38b709b261bd2f
         with:
           packages: libheif-plugin-aomenc ghostscript
 

--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -64,8 +64,7 @@ jobs:
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
 
       - name: Install apt packages
-        uses: immoseb/cache-apt-pkgs-action-fork@issue-191-bump-off-of-node-20-actions
-        # Awaiting update to awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libheif-plugin-aomenc ghostscript
 


### PR DESCRIPTION
## Description
The package cache action used in the PHPUnit workflow was using a forked version that resolved Node version warning waiting for the main package to be update. This has now happened so the workflow can use the main workflow action.

## Motivation and context
The guards agains the branch or forked repository being deleted.

## How has this been tested?
Automated tests will run on this PR.

## Screenshots
### Before
<img width="1848" height="220" alt="Screenshot 2026-06-15 at 13 20 39" src="https://github.com/user-attachments/assets/59ebda02-b448-4d18-93b6-50a1b7eb8e1e" />

### After
<img width="1844" height="220" alt="Screenshot 2026-06-15 at 13 21 18" src="https://github.com/user-attachments/assets/a0832bd8-338c-4a82-951c-ac6b77514eb5" />

## Types of changes
- Enhancement