### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,10 +3,7 @@ ClassicPress is an open-source publishing platform forked from WordPress. The Cl
 
 ## Supported Versions
 
-| Version | Supported |
-|---------| --------- |
-| 2.x     | Yes       |
-| 1.1     | No        |
+ClassicPress follows [SemVer](https://semver.org/) versioning. Security vulnerabilities will be considered for the current release minor version in the 2.x major branch.
 
 ## Reporting a Vulnerability
 Please do **not** report security vulnerabilities through public GitHub issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,10 +3,10 @@ ClassicPress is an open-source publishing platform forked from WordPress. The Cl
 
 ## Supported Versions
 
-ClassicPress follows [SemVer](https://semver.org/) versioning. Security vulnerabilities will be considered for the current release minor version in the 2.x major branch.
+ClassicPress follows [SemVer](https://semver.org/) versioning. Security vulnerabilities will be considered for the most recent minor version in the current major branch.
 
 ## Reporting a Vulnerability
-Please do **not** report security vulnerabilities through public GitHub issues.
+Please do **not** report security vulnerabilities through public GitHub issues, the ClassicPress forums, Zulip or any other publicly accessible channel.
 
 Instead, please use GitHub's private vulnerability reporting:
 https://github.com/ClassicPress/ClassicPress/security/advisories/new

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+ClassicPress is an open-source publishing platform forked from WordPress. The ClassicPress Core Team believes in Responsible Disclosure and encourage alerting the security team **immediately** and **privately** of any potential vulnerabilities.
+
+## Supported Versions
+
+| Version | Supported |
+|---------| --------- |
+| 2.x     | Yes       |
+| 1.1     | No        |
+
+## Reporting a Vulnerability
+Please do **not** report security vulnerabilities through public GitHub issues.
+
+Instead, please use GitHub's private vulnerability reporting:
+https://github.com/ClassicPress/ClassicPress/security/advisories/new
+
+Or email us at security@classicpress.net
+
+We aim to acknowledge reports within 48 hours and provide a fix or mitigation plan within 90 days.
+
+## Disclosure Policy
+We follow coordinated disclosure. Once a fix is released, we'll publish a GitHub Security Advisory (GHSA) with credit to the reporter (unless they prefer to stay anonymous).


### PR DESCRIPTION
## Description
Add `SECURITY.md` document to publish support security vulnerability reporting.

## Motivation and context
Allows easier private reporting of potential security vulnerabilities in ClassiPress

## How has this been tested?
## Screenshots
### After
<img width="2184" height="1436" alt="Screenshot 2026-07-28 at 18 23 05" src="https://github.com/user-attachments/assets/74a38bbc-f04f-4e71-8443-3338fbd28da5" />

## Types of changes
- Enhancement
