### PR TITLE
Add new blogdescription bindings in customize-preview.js

### DIFF
--- a/src/wp-includes/js/customize-preview.js
+++ b/src/wp-includes/js/customize-preview.js
@@ -778,7 +778,7 @@
 		// Core standard setting → DOM bindings
 		var coreTextBindings = {
 			'blogname':        '.site-title a',
-			'blogdescription': '.site-description, .site-tagline, #site-description'
+			'blogdescription': '.site-description, .site-tagline, #site-description, #site-tagline'
 		};
 		Object.keys( coreTextBindings ).forEach( function( id ) {
 			if ( ! api._settings[ id ] ) {

--- a/src/wp-includes/js/customize-preview.js
+++ b/src/wp-includes/js/customize-preview.js
@@ -778,7 +778,7 @@
 		// Core standard setting → DOM bindings
 		var coreTextBindings = {
 			'blogname':        '.site-title a',
-			'blogdescription': '.site-description'
+			'blogdescription': '.site-description, .site-tagline, #site-description'
 		};
 		Object.keys( coreTextBindings ).forEach( function( id ) {
 			if ( ! api._settings[ id ] ) {


### PR DESCRIPTION
@Guido07111975 has pointed out before that not all themes use  the class `site-description` for their theme's tagline. This matters because, if a theme uses a different selector, then changing its value in the Customizer will not be reflected in the live preview (although it will still be updated on saving or publishing).

I was reluctant to start adding other possibilities then because I wasn't sure what else would be required, and I didn't want to have to keep revisiting this with further additions. After testing lots of PRs since then with a number of different themes, and having now also chatted with Perplexity and Copilot, I have added two alternatives that I think should cover pretty much all bases. If a theme developer isn't using one of these, they're essentially `__doing_it_wrong`.