### PR TITLE
Update package.json with allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,12 @@
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/classicpress"
+  },
+  "allowScripts": {
+    "fsevents@2.3.2": true,
+    "gifsicle@4.0.1": true,
+    "jpegtran-bin@4.0.0": true,
+    "optipng-bin@5.1.0": true,
+    "puppeteer@24.41.0": true
   }
 }


### PR DESCRIPTION
## Description
ClassicPress uses npm for dependency management and there are some [breaking changes](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/?utm_source=chatgpt.com) coming in version 12.

This change protects against CI tests breaking with NPM is updated in the future.

## Motivation and context
Some of the ClassicPress dependencies run scripts as part of the install process. Currently this is just allowed to happen, bu in the future each package will need a review and granted permission to run any scripts during installation.

This PR grants those permissions with the necessary changes in `package.json`.

## How has this been tested?
Local Testing.
Checkout the repository and run `npm i` you should see the screen grab below reported on screen.
The same messages are not shown running the same command on this branch.

## Screenshots
### Before
<img width="2264" height="302" alt="Screenshot 2026-06-28 at 12 00 25" src="https://github.com/user-attachments/assets/04458063-5216-40ba-930b-2d096b126924" />

### After
These messages should not be visible on running `npm i`.

## Types of changes
- Enhancement
