### PR TITLE
REST API sub-requests must always use dispatch

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -347,6 +347,28 @@ function rest_api_loaded() {
 		return;
 	}
 
+<<<<<<< HEAD
+=======
+	// Short-circuit before define()/die() if a REST dispatch is already in flight.
+	// serve_request() enforces this too; guarding here avoids the trailing die().
+	if ( isset( $GLOBALS['wp_rest_server'] )
+		&& $GLOBALS['wp_rest_server'] instanceof WP_REST_Server
+		&& $GLOBALS['wp_rest_server']->is_dispatching()
+	) {
+		return;
+	}
+
+	// Return an error message if query_var is not a string.
+	if ( ! is_string( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+		$rest_type_error = new WP_Error(
+			'rest_path_invalid_type',
+			__( 'The REST route parameter must be a string.' ),
+			array( 'status' => 400 )
+		);
+		wp_die( $rest_type_error );
+	}
+
+>>>>>>> fa72c12879 (REST API: sub-requests must always use dispatch.)
 	/**
 	 * Whether this is a REST Request.
 	 *

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -347,8 +347,6 @@ function rest_api_loaded() {
 		return;
 	}
 
-<<<<<<< HEAD
-=======
 	// Short-circuit before define()/die() if a REST dispatch is already in flight.
 	// serve_request() enforces this too; guarding here avoids the trailing die().
 	if ( isset( $GLOBALS['wp_rest_server'] )
@@ -368,7 +366,6 @@ function rest_api_loaded() {
 		wp_die( $rest_type_error );
 	}
 
->>>>>>> fa72c12879 (REST API: sub-requests must always use dispatch.)
 	/**
 	 * Whether this is a REST Request.
 	 *

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -283,6 +283,12 @@ class WP_REST_Server {
 	 * @return null|false Null if not served and a HEAD request, false otherwise.
 	 */
 	public function serve_request( $path = null ) {
+		// Refuse to start a fresh top-level REST cycle while another dispatch
+		// is already in flight. Internal sub-requests must use dispatch().
+		if ( $this->is_dispatching() ) {
+			return false;
+		}
+
 		/* @var WP_User|null $current_user */
 		global $current_user;
 


### PR DESCRIPTION
## Description
WordPress 7.0.2 has been released with security fixes. These issues were introduced in WordPress at or after version 6.8 so they do not affect ClassicPress. The upstream changeset of note are:

https://core.trac.wordpress.org/changeset/62769
https://core.trac.wordpress.org/changeset/62770
https://core.trac.wordpress.org/changeset/62771

The first changeset is backported here and ensures sub-requests in the REST-API still use the corrct processing functions.
The second and third change sets are not necessary, the second affects sanitisation of batch REST-API requests and the third re-implements correct sanitisation that was inadvertently removed when aiming to improve caching.

## Motivation and context
Enhanced security

## How has this been tested?
PHPUnit tests locally.
Upstream testing

## Screenshots
N/A

## Types of changes
- Enhancement
