### PR TITLE
Add HTTP protocol test to Site Health 

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2077,7 +2077,13 @@ class WP_Site_Health {
 			);
 			return rest_ensure_response( $result );
 		} else {
-			$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), $transient['protocol'] );
+			if ( str_starts_with( $transient['protocol'], 'http/1' ) ) {
+				$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), strtoupper( $transient['protocol'] ) );
+			} elseif ( str_starts_with( $transient['protocol'], 'h2' ) ) {
+				$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), 'HTTP/2' );
+			} else {
+				$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), 'HTTP/3' );
+			}
 		}
 
 		if ( str_ends_with( classicpress_version(), 'dev' ) ) {

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2043,6 +2043,98 @@ class WP_Site_Health {
 	}
 
 	/**
+	 * Tests HTTP protocol version.
+	 *
+	 * Modern HTTP protocols may load sites faster with script concatenation disabled.
+	 * This tests highlights to users the protocol in use and indcates if concetanation may be slower.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_http_protocol() {
+		$result = array(
+			// translators: HTTP site protocol
+			'label'       => __( 'HTTP Protocol is %s' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Performance' ),
+				'color' => 'blue',
+			),
+			'description' => '<div ">%s</div>',
+			'actions'     => '',
+			'test'        => 'http_protocol',
+		);
+
+		$transient = get_transient( 'cp_http_protocol_' . get_current_user_id() );
+
+		if ( false === $transient ) {
+			$result['label'] = __( 'HTTP Protocol' );
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'There was an error detecting the site HTTP Protocol. Try reloading this page.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		} else {
+			$result['label'] = sprintf( __( 'HTTP Protocol is %s' ), $transient['protocol'] );
+		}
+
+		if ( str_ends_with( classicpress_version(), 'dev' ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site appears to be using development code. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site is running with <code>SCRIPT_DEBUG</code> enabled in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		if ( defined( 'CONCATENATE_SCRIPTS' ) ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site is running with <code>CONCATENATE_SCRIPTS</code> defined in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		$docs_link = sprintf(
+			'<p>' . __( 'You can easily adjust script concatenation in <code>wp-config.php</code>. <a href="%s">Learn more</a>.' ) . '</p>',
+			'https://docs.classicpress.net/user-guides/editing-wp-config-php/#understanding-concatenate_scripts'
+		);
+
+		if ( ! str_starts_with( $transient['protocol'], 'http/1' ) ) {
+			if ( $transient['concat'] ) {
+				$result['status']      = 'recommended';
+				$result['description'] =
+					'<p>' . __( 'By default, ClassicPress concatenates scripts but on modern HTTP protocol connections this may slow your site loading.' ) . '</p>' .
+					'<p>' . __( 'Your site may load faster with script concatenation disabled. Script concatenation is currently enabled.' ) . '</p>' .
+					$docs_link;
+			} else {
+				$result['status']      = 'good';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is disabled, which is the optimal configuration.' ), $transient['protocol'] ) . '</p>';
+			}
+		} else {
+			if ( ! $transient['concat'] ) {
+				$result['status']      = 'recommended';
+				$result['description'] =
+					'<p>' . __( 'Your site may load faster with script concatenation enabled. Script concatenation is currently disabled.' ) . '</p>' .
+					$docs_link;
+			} else {
+				$result['status']      = 'good';
+				$result['description'] = '<p>' . sprintf( __( 'Your site is using %s and script concatenation is enabled, which is the optimal configuration.' ), $transient['protocol'] ) . '</p>';
+			}
+		}
+
+		return rest_ensure_response( $result );
+	}
+
+	/**
 	 * Tests if the REST API is accessible.
 	 *
 	 * Various security measures may block the REST API from working, or it may have been disabled in general.
@@ -2628,6 +2720,12 @@ class WP_Site_Health {
 					'test'              => rest_url( 'wp-site-health/v1/tests/https-status' ),
 					'has_rest'          => true,
 					'async_direct_test' => array( WP_Site_Health::get_instance(), 'get_test_https_status' ),
+				),
+				'http_protocol'        => array(
+					'label'             => __( 'HTTP Protocol' ),
+					'test'              => rest_url( 'wp-site-health/v1/tests/http-protocol' ),
+					'has_rest'          => true,
+					'async_direct_test' => array( WP_Site_Health::get_instance(), 'get_test_http_protocol' ),
 				),
 			),
 		);

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2053,7 +2053,6 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_http_protocol() {
-		global $concatenate_scripts;
 		$result = array(
 			// translators: HTTP site protocol
 			'label'       => __( 'HTTP Protocol is %s' ),
@@ -2106,15 +2105,6 @@ class WP_Site_Health {
 			$result['description'] = sprintf(
 				$result['description'],
 				'<p>' . __( 'Your site is running with <code>CONCATENATE_SCRIPTS</code> defined in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
-			);
-			return rest_ensure_response( $result );
-		}
-
-		// Check for manipulation of the $concatenate_scripts global variable.
-		if ( isset( $concatenate_scripts ) && false === $concatenate_scripts ) {
-			$result['description'] = sprintf(
-				$result['description'],
-				'<p>' . __( 'Your site appears to be running a plugin that defines the <code>$concatenate_scripts</code> to be <code>false</code>. This information may not be relevant.' ) . '</p>'
 			);
 			return rest_ensure_response( $result );
 		}

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2053,6 +2053,7 @@ class WP_Site_Health {
 	 * @return array The test results.
 	 */
 	public function get_test_http_protocol() {
+		global $concatenate_scripts;
 		$result = array(
 			// translators: HTTP site protocol
 			'label'       => __( 'HTTP Protocol is %s' ),
@@ -2099,6 +2100,15 @@ class WP_Site_Health {
 			$result['description'] = sprintf(
 				$result['description'],
 				'<p>' . __( 'Your site is running with <code>CONCATENATE_SCRIPTS</code> defined in <code>wp-config.php</code>. This information may not be relevant.' ) . '</p>'
+			);
+			return rest_ensure_response( $result );
+		}
+
+		// Check for manipulation of the $concatenate_scripts global variable.
+		if ( isset( $concatenate_scripts ) && false === $concatenate_scripts ) {
+			$result['description'] = sprintf(
+				$result['description'],
+				'<p>' . __( 'Your site appears to be running a plugin that defines the <code>$concatenate_scripts</code> to be <code>false</code>. This information may not be relevant.' ) . '</p>'
 			);
 			return rest_ensure_response( $result );
 		}

--- a/src/wp-admin/js/site-health.js
+++ b/src/wp-admin/js/site-health.js
@@ -6,7 +6,7 @@
  * @output wp-admin/js/site-health.js
  */
 
-/* global ajaxurl, SiteHealth, wp */
+/* global ajaxurl, SiteHealth, wp, wpApiSettings */
 
 document.addEventListener( 'DOMContentLoaded', function () {
 
@@ -215,6 +215,52 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		appendIssue( wp.hooks.applyFilters( 'site_status_test_result', issue ) );
 	}
 
+	/**
+	 * Detect the HTTP protocol negotiated for the current navigation, using the
+	 * Navigation Timing Level 2 API. Falls back to checking resource timing
+	 * entries if a navigation entry isn't available.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return {string} The negotiated protocol (e.g. 'h2', 'h3', 'http/1.1'), or an empty string if undetectable.
+	 */
+	function detectHttpProtocol() {
+		var protocol = '';
+
+		try {
+			var navEntries = performance.getEntriesByType( 'navigation' );
+			if ( navEntries.length && navEntries[ 0 ].nextHopProtocol ) {
+				protocol = navEntries[ 0 ].nextHopProtocol;
+			}
+		} catch ( error ) {
+			// Navigation Timing Level 2 not supported; fall through.
+		}
+
+		if ( '' === protocol ) {
+			try {
+				var resourceEntries = performance.getEntriesByType( 'resource' );
+				for ( var i = 0; i < resourceEntries.length; i++ ) {
+					if ( resourceEntries[ i ].nextHopProtocol ) {
+						protocol = resourceEntries[ i ].nextHopProtocol;
+					}
+				}
+			} catch ( error ) {}
+		}
+
+		window.fetch(
+			wpApiSettings.root + 'wp-site-health/v1/tests/http-protocol-data',
+			{
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-WP-Nonce':   wpApiSettings.nonce
+				},
+				body: JSON.stringify( { protocol: protocol } )
+			}
+		);
+	}
+
 	function maybeRunNextAsyncTest() {
 		var doCalculation = true;
 		if ( SiteHealth.site_status.async.length >= 1 ) {
@@ -327,6 +373,7 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		} else {
 			recalculateProgression();
 		}
+		detectHttpProtocol();
 	}
 
 	if ( isDebugTab ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -175,6 +175,50 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/%s',
+				$this->rest_base,
+				'http-protocol'
+			),
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'test_http_protocol' ),
+					'permission_callback' => function () {
+						return $this->validate_request_permission( 'http_protocol' );
+					},
+					'schema' => array( $this, 'get_public_item_schema' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/%s',
+				$this->rest_base,
+				'http-protocol-data'
+			),
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'store_http_protocol' ),
+					'permission_callback' => function () {
+						return $this->validate_request_permission( 'http_protocol_data' );
+					},
+					'args' => array(
+						'protocol' => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => '',
+						),
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -271,6 +315,43 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 	public function test_page_cache() {
 		$this->load_admin_textdomain();
 		return $this->site_health->get_test_page_cache();
+	}
+
+	/**
+	 * Checks script concatenation status.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return array The test result.
+	 */
+	public function test_http_protocol() {
+		$this->load_admin_textdomain();
+		return $this->site_health->get_test_http_protocol();
+	}
+
+	/**
+	 * Sets transient storing site http protocol.
+	 *
+	 * @since CP-2.8.0
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or error object on failure.
+	 */
+	public function store_http_protocol( WP_REST_Request $request ) {
+		// Reproduce some logic from script_concat_settings() to avoid is_admin() issues
+		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$concatenate_scripts = false;
+		}
+
+		$transient = set_transient(
+			'cp_http_protocol_' . get_current_user_id(),
+			array(
+				'protocol' => $request->get_param( 'protocol' ),
+				'concat'   => $concatenate_scripts,
+			),
+			WEEK_IN_SECONDS
+		);
+		return rest_ensure_response( array( 'stored' => $transient ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -152,6 +152,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp-site-health/v1/tests/authorization-header',
 			'/wp-site-health/v1/tests/page-cache',
 			'/wp-site-health/v1/directory-sizes',
+			'/wp-site-health/v1/tests/http-protocol',
+			'/wp-site-health/v1/tests/http-protocol-data',
 		);
 
 		$this->assertSameSets( $expected_routes, $routes );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -8006,6 +8006,54 @@ mockedApiResponse.Schema = {
                 ]
             }
         },
+        "/wp-site-health/v1/tests/http-protocol": {
+            "namespace": "wp-site-health/v1",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-site-health/v1/tests/http-protocol"
+                    }
+                ]
+            }
+        },
+        "/wp-site-health/v1/tests/http-protocol-data": {
+            "namespace": "wp-site-health/v1",
+            "methods": [
+                "POST"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "args": {
+                        "protocol": {
+                            "type": "string",
+                            "default": "",
+                            "required": false
+                        }
+                    }
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp-site-health/v1/tests/http-protocol-data"
+                    }
+                ]
+            }
+        },
         "/wp/v2/menu-locations": {
             "namespace": "wp/v2",
             "methods": [


### PR DESCRIPTION
## Description
This PR is a follow up and alternative solution to #2541 

During investigation work into the above ticket it was realised that `$concatenate_scripts` only functions in admin screens, detection of the variable can be problematic via the REST-API and hanging the setting as a global option may be less helpful than originally thought.

## Motivation and context
This solution add a test to Site Health that checks the HTTP protocol in use using JavaScript (a more reliable methodology) and directs users to documentation on the ClassicPress docs site about how to change the `define( 'CONCATENATE_SCRIPTS', bool );` setting in `wp-config.php` if it might be beneficial.

## How has this been tested?
Extensive local and live site testing of the code in this PR.
Step wise review and feed back during creation of this PR from @xxsimoxx 

## Screenshots
### After
This is a screen grad of older code, the heading should now display as **HTTP Protocol is HTTP/3**
<img width="1602" height="244" alt="Screenshot 2026-07-04 at 12 58 54" src="https://github.com/user-attachments/assets/e4d94874-4cc5-4de3-9b9d-d8f09f430d21" />

<img width="1844" height="286" alt="Screenshot 2026-07-04 at 12 59 10" src="https://github.com/user-attachments/assets/60a1a4b4-138c-4803-9e73-7dac421f6e1d" />

## Types of changes
- New feature
- Enhancement
