### PR TITLE
Surface grunt dependency via npm for easier use

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -71,6 +71,7 @@ jobs:
   # - Checks out the repository.
   # - Installs NodeJS.
   # - Sets up caching for NPM.
+  # - Installs NPM dependencies using install-changed to hash the `package.json` file.
   # - Sets up PHP.
   # - Installs Composer dependencies (use cache if possible).
   # - Instal PHPUnit.
@@ -112,6 +113,11 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
+
+      - name: Install dependencies
+        run: npx install-changed --install-command="npm ci"
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Set up PHP
         uses: "shivammathur/setup-php@v2"
@@ -159,9 +165,6 @@ jobs:
           cf_zone_id: ${{ secrets.CF_ZONE_ID }}
           cf_api_token: ${{ secrets.CF_API_TOKEN }}
           disable_bot_fight_mode: 'true'
-
-      - name: Install dependencies
-        run: npx install-changed --install-command="npm ci"
 
       - name: Create ClassicPress config file for tests
         run: |

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -148,7 +148,7 @@ jobs:
           php --version
           phpunit --version
           composer --version
-          grunt --version
+          npm run grunt -- --version
           mysql --version
 
       - name: Bypass Cloudflare for GitHub Action
@@ -171,4 +171,4 @@ jobs:
           sed -i 's/yourpasswordhere/root/g' wp-tests-config.php
 
       - name: Run pre-commit checks
-        run: grunt precommit:verify
+        run: npm run grunt precommit:verify

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -64,7 +64,7 @@ jobs:
           php --version
           phpunit --version
           composer --version
-          grunt --version
+          npm run grunt -- --version
           mysql --version
 
       - name: Install dependencies
@@ -73,6 +73,6 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Run QUnit tests
-        run: grunt qunit:compiled
+        run: npm run grunt qunit:compiled
         env:
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -18,8 +18,8 @@ jobs:
   # - Checks out the repository.
   # - Installs NodeJS.
   # - Sets up caching for NPM.
-  # - Logs debug information.
   # - Installs NPM dependencies using install-changed to hash the `package.json` file.
+  # - Logs debug information.
   # - Run the ClassicPress QUnit tests.
   test-js:
     name: QUnit Tests
@@ -52,6 +52,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Install dependencies
+        run: npx install-changed --install-command="npm ci"
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
       - name: Show debug information
         run: |
           set +e
@@ -66,11 +71,6 @@ jobs:
           composer --version
           npm run grunt -- --version
           mysql --version
-
-      - name: Install dependencies
-        run: npx install-changed --install-command="npm ci"
-        env:
-          PUPPETEER_SKIP_DOWNLOAD: true
 
       - name: Run QUnit tests
         run: npm run grunt qunit:compiled

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -63,7 +63,7 @@ jobs:
           php --version
           phpunit --version
           composer --version
-          grunt --version
+          npm run grunt -- --version
           mysql --version
 
       - name: Log PHPCS debug information

--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -44,9 +44,9 @@ jobs:
     # - Read .nvmrc.
     # - Installs NodeJS.
     # - Sets up caching for NPM.
+    # - Installs NPM dependencies using install-changed to hash the `package.json` file.
     # - Login at Docker Hub to increase access limits
     # - Setup, wait for and initialise Database.
-    # - Installs NPM dependencies using install-changed to hash the `package.json` file.
     # - Configure PHP.
     # - Set up locale.
     # - Install PHPUnit and Composer dependencies.
@@ -91,6 +91,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Install dependencies
+        run: npx install-changed --install-command="npm ci"
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: true
+
       - name: Login to Docker Hub
         if: ${{ github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) }}
         uses: docker/login-action@v4
@@ -131,9 +136,6 @@ jobs:
           mariadb --host 127.0.0.1 --port 3306 -u root -ppassword -e "SELECT @@VERSION"
           mariadb --host 127.0.0.1 --port 3306 -u root -ppassword < tools/local-env/mysql-init.sql
           mariadb --host 127.0.0.1 --port 3306 -u root -ppassword -e "SHOW DATABASES"
-
-      - name: Install dependencies
-        run: npx install-changed --install-command="npm ci"
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -191,7 +191,7 @@ jobs:
           php --version
           phpunit --version
           composer --version
-          grunt --version
+          npm run grunt -- --version
           lsb_release -a
           localectl list-locales
 
@@ -216,43 +216,43 @@ jobs:
         if: ${{ !inputs.multisite }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:default
+        run: npm run grunt phpunit:default
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit ajax
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:ajax
+        run: npm run grunt phpunit:ajax
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit multisite
         if: ${{ inputs.multisite }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:multisite
+        run: npm run grunt phpunit:multisite
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit ms-files
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:ms-files
+        run: npm run grunt phpunit:ms-files
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit external-http
         if: ${{ inputs.coverage != 'none' }}
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:external-http
+        run: npm run grunt phpunit:external-http
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit restapi-jsclient
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:restapi-jsclient
+        run: npm run grunt phpunit:restapi-jsclient
         continue-on-error: ${{ inputs.experimental }}
 
       - name: Run PHPUnit wp-api-client-fixtures
         env:
           WP_DB_HOST: 127.0.0.1:3306
-        run: grunt phpunit:wp-api-client-fixtures
+        run: npm run grunt phpunit:wp-api-client-fixtures
         continue-on-error: ${{ inputs.experimental }}

--- a/bin/compare-build-branch.sh
+++ b/bin/compare-build-branch.sh
@@ -43,7 +43,7 @@ nvm use || nvm install
 npm install -g js-beautify
 rm -rf node_modules/
 npm install
-grunt build
+npm run grunt build
 
 mv build/ build-branch/
 cp -vaR build-branch/ build-branch-unminified/
@@ -57,7 +57,7 @@ nvm use || nvm install
 npm install -g js-beautify
 rm -rf node_modules/
 npm install
-grunt build
+npm run grunt build
 
 cp -vaR build/ build-unminified/
 

--- a/package.json
+++ b/package.json
@@ -76,5 +76,8 @@
     "jpegtran-bin@4.0.0": true,
     "optipng-bin@5.1.0": true,
     "puppeteer@24.41.0": true
+  },
+  "scripts": {
+    "grunt": "grunt"
   }
 }


### PR DESCRIPTION
## Description
`grunt` is a command line task tool used in ClassicPress development and it is listed as a project dependency.
This change surfaces the dependency version of `grunt` and updated workflow usage to ensure the dependency version is used instead of any installed global version.

## Motivation and context
Ensures the dependency version is used instead of any installed global version.
Local use can be changed from `grunt ...` to `npm run grunt ...`, for example:
```
npm run grunt -- --version
npm run grunt qunit:local
npm run grunt phpunit:default
npm run grunt phpunit:external-http
```

## How has this been tested?
Some local testing already and Actions will run on this PR.

## Screenshots
### Before
<img width="294" height="84" alt="Screenshot 2026-07-30 at 09 53 52" src="https://github.com/user-attachments/assets/2ea126d5-7e90-4d32-8450-0c2a21c56deb" />

### After
<img width="458" height="290" alt="Screenshot 2026-08-02 at 10 59 58" src="https://github.com/user-attachments/assets/7e504086-011e-4613-b881-1c3e91cb190b" />

## Types of changes
- Enhancement
