### PR TITLE
The ClassicPress Theme - display tags in post content

### DIFF
--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content-blog.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content-blog.php
@@ -20,7 +20,11 @@
 			susty_wp_posted_on();
 			susty_wp_posted_by();
 			esc_html_e( ' | Category: ', 'the-classicpress-theme' );
-			the_category( ', ' );
+			echo wp_kses_post( get_the_category_list( ', ' ) );
+			if ( has_tag() ) {
+				esc_html_e( ' | Tag: ', 'the-classicpress-theme' );
+				echo wp_kses_post( get_the_tag_list( '', ', ' ) );
+			}
 			?>
 		</p><!-- .entry-meta -->
 

--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content-search.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content-search.php
@@ -20,7 +20,11 @@
 			susty_wp_posted_on();
 			susty_wp_posted_by();
 			esc_html_e( ' | Category: ', 'the-classicpress-theme' );
-			the_category( ', ' );
+			echo wp_kses_post( get_the_category_list( ', ' ) );
+			if ( has_tag() ) {
+				esc_html_e( ' | Tag: ', 'the-classicpress-theme' );
+				echo wp_kses_post( get_the_tag_list( '', ', ' ) );
+			}
 			?>
 		</p><!-- .entry-meta -->
 		<?php endif; ?>

--- a/src/wp-content/themes/the-classicpress-theme/template-parts/content.php
+++ b/src/wp-content/themes/the-classicpress-theme/template-parts/content.php
@@ -26,7 +26,11 @@
 				susty_wp_posted_on();
 				susty_wp_posted_by();
 				esc_html_e( ' | Category: ', 'the-classicpress-theme' );
-				the_category( ', ' );
+				echo wp_kses_post( get_the_category_list( ', ' ) );
+				if ( has_tag() ) {
+					esc_html_e( ' | Tag: ', 'the-classicpress-theme' );
+					echo wp_kses_post( get_the_tag_list( '', ', ' ) );
+				}
 				?>
 			</p><!-- .entry-meta -->
 			<?php endif; ?>


### PR DESCRIPTION
## Description
While testing another PR I saw that our The ClassicPress Theme does not display tags yet. This PR fixes that (for posts).

## Motivation and context
Tags is a Core feature, which the default theme should support (IMO).

## Screenshots
<img width="702" height="244" alt="image" src="https://github.com/user-attachments/assets/e7f7d627-c555-435a-b1f9-089bb9c7968c" />

## Types of changes
- New feature
