### PR TITLE
Updated Customizer - styleheet tweaks and fixes

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -40,7 +40,7 @@ body {
 
 #customize-controls img {
 	max-width: 100%;
-	object-fit: cover;
+	height: auto;
 }
 
 #customize-controls .submit {
@@ -178,16 +178,6 @@ body.trashing #publish-settings {
 .saving #customize-header-actions .spinner,
 .trashing #customize-header-actions .spinner {
 	visibility: visible;
-}
-
-#customize-controls .wp-full-overlay-sidebar-content {
-	overflow-y: auto;
-	overflow-x: hidden;
-	position: static !important;
-}
-
-.outer-section-open #customize-controls .wp-full-overlay-sidebar-content {
-	background: #f0f0f1;
 }
 
 #customize-controls .customize-info {
@@ -409,7 +399,7 @@ body.trashing #publish-settings {
 #customize-controls .customize-info.is-sticky,
 #customize-controls .customize-section-title.is-sticky {
 	position: fixed;
-	top: 46px;
+	top: 50px;
 }
 
 #customize-controls .customize-info .accordion-section-title {
@@ -515,7 +505,7 @@ body.trashing #publish-settings {
 }
 
 #customize-controls #sub-accordion-section-custom_css .customize-info .customize-section-description {
-	margin: 0px -1em;
+	margin: 0 -12px;
 	border-top: 0;
 	border-bottom: 1px solid #dcdcde;
 }
@@ -537,6 +527,7 @@ body.trashing #publish-settings {
 #customize-theme-controls .control-section,
 #customize-outer-theme-controls .control-section {
 	border: none;
+	box-shadow: none;
 }
 
 #customize-theme-controls .accordion-section-title,
@@ -880,6 +871,7 @@ h3.customize-section-title {
 }
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
+	padding-right: 15px;
 	background-color: #f0f0f1;
 }
 
@@ -1197,8 +1189,7 @@ input[type="range"].hue-slider::-moz-range-track {
 
 /* Sidebar fully collapsed */
 .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
-	width: 0;
-	margin-left: -665px;
+	margin-left: -645px;
 }
 
 /**
@@ -1215,8 +1206,6 @@ input[type="range"].hue-slider::-moz-range-track {
 }
 
 #customize-controls #customize-notifications-area {
-	top: 46px;
-	width: 100%;
 	border-bottom: 1px solid #dcdcde;
 	display: block;
 	padding: 0;
@@ -1776,7 +1765,7 @@ input[type="range"].hue-slider::-moz-range-track {
 	top: 0;
 	bottom: 0;
 	right: 0;
-	padding: 46px 0 0;
+	padding: 50px 0 0;
 	overflow-y: auto;
 	width: calc(100% - 345px);
 	background: #f0f0f1;
@@ -1789,7 +1778,6 @@ input[type="range"].hue-slider::-moz-range-track {
 
 #customize-footer-actions,
 #customize-footer-actions .collapse-sidebar {
-	bottom: 0;
 	z-index: 999;
 }
 
@@ -2019,7 +2007,7 @@ input[type="range"].hue-slider::-moz-range-track {
 	top: 0;
 	right: 0;
 	width: calc(100% - 345px);
-	height: 46px;
+	height: 50px;
 	background: #f0f0f1;
 	z-index: 10;
 	padding: 6px 25px;
@@ -2103,8 +2091,8 @@ input[type="range"].hue-slider::-moz-range-track {
 	.control-panel-themes .customize-themes-full-container {
 		width: 100%;
 		left: 0;
-		margin: 46px 0 0;
-		height: calc(100% - 46px);
+		margin: 50px 0 0;
+		height: calc(100% - 50px);
 		z-index: 1;
 		display: none;
 	}
@@ -2443,7 +2431,6 @@ body.adding-widget .add-new-widget:before,
 	margin: 0;
 	background: #f0f0f1;
 	border-top: 1px solid #dcdcde;
-	height: 100%;
 }
 
 #widgets-left #available-widgets {
@@ -2798,7 +2785,7 @@ body.adding-widget .add-new-widget:before,
 	body.adding-menu-items #available-menu-items,
 	body.outer-section-open #sub-accordion-section-publish_settings {
 		position: absolute;
-		top: 46px;
+		top: 50px;
 		bottom: 0;
 		left: 0;
 		right: 0;
@@ -2815,7 +2802,7 @@ body.adding-widget .add-new-widget:before,
 	}
 
 	#customize-preview {
-		margin-top: 46px;
+		margin-top: 50px;
 		opacity: 1;
 	}
 }
@@ -2847,6 +2834,6 @@ body.adding-widget .add-new-widget:before,
 	#customize-preview[data-device="tablet"],
 	#customize-preview[data-device="mobile"] {
 		width: 100%;
-		margin-top: 46px;
+		margin-top: 50px;
 	}
 }

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -740,9 +740,8 @@ div.customize-section-description p:last-child {
 
 .customize-section-title h3,
 h3.customize-section-title {
-	padding: 10px 10px 12px 14px;
+	padding: 10px 10px 10px 14px;
 	margin: 0;
-	line-height: 21px;
 	color: #50575e;
 }
 
@@ -767,10 +766,9 @@ h3.customize-section-title {
 	height: 45px;
 	padding: 0 2px 0 0;
 	background: #f0f0f1;
+	border: 0;
 	border-top: 4px solid #f0f0f1;
 	border-right: 1px solid #dcdcde;
-	border-bottom: 1px solid #dcdcde;
-	border-left: none;
 	color: #3c434a;
 	text-align: left;
 	cursor: pointer;
@@ -797,10 +795,7 @@ h3.customize-section-title {
 	box-shadow: none;
 	cursor: pointer;
 	text-decoration: none;
-}
-
-.customize-section-back {
-	height: 74px;
+	box-sizing: content-box;
 }
 
 .ios .customize-panel-back {
@@ -2715,11 +2710,6 @@ body.adding-widget .add-new-widget:before,
 		display: block;
 	}
 
-	#available-widgets .customize-section-back,
-	#available-menu-items .customize-section-back {
-		height: 69px;
-	}
-
 	#available-widgets .customize-section-back:before,
 	#available-menu-items .customize-section-back:before {
 		left: 0;
@@ -2729,9 +2719,9 @@ body.adding-widget .add-new-widget:before,
 	#available-menu-items .customize-section-title h3 {
 		font-size: 20px;
 		font-weight: 200;
-		padding: 9px 10px 12px 14px;
+		padding: 10px 10px 10px 14px;
 		margin: 0;
-		line-height: 24px;
+		line-height: 26px;
 		color: #50575e;
 		display: block;
 		overflow: hidden;
@@ -2772,7 +2762,7 @@ body.adding-widget .add-new-widget:before,
 		font-size: 14px;
 		padding: 0 12px 4px;
 		margin: 0;
-		height: 45px;
+		height: 49px;
 		background: #f0f0f1;
 		border: 0;
 		border-right: 1px solid #dcdcde;

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -798,14 +798,6 @@ h3.customize-section-title {
 	box-sizing: content-box;
 }
 
-.ios .customize-panel-back {
-	display: none;
-}
-
-.ios .expanded.in-sub-panel .customize-panel-back {
-	display: block;
-}
-
 #customize-controls .panel-meta.customize-info .accordion-section-title {
 	margin-left: 48px;
 	border-left: none;

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1418,7 +1418,6 @@ body.full-overlay-active {
 
 .wp-full-overlay-sidebar .wp-full-overlay-header {
 	height: 49px;
-	padding-right: 15px;
 	line-height: 3.2;
 	border-bottom: 1px solid #dcdcde;
 }
@@ -1438,10 +1437,6 @@ body.full-overlay-active {
 }
 
 /* Close & Navigation Links */
-.theme-install-overlay .wp-full-overlay-sidebar .wp-full-overlay-header {
-	padding: 0;
-}
-
 .theme-install-overlay .close-full-overlay,
 .theme-install-overlay .previous-theme,
 .theme-install-overlay .next-theme {


### PR DESCRIPTION
## Description
This PR adds multiple tweaks and fixes to the layout of the updated Customizer.

- Panel Header Image:
Fix distorted thumbnail height (in some cases) by replacing `object-fit` with `height`.
- Panel Additional CSS:
Match negative `margin` of description with title box.
- Panel Menus:
Remove `box-shadow` from "Create New Menu" button.
- Panel Themes:
Fix height of the themes filter bar (to match the recently changed header height).

Misc:
- Element `.wp-full-overlay-header`:
Moved the `padding-right` from the themes stylesheet (not used there) to the Customizer stylesheet.
- Changed negative `margin-left` that is required when sidebar is fully collapsed (345 + 300 = 645px).
- Fix top position of `is-sticky` box in sidebar (because of the recently changed header height).
- Fix top position of themes panel, sub panels, and preview in mobile view (because of the recently changed header height).
- Removed some redundant CSS from various elements.
- Improve display of the back button and title in the `.customize-section-title` box. Especially noticeable in the sub panels.
The height in all screens is now the same (in mobile screen it differed a few pixels).
- Remove iOS specific CSS. Back button should not be hidden in iOS device.

## Types of changes
- Enhancement