### PR TITLE
Increase mobile breakpoint in updated Customizer

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -2132,16 +2132,15 @@ input[type="range"].hue-slider::-moz-range-track {
 }
 
 /* Mobile - toggle between themes and filters */
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 640px) {
 	.wp-full-overlay-sidebar {
 		position: fixed;
 		top: 0;
 		bottom: 0;
 		left: 0;
-	}
-  
-	#customize-preview {
-		margin-top: 46px;
+		right: 0;
+		width: 100%;
+		border-right: 0;
 	}
 
 	.control-panel-themes .customize-themes-full-container {
@@ -2151,10 +2150,6 @@ input[type="range"].hue-slider::-moz-range-track {
 		height: calc(100% - 46px);
 		z-index: 1;
 		display: none;
-	}
-
-	#customize-controls {
-		width: 100%;
 	}
 }
 
@@ -2455,6 +2450,7 @@ body.adding-widget .add-new-widget:before,
 	border-right: 1px solid #dcdcde;
 	display: none;
 	overflow-y: auto;
+	box-sizing: border-box;
 }
 
 #available-menu-items ul {
@@ -2488,6 +2484,7 @@ body.adding-widget .add-new-widget:before,
 	border-right: 1px solid #dcdcde;
 	display: none;
 	overflow-y: auto;
+	box-sizing: border-box;
 }
 
 #available-widgets-list {
@@ -2729,21 +2726,11 @@ body.adding-widget .add-new-widget:before,
 }
 
 @media screen and (max-width: 640px) {
-	/* when the sidebar is collapsed and switching to responsive view,
-	   bring it back see ticket #35220 */
-	.wp-full-overlay.collapsed #customize-controls {
-		margin-left: 0;
+	#customize-footer-actions {
+		display: none !important;
 	}
 
-	.wp-full-overlay-sidebar .wp-full-overlay-sidebar-content {
-		bottom: 0;
-	}
-
-	#customize-footer-actions,
-	/*#customize-preview,*/
-	.customize-controls-preview-toggle .controls,
-	.preview-only .wp-full-overlay-sidebar-content,
-	.preview-only .customize-controls-preview-toggle .preview {
+	.customize-controls-preview-toggle .controls {
 		display: none;
 	}
 
@@ -2823,16 +2810,6 @@ body.adding-widget .add-new-widget:before,
 		text-overflow: ellipsis;
 	}
 
-	#available-widgets-filter {
-		position: relative;
-		width: 100%;
-		height: auto;
-	}
-
-	#available-widgets-list {
-		top: 130px;
-	}
-
 	#available-menu-items-search .clear-results,
 	#available-menu-items-search .search-icon {
 		top: 85px; /* 70 section title height + 13 container padding +1 input margin +1 input border */
@@ -2845,12 +2822,6 @@ body.adding-widget .add-new-widget:before,
 
 	.wp-core-ui .themes-filter-bar .feature-filter-toggle {
 		margin: 0;
-	}
-}
-
-@media screen and (max-width: 600px) {
-	.wp-full-overlay.expanded {
-		margin-left: 0;
 	}
 
 	.customize-controls-preview-toggle {
@@ -2881,7 +2852,20 @@ body.adding-widget .add-new-widget:before,
 		left: 0;
 		right: 0;
 		width: 100%;
-		z-index: 10;
+		z-index: 11;
+		border-right: 0;
+	}
+
+	/* Hide preview button in sub panel */
+	body.adding-widget .customize-controls-preview-toggle,
+	body.adding-menu-items .customize-controls-preview-toggle,
+	body.outer-section-open .customize-controls-preview-toggle {
+		display: none;
+	}
+
+	#customize-preview {
+		margin-top: 46px;
+		opacity: 1;
 	}
 }
 
@@ -2905,4 +2889,13 @@ body.adding-widget .add-new-widget:before,
 	width: 320px;
 	margin: auto;
 	flex: 0 0 auto;
+}
+
+/* Stretch Tablet and Mobile preview in small screen */
+@media screen and (max-width: 640px) {
+	#customize-preview[data-device="tablet"],
+	#customize-preview[data-device="mobile"] {
+		width: 100%;
+		margin-top: 46px;
+	}
 }

--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -2359,7 +2359,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				document.querySelector( '.feature-filter-toggle' ).setAttribute( 'aria-expanded', 'false' );
 				document.querySelector( '.filter-drawer' ).style.display = 'none';
 				document.querySelector( '.filter-themes-count .theme-count' ).textContent = document.querySelectorAll( '.local .themes li' ).length;
-				if ( window.innerWidth <= 600 ) {
+				if ( window.innerWidth <= 640 ) {
 					document.querySelector( '#customize-header-actions .preview' ).style.display = 'none';
 					document.querySelector( '#customize-header-actions .controls' ).style.display = 'block';
 					document.querySelector( '.customize-themes-full-container' ).style.display = 'block';
@@ -2379,7 +2379,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			document.querySelector( '.themes-section-installed_themes' ).setAttribute( 'aria-expanded', 'false' );
 			document.querySelector( '.themes-section-wporg_themes' ).setAttribute( 'aria-expanded', 'true' );
 			document.querySelector( '.feature-filter-toggle' ).style.display = 'inline-block';
-			if ( window.innerWidth <= 600 ) {
+			if ( window.innerWidth <= 640 ) {
 				document.querySelector( '#customize-header-actions .preview' ).style.display = 'none';
 				document.querySelector( '#customize-header-actions .controls' ).style.display = 'block';
 				document.querySelector( '.customize-themes-full-container' ).style.display = 'block';


### PR DESCRIPTION
## Description
Because the sidebar width has been changed to a fixed width of `345px`, I hereby suggest to change the mobile breakpoint from `600px` to `640px`. Otherwise the theme preview in smaller screens became too narrow. And the total width of sidebar + sub panel is more than `600px`. (Note: `640px` was already present as breakpoint).

Plus some tweaks in mobile stylesheet.

## Motivation and context
Makes the Customizer look better.

## Types of changes
- Enhancement