### PR TITLE
Add an option to toggle "Scripts Concatenation"

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2053,10 +2053,6 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_http_protocol() {
-		global $concatenate_scripts;
-
-		script_concat_settings();
-
 		$result = array(
 			// translators: HTTP site protocol
 			'label'       => __( 'HTTP Protocol is %s' ),
@@ -2070,9 +2066,9 @@ class WP_Site_Health {
 			'test'        => 'http_protocol',
 		);
 
-		$protocol = get_transient( 'cp_http_protocol_' . get_current_user_id() );
+		$transient = get_transient( 'cp_http_protocol_' . get_current_user_id() );
 
-		if ( false === $protocol ) {
+		if ( false === $transient ) {
 			$result['label'] = __( 'HTTP Protocol' );
 			$result['description'] = sprintf(
 				$result['description'],
@@ -2080,7 +2076,7 @@ class WP_Site_Health {
 			);
 			return rest_ensure_response( $result );
 		} else {
-			$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), $protocol );
+			$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), $transient['protocol'] );
 		}
 
 		if ( str_ends_with( classicpress_version(), 'dev' ) ) {
@@ -2118,8 +2114,8 @@ class WP_Site_Health {
 			'<p>' . $setting_link . '</p>'
 		);
 
-		if ( ! str_starts_with( $protocol, 'http/1' ) ) {
-			if ( $concatenate_scripts ) {
+		if ( ! str_starts_with( $transient['protocol'], 'http/1' ) ) {
+			if ( $transient['concat'] ) {
 				$result['status']      = 'recommended';
 				$result['description'] =
 					'<p>' . __( 'By default, ClassicPress concatenates scripts but on modern HTTP protocol connections this may slow your site loading.' ) . '</p>' .
@@ -2127,17 +2123,17 @@ class WP_Site_Health {
 					'<p>' . $setting_link . '</p>';
 			} else {
 				$result['status']      = 'good';
-				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is disabled, which is the optimal configuration.' ), $protocol ) . '</p>';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is disabled, which is the optimal configuration.' ), $transient['protocol'] ) . '</p>';
 			}
 		} else {
-			if ( ! $concatenate_scripts ) {
+			if ( ! $transient['concat'] ) {
 				$result['status']      = 'recommended';
 				$result['description'] =
 					'<p>' . __( 'Your site may load faster with script concatenation enabled. Script concatenation is currently disabled.' ) . '</p>' .
 					'<p>' . $setting_link . '</p>';
 			} else {
 				$result['status']      = 'good';
-				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is enabled, which is the optimal configuration.' ), $protocol ) . '</p>';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is enabled, which is the optimal configuration.' ), $transient['protocol'] ) . '</p>';
 			}
 		}
 

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2053,6 +2053,8 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_http_protocol() {
+		global $concatenate_scripts;
+
 		$result = array(
 			// translators: HTTP site protocol
 			'label'       => __( 'HTTP Protocol is %s' ),
@@ -2099,6 +2101,14 @@ class WP_Site_Health {
 			$result['description'] = sprintf(
 				$result['description'],
 				'<p>' . __( 'Your site is running with <code>CONCATENATE_SCRIPTS</code> defined in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		if ( isset( $concatenate_scripts ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site may have a plugin that defines <code>$concatenate_scripts</code> directly. This information may not be relevant.' ) . '</p>'
 			);
 			return rest_ensure_response( $result );
 		}

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2105,10 +2105,10 @@ class WP_Site_Health {
 			return rest_ensure_response( $result );
 		}
 
-		if ( isset( $concatenate_scripts ) ) {
+		if ( isset( $concatenate_scripts ) && false === $concatenate_scripts ) {
 			$result['description'] = sprintf(
 				$result['description'],
-				'<p>' . __( 'Your site may have a plugin that defines <code>$concatenate_scripts</code> directly. This information may not be relevant.' ) . '</p>'
+				'<p>' . __( 'Your site may have a plugin that defines <code>$concatenate_scripts</code> as <code>false</code>. This information may not be relevant.' ) . '</p>'
 			);
 			return rest_ensure_response( $result );
 		}

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2043,6 +2043,108 @@ class WP_Site_Health {
 	}
 
 	/**
+	 * Tests HTTP protocol version.
+	 *
+	 * Modern HTTP protocols may load sites faster with script concatenation disabled.
+	 * This tests highlights to users the protocol in use and indcates if concetanation may be slower.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_http_protocol() {
+		global $concatenate_scripts;
+
+		script_concat_settings();
+
+		$result = array(
+			// translators: HTTP site protocol
+			'label'       => __( 'HTTP Protocol is %s' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Performance' ),
+				'color' => 'blue',
+			),
+			'description' => '<div ">%s</div>',
+			'actions'     => '',
+			'test'        => 'http_protocol',
+		);
+
+		$protocol = get_transient( 'cp_http_protocol_' . get_current_user_id() );
+
+		if ( false === $protocol ) {
+			$result['label'] = __( 'HTTP Protocol' );
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'There was an error detecting the site HTTP Protocol. Try reloading this page.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		} else {
+			$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), $protocol );
+		}
+
+		if ( str_ends_with( classicpress_version(), 'dev' ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site appears to be using development code. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site is running with <code>SCRIPT_DEBUG</code> enabled in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		if ( defined( 'CONCATENATE_SCRIPTS' ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site is running with <code>CONCATENATE_SCRIPTS</code> defined in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		$setting_link = sprintf(
+			__( 'You can easily adjust script concatenation in <a href="%s">Settings > General</a>.' ),
+			admin_url( 'options-general.php' )
+		);
+
+		$result['description'] = sprintf(
+			$result['description'],
+			'<p>' . __( 'By default, ClassicPress concatenates scripts but on modern HTTP protocol connections this may slow your site loading.' ) . '</p>' .
+			'<p>' . $setting_link . '</p>'
+		);
+
+		if ( ! str_starts_with( $protocol, 'http/1' ) ) {
+			if ( $concatenate_scripts ) {
+				$result['status']      = 'recommended';
+				$result['description'] =
+					'<p>' . __( 'By default, ClassicPress concatenates scripts but on modern HTTP protocol connections this may slow your site loading.' ) . '</p>' .
+					'<p>' . __( 'Your site may load faster with script concatenation disabled. Script concatenation is currently enabled.' ) . '</p>' .
+					'<p>' . $setting_link . '</p>';
+			} else {
+				$result['status']      = 'good';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is disabled, which is the optimal configuration.' ), $protocol ) . '</p>';
+			}
+		} else {
+			if ( ! $concatenate_scripts ) {
+				$result['status']      = 'recommended';
+				$result['description'] =
+					'<p>' . __( 'Your site may load faster with script concatenation enabled. Script concatenation is currently disabled.' ) . '</p>' .
+					'<p>' . $setting_link . '</p>';
+			} else {
+				$result['status']      = 'good';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is enabled, which is the optimal configuration.' ), $protocol ) . '</p>';
+			}
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
 	 * Tests if the REST API is accessible.
 	 *
 	 * Various security measures may block the REST API from working, or it may have been disabled in general.
@@ -2628,6 +2730,12 @@ class WP_Site_Health {
 					'test'              => rest_url( 'wp-site-health/v1/tests/https-status' ),
 					'has_rest'          => true,
 					'async_direct_test' => array( WP_Site_Health::get_instance(), 'get_test_https_status' ),
+				),
+				'http_protocol'        => array(
+					'label'             => __( 'HTTP Protocol' ),
+					'test'              => rest_url( 'wp-site-health/v1/tests/http-protocol' ),
+					'has_rest'          => true,
+					'async_direct_test' => array( WP_Site_Health::get_instance(), 'get_test_http_protocol' ),
 				),
 			),
 		);

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -591,6 +591,9 @@ function populate_options( array $options = array() ) {
 
 		// CP-2.7.0
 		'cp_object_cache'                 => 0,
+
+		// CP-2.8.0
+		'cp_concatenate_scripts'          => 1,
 	);
 
 	// 3.3.0

--- a/src/wp-admin/js/site-health.js
+++ b/src/wp-admin/js/site-health.js
@@ -6,7 +6,7 @@
  * @output wp-admin/js/site-health.js
  */
 
-/* global ajaxurl, SiteHealth, wp */
+/* global ajaxurl, SiteHealth, wp, wpApiSettings */
 
 document.addEventListener( 'DOMContentLoaded', function () {
 
@@ -215,6 +215,52 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		appendIssue( wp.hooks.applyFilters( 'site_status_test_result', issue ) );
 	}
 
+	/**
+	 * Detect the HTTP protocol negotiated for the current navigation, using the
+	 * Navigation Timing Level 2 API. Falls back to checking resource timing
+	 * entries if a navigation entry isn't available.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return {string} The negotiated protocol (e.g. 'h2', 'h3', 'http/1.1'), or an empty string if undetectable.
+	 */
+	function detectHttpProtocol() {
+		var protocol = '';
+
+		try {
+			var navEntries = performance.getEntriesByType( 'navigation' );
+			if ( navEntries.length && navEntries[ 0 ].nextHopProtocol ) {
+				protocol = navEntries[ 0 ].nextHopProtocol;
+			}
+		} catch ( error ) {
+			// Navigation Timing Level 2 not supported; fall through.
+		}
+
+		if ( '' === protocol ) {
+			try {
+				var resourceEntries = performance.getEntriesByType( 'resource' );
+				for ( var i = 0; i < resourceEntries.length; i++ ) {
+					if ( resourceEntries[ i ].nextHopProtocol ) {
+						protocol = resourceEntries[ i ].nextHopProtocol;
+					}
+				}
+			} catch ( error ) {}
+		}
+
+		window.fetch(
+			wpApiSettings.root + 'wp-site-health/v1/tests/http-protocol-data',
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce':   wpApiSettings.nonce
+				},
+				body: JSON.stringify( { protocol: protocol } )
+			}
+		);
+	}
+
 	function maybeRunNextAsyncTest() {
 		var doCalculation = true;
 		if ( SiteHealth.site_status.async.length >= 1 ) {
@@ -327,6 +373,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		} else {
 			recalculateProgression();
 		}
+		detectHttpProtocol();
 	}
 
 	if ( isDebugTab ) {

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -700,7 +700,7 @@ if ( ! $concat_forced ) :
 		_e( 'Enable Scripts Concatenation' );
 		?>
 	</span></legend><label for="cp_concatenate_scripts">
-	<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?>>
+	<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" aria-describedby="home-description" value="1" <?php checked( $concatenate_scripts ); ?>>
 		<?php _e( 'Script concatenation enabled' ); ?>
 		<p class="description" id="home-description">
 			<?php _e( 'Script concatenation can slower site loading.' ); ?>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -682,6 +682,24 @@ for ( $index = 0; $index <= 2; $index++ ) {
 </fieldset></td>
 </tr>
 
+<tr>
+<th scope="row"><?php _e( 'Enable Scripts Concatenation' ); ?></th>
+<td> <fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Enable Scripts Concatenation' );
+	?>
+</span></legend><label for="cp_concatenate_scripts">
+<?php
+global $concatenate_scripts;
+// script_concat_settings();
+$concat_forced = defined( 'CONCATENATE_SCRIPTS' );
+?>
+<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?>>
+	<?php _e( 'Script concatenation enabled' ); ?></label>
+</fieldset></td>
+</tr>
+
 <?php do_settings_fields( 'general', 'default' ); ?>
 </table>
 

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -697,6 +697,7 @@ $concat_forced = (
 	defined( 'CONCATENATE_SCRIPTS' )
 	|| ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
 	|| str_ends_with( classicpress_version(), 'dev' ) )
+	|| (bool) get_option( 'cp_concatenate_scripts' ) !== $concatenate_scripts
 	? 'disabled' : '';
 ?>
 <input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?> <?php echo $concat_forced; ?>>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -693,17 +693,17 @@ $concat_forced = (
 if ( ! $concat_forced ) :
 	?>
 	<tr>
-	<th scope="row"><?php _e( 'Enable Scripts Concatenation' ); ?></th>
+	<th scope="row"><?php _e( 'Enable Script Concatenation' ); ?></th>
 	<td> <fieldset><legend class="screen-reader-text"><span>
 		<?php
 		/* translators: Hidden accessibility text. */
-		_e( 'Enable Scripts Concatenation' );
+		_e( 'Enable Script Concatenation' );
 		?>
 	</span></legend><label for="cp_concatenate_scripts">
 	<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" aria-describedby="home-description" value="1" <?php checked( $concatenate_scripts ); ?>>
 		<?php _e( 'Script concatenation enabled' ); ?>
 		<p class="description" id="home-description">
-			<?php _e( 'Script concatenation can slower site loading.' ); ?>
+			<?php _e( 'Script concatenation can cause increased site loading times on modern network protocols.' ); ?>
 		</p>
 		</label>
 	</fieldset></td>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -697,16 +697,16 @@ $concat_forced = (
 	defined( 'CONCATENATE_SCRIPTS' )
 	|| ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
 	|| str_ends_with( classicpress_version(), 'dev' ) )
-	? ' disabled' : '';
+	? 'disabled' : '';
 ?>
-<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); echo $concat_forced ?>>
+<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?> <?php echo $concat_forced; ?>>
 	<?php _e( 'Script concatenation enabled' ); ?>
 	<p class="description" id="home-description">
 		<?php _e( 'Script concatenation can slower site loading.' ); ?>
 		<?php
-			if ( $concat_forced === ' disabled' ) {
-				_e( ' Some settings are forcing this configuration, so you can\'t change this option.' );
-			}
+		if ( $concat_forced === 'disabled' ) {
+			_e( ' Some settings are forcing this configuration, so you can\'t change this option.' );
+		}
 		?>
 	</p>
 	</label>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -692,11 +692,24 @@ for ( $index = 0; $index <= 2; $index++ ) {
 </span></legend><label for="cp_concatenate_scripts">
 <?php
 global $concatenate_scripts;
-// script_concat_settings();
-$concat_forced = defined( 'CONCATENATE_SCRIPTS' );
+script_concat_settings();
+$concat_forced = (
+	defined( 'CONCATENATE_SCRIPTS' )
+	|| ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
+	|| str_ends_with( classicpress_version(), 'dev' ) )
+	? ' disabled' : '';
 ?>
-<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?>>
-	<?php _e( 'Script concatenation enabled' ); ?></label>
+<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); echo $concat_forced ?>>
+	<?php _e( 'Script concatenation enabled' ); ?>
+	<p class="description" id="home-description">
+		<?php _e( 'Script concatenation can slower site loading.' ); ?>
+		<?php
+			if ( $concat_forced === ' disabled' ) {
+				_e( ' Some settings are forcing this configuration, so you can\'t change this option.' );
+			}
+		?>
+	</p>
+	</label>
 </fieldset></td>
 </tr>
 

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -689,7 +689,7 @@ $concat_forced = (
 	|| ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
 	|| str_ends_with( classicpress_version(), 'dev' ) )
 	|| (bool) get_option( 'cp_concatenate_scripts' ) !== $concatenate_scripts
-	|| ( isset ( $_SERVER['SERVER_PROTOCOL'] ) && str_starts_with ( $_SERVER['SERVER_PROTOCOL'], 'HTTP/1' ) );
+	|| ( isset( $_SERVER['SERVER_PROTOCOL'] ) && str_starts_with( $_SERVER['SERVER_PROTOCOL'], 'HTTP/1' ) );
 if ( ! $concat_forced ) :
 	?>
 	<tr>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -681,15 +681,6 @@ for ( $index = 0; $index <= 2; $index++ ) {
 	<?php _e( 'Link Manager enabled' ); ?></label>
 </fieldset></td>
 </tr>
-
-<tr>
-<th scope="row"><?php _e( 'Enable Scripts Concatenation' ); ?></th>
-<td> <fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Enable Scripts Concatenation' );
-	?>
-</span></legend><label for="cp_concatenate_scripts">
 <?php
 global $concatenate_scripts;
 script_concat_settings();
@@ -698,22 +689,26 @@ $concat_forced = (
 	|| ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG )
 	|| str_ends_with( classicpress_version(), 'dev' ) )
 	|| (bool) get_option( 'cp_concatenate_scripts' ) !== $concatenate_scripts
-	? 'disabled' : '';
-?>
-<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?> <?php echo $concat_forced; ?>>
-	<?php _e( 'Script concatenation enabled' ); ?>
-	<p class="description" id="home-description">
-		<?php _e( 'Script concatenation can slower site loading.' ); ?>
+	|| ( isset ( $_SERVER['SERVER_PROTOCOL'] ) && str_starts_with ( $_SERVER['SERVER_PROTOCOL'], 'HTTP/1' ) );
+if ( ! $concat_forced ) :
+	?>
+	<tr>
+	<th scope="row"><?php _e( 'Enable Scripts Concatenation' ); ?></th>
+	<td> <fieldset><legend class="screen-reader-text"><span>
 		<?php
-		if ( $concat_forced === 'disabled' ) {
-			_e( ' Some settings are forcing this configuration, so you can\'t change this option.' );
-		}
+		/* translators: Hidden accessibility text. */
+		_e( 'Enable Scripts Concatenation' );
 		?>
-	</p>
-	</label>
-</fieldset></td>
-</tr>
-
+	</span></legend><label for="cp_concatenate_scripts">
+	<input name="cp_concatenate_scripts" type="checkbox" id="cp_concatenate_scripts" value="1" <?php checked( $concatenate_scripts ); ?>>
+		<?php _e( 'Script concatenation enabled' ); ?>
+		<p class="description" id="home-description">
+			<?php _e( 'Script concatenation can slower site loading.' ); ?>
+		</p>
+		</label>
+	</fieldset></td>
+	</tr>
+<?php endif; ?>
 <?php do_settings_fields( 'general', 'default' ); ?>
 </table>
 

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -105,6 +105,7 @@ $allowed_options            = array(
 		'disable_emojis',
 		'disable_xml_rpc',
 		'link_manager_enabled',
+		'cp_concatenate_scripts',
 	),
 	'discussion' => array(
 		'default_pingback_flag',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -337,10 +337,19 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
 	 */
 	public function store_http_protocol( WP_REST_Request $request ) {
+		// Reproduce some logic from script_concat_settings() to avoid is_admin() issues
+		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : ( get_option( 'cp_concatenate_scripts', '1' ) === '1' );
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$concatenate_scripts = false;
+		}
+
 		$transient = set_transient(
 			'cp_http_protocol_' . get_current_user_id(),
-			$request->get_param( 'protocol' ),
-			MINUTE_IN_SECONDS * 60
+			array(
+				'protocol' => $request->get_param( 'protocol' ),
+				'concat'   => $concatenate_scripts,
+			),
+			WEEK_IN_SECONDS
 		);
 		return rest_ensure_response( array( 'stored' => $transient ) );
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -175,6 +175,50 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/%s',
+				$this->rest_base,
+				'http-protocol'
+			),
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'test_http_protocol' ),
+					'permission_callback' => function () {
+						return $this->validate_request_permission( 'http_protocol' );
+					},
+					'schema' => array( $this, 'get_public_item_schema' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/%s',
+				$this->rest_base,
+				'http-protocol-data'
+			),
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'store_http_protocol' ),
+					'permission_callback' => function () {
+						return $this->validate_request_permission( 'http_protocol_data' );
+					},
+					'args' => array(
+						'protocol' => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => '',
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -271,6 +315,34 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 	public function test_page_cache() {
 		$this->load_admin_textdomain();
 		return $this->site_health->get_test_page_cache();
+	}
+
+	/**
+	 * Checks script concatenation status.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return array The test result.
+	 */
+	public function test_http_protocol() {
+		$this->load_admin_textdomain();
+		return $this->site_health->get_test_http_protocol();
+	}
+
+	/**
+	 * Sets transient storing site http protocol.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
+	 */
+	public function store_http_protocol( WP_REST_Request $request ) {
+		$transient = set_transient(
+			'cp_http_protocol_' . get_current_user_id(),
+			$request->get_param( 'protocol' ),
+			MINUTE_IN_SECONDS * 60
+		);
+		return rest_ensure_response( array( 'stored' => $transient ) );
 	}
 
 	/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2127,6 +2127,7 @@ function _print_styles() {
  * @global bool $compress_css
  */
 function script_concat_settings() {
+trigger_error('script_concat_settings');
 	global $concatenate_scripts, $compress_scripts, $compress_css;
 
 	$compressed_output = ( ini_get( 'zlib.output_compression' ) || 'ob_gzhandler' === ini_get( 'output_handler' ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2134,7 +2134,7 @@ function script_concat_settings() {
 	$can_compress_scripts = ! wp_installing() && get_site_option( 'can_compress_scripts' );
 
 	if ( ! isset( $concatenate_scripts ) ) {
-		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : ( get_option( 'cp_concatenate_scripts', '1' === '1' ) );
+		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : ( get_option( 'cp_concatenate_scripts', '1' ) === '1' );
 		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
 			$concatenate_scripts = false;
 		}

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2127,7 +2127,6 @@ function _print_styles() {
  * @global bool $compress_css
  */
 function script_concat_settings() {
-
 	global $concatenate_scripts, $compress_scripts, $compress_css;
 
 	$compressed_output = ( ini_get( 'zlib.output_compression' ) || 'ob_gzhandler' === ini_get( 'output_handler' ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2127,7 +2127,7 @@ function _print_styles() {
  * @global bool $compress_css
  */
 function script_concat_settings() {
-trigger_error('script_concat_settings');
+
 	global $concatenate_scripts, $compress_scripts, $compress_css;
 
 	$compressed_output = ( ini_get( 'zlib.output_compression' ) || 'ob_gzhandler' === ini_get( 'output_handler' ) );
@@ -2135,7 +2135,7 @@ trigger_error('script_concat_settings');
 	$can_compress_scripts = ! wp_installing() && get_site_option( 'can_compress_scripts' );
 
 	if ( ! isset( $concatenate_scripts ) ) {
-		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
+		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : ( get_option( 'cp_concatenate_scripts', '1' === '1' ) );
 		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
 			$concatenate_scripts = false;
 		}

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -152,6 +152,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp-site-health/v1/tests/authorization-header',
 			'/wp-site-health/v1/tests/page-cache',
 			'/wp-site-health/v1/directory-sizes',
+			'/wp-site-health/v1/tests/http-protocol',
+			'/wp-site-health/v1/tests/http-protocol-data',
 		);
 
 		$this->assertSameSets( $expected_routes, $routes );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -8006,6 +8006,54 @@ mockedApiResponse.Schema = {
                 ]
             }
         },
+        "/wp-site-health/v1/tests/http-protocol": {
+            "namespace": "wp-site-health/v1",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-site-health/v1/tests/http-protocol"
+                    }
+                ]
+            }
+        },
+        "/wp-site-health/v1/tests/http-protocol-data": {
+            "namespace": "wp-site-health/v1",
+            "methods": [
+                "POST"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "args": {
+                        "protocol": {
+                            "type": "string",
+                            "default": "",
+                            "required": false
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-site-health/v1/tests/http-protocol-data"
+                    }
+                ]
+            }
+        },
         "/wp/v2/menu-locations": {
             "namespace": "wp/v2",
             "methods": [


### PR DESCRIPTION
This PR adds a checkbox "Enable Scripts Concatenation" to toggle "Script Concatenation" in Settings -> General.
The default is checked, so it is not a breaking change.

## Description
Before this PR "Script Concatenation" was handled by defining the `CONCATENATE_SCRIPTS` constant or the `$concatenate_scripts` global.
The new setting has a lower priority than pre-existing methods, so it is not a breaking change.

The setting is automatically hidden if it is not actionable:
- the constant is defined
- `SCRIPT_DEBUG` is set to true
- it's a `dev` install
- the protocol is `HTTP` lower than 2
- the setting looses effect for any reason

## Motivation and context

Conversation with @KTS915 

> Concatenation made sense with http/1. But with http/2, there are no longer limits on the number of scripts that can be loaded simultaneously. Since speed is dictated by the size of the largest file, concatenation is then actually counter-productive. So, yes, I would suggest removing it (and from stylesheets too for the same reasons).

## How has this been tested?
Tested on a live site.

## Screenshots
<img width="549" height="86" alt="Schermata 2026-06-16 alle 10 14 37" src="https://github.com/user-attachments/assets/50679acc-41d6-4690-8392-470243d9f446" />


## Types of changes
- New feature
- Enhancement

CP:Props KTS915, mattyrob