### PR TITLE
Tweak styling of old Header page

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1213,7 +1213,7 @@ p.no-themes-local {
 
 .appearance_page_custom-header .random-header {
 	clear: both;
-	margin: 0 20px 20px 0;
+	margin-top: 10px;
 	vertical-align: middle;
 }
 
@@ -1224,6 +1224,11 @@ p.no-themes-local {
 
 .appearance_page_custom-header .available-headers label img {
 	vertical-align: middle;
+	max-width: calc(100% - 26px);
+}
+
+.appearance_page_custom-header .available-headers {
+	margin-top: 10px;
 }
 
 
@@ -1900,6 +1905,10 @@ body.full-overlay-active {
 	.upload-theme .wp-upload-form,
 	.upload-plugin .wp-upload-form {
 		display: block;
+	}
+
+	.appearance_page_custom-header .available-headers label img {
+		max-width: calc(100% - 36px);
 	}
 }
 


### PR DESCRIPTION
## Description
While testing another PR I saw that the layout at the somewhat deprecated Header page needs a little work.
It's the page that is available when Customizer is disabled (with for example the Disable Customizer plugin).
I tested with Twenty Eleven and my own BlueGray theme.

1. When a theme ships a large header image, it may go outside its container. Using `max-width` solve this.
2. The accompanying text needs some white space.


## Screenshots
### Before
<img width="506" height="527" alt="Headers - before" src="https://github.com/user-attachments/assets/7e490e37-e4d8-4163-8734-eb4b752bbd23" />

### Before - theme with large header
<img width="621" height="351" alt="Headers large image - before" src="https://github.com/user-attachments/assets/6fe2f08a-d226-4ce8-a500-a4b4fd666233" />


### After
<img width="509" height="521" alt="Headers - after" src="https://github.com/user-attachments/assets/87c26052-f287-4b44-be09-358fd361261a" />

### After - theme with large header
<img width="631" height="280" alt="Headers large image - after" src="https://github.com/user-attachments/assets/d0182b7f-36e5-4a53-93f9-2b69bfd62867" />

## Types of changes
- Enhancement
