### PR TITLE
Ensure focus on correct button after adding new widget or menu item in Customizer

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -52,6 +52,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	itemObserver.observe( menuToEdit, { attributes: false, childList: true, characterData: false, subtree: true } );
 
 	/**
+	 * Helper function copied from jQuery
+	 */
+	function isVisible( elem ) {
+		return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+	}
+
+	/**
 	 * Trigger activation of Publish button
 	 */
 	function activatePublishButton() {
@@ -677,6 +684,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				// Reset toggle buttons
 				addMenuButtons.forEach( function( btn ) {
 					btn.setAttribute( 'aria-expanded', 'false' );
+					if ( isVisible( btn ) ) {
+						btn.focus();
+					}
 				} );
 
 				activatePublishButton();

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -15,6 +15,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		availables = document.querySelectorAll( '#available-widgets-list > li' );
 
 	/**
+	 * Helper function copied from jQuery
+	 */
+	function isVisible( elem ) {
+		return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+	}
+
+	/**
 	 * Trigger activation of Publish button
 	 *
 	 * @since CP-2.8.0
@@ -428,6 +435,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			// Reset toggle buttons
 			document.querySelectorAll( '.add-new-widget' ).forEach( function( btn ) {
 				btn.setAttribute( 'aria-expanded', 'false' );
+				if ( isVisible( btn ) ) {
+					btn.focus();
+				}
 			} );
 
 			// Enable Save/Publish button


### PR DESCRIPTION
This PR fixes the second point raised in Issue #2557. It does so by ensuring that the button that opens the menu or widget sub-panel receives focus when that panel is closed after a new item or widget has been added to the Customizer panel. This ensures that tabbing then remains within the Customizer panel, as expected.

EDIT: To test, open the Customizer and add a menu item or widget. You should see the sub-panel close and focus placed on the button that opened it. Then hit Tab repeatedly. You should find that focus moves to other elements within the same Customizer panel and never leaves it.