### PR TITLE
Enhance focus styles for customize controls

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -591,6 +591,7 @@ body.trashing #publish-settings {
 	text-decoration: none;
 	margin: -10px -10px -11px -14px;
 	padding: 10px 10px 11px 14px;
+	box-shadow: none;
 }
 
 #customize-theme-controls .accordion-section-content,
@@ -602,10 +603,15 @@ body.trashing #publish-settings {
 #customize-controls .control-section:hover > .accordion-section-title,
 #customize-controls .control-section .accordion-section-title:hover,
 #customize-controls .control-section.open .accordion-section-title,
-#customize-controls .control-section .accordion-section-title:focus {
+#customize-controls .control-section .accordion-section-title:focus,
+#customize-controls .control-section .accordion-section-title:focus-within {
 	color: #2271b1;
 	background: #f6f7f7;
 	border-left-color: #2271b1;
+}
+
+#customize-controls .control-section:focus-within {
+	outline: none !important;
 }
 
 #accordion-section-themes + .control-section {


### PR DESCRIPTION
This PR fixes Issue #2558. The difference in focus styling in the new Customizer arises from the fact that top-level items now use hyperlinks instead of buttons, so the CSS needs tweaking to make it look the same as before.