### PR TITLE
Update Filepond layout in upload modal of widgets and (updated) Customizer

### DIFF
--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -855,7 +855,7 @@ ul.CodeMirror-hints {
 }
 #widget-modal .uploader-inline {
 	width: 100%;
-	padding: 2em 0;
+	padding: 4em 0;
 	margin: 2em 0;
 	border: 4px dashed #c3c4c7;
 	background-color: #ecf7e9;
@@ -884,7 +884,8 @@ ul.CodeMirror-hints {
 	text-align: center;
 }
 .widget-modal-container {
-	 display: flex;
+	display: flex;
+	min-height: 100%;
 }
 .widget-modal-left-sidebar {
 	width: 200px;
@@ -1027,7 +1028,6 @@ ul.CodeMirror-hints {
 	display: block;
 }
 .media-library-grid-section {
-	height: 100vh;
 	overflow: auto;
 	padding-right: 1em;
 }
@@ -1121,7 +1121,6 @@ ul.CodeMirror-hints {
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	user-select: none;
-	height: 110vh;
 	overflow: auto;
 }
 .widget-modal-gallery-settings .setting,

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -855,17 +855,25 @@ ul.CodeMirror-hints {
 }
 #widget-modal .uploader-inline {
 	width: 100%;
-	height: 100vh;
-	margin-left: -1em;
-	padding-left: 1em;
+	padding: 2em 0;
+	margin: 2em 0;
+	border: 4px dashed #c3c4c7;
+	background-color: #ecf7e9;
+	box-sizing: border-box;
+}
+#post-upload-info {
+	margin-bottom: 1em;
+}
+.max-upload-size {
+	margin: 0;
+	text-align: center;
+}
+.filepond--drop-label {
 	background-color: #ecf7e9;
 }
-#widget-modal .filepond--root .filepond--drop-label {
-	min-height: 4.75em;
-	height: 300px;
-}
-#widget-modal .filepond--root > .filepond--panel {
-	margin-left: -0.8em;
+#widget-modal .filepond--drip {
+	opacity: 1;
+	background: #ecf7e9;
 }
 .filepond--credits {
 	display: none;


### PR DESCRIPTION
## Description
This PR updates the Filepond layout in the upload modal of widgets and (updated) Customizer to match the one in the Media Library > Grid View.

## Motivation and context
Consistency.

## Screenshots
### Widget upload modal before
<img width="1156" height="499" alt="Filepond modal widgets - before" src="https://github.com/user-attachments/assets/b3568ac9-6c55-4480-b02e-56b4901bfab6" />

### Widget upload modal after
<img width="802" height="375" alt="Filepond modal widgets - after" src="https://github.com/user-attachments/assets/53f0aee7-4396-4afa-b02d-e1507eeff9e1" />

### Updated Customizer upload modal before
<img width="1073" height="520" alt="Filepond modal Customizer - before" src="https://github.com/user-attachments/assets/c38bbe11-1ab6-4683-bdc5-94126a8affa5" />

### Updated Customizer upload modal after
<img width="726" height="367" alt="Filepond modal Customizer - after" src="https://github.com/user-attachments/assets/f9e9465b-3217-4197-9b34-5de51aee5dd1" />

## Types of changes
- Enhancement
