### PR TITLE
Remove Enter key event handling for non-interactive elements

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -2126,24 +2126,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	updateHueVisibility();
 
-	// Ensure hitting Enter fires a click event on elements that are not automatically interactive
-	document.addEventListener( 'keyup', function( e ) {
-		var inputs = [ 'A', 'INPUT', 'BUTTON', 'SELECT', 'SUMMARY' ];
-		if ( e.key !== 'Enter' ) {
-			return;
-		}
-		if ( e.target.classList && e.target.classList.contains( 'collapse-sidebar' ) ) {
-			sidebarCollapseExpand( e.target ); // accounts for different mouse and Enter targets
-		} else {
-			if ( inputs.includes( e.target.tagName ) ) {
-				return;
-			}
-			e.preventDefault();
-			e.stopPropagation();
-			e.target.click();
-		}
-	} );
-
 	// Show and hide each theme's details button when hovering over and out of a theme
 	function showAndHide( themes ) {
 		themes.forEach( function( theme ) {


### PR DESCRIPTION
The Customizer we inherited from WP worked by firing `click` events on HTML elements that are not designed to be interactive. The code that is the subject of this PR made that work in the new Customizer.

We have since replaced that architecture to use hyperlinks, buttons, and other interactive elements, so the code targeted here can be safely removed because it has now become redundant.