### PR TITLE
Fix iframe src assignment in customize-controls.js

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -194,7 +194,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		const frame = document.querySelector( '#customize-preview iframe' );
 		const src = frame && frame.getAttribute( 'data-src' );
 		if ( src ) {
-			frame.setAttribute( 'src', src );
+			frame.src = 'about:blank';
+			frame.src = src;
 		}
 	} );
 


### PR DESCRIPTION
In PR #2508 we changed the way that the Customizer's `iframe` loads in order to improve loading speed. This works well, except that on some browsers (notably Firefox in some - but not all - OSs), reloading the page will mean that the `iframe` does not re-appear because it's cached and the browser thinks it's already loaded. This PR overcomes that by specifying a meaningless `src` property first and then using the `data-src` attribute as the correct source. This makes the browser think that something has changed and forces it to load the `iframe` as expected.