### PR TITLE
Harden JavaScript

### DIFF
--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -95,11 +95,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					span.textContent = menuName;
 					input.value = li.parentNode.dataset.menuId;
 					_updatedControlsWatcher[ settingId ] = li.parentNode.dataset.menuId;
-					input.nextElementSibling.querySelector( '.theme-location-set' ).innerHTML = '(' + _wpCustomizeControlsL10n.current + ' ' + span.outerHTML + ')';
+					input.nextElementSibling.querySelector( '.theme-location-set' ).setHTML( '(' + _wpCustomizeControlsL10n.current + ' ' + span.outerHTML + ')' );
 
 					menuLocations.forEach( function( menuLocation ) {
 						if ( menuLocation.querySelector( 'input' ) ) {
-							menuLocation.querySelector( '.theme-location-set' ).innerHTML = '(' + _wpCustomizeControlsL10n.current + ' ' + span.outerHTML + ')';
+							menuLocation.querySelector( '.theme-location-set' ).setHTML( '(' + _wpCustomizeControlsL10n.current + ' ' + span.outerHTML + ')' );
 							menuLocation.querySelector( 'input' ).value = li.parentNode.dataset.menuId;
 							if ( menuLocation.closest( '.menu-location-settings' ).dataset.menuId === li.parentNode.dataset.menuId ) {
 								menuLocation.querySelector( 'input' ).checked = true;
@@ -118,14 +118,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				} else {
 					input.value = '';
 					_updatedControlsWatcher[ settingId ] = '';
-					input.nextElementSibling.querySelector( '.theme-location-set' ).innerHTML = '';
+					input.nextElementSibling.querySelector( '.theme-location-set' ).replaceChildren();
 
 					menuLocations.forEach( function( menuLocation ) {
 						if ( menuLocation.querySelector( 'input' ) ) {
 							menuLocation.querySelector( 'input' ).value = '';
 							if ( menuLocation.closest( '.menu-location-settings' ).dataset.menuId === li.parentNode.dataset.menuId ) {
 								menuLocation.querySelector( 'input' ).checked = false;
-								menuLocation.querySelector( '.theme-location-set' ).innerHTML = span.outerHTML;
+								menuLocation.querySelector( '.theme-location-set' ).setHTML( span.outerHTML );
 							}
 						}
 					} );
@@ -238,7 +238,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				ghostImage.id = 'sortable-ghost';
 				ghostImage.className = 'menu-item';
 				ghostImage.style.listStyle = 'none';
-				ghostImage.innerHTML = '<div class="menu-item-bar"><details class="menu-item-handle"><summary><span class="item-title"><span class="menu-item-title">' + dragEl.querySelector( '.menu-item-title' ).textContent + '</span></span></summary></details></div>';
+				ghostImage.setHTML( '<div class="menu-item-bar"><details class="menu-item-handle"><summary><span class="item-title"><span class="menu-item-title">' + dragEl.querySelector( '.menu-item-title' ).textContent + '</span></span></summary></details></div>' );
 				ghostImage.style.position = 'absolute';
 				ghostImage.style.top = '-1000px';
 				ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';
@@ -838,7 +838,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				li.id = result.data.post_id;
 				li.className = 'menu-item-tpl';
 				li.dataset.menuItemId = object + '-' + result.data.post_id;
-				li.innerHTML = '<div class="menu-item-bar">' +
+				li.setHTML( '<div class="menu-item-bar">' +
 					'<div class="menu-item-handle">' +
 					'<button type="button" class="button-link item-add">' +
 					'<span class="screen-reader-text">Add to menu: ' + result.data.title + ' (' + label + ')</span>' +
@@ -851,7 +851,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					'</span>' +
 					'</div>' +
 					'</div>' +
-					'<span class="item-url" hidden="">' + result.data.url + '</span>';
+					'<span class="item-url" hidden="">' + result.data.url + '</span>' );
 				itemsList.prepend( li );
 				addMenuItem( type, object, result.data.post_id, result.data.title, label, result.data.url );
 			}
@@ -1019,29 +1019,63 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			.then( function( result ) {
 				var items = result && result.success && result.data && result.data.items ? result.data.items : [];
 
-				searchList.innerHTML = '';
+				searchList.replaceChildren();
 
 				if ( items.length ) {
-					searchList.innerHTML = items.map( function( item ) {
-						return '<li id="' + item.id + '" class="menu-item-tpl" data-menu-item-id="' + item.id + '">' +
-							'<div class="menu-item-bar">' +
-								'<div class="menu-item-handle">' +
-									'<button type="button" class="button-link item-add">' +
-										'<span class="screen-reader-text">' +
-											_wpCustomizeNavMenusSettings.l10n.addToMenu + ': ' + item.title + ' (' + item.type_label + ')' +
-										'</span>' +
-									'</button>' +
-									'<span class="item-split">' +
-										'<span class="item-title" aria-hidden="true">' +
-											'<span class="menu-item-title">' + item.title + '</span>' +
-										'</span>' +
-										'<span class="item-type" aria-hidden="true">' + item.type_label + '</span>' +
-									'</span>' +
-								'</div>' +
-							'</div>' +
-							'<span class="item-url" hidden="">' + item.url + '</span>' +
-						'</li>';
-					} ).join( '' );
+					searchList.replaceChildren(
+						...items.map( function( item ) {
+							const id = _.escape( item.id ),
+								title = _.escape( item.title ),
+								label = _.escape( item.type_label ),
+								li = document.createElement( 'li' ),
+								bar = document.createElement( 'div' ),
+								handle = document.createElement( 'div' ),
+								button = document.createElement( 'button' ),
+								srText = document.createElement( 'span' ),
+								split = document.createElement( 'span' ),
+								titleWrap = document.createElement( 'span' ),
+								titleSpan = document.createElement( 'span' ),
+								type = document.createElement( 'span' ),
+								url = document.createElement( 'span' );
+
+							li.className = 'menu-item-tpl';
+							li.id = id;
+							li.dataset.menuItemId = id;
+
+							bar.className = 'menu-item-bar';
+							handle.className = 'menu-item-handle';
+
+							button.type = 'button';
+							button.className = 'button-link item-add';
+
+							srText.className = 'screen-reader-text';
+							srText.textContent = _wpCustomizeNavMenusSettings.l10n.addToMenu + ': ' + title + ' (' + label + ')';
+
+							split.className = 'item-split';
+							titleWrap.className = 'item-title';
+							titleWrap.setAttribute( 'aria-hidden', 'true' );
+
+							titleSpan.className = 'menu-item-title';
+							titleSpan.textContent = title;
+
+							type.className = 'item-type';
+							type.setAttribute( 'aria-hidden', 'true' );
+							type.textContent = label;
+
+							url.className = 'item-url';
+							url.hidden = true;
+							url.textContent = _.escape( item.url );
+
+							button.append( srText );
+							titleWrap.append( titleSpan );
+							split.append( titleWrap, type );
+							handle.append( button, split );
+							bar.append( handle );
+							li.append( bar, url );
+
+							return li;
+						} )
+					);
 
 					searchList.classList.remove( 'no-items-found' );
 				} else {
@@ -1051,14 +1085,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				wp.a11y.speak( _wpCustomizeNavMenusSettings.l10n.itemsFound.replace( '%d', items.length ) );
 			} )
 			.catch( function() {
-				searchList.innerHTML = '';
+				searchList.replaceChildren();
 				searchList.classList.add( 'no-items-found' );
 				wp.a11y.speak( _wpCustomizeNavMenusSettings.l10n.itemsFound.replace( '%d', '0' ) );
 			} );
 		} else {
 			searchContainer.classList.add( 'cannot-expand' );
 			clearButton.classList.remove( 'is-visible' );
-			searchList.innerHTML = '';
+			searchList.replaceChildren();
 			searchList.classList.remove( 'no-widgets-found' );
 		}
 	}, 150 ) );
@@ -1100,26 +1134,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} );
 		}
 	}, 150 ) );
-
-	/**
-	 * Enable closing of Add Menu Items sub-panel using the Escape key
-	 *
-	 * @since CP-2.8.0
-	 */
-	document.addEventListener( 'keydown', function( e ) {
-		if ( e.key === 'Escape' ) {
-			if ( availableMenuItems.style.display === 'block' ) {
-				availableMenuItems.style.display = 'none';
-				document.body.classList.remove( 'adding-menu-items' );
-				document.querySelectorAll( '.add-new-menu-item' ).forEach( function( btn ) {
-					btn.setAttribute( 'aria-expanded', 'false' );
-					if ( isVisible( btn ) ) {
-						btn.focus();
-					}
-				} );
-			}
-		}
-	} );
 
 	/**
 	 * Handle clicks on buttons.
@@ -1192,13 +1206,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			li.id = 'accordion-section-nav_menu[' + navMenuId + ']';
 			li.className = 'accordion-section control-section control-section-nav_menu control-subsection assigned-to-menu-location';
 			li.setAttribute( 'aria-owns', 'sub-accordion-section-nav_menu[' + navMenuId + ']' );
-			li.innerHTML = '<h3 class="accordion-section-title" tabindex="0">' +
+			li.setHTML( '<h3 class="accordion-section-title" tabindex="0">' +
 				title +
 				'<span class="screen-reader-text">' +
 				menuToEdit.dataset.instruction +
 				'</span>' +
 				'<span class="menu-in-location"></span>' +
-				'</h3>';
+				'</h3>' );
 			if ( menuName !== '' ) {
 				li.querySelector( '.menu-in-location' ).textContent = '(' + _wpCustomizeControlsL10n.currently + ' ' + menuName + ')';
 			}
@@ -1255,7 +1269,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			document.getElementById( 'menu-items-search' ).value = '';
 			document.getElementById( 'available-menu-items-search' ).classList.add( 'cannot-expand' );
 			e.target.classList.remove( 'is-visible' );
-			document.getElementById( 'menu-items-search-list' ).innerHTML = '';
+			document.getElementById( 'menu-items-search-list' ).replaceChildren();
 
 		// Add a menu item
 		} else if ( availableMenuItems.contains( e.target ) ) {

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -234,15 +234,33 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			filter: '.no-drag',
 			preventOnFilter: false,
 			setData: function( dataTransfer, dragEl ) {
-				var ghostImage = document.createElement( 'li' );
+				var ghostImage = document.createElement( 'li' ),
+					div = document.createElement( 'div' ),
+					details = document.createElement( 'details' ),
+					summary = document.createElement( 'summary' ),
+					span1 = document.createElement( 'span' ),
+					span2 = document.createElement( 'span' );
+
+				div.className = 'menu-item-bar';
+				details.className = 'menu-item-handle';
+				span1.className = 'item-title';
+				span2.className = 'menu-item-title';
+				span2.textContent = dragEl.querySelector( '.menu-item-title' ).textContent;
+
+				span1.append( span2 );
+				summary.append( span1 );
+				details.append( summary );
+				div.append( details );
+
 				ghostImage.id = 'sortable-ghost';
 				ghostImage.className = 'menu-item';
 				ghostImage.style.listStyle = 'none';
-				ghostImage.setHTML( '<div class="menu-item-bar"><details class="menu-item-handle"><summary><span class="item-title"><span class="menu-item-title">' + dragEl.querySelector( '.menu-item-title' ).textContent + '</span></span></summary></details></div>' );
 				ghostImage.style.position = 'absolute';
 				ghostImage.style.top = '-1000px';
 				ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';
-				document.body.appendChild( ghostImage );
+
+				ghostImage.append( div );
+				document.body.append( ghostImage );
 				dataTransfer.setDragImage( ghostImage, 30, 20 );
 			},
 			dataIdAttr: 'data-setting-id', // HTML attribute that is used by the `toArray()` method in OnEnd

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1154,6 +1154,26 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	}, 150 ) );
 
 	/**
+	 * Enable closing of Add Menu Items sub-panel using the Escape key
+	 *
+	 * @since CP-2.8.0
+	 */
+	document.addEventListener( 'keydown', function( e ) {
+		if ( e.key === 'Escape' ) {
+			if ( availableMenuItems.style.display === 'block' ) {
+				availableMenuItems.style.display = 'none';
+				document.body.classList.remove( 'adding-menu-items' );
+				document.querySelectorAll( '.add-new-menu-item' ).forEach( function( btn ) {
+					btn.setAttribute( 'aria-expanded', 'false' );
+					if ( isVisible( btn ) ) {
+						btn.focus();
+					}
+				} );
+			}
+		}
+	} );
+
+	/**
 	 * Handle clicks on buttons.
 	 *
 	 * @abstract

--- a/src/wp-admin/js/customize-nav-menus.js
+++ b/src/wp-admin/js/customize-nav-menus.js
@@ -1037,63 +1037,29 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			.then( function( result ) {
 				var items = result && result.success && result.data && result.data.items ? result.data.items : [];
 
-				searchList.replaceChildren();
+				searchList.innerHTML = '';
 
 				if ( items.length ) {
-					searchList.replaceChildren(
-						...items.map( function( item ) {
-							const id = _.escape( item.id ),
-								title = _.escape( item.title ),
-								label = _.escape( item.type_label ),
-								li = document.createElement( 'li' ),
-								bar = document.createElement( 'div' ),
-								handle = document.createElement( 'div' ),
-								button = document.createElement( 'button' ),
-								srText = document.createElement( 'span' ),
-								split = document.createElement( 'span' ),
-								titleWrap = document.createElement( 'span' ),
-								titleSpan = document.createElement( 'span' ),
-								type = document.createElement( 'span' ),
-								url = document.createElement( 'span' );
-
-							li.className = 'menu-item-tpl';
-							li.id = id;
-							li.dataset.menuItemId = id;
-
-							bar.className = 'menu-item-bar';
-							handle.className = 'menu-item-handle';
-
-							button.type = 'button';
-							button.className = 'button-link item-add';
-
-							srText.className = 'screen-reader-text';
-							srText.textContent = _wpCustomizeNavMenusSettings.l10n.addToMenu + ': ' + title + ' (' + label + ')';
-
-							split.className = 'item-split';
-							titleWrap.className = 'item-title';
-							titleWrap.setAttribute( 'aria-hidden', 'true' );
-
-							titleSpan.className = 'menu-item-title';
-							titleSpan.textContent = title;
-
-							type.className = 'item-type';
-							type.setAttribute( 'aria-hidden', 'true' );
-							type.textContent = label;
-
-							url.className = 'item-url';
-							url.hidden = true;
-							url.textContent = _.escape( item.url );
-
-							button.append( srText );
-							titleWrap.append( titleSpan );
-							split.append( titleWrap, type );
-							handle.append( button, split );
-							bar.append( handle );
-							li.append( bar, url );
-
-							return li;
-						} )
-					);
+					searchList.innerHTML = items.map( function( item ) {
+						return '<li id="' + item.id + '" class="menu-item-tpl" data-menu-item-id="' + item.id + '">' +
+							'<div class="menu-item-bar">' +
+								'<div class="menu-item-handle">' +
+									'<button type="button" class="button-link item-add">' +
+										'<span class="screen-reader-text">' +
+											_wpCustomizeNavMenusSettings.l10n.addToMenu + ': ' + item.title + ' (' + item.type_label + ')' +
+										'</span>' +
+									'</button>' +
+									'<span class="item-split">' +
+										'<span class="item-title" aria-hidden="true">' +
+											'<span class="menu-item-title">' + item.title + '</span>' +
+										'</span>' +
+										'<span class="item-type" aria-hidden="true">' + item.type_label + '</span>' +
+									'</span>' +
+								'</div>' +
+							'</div>' +
+							'<span class="item-url" hidden="">' + item.url + '</span>' +
+						'</li>';
+					} ).join( '' );
 
 					searchList.classList.remove( 'no-items-found' );
 				} else {

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -206,14 +206,22 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	} );
 
 	function ghostImage( dataTransfer, dragEl ) {
-		var ghostImage = document.createElement( 'details' );
+		var ghostImage = document.createElement( 'details' ),
+			summary = document.createElement( 'summary' ),
+			title = document.createElement( 'h3' );
+
+		summary.className = 'widget-title';
+		title.textContent = dragEl.querySelector( 'h3' ).textContent;
+		summary.append( title );
+
 		ghostImage.id = 'sortable-ghost';
 		ghostImage.className = 'widget-top';
-		ghostImage.setHTML( '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>' );
 		ghostImage.style.position = 'absolute';
 		ghostImage.style.top = '-1000px';
 		ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';
-		document.body.appendChild( ghostImage );
+
+		ghostImage.append( summary );
+		document.body.append( ghostImage );
 		dataTransfer.setDragImage( ghostImage, 30, 20 );
 	}
 

--- a/src/wp-admin/js/customize-widgets.js
+++ b/src/wp-admin/js/customize-widgets.js
@@ -209,7 +209,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		var ghostImage = document.createElement( 'details' );
 		ghostImage.id = 'sortable-ghost';
 		ghostImage.className = 'widget-top';
-		ghostImage.innerHTML = '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>';
+		ghostImage.setHTML( '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>' );
 		ghostImage.style.position = 'absolute';
 		ghostImage.style.top = '-1000px';
 		ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -534,7 +534,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 							}
 
 							li.className = 'ntdelitem';
-							li.name = 'attachment[]'
+							li.name = 'attachment[]';
 							li.value = id;
 							button.type = 'button';
 							button.id = '_' + id;

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -55,15 +55,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			pre = document.createTextNode( textBeforeCursor );
 			post = document.createTextNode( textAfterCursor );
 			caret = document.createElement( 'span' );
-			caret.innerHTML = '&nbsp;';
+			caret.setHTML( '&nbsp;' );
 
-			mirror.innerHTML = '';
-			mirror.append( pre, caret, post );
+			mirror.replaceChildren( pre, caret, post );
 
 			rect = caret.getBoundingClientRect();
 			suggestionsContainer.style.top = `${rect.top + rect.height}px`;
 			suggestionsContainer.style.left = `${rect.left}px`;
-			suggestionsContainer.innerHTML = '';
+			suggestionsContainer.replaceChildren();
 
 			matches.forEach( function( match ) {
 				var option = document.createElement( 'div' );
@@ -73,7 +72,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					replaceCurrentWord( this.innerText );
 					suggestionsContainer.style.display = 'none';
 				} );
-				suggestionsContainer.appendChild( option );
+				suggestionsContainer.append( option );
 			} );
 			suggestionsContainer.style.display = 'block';
 		} );
@@ -212,7 +211,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		 * @return {void}
 		 */
 		close: function() {
-			document.getElementById( 'find-posts-response' ).innerHTML = '';
+			document.getElementById( 'find-posts-response' ).replaceChildren();
 			document.getElementById( 'find-posts' ).style.display = 'none';
 			document.querySelector( '.ui-find-overlay' ).style.display = 'none';
 		},
@@ -329,7 +328,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( success ) {
-			document.getElementById( 'post-' + id ).innerHTML = success.data;
+			document.getElementById( 'post-' + id ).setHTML( success.data );
 			hideColumns( 'post-' + id );
 			wp.a11y.speak( wp.i18n.__( 'Changes saved.' ) );
 		} )
@@ -818,13 +817,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						div = document.createElement( 'div' );
 						div.id = 'message';
 						div.className = 'notice notice-error is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.setHTML( '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>' );
 						document.querySelector( '.page-title-action' ).after( div );
 					} else {
 						div = document.createElement( 'div' );
 						div.id = 'message';
 						div.className = 'updated notice notice-success is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.setHTML( '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>' );
 						document.querySelector( '.page-title-action' ).after( div );
 
 						// Update selected attribute in DOM.
@@ -842,7 +841,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				div = document.createElement( 'div' );
 				div.id = 'message';
 				div.className = 'notice notice-error is-dismissible';
-				div.innerHTML = '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>';
+				div.setHTML( '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>' );
 				document.querySelector( '.page-title-action' ).after( div );
 			} );
 		} );

--- a/src/wp-admin/js/media.js
+++ b/src/wp-admin/js/media.js
@@ -465,7 +465,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			action.addEventListener( 'click', function( event ) {
 				var tr, checkboxes, delButtons, dateSplit, author, authorsList, cats,
 					catsArray, categoriesList, mediaTags, hiddenTr, cancel, inputs,
-					te = '',
+					te = document.createDocumentFragment(),
+					ul = document.createElement( 'ul' ),
 					quickEdit = document.getElementById( 'quick-edit' ),
 					bulkEdit = document.getElementById( 'bulk-edit' ),
 					optionValue = document.querySelector( 'select[name="action"]' ).value,
@@ -512,6 +513,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					 * checkboxes in the post table.
 					 */
 					checkboxes.forEach( function( checkbox ) {
+						const li = document.createElement( 'li' ),
+							button = document.createElement( 'button' ),
+							span1 = document.createElement( 'span' ),
+							span2 = document.createElement( 'span' );
 
 						// If the checkbox for a post is selected, add the post to the edit list.
 						if ( checkbox.checked ) {
@@ -528,7 +533,22 @@ document.addEventListener( 'DOMContentLoaded', function() {
 								tr = document.getElementById( 'post-' + id );
 							}
 
-							te += '<li class="ntdelitem" name="attachment[]" value="' + id + '"><button type="button" id="_' + id + '" class="button-link ntdelbutton"><span class="screen-reader-text">' + buttonVisuallyHiddenText + '</span></button><span class="ntdeltitle" aria-hidden="true">' + theTitle + '</span></li>';
+							li.className = 'ntdelitem';
+							li.name = 'attachment[]'
+							li.value = id;
+							button.type = 'button';
+							button.id = '_' + id;
+							button.className = 'button-link ntdelbutton';
+							span1.className = 'screen-reader-text';
+							span1.textContent = buttonVisuallyHiddenText;
+							span2.className = 'ntdeltitle';
+							span2.textContent = theTitle.split( '</span>' )[1];
+							span2.setAttribute( 'aria-hidden', 'true' );
+
+							button.append( span1 );
+							li.append( button, span2 );
+							te.append( li );
+
 						}
 					} );
 
@@ -640,7 +660,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						autoCompleteTextarea( bulkEdit.querySelector( 'textarea' ) );
 
 						// Populate the list of items to bulk edit.
-						document.getElementById( 'bulk-titles' ).innerHTML = '<ul id="bulk-titles-list" role="list">' + te + '</ul>';
+						ul.id = 'bulk-titles-list';
+						ul.role = 'list';
+						ul.append( te );
+						document.getElementById( 'bulk-titles' ).replaceChildren( ul );
 
 						// Scroll to Bulk Edit.
 						bulkEdit.scrollIntoView( {
@@ -785,7 +808,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		// Set up variables when a change of upload category is made.
 		uploadCatSelect.addEventListener( 'change', function( e ) {
-			var div,
+			var div = document.createElement( 'div' ),
+				para = document.createElement( 'p' ),
+				button = document.createElement( 'button' ),
 				dismissible = document.querySelector( '.is-dismissible' ),
 				uploadCatFolder = new URLSearchParams( {
 					action: 'media-cat-upload',
@@ -812,36 +837,38 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				throw new Error( response.status );
 			} )
 			.then( function( response ) {
-				if ( response.success ) {
-					if ( response.data.value == '' ) {
-						div = document.createElement( 'div' );
-						div.id = 'message';
-						div.className = 'notice notice-error is-dismissible';
-						div.setHTML( '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>' );
-						document.querySelector( '.page-title-action' ).after( div );
-					} else {
-						div = document.createElement( 'div' );
-						div.id = 'message';
-						div.className = 'updated notice notice-success is-dismissible';
-						div.setHTML( '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>' );
-						document.querySelector( '.page-title-action' ).after( div );
+				div.id = 'message';
+				para.textContent = response.data.message;
+				button.className = 'notice-dismiss';
+				button.type = 'button';
 
-						// Update selected attribute in DOM.
-						uploadCatSelect.childNodes.forEach( function( option ) {
-							if ( option.value === e.target.value ) {
-								option.setAttribute( 'selected', true );
-							} else {
-								option.removeAttribute( 'selected' );
-							}
-						} );
-					}
+				if ( response.success ) {
+					div.className = 'updated notice notice-success is-dismissible';
+					div.append( para, button );
+					document.querySelector( '.page-title-action' ).after( div );
+
+					// Update selected attribute in DOM.
+					uploadCatSelect.childNodes.forEach( function( option ) {
+						if ( option.value === e.target.value ) {
+							option.setAttribute( 'selected', true );
+						} else {
+							option.removeAttribute( 'selected' );
+						}
+					} );
+				} else {
+					div.className = 'notice notice-error is-dismissible';
+					div.append( para, button );
+					document.querySelector( '.page-title-action' ).after( div );
 				}
 			} )
 			.catch( function( error ) {
-				div = document.createElement( 'div' );
+				para.textContent = error;
+				button.className = 'notice-dismiss';
+				button.type = 'button';
+
 				div.id = 'message';
 				div.className = 'notice notice-error is-dismissible';
-				div.setHTML( '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>' );
+				div.append( para, button );
 				document.querySelector( '.page-title-action' ).after( div );
 			} );
 		} );

--- a/src/wp-admin/js/nav-menu.js
+++ b/src/wp-admin/js/nav-menu.js
@@ -1023,8 +1023,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						throw new Error( response.status );
 					} )
 					.then( function( menuMarkup ) {
+						const container = document.createElement( 'ul' );
 
-						editMenu.insertAdjacentHTML( 'beforeend', menuMarkup );
+						container.setHTML( menuMarkup, {
+							sanitizer: {}
+						} );
+						editMenu.insertAdjacentHTML( 'beforeend', container.innerHTML );
+
 						advancedMenuProperties.forEach( function( property ) {
 							var pendingValue = editMenu.querySelector( '.pending .field-' + property.value );
 							if ( ! property.checked ) {
@@ -1394,12 +1399,16 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( menuMarkup ) {
-			var ins = document.getElementById( 'menu-instructions' );
+			const container = document.createElement( 'ul' ),
+				ins = document.getElementById( 'menu-instructions' );
 
 			menuMarkup = menuMarkup || '';
 			menuMarkup = menuMarkup.toString().trim(); // Trim leading whitespaces.
 
-			editMenu.insertAdjacentHTML( placing, menuMarkup );
+			container.setHTML( menuMarkup, {
+				sanitizer: {}
+			} );
+			editMenu.insertAdjacentHTML( placing, container.innerHTML );
 
 			advancedMenuProperties.forEach( function( property ) {
 				var pendingValues = editMenu.querySelectorAll( '.pending .field-' + property.value );

--- a/src/wp-admin/js/nav-menu.js
+++ b/src/wp-admin/js/nav-menu.js
@@ -563,17 +563,17 @@ document.addEventListener( 'DOMContentLoaded', function() {
 						* Process the quick search response into a search result
 						*/
 						var matched, newID, items,
-							div = document.createElement( 'div' ),
+							template = document.createElement( 'template' ),
 							takenIDs = {},
 							form = document.getElementById( 'nav-menu-meta' ),
 							pattern = /menu-item[(\[^]\]*/,
 							wrapper = panel.closest( '.accordion-section-content' ),
 							selectAll = wrapper.querySelector( '.button-controls .select-all' );
 
-						div.innerHTML = menuMarkup;
-						items = div.querySelectorAll( 'li' );
+						template.innerHTML = menuMarkup;
+						items = template.content.querySelectorAll( 'li' );
 						if ( ! items.length ) {
-							panel.querySelector( '.categorychecklist' ).innerHTML = '<li><p>' + wp.i18n.__( 'No results found.' ) + '</p></li>';
+							panel.querySelector( '.categorychecklist' ).setHTML( '<li><p>' + wp.i18n.__( 'No results found.' ) + '</p></li>' );
 							panel.querySelector( '.spinner' ).classList.remove( 'is-active' );
 							wrapper.classList.add( 'has-no-menu-item' );
 							return;
@@ -598,10 +598,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 								takenIDs[newID] = true;
 								if ( newID !== matched[1] ) {
-									item.innerHTML = item.innerHTML.replace( new RegExp(
-										'menu-item\\[' + matched[1] + '\\]', 'g'),
+									item.setHTML( item.innerHTML.replace(
+										new RegExp( 'menu-item\\[' + matched[1] + '\\]', 'g'),
 										'menu-item[' + newID + ']'
-									);
+									) );
 								}
 							}
 							panel.querySelector( '.categorychecklist' ).append( item );
@@ -1093,7 +1093,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					}
 
 					// Update the post type menu meta box with new content from the response.
-					e.target.closest( '.inside' ).innerHTML = metaBoxData.markup;
+					e.target.closest( '.inside' ).setHTML( metaBoxData.markup );
 				} )
 				.catch( function( error ) {
 					console.log( error );
@@ -1127,15 +1127,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				if ( e.target.checked === true ) {
 					li = document.createElement( 'li' );
 					li.dataset.menuItemId = menuItemID;
-					li.innerHTML = '<span class="pending-menu-item-name">' + menuItemName + '</span> ' + '<span class="pending-menu-item-type">(' + menuItemType + ')</span>' + '<span class="separator"></span>';
+					li.setHTML( '<span class="pending-menu-item-name">' + menuItemName + '</span> ' + '<span class="pending-menu-item-type">(' + menuItemType + ')</span>' + '<span class="separator"></span>' );
 					document.querySelector( '#pending-menu-items-to-delete ul' ).append( li );
 				}
 
 				document.querySelectorAll( '#pending-menu-items-to-delete li .separator' ).forEach( function( sep, index ) {
 					if ( index === document.querySelectorAll( '#pending-menu-items-to-delete li .separator' ).length - 1 ) {
-						sep.innerHTML = '.';
+						sep.setHTML( '.' );
 					} else {
-						sep.innerHTML = ', ';
+						sep.setHTML( ', ' );
 					}
 				} );
 			}

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -6,7 +6,7 @@
 /* global pluginL10n */
 document.addEventListener( 'DOMContentLoaded', function() {
 
-	var iframe, iframeBody, tabbables, firstTabbable, lastTabbable, closeButton,
+	var iframeBody, tabbables, firstTabbable, lastTabbable, closeButton,
 		uploadViewToggle = document.querySelector( '.upload-view-toggle' ),
 		wrap = document.querySelector( '.wrap' ),
 		body = document.body,
@@ -36,8 +36,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					wp.i18n.__( 'Plugin details' );
 
 			const button = document.createElement( 'button' ),
-				span = document.createElement( 'span' ),
-				iframe = document.createElement( 'iframe' );
+				span = document.createElement( 'span' );
 
 			e.preventDefault();
 			e.stopPropagation();
@@ -52,6 +51,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			span.textContent = pluginL10n.close;
 			button.append( span );
 
+			iframe = document.createElement( 'iframe' );
 			iframe.id = 'TB_iframeContent';
 			iframe.src = urlNoQuery[0];
 			iframe.name = 'TB_iframeContent' + Math.round( Math.random() * 1000 );
@@ -69,8 +69,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			if ( iframe ) {
 				iframe.addEventListener( 'load', function() {
+					iframeLoaded( iframe );
 					dialog.classList.remove( 'modal-loading' );
-					iframeLoaded();
 				} );
 			}
 
@@ -100,7 +100,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	 *
 	 * @since CP-2.1.0
 	 */
-	function iframeLoaded() {
+	function iframeLoaded( iframe ) {
 
 		// Get the iframe body.
 		iframeBody = iframe.contentWindow.document.querySelector( 'body' );

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -35,16 +35,38 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					) :
 					wp.i18n.__( 'Plugin details' );
 
+			const button = document.createElement( 'button' ),
+				span = document.createElement( 'span' ),
+				iframe = document.createElement( 'iframe' );
+
 			e.preventDefault();
 			e.stopPropagation();
 
+			dialog.classList.add( 'modal-loading' );
 			urlNoQuery = url.split( 'TB_' );
 
-			dialog.classList.add( 'modal-loading' );
-			dialog.showModal();
-			dialog.insertAdjacentHTML( 'beforeend', '<button type="button" id="dialog-close-button" autofocus><span class="screen-reader-text">' + pluginL10n.close + '</span></button><iframe frameborder="0" hspace="0" allowtransparency="true" src="' + urlNoQuery[0] + '" id="TB_iframeContent" name="TB_iframeContent' + Math.round( Math.random() * 1000 ) + '" style="width: ' + ( width * 9 / 10 ) + 'px;max-width:800px;height: ' + ( height * 9 / 10 ) + 'px;" title="' + title + '">' + pluginL10n.noiframes + '</iframe>' );
+			button.type = 'button';
+			button.id = 'dialog-close-button';
+			button.setAttribute( 'autofocus', 'true' );
+			span.className = 'screen-reader-text';
+			span.textContent = pluginL10n.close;
+			button.append( span );
 
-			iframe = dialog.querySelector( 'iframe' );
+			iframe.id = 'TB_iframeContent';
+			iframe.src = urlNoQuery[0];
+			iframe.name = 'TB_iframeContent' + Math.round( Math.random() * 1000 );
+			iframe.title = title;
+			iframe.textContent = pluginL10n.noiframes;
+			iframe.setAttribute( 'frameborder', '0' );
+			iframe.setAttribute( 'hspace', '0' );
+			iframe.setAttribute( 'allowtransparency', 'true' );
+			iframe.style.width = ( width * 9 / 10 ) + 'px';
+			iframe.style.maxWidth = '800px';
+			iframe.style.height = ( height * 9 / 10 ) + 'px';
+
+			dialog.append( button, iframe );
+			dialog.showModal();
+
 			if ( iframe ) {
 				iframe.addEventListener( 'load', function() {
 					dialog.classList.remove( 'modal-loading' );

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -36,7 +36,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					wp.i18n.__( 'Plugin details' );
 
 			const button = document.createElement( 'button' ),
-				span = document.createElement( 'span' );
+				span = document.createElement( 'span' ),
+				iframe = document.createElement( 'iframe' );
 
 			e.preventDefault();
 			e.stopPropagation();
@@ -51,7 +52,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			span.textContent = pluginL10n.close;
 			button.append( span );
 
-			iframe = document.createElement( 'iframe' );
 			iframe.id = 'TB_iframeContent';
 			iframe.src = urlNoQuery[0];
 			iframe.name = 'TB_iframeContent' + Math.round( Math.random() * 1000 );

--- a/src/wp-admin/js/plugin-install.js
+++ b/src/wp-admin/js/plugin-install.js
@@ -74,7 +74,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				} );
 			}
 
-			closeButton = dialog.querySelector( '#dialog-close-button' );
+			closeButton = document.getElementById( 'dialog-close-button' );
 			closeButton.addEventListener( 'click', function() {
 				dialog.close();
 				if ( iframe != null ) {
@@ -86,13 +86,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			// Remove iframe contents when hitting the Escape button
 			dialog.addEventListener( 'keydown', function( e ) {
 				if ( e.key === 'Escape' ) {
-					if ( iframe != null ) {
-						iframe.remove();
-					}
-					closeButton.remove();
-				} else if ( e.key === 'Enter' && e.target.id === 'dialog-close-button' ) {
-					e.preventDefault();
-					dialog.close();
 					if ( iframe != null ) {
 						iframe.remove();
 					}
@@ -254,16 +247,17 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			document.querySelectorAll( '#section-holder div.section' ).forEach( function( section ) {
 				section.style.display = 'none'; // Hide them all.
 			} );
-			document.querySelector( '#section-' + tab ).style.display = 'block';
+			document.getElementById( 'section-' + tab ).style.display = 'block';
 		} );
 	} );
 
 	/* Plugin install Category filter JS */
 	document.querySelectorAll( '.plugin-categories-filter a' ).forEach( function( filter ) {
 		filter.addEventListener( 'click', function( event ) {
-			event.preventDefault();
 			var category = filter.dataset.pluginTag;
-			document.querySelector( '#typeselector' ).value = 'tag';
+			event.preventDefault();
+
+			document.getElementById( 'typeselector' ).value = 'tag';
 			document.querySelector( '.plugin-install-php .wp-filter-search' ).value = category;
 			document.querySelector( '.plugin-install-php .wp-filter-search' ).dispatchEvent( new Event( 'input' ) );
 		} );

--- a/src/wp-admin/js/revisions-list.js
+++ b/src/wp-admin/js/revisions-list.js
@@ -3,7 +3,7 @@
  *
  * @since CP-2.6.0.
  *
- * @output wp-admin/js/revisions.js
+ * @output wp-admin/js/revisions-list.js
  */
 
 /* global console, ajaxurl */

--- a/src/wp-admin/js/revisions-list.js
+++ b/src/wp-admin/js/revisions-list.js
@@ -34,7 +34,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} )
 			.then( function( result ) {
 				dialog.querySelector( 'h2' ).textContent = result.data.title;
-				dialog.querySelector( '#modal-revision-content-inner' ).innerHTML = result.data.content;
+				dialog.querySelector( '#modal-revision-content-inner' ).setHTML( result.data.content );
 				dialog.showModal();
 			} )
 			.catch( function( error ) {
@@ -65,7 +65,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		document.body.style.overflow = '';
 		dialog.close();
 		dialog.querySelector( 'h2' ).textContent = '';
-		dialog.querySelector( '#modal-revision-content-inner' ).innerHTML = '';
+		dialog.querySelector( '#modal-revision-content-inner' ).replaceChildren();
 	}
 	closeButton.addEventListener( 'click', closeModalDialog );
 	modalButton.addEventListener( 'click', closeModalDialog );

--- a/src/wp-admin/js/revisions.js
+++ b/src/wp-admin/js/revisions.js
@@ -245,9 +245,21 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	 */
 	function compareRevisions( revisions ) {
 		if ( chunks.hasOwnProperty( revisions ) ) {
-			fromAuthorCard.setHTML( chunks[ revisions ].author_left );
-			toAuthorCard.setHTML( chunks[ revisions ].author_right );
-			diff.setHTML( chunks[ revisions ].diffs );
+			fromAuthorCard.setHTML( chunks[ revisions ].author_left, {
+				sanitizer: {
+					allowAttributes: ['class']
+				}
+			} );
+			toAuthorCard.setHTML( chunks[ revisions ].author_right, {
+				sanitizer: {
+					allowAttributes: ['class']
+				}
+			} );
+			diff.setHTML( chunks[ revisions ].diffs, {
+				sanitizer: {
+					allowAttributes: ['class', 'aria-hidden']
+				}
+			} );
 		} else {
 			getDiff( revisions );
 		}
@@ -308,9 +320,21 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 
 			// Display the appropriate diff and metadata
-			fromAuthorCard.setHTML( chunks[ index ].author_left );
-			toAuthorCard.setHTML( chunks[ index ].author_right );
-			diff.setHTML( chunks[ index ].diffs );
+			fromAuthorCard.setHTML( chunks[ index ].author_left, {
+				sanitizer: {
+					allowAttributes: ['class']
+				}
+			} );
+			toAuthorCard.setHTML( chunks[ index ].author_right , {
+				sanitizer: {
+					allowAttributes: ['class']
+				}
+			} );
+			diff.setHTML( chunks[ index ].diffs, {
+				sanitizer: {
+					allowAttributes: ['class', 'aria-hidden']
+				}
+			} );
 		} )
 		.catch( function( error ) {
 			console.error( _wpRevisionsSettings.error, error );

--- a/src/wp-admin/js/revisions.js
+++ b/src/wp-admin/js/revisions.js
@@ -182,11 +182,11 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		option.addEventListener( 'mouseover', function() {
 			tooltip.style.backgroundColor = '#fff';
-			tooltip.innerHTML = option.dataset.tooltip.replace( '{{', '<span style="color:#d63638">' ).replace( '}}', '</span>' ).replace( '[[', '<strong>' ).replace( ']]', '</strong><br>' );
+			tooltip.setHTML( option.dataset.tooltip.replace( '{{', '<span style="color:#d63638">' ).replace( '}}', '</span>' ).replace( '[[', '<strong>' ).replace( ']]', '</strong><br>' ) );
 		} );
 		option.addEventListener( 'mouseout', function() {
 			tooltip.style.backgroundColor = 'transparent';
-			tooltip.innerHTML = '';
+			tooltip.replaceChildren();
 		} );
 	} );
 
@@ -245,9 +245,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	 */
 	function compareRevisions( revisions ) {
 		if ( chunks.hasOwnProperty( revisions ) ) {
-			fromAuthorCard.innerHTML = chunks[ revisions ].author_left;
-			toAuthorCard.innerHTML = chunks[ revisions ].author_right;
-			diff.innerHTML = chunks[ revisions ].diffs;
+			fromAuthorCard.setHTML( chunks[ revisions ].author_left );
+			toAuthorCard.setHTML( chunks[ revisions ].author_right );
+			diff.setHTML( chunks[ revisions ].diffs );
 		} else {
 			getDiff( revisions );
 		}
@@ -308,9 +308,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 
 			// Display the appropriate diff and metadata
-			fromAuthorCard.innerHTML = chunks[ index ].author_left;
-			toAuthorCard.innerHTML = chunks[ index ].author_right;
-			diff.innerHTML = chunks[ index ].diffs;
+			fromAuthorCard.setHTML( chunks[ index ].author_left );
+			toAuthorCard.setHTML( chunks[ index ].author_right );
+			diff.setHTML( chunks[ index ].diffs );
 		} )
 		.catch( function( error ) {
 			console.error( _wpRevisionsSettings.error, error );

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -223,7 +223,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( result ) {
-			const container = document.createElement( 'div' );
+			const container = document.createElement( 'ul' );
 
 			if ( i === 1 ) {
 				themesGrid.replaceChildren(); // clear the current grid

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -333,7 +333,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Open the modal or perform other operations
 	document.addEventListener( 'click', function( e ) {
-		var img, template, clone, response, span,
+		var img, template, clone, response, span, container,
 			customizer = document.body.className.includes( 'wp-customizer' ) ? true : false,
 			theme = e.target.closest( '.theme' ),
 			allThemes = document.querySelectorAll( '.themes li:not( .add-new-theme )' ),
@@ -643,10 +643,15 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					}
 				}
 
+				container = document.createElement( 'div' );
+				container.setHTML( theme.dataset.ratings, {
+					sanitizer: {}
+				} );
+
 				previewDialog.querySelector( '.theme-name' ).textContent = theme.querySelector( '.theme-name' ).textContent;
 				previewDialog.querySelector( '.theme-by' ).textContent = theme.querySelector( '.theme-author' ).textContent;
 				previewDialog.querySelector( '.theme-screenshot img' ).src = theme.querySelector( '.theme-screenshot img' ).src;
-				previewDialog.querySelector( '.theme-rating' ).insertAdjacentHTML( 'afterbegin', theme.dataset.ratings );
+				previewDialog.querySelector( '.theme-rating' ).insertAdjacentHTML( 'afterbegin', container.innerHTML );
 				previewDialog.querySelector( '.num-ratings' ).textContent = '(' + theme.dataset.numRatings + ' ' + _wpThemeSettings.l10n.ratings + ')';
 				previewDialog.querySelector( '.num-ratings' ).href = 'https://wordpress.org/support/theme/' + theme.id + '/reviews/';
 				previewDialog.querySelector( '.theme-version' ).textContent = _wpThemeSettings.l10n.version + ' ' + theme.dataset.version;

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -328,7 +328,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Open the modal or perform other operations
 	document.addEventListener( 'click', function( e ) {
-		var img, template, clone, response, span, topModal,
+		var img, template, clone, response, span,
 			customizer = document.body.className.includes( 'wp-customizer' ) ? true : false,
 			theme = e.target.closest( '.theme' ),
 			allThemes = document.querySelectorAll( '.themes li:not( .add-new-theme )' ),
@@ -390,7 +390,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 				if ( theme.dataset.hasUpdate === '1' ) {
 					if ( theme.dataset.updateResponse === '1-1' ) {
-						dialog.querySelector( '.has-update span' ).innerHTML = theme.dataset.update;
+						dialog.querySelector( '.has-update span' ).setHTML( theme.dataset.update );
 						dialog.querySelector( '.has-update' ).removeAttribute( 'hidden' );
 					} else {
 						dialog.querySelector( '.incompat-update' ).removeAttribute( 'hidden' );
@@ -526,26 +526,6 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} else if ( e.target.className.includes( 'update-theme' ) ) { // Customizer
 			e.target.closest( '.update-message' ).classList.add( 'updating-message' );
 			updateIndividualTheme( e.target.closest( 'li' ).dataset.id );
-
-		// Get further details about a theme when it has an update
-		} else if ( e.target.className.includes( 'open-plugin-details-modal' ) ) {
-			e.preventDefault();
-			topModal = document.createElement( 'dialog' );
-			topModal.id = 'theme-update-modal';
-			topModal.className = 'theme-overlay';
-			topModal.setAttribute( 'aria-label', e.target.getAttribute( 'aria-label' ) );
-			topModal.setHTML( '<div class="theme-overlay">' +
-				'<div class="wp-clearfix">' +
-					'<div class="theme-header">' +
-						'<button id="theme-update-modal-close" class="close dashicons dashicons-no" autofocus>' +
-							'<span class="screen-reader-text">' + dialog.querySelector( '.close .screen-reader-text' ).textContent + '</span>' +
-						'</button>' +
-					'</div>' +
-					'<iframe src="' + e.target.href + '">' +
-					'</iframe>' +
-				'</div>' );
-			document.body.append( topModal );
-			topModal.showModal();
 
 		// Close update modal
 		} else if ( e.target.id === 'theme-update-modal-close' ) {

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -110,7 +110,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		previewDialog.querySelector( '.theme-name' ).textContent = '';
 		previewDialog.querySelector( '.theme-by' ).textContent = '';
 		previewDialog.querySelector( '.theme-screenshot img' ).src = '';
-		previewDialog.querySelector( '.theme-rating' ).setHTML( ' <a class="num-ratings" href=""></a>' );
+		previewDialog.querySelector( '.theme-rating' ).innerHTML = ' <a class="num-ratings" href=""></a>';
 		previewDialog.querySelector( '.theme-version' ).textContent = '';
 		previewDialog.querySelector( '.theme-description' ).textContent = '';
 		previewDialog.querySelector( 'iframe' ).src = '';
@@ -223,6 +223,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			throw new Error( response.status );
 		} )
 		.then( function( result ) {
+			const container = document.createElement( 'div' );
+
 			if ( i === 1 ) {
 				themesGrid.replaceChildren(); // clear the current grid
 			}
@@ -230,7 +232,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			document.querySelector( '.filter-count .theme-count' ).textContent = result.data.count;
 
 			// Populate grid with new items
-			themesGrid.insertAdjacentHTML( 'beforeend', result.data.html );
+			container.setHTML( result.data.html, {
+				sanitizer: {}
+			} );
+			themesGrid.insertAdjacentHTML( 'beforeend', container.innerHTML );
 
 			showAndHide( document.querySelectorAll( '.themes li:not( .add-new-theme )' ) );
 		} )

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -390,7 +390,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 				if ( theme.dataset.hasUpdate === '1' ) {
 					if ( theme.dataset.updateResponse === '1-1' ) {
-						dialog.querySelector( '.has-update span' ).setHTML( theme.dataset.update );
+						dialog.querySelector( '.has-update span' ).innerHTML = theme.dataset.update;
 						dialog.querySelector( '.has-update' ).removeAttribute( 'hidden' );
 					} else {
 						dialog.querySelector( '.incompat-update' ).removeAttribute( 'hidden' );

--- a/src/wp-admin/js/theme.js
+++ b/src/wp-admin/js/theme.js
@@ -110,7 +110,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		previewDialog.querySelector( '.theme-name' ).textContent = '';
 		previewDialog.querySelector( '.theme-by' ).textContent = '';
 		previewDialog.querySelector( '.theme-screenshot img' ).src = '';
-		previewDialog.querySelector( '.theme-rating' ).innerHTML = ' <a class="num-ratings" href=""></a>';
+		previewDialog.querySelector( '.theme-rating' ).setHTML( ' <a class="num-ratings" href=""></a>' );
 		previewDialog.querySelector( '.theme-version' ).textContent = '';
 		previewDialog.querySelector( '.theme-description' ).textContent = '';
 		previewDialog.querySelector( 'iframe' ).src = '';
@@ -146,7 +146,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				div = document.createElement( 'div' );
 
 			div.className = 'notice inline notice-success notice-alt';
-			div.innerHTML = '<p>' + _wpThemeSettings.l10n.installed + '</p>';
+			div.setHTML( '<p>' + _wpThemeSettings.l10n.installed + '</p>' );
 			theme.querySelector( '.theme-screenshot' ).after( div );
 			theme.querySelector( '.theme-install' ).textContent = _wpThemeSettings.l10n.activate;
 			theme.querySelector( '.theme-install' ).href = theme.dataset.activateNonce;
@@ -185,7 +185,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			var theme = document.getElementById( slug ) || document.getElementById( 'customize-control-installed_theme_' + slug ),
 				notice = theme.querySelector( '.update-message' );
 
-			notice.innerHTML = '<p>' + _wpThemeSettings.l10n.updated + '</p>';
+			notice.setHTML( '<p>' + _wpThemeSettings.l10n.updated + '</p>' );
 			notice.className = 'notice inline updated-message notice-success notice-alt';
 		} )
 		.catch( function( error ) {
@@ -224,7 +224,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		} )
 		.then( function( result ) {
 			if ( i === 1 ) {
-				themesGrid.innerHTML = ''; // clear the current grid
+				themesGrid.replaceChildren(); // clear the current grid
 			}
 			// Update count
 			document.querySelector( '.filter-count .theme-count' ).textContent = result.data.count;
@@ -377,7 +377,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 				dialog.querySelector( '.theme-name' ).textContent = theme.querySelector( '.theme-name' ).textContent;
 				dialog.querySelector( '.theme-version' ).textContent = _wpThemeSettings.l10n.version + ' ' + theme.dataset.version;
-				dialog.querySelector( '.theme-author' ).innerHTML = theme.querySelector( '.theme-author' ).innerHTML;
+				dialog.querySelector( '.theme-author' ).setHTML( theme.querySelector( '.theme-author' ).innerHTML );
 
 				// Notices
 				if ( theme.dataset.compatibleWp !== '1' && theme.dataset.compatiblePhp !== '1' ) {
@@ -390,7 +390,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 				if ( theme.dataset.hasUpdate === '1' ) {
 					if ( theme.dataset.updateResponse === '1-1' ) {
-						dialog.querySelector( '.has-update span' ).innerHTML = theme.dataset.update;
+						dialog.querySelector( '.has-update span' ).setHTML( theme.dataset.update );
 						dialog.querySelector( '.has-update' ).removeAttribute( 'hidden' );
 					} else {
 						dialog.querySelector( '.incompat-update' ).removeAttribute( 'hidden' );
@@ -534,7 +534,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			topModal.id = 'theme-update-modal';
 			topModal.className = 'theme-overlay';
 			topModal.setAttribute( 'aria-label', e.target.getAttribute( 'aria-label' ) );
-			topModal.innerHTML = '<div class="theme-overlay">' +
+			topModal.setHTML( '<div class="theme-overlay">' +
 				'<div class="wp-clearfix">' +
 					'<div class="theme-header">' +
 						'<button id="theme-update-modal-close" class="close dashicons dashicons-no" autofocus>' +
@@ -543,7 +543,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					'</div>' +
 					'<iframe src="' + e.target.href + '">' +
 					'</iframe>' +
-				'</div>';
+				'</div>' );
 			document.body.append( topModal );
 			topModal.showModal();
 
@@ -601,7 +601,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} else if ( e.target.className === 'button drawer-toggle' || e.target.className === 'button-link edit-filters' ) {
 				document.body.classList.add( 'show-filters' );
 				document.body.classList.remove( 'filters-applied' );
-				document.querySelector( '.filtered-by .tags' ).innerHTML = '';
+				document.querySelector( '.filtered-by .tags' ).replaceChildren();
 				if ( document.querySelector( '.filter-drawer' ).checkVisibility() ) {
 					document.querySelector( '.drawer-toggle' ).setAttribute( 'aria-expanded', false );
 				} else {

--- a/src/wp-admin/js/updates.js
+++ b/src/wp-admin/js/updates.js
@@ -217,7 +217,7 @@
 			el.id = data.id;
 		}
 		el.classList.add( ...data.className.split( ' ' ) );
-		el.querySelector( 'p' ).innerHTML = data.message;
+		el.querySelector( 'p' ).setHTML( data.message );
 
 		return el;
 	}
@@ -272,7 +272,7 @@
 		}
 
 		td.colSpan = data.colspan;
-		td.innerHTML = data.content;
+		td.setHTML( data.content );
 
 		return el;
 	}

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -275,7 +275,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			}
 			if ( title ) {
 				title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
-				widget.querySelector( '.in-widget-title' ).innerHTML = title;
+				widget.querySelector( '.in-widget-title' ).setHTML( title );
 			}
 
 			if ( widget.querySelector( 'p.widget-error' ) != null ) {
@@ -410,7 +410,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		var ghostImage = document.createElement( 'details' );
 		ghostImage.id = 'sortable-ghost';
 		ghostImage.className = 'widget-top';
-		ghostImage.innerHTML = '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>';
+		ghostImage.setHTML( '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>' );
 		ghostImage.style.position = 'absolute';
 		ghostImage.style.top = '-1000px';
 		ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';
@@ -446,9 +446,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			if ( addNew ) {
 				if ( 'multi' === addNew ) {
-					widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
+					widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
 						return tag.replace( /__i__|%i%/g, newMultiValue );
-					} );
+					} ) );
 
 					widget.id = widget.id.replace( '__i__', newMultiValue );
 					widget.querySelector( 'input.multi_number' ).value = newMultiValue;
@@ -475,9 +475,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					widget.addEventListener( 'change', unsavedWidget );
 				}
 			} else {
-				widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
+				widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
 					return tag.replace( /__i__|%i%/g, newMultiValue );
-				} );
+				} ) );
 
 				widget.id = widget.id.replace( '__i__', newMultiValue );
 				widget.querySelector( 'input.multi_number' ).value = newMultiValue;
@@ -589,13 +589,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					}
 				} else {
 					if ( responseText && responseText.length > 2 ) {
-						widget.querySelector( '.widget-content' ).innerHTML = responseText;
+						widget.querySelector( '.widget-content' ).setHTML( responseText );
 
 						let title = widget.querySelector( 'input[id*="-title"]' ) ? widget.querySelector( 'input[id*="-title"]' ).value : '';
 						if ( title ) {
 							title = ': ' + title.replace( /<[^<>]+>/g, '' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
 						}
-						widget.querySelector( '.in-widget-title' ).innerHTML = title;
+						widget.querySelector( '.in-widget-title' ).setHTML( title );
 
 						widget.querySelector( '.widget-control-save' ).disabled = true;
 						widget.querySelector( '.widget-control-save' ).value = wp.i18n.__( 'Saved' );
@@ -724,9 +724,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.querySelector( '.widgets-chooser' ).remove();
 
 		if ( 'multi' === add ) {
-			widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( m ) {
+			widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( m ) {
 				return m.replace( /__i__|%i%/g, newMultiValue );
-			} );
+			} ) );
 
 			widget.id = widgetId.replace( '__i__', newMultiValue );
 			widget.querySelector( 'input.multi_number' ).value = newMultiValue;

--- a/src/wp-admin/js/widgets.js
+++ b/src/wp-admin/js/widgets.js
@@ -407,14 +407,22 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 
 	function ghostImage( dataTransfer, dragEl ) {
-		var ghostImage = document.createElement( 'details' );
+		var ghostImage = document.createElement( 'details' ),
+			summary = document.createElement( 'summary' ),
+			title = document.createElement( 'h3' );
+
+		summary.className = 'widget-title';
+		title.textContent = dragEl.querySelector( 'h3' ).textContent;
+		summary.append( title );
+
 		ghostImage.id = 'sortable-ghost';
 		ghostImage.className = 'widget-top';
-		ghostImage.setHTML( '<summary class="widget-title"><h3>' + dragEl.querySelector( 'h3' ).textContent + '</h3></summary>' );
 		ghostImage.style.position = 'absolute';
 		ghostImage.style.top = '-1000px';
 		ghostImage.style.width = dragEl.getBoundingClientRect().width + 'px';
-		document.body.appendChild( ghostImage );
+
+		ghostImage.append( summary );
+		document.body.append( ghostImage );
 		dataTransfer.setDragImage( ghostImage, 30, 20 );
 	}
 
@@ -446,9 +454,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 			if ( addNew ) {
 				if ( 'multi' === addNew ) {
-					widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
+					widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
 						return tag.replace( /__i__|%i%/g, newMultiValue );
-					} ) );
+					} );
 
 					widget.id = widget.id.replace( '__i__', newMultiValue );
 					widget.querySelector( 'input.multi_number' ).value = newMultiValue;
@@ -475,9 +483,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					widget.addEventListener( 'change', unsavedWidget );
 				}
 			} else {
-				widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
+				widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( tag ) {
 					return tag.replace( /__i__|%i%/g, newMultiValue );
-				} ) );
+				} );
 
 				widget.id = widget.id.replace( '__i__', newMultiValue );
 				widget.querySelector( 'input.multi_number' ).value = newMultiValue;
@@ -589,7 +597,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					}
 				} else {
 					if ( responseText && responseText.length > 2 ) {
-						widget.querySelector( '.widget-content' ).setHTML( responseText );
+						widget.querySelector( '.widget-content' ).innerHTML = responseText;
 
 						let title = widget.querySelector( 'input[id*="-title"]' ) ? widget.querySelector( 'input[id*="-title"]' ).value : '';
 						if ( title ) {
@@ -602,9 +610,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 						widget.classList.remove( 'widget-dirty' );
 
-						document.dispatchEvent( new CustomEvent('widget-updated', {
+						document.dispatchEvent( new CustomEvent( 'widget-updated', {
 							detail: { widget: widget }
-						}));
+						} ) );
 					}
 					document.querySelectorAll( '.spinner' ).forEach( function( spinner ) {
 						spinner.classList.remove( 'is-active' );
@@ -724,9 +732,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		widget.querySelector( '.widgets-chooser' ).remove();
 
 		if ( 'multi' === add ) {
-			widget.setHTML( widget.innerHTML.replace( /<[^<>]+>/g, function( m ) {
+			widget.innerHTML = widget.innerHTML.replace( /<[^<>]+>/g, function( m ) {
 				return m.replace( /__i__|%i%/g, newMultiValue );
-			} ) );
+			} );
 
 			widget.id = widgetId.replace( '__i__', newMultiValue );
 			widget.querySelector( 'input.multi_number' ).value = newMultiValue;

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -29,22 +29,62 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	// Update details within modal
 	function setAddedMediaFields( id ) {
-		var form = document.createElement( 'form' );
+		const form = document.createElement( 'form' ),
+			input = document.createElement( 'input' ),
+			para = document.createElement( 'p' ),
+			message = document.createElement( 'span' ),
+			required = document.createElement( 'span' ),
+			span1 = document.createElement( 'span' ),
+			label1 = document.createElement( 'label' ),
+			input1 = document.createElement( 'input' ),
+			innerSpan1 = document.createElement( 'span' ),
+			innerInput1 = document.createElement( 'input' ),
+			span2 = document.createElement( 'span' ),
+			label2 = document.createElement( 'label' ),
+			input2 = document.createElement( 'input' ),
+			innerSpan2 = document.createElement( 'span' ),
+			innerInput2 = document.createElement( 'input' );
+			
 		form.className = 'compat-item';
-		form.setHTML( '<input type="hidden" id="menu-order" name="attachments[' + id + '][menu_order]" value="0">' +
-			'<p class="media-types media-types-required-info"><span class="required-field-message">Required fields are marked <span class="required">*</span></span></p>' +
-			'<span class="setting" data-setting="media_category">' +
-				'<label for="attachments-' + id + '-media_category">' +
-					'<span class="alignleft">Media Categories</span>' +
-				'</label>' +
-				'<input type="text" class="text" id="attachments-' + id + '-media_category" name="attachments[' + id + '][media_category]" value="">' +
-			'</span>' +
-			'<span class="setting" data-setting="media_post_tag">' +
-				'<label for="attachments-' + id + '-media_post_tag">' +
-					'<span class="alignleft">Media Tags</span>' +
-				'</label>' +
-				'<input type="text" class="text" id="attachments-' + id + '-media_post_tag" name="attachments[' + id + '][media_post_tag]" value="">' +
-			'</span>' );
+		input.type = 'hidden';
+		input.id = 'menu-order';
+		input.name = 'attachments[' + id + '][menu_order]';
+		input.value = '0';
+		para.className = 'media-types media-types-required-info';
+		message.className = 'required-field-message';
+		message.textContent = 'Required fields are marked ';
+		required.className = 'required';
+		required.textContent = '*';
+
+		span1.className = 'setting';
+		span1.dataset.setting = 'media_category';
+		label1.htmlFor = 'attachments-' + id + '-media_category';
+		innerSpan1.className = 'alignleft';
+		innerSpan1.textContent = 'Media Categories';
+		input1.type = 'text';
+		input1.className = 'text';
+		input1.id = 'attachments-' + id + '-media_category';
+		input1.name = 'attachments[' + id + '][media_category]';
+		input1.value = '';
+
+		span2.className = 'setting';
+		span2.dataset.setting = 'media_post_tag';
+		label2.htmlFor = 'attachments-' + id + '-media_post_tag';
+		innerSpan2.className = 'alignleft';
+		innerSpan2.textContent = 'Media Tags';
+		input2.type = 'text';
+		input2.className = 'text';
+		input2.id = 'attachments-' + id + '-media_post_tag';
+		input2.name = 'attachments[' + id + '][media_post_tag]';
+		input2.value = '';
+
+		message.append( required );
+		para.append( message );
+		label1.append( innerSpan1 );
+		span1.append( label1, input1 );
+		label2.append( innerSpan2 );
+		span2.append( label2, input2 );
+		form.append( input, para, span1, span2 );
 
 		if ( document.querySelector( '.compat-item' ) != null ) {
 			document.querySelector( '.compat-item' ).remove();
@@ -475,7 +515,12 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 	/* Populate media items within grid */
 	function populateGridItem( attachment ) {
-		var gridItem = document.createElement( 'li' ),
+		const gridItem = document.createElement( 'li' ),
+			wrapper = document.createElement( 'div' ),
+			thumbnail = document.createElement( 'div' ),
+			button = document.createElement( 'button' ),
+			spanIcon = document.createElement( 'span' ),
+			spanSRT = document.createElement( 'span' ),
 			image = '<img src="' + attachment.url + '" alt="' + attachment.alt + '">';
 
 		if ( attachment.type === 'application' ) {
@@ -517,13 +562,19 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		gridItem.setAttribute( 'data-delete-nonce', attachment.nonces.delete );
 		gridItem.setAttribute( 'data-edit-nonce', attachment.nonces.edit );
 
-		gridItem.setHTML( '<div class="select-attachment-preview type-' + attachment.type + ' subtype-' + attachment.subtype + '">' +
-			'<div class="media-thumbnail">' + image + '</div>' +
-			'</div>' +
-			'<button type="button" class="check" tabindex="-1">' +
-			'<span class="media-modal-icon"></span>' +
-			'<span class="screen-reader-text">' + _wpMediaGridSettings.deselect + '></span>' +
-			'</button>' );
+		wrapper.className = 'select-attachment-preview type-' + attachment.type + ' subtype-' + attachment.subtype;
+		thumbnail.className = 'media-thumbnail';
+		button.type = 'button';
+		button.className = 'check';
+		button.tabIndex = -1;
+		spanIcon.className = 'media-modal-icon';
+		spanSRT.className =  'screen-reader-text';
+		spanSRT.textContent = _wpMediaGridSettings.deselect;
+
+		thumbnail.append( image );
+		wrapper.append( thumbnail );
+		button.append( spanIcon, spanSRT );
+		gridItem.append( wrapper, button );
 
 		return gridItem;
 	}

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -809,32 +809,29 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				throw new Error( response.status );
 			} )
 			.then( function( response ) {
+				div.id = 'message';
+				para.textContent = response.data.message;
+				button.className = 'notice-dismiss';
+				button.type = 'button';
+
 				if ( response.success ) {
-					div.id = 'message';
-					para.textContent = response.data.message;
-					button.className = 'notice-dismiss';
-					button.type = 'button';
+					div.className = 'updated notice notice-success is-dismissible';
+					div.append( para, button );
+					document.querySelector( '.page-title-action' ).after( div );
 
-					if ( response.data.value == '' ) {
-						div.id = 'message';
-						div.className = 'notice notice-error is-dismissible';
-						div.append( para, button );
-						document.querySelector( '.page-title-action' ).after( div );
-						close.click();
-					} else {
-						div.className = 'updated notice notice-success is-dismissible';
-						div.append( para, button );
-						document.querySelector( '.page-title-action' ).after( div );
-
-						// Update selected attribute in DOM.
-						uploadCatSelect.childNodes.forEach( function( option ) {
-							if ( option.value === e.target.value ) {
-								option.setAttribute( 'selected', true );
-							} else {
-								option.removeAttribute( 'selected' );
-							}
-						} );
-					}
+					// Update selected attribute in DOM.
+					uploadCatSelect.childNodes.forEach( function( option ) {
+						if ( option.value === e.target.value ) {
+							option.setAttribute( 'selected', true );
+						} else {
+							option.removeAttribute( 'selected' );
+						}
+					} );
+				} else {
+					div.className = 'notice notice-error is-dismissible';
+					div.append( para, button );
+					document.querySelector( '.page-title-action' ).after( div );
+					close.click();
 				}
 			} )
 			.catch( function( error ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -42,7 +42,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			label2 = document.createElement( 'label' ),
 			input2 = document.createElement( 'input' ),
 			innerSpan2 = document.createElement( 'span' );
-			
+
 		form.className = 'compat-item';
 		input.type = 'hidden';
 		input.id = 'menu-order';

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -809,29 +809,32 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				throw new Error( response.status );
 			} )
 			.then( function( response ) {
-				div.id = 'message';
-				para.textContent = response.data.message;
-				button.className = 'notice-dismiss';
-				button.type = 'button';
-
 				if ( response.success ) {
-					div.className = 'updated notice notice-success is-dismissible';
-					div.append( para, button );
-					document.querySelector( '.page-title-action' ).after( div );
+					div.id = 'message';
+					para.textContent = response.data.message;
+					button.className = 'notice-dismiss';
+					button.type = 'button';
 
-					// Update selected attribute in DOM.
-					uploadCatSelect.childNodes.forEach( function( option ) {
-						if ( option.value === e.target.value ) {
-							option.setAttribute( 'selected', true );
-						} else {
-							option.removeAttribute( 'selected' );
-						}
-					} );
-				} else {
-					div.className = 'notice notice-error is-dismissible';
-					div.append( para, button );
-					document.querySelector( '.page-title-action' ).after( div );
-					close.click();
+					if ( response.data.value == '' ) {
+						div.id = 'message';
+						div.className = 'notice notice-error is-dismissible';
+						div.append( para, button );
+						document.querySelector( '.page-title-action' ).after( div );
+						close.click();
+					} else {
+						div.className = 'updated notice notice-success is-dismissible';
+						div.append( para, button );
+						document.querySelector( '.page-title-action' ).after( div );
+
+						// Update selected attribute in DOM.
+						uploadCatSelect.childNodes.forEach( function( option ) {
+							if ( option.value === e.target.value ) {
+								option.setAttribute( 'selected', true );
+							} else {
+								option.removeAttribute( 'selected' );
+							}
+						} );
+					}
 				}
 			} )
 			.catch( function( error ) {

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -31,7 +31,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 	function setAddedMediaFields( id ) {
 		var form = document.createElement( 'form' );
 		form.className = 'compat-item';
-		form.innerHTML = '<input type="hidden" id="menu-order" name="attachments[' + id + '][menu_order]" value="0">' +
+		form.setHTML( '<input type="hidden" id="menu-order" name="attachments[' + id + '][menu_order]" value="0">' +
 			'<p class="media-types media-types-required-info"><span class="required-field-message">Required fields are marked <span class="required">*</span></span></p>' +
 			'<span class="setting" data-setting="media_category">' +
 				'<label for="attachments-' + id + '-media_category">' +
@@ -44,7 +44,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 					'<span class="alignleft">Media Tags</span>' +
 				'</label>' +
 				'<input type="text" class="text" id="attachments-' + id + '-media_post_tag" name="attachments[' + id + '][media_post_tag]" value="">' +
-			'</span>';
+			'</span>' );
 
 		if ( document.querySelector( '.compat-item' ) != null ) {
 			document.querySelector( '.compat-item' ).remove();
@@ -517,13 +517,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		gridItem.setAttribute( 'data-delete-nonce', attachment.nonces.delete );
 		gridItem.setAttribute( 'data-edit-nonce', attachment.nonces.edit );
 
-		gridItem.innerHTML = '<div class="select-attachment-preview type-' + attachment.type + ' subtype-' + attachment.subtype + '">' +
+		gridItem.setHTML( '<div class="select-attachment-preview type-' + attachment.type + ' subtype-' + attachment.subtype + '">' +
 			'<div class="media-thumbnail">' + image + '</div>' +
 			'</div>' +
 			'<button type="button" class="check" tabindex="-1">' +
 			'<span class="media-modal-icon"></span>' +
 			'<span class="screen-reader-text">' + _wpMediaGridSettings.deselect + '></span>' +
-			'</button>';
+			'</button>' );
 
 		return gridItem;
 	}
@@ -565,7 +565,7 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			if ( result.success ) {
 
 				// Clear existing grid
-				mediaGrid.innerHTML = '';
+				mediaGrid.replaceChildren();
 
 				if ( result.data.length === 0 ) {
 
@@ -713,7 +713,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		// Set up variables when a change of upload category is made.
 		uploadCatSelect.addEventListener( 'change', function( e ) {
-			var div,
+			var div = document.createElement( 'div' ),
+				para = document.createElement( 'p' ),
+				button = document.createElement( 'button' ),
 				dismissible = document.querySelector( '.is-dismissible' ),
 				uploadCatFolder = new URLSearchParams( {
 					action: 'media-cat-upload',
@@ -757,18 +759,20 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} )
 			.then( function( response ) {
 				if ( response.success ) {
+					div.id = 'message';
+					para.textContent = response.data.message;
+					button.className = 'notice-dismiss';
+					button.type = 'button';
+
 					if ( response.data.value == '' ) {
-						div = document.createElement( 'div' );
 						div.id = 'message';
 						div.className = 'notice notice-error is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.append( para, button );
 						document.querySelector( '.page-title-action' ).after( div );
 						close.click();
 					} else {
-						div = document.createElement( 'div' );
-						div.id = 'message';
 						div.className = 'updated notice notice-success is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.append( para, button );
 						document.querySelector( '.page-title-action' ).after( div );
 
 						// Update selected attribute in DOM.
@@ -783,10 +787,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				}
 			} )
 			.catch( function( error ) {
-				div = document.createElement( 'div' );
+				para.textContent = error;
+				button.className = 'notice-dismiss';
+				button.type = 'button';
+
 				div.id = 'message';
 				div.className = 'notice notice-error is-dismissible';
-				div.innerHTML = '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>';
+				div.append( para, button );
 				document.querySelector( '.page-title-action' ).after( div );
 			} );
 		} );

--- a/src/wp-includes/js/media-grid.js
+++ b/src/wp-includes/js/media-grid.js
@@ -38,12 +38,10 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			label1 = document.createElement( 'label' ),
 			input1 = document.createElement( 'input' ),
 			innerSpan1 = document.createElement( 'span' ),
-			innerInput1 = document.createElement( 'input' ),
 			span2 = document.createElement( 'span' ),
 			label2 = document.createElement( 'label' ),
 			input2 = document.createElement( 'input' ),
-			innerSpan2 = document.createElement( 'span' ),
-			innerInput2 = document.createElement( 'input' );
+			innerSpan2 = document.createElement( 'span' );
 			
 		form.className = 'compat-item';
 		input.type = 'hidden';
@@ -520,8 +518,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			thumbnail = document.createElement( 'div' ),
 			button = document.createElement( 'button' ),
 			spanIcon = document.createElement( 'span' ),
-			spanSRT = document.createElement( 'span' ),
-			image = '<img src="' + attachment.url + '" alt="' + attachment.alt + '">';
+			spanSRT = document.createElement( 'span' );
+
+		let image = '<img src="' + attachment.url + '" alt="' + attachment.alt + '">';
 
 		if ( attachment.type === 'application' ) {
 			if ( attachment.subtype === 'vnd.openxmlformats-officedocument.spreadsheetml.sheet' ) {

--- a/src/wp-includes/js/plupload/handlers.js
+++ b/src/wp-includes/js/plupload/handlers.js
@@ -28,7 +28,9 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		// Set up variables when a change of upload category is made.
 		uploadCatSelect.addEventListener( 'change', function( e ) {
-			var div,
+			var div = document.createElement( 'div' ),
+				para = document.createElement( 'p' ),
+				button = document.createElement( 'button' ),
 				uploadCatFolder = new URLSearchParams( {
 					action: 'media-cat-upload',
 					option: 'media_cat_upload_folder',
@@ -55,11 +57,14 @@ document.addEventListener( 'DOMContentLoaded', function() {
 			} )
 			.then( function( response ) {
 				if ( response.success ) {
+					div.id = 'message';
+					para.textContent = response.data.message;
+					button.className = 'notice-dismiss';
+					button.type = 'button';
+
 					if ( response.data.value == '' ) {
-						div = document.createElement( 'div' );
-						div.id = 'message';
 						div.className = 'notice notice-error is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.append( para, button );
 						document.querySelector( '.wrap h1' ).after( div );
 
 						// Disable uploads.
@@ -74,10 +79,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 							e.preventDefault();
 						}, false );
 					} else {
-						div = document.createElement( 'div' );
-						div.id = 'message';
 						div.className = 'updated notice notice-success is-dismissible';
-						div.innerHTML = '<p>' + response.data.message + '</p><button class="notice-dismiss" type="button"></button>';
+						div.append( para, button );
 						document.querySelector( '.wrap h1' ).after( div );
 
 						// Update selected attribute in DOM.
@@ -96,10 +99,13 @@ document.addEventListener( 'DOMContentLoaded', function() {
 				}
 			} )
 			.catch( function( error ) {
-				div = document.createElement( 'div' );
+				para.textContent = error;
+				button.className = 'notice-dismiss';
+				button.type = 'button';
+
 				div.id = 'message';
 				div.className = 'notice notice-error is-dismissible';
-				div.innerHTML = '<p>' + error + '</p><button class="notice-dismiss" type="button"></button>';
+				div.append( para, button );
 				document.querySelector( '.wrap h1' ).after( div );
 			} );
 		} );

--- a/src/wp-includes/js/polyfill.js
+++ b/src/wp-includes/js/polyfill.js
@@ -3,64 +3,62 @@
  * Supports Safari and older browser variants natively.
  * Includes dynamic custom data-* attribute routing.
  */
-// Use only if the browser does not already have native setHTML
 if ( ! ( 'setHTML' in Element.prototype ) ) {
 
-	// 1. Establish strict safety baselines
+	// Establish strict safety baselines
 	const ALLOWED_TAGS = ['P', 'BR', 'SPAN', 'DIV', 'A', 'IMG', 'B', 'I', 'STRONG', 'EM', 'U', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI'];
-	const ALLOWED_ATTR = ['id', 'class', 'href', 'src', 'alt', 'title', 'target'];
+	const ALLOWED_ATTR = ['id', 'class', 'href', 'src', 'alt', 'title', 'target', 'style'];
 
 	Element.prototype.setHTML = function( input, options = {} ) {
-		// 2. Map and parse parameters to uppercase/lowercase for accurate matrix comparisons
+		const config = options.sanitizer || {};
+		
+		// If an elements/attributes array is passed, use it. Otherwise, use the defaults.
+		const validTags = config.elements ? config.elements.map( t => t.toUpperCase() ) : ALLOWED_TAGS;
+		const validAttrs = config.attributes ? config.attributes.map( a => a.toLowerCase() ) : ALLOWED_ATTR;
+
+		// Map and parse parameters to uppercase/lowercase for accurate matrix comparisons
 		const config = options.sanitizer || {};
 		const validTags = config.allowElements ? config.allowElements.map( t => t.toUpperCase() ) : ALLOWED_TAGS;
 		const validAttrs = config.allowAttributes ? config.allowAttributes.map( a => a.toLowerCase() ) : ALLOWED_ATTR;
 
-		// 3. Mount content safely within an inert browser memory fragment
+		// Mount content safely within an inert browser memory fragment
 		const template = document.createElement( 'template' );
 		template.innerHTML = input;
 		const fragment = template.content;
 
-		// 4. Create an optimized flat tree iterator
-		const walker = document.createTreeWalker( fragment, NodeFilter.SHOW_ELEMENT );
-		let currentNode = walker.currentNode;
-		const nodesToRemove = [];
+		// Use a NodeIterator to safely modify nodes while looping
+		const iterator = document.createNodeIterator( fragment, NodeFilter.SHOW_ELEMENT );
+		let currentNode;
 
-		while ( currentNode ) {
-			if ( currentNode !== fragment ) {
-				const tagName = currentNode.tagName;
+		while ( ( currentNode = iterator.nextNode() ) ) {
+			const tagName = currentNode.tagName;
 
-				// Tag Filter: Flag for complete destruction if missing from the whitelist
-				if ( ! validTags.includes( tagName ) ) {
-					nodesToRemove.push( currentNode );
-				} else {
-					// Attribute Filter: Strip unapproved data points out of approved elements
-					const attrs = currentNode.attributes;
-					if ( attrs ) {
-						for ( let i = attrs.length - 1; i >= 0; i-- ) {
-							const attrName = attrs[i].name.toLowerCase();
-							const attrValue = attrs[i].value.trim().toLowerCase();
+			// Tag Filter: Flag for complete destruction if missing from the whitelist
+			if ( ! validTags.includes( tagName ) ) {
+				currentNode.remove();
+				continue;
+			}
 
-							// Evaluate structural integrity rules
-							const isDataAttr = attrName.startsWith( 'data-' ) && attrName.length > 5;
-							const isAllowed = isDataAttr || validAttrs.includes( attrName );
-							const isMaliciousUri = ( 'href' === attrName || 'src' === attrName ) && attrValue.startsWith( 'javascript:' );
+			// Attribute Filter: Strip unapproved data points out of approved elements
+			const attrs = currentNode.attributes;
+			if ( attrs ) {
+				for ( let i = attrs.length - 1; i >= 0; i-- ) {
+					const attrName = attrs[i].name.toLowerCase();
+					const attrValue = attrs[i].value.trim().toLowerCase();
 
-							if ( ! isAllowed || isMaliciousUri ) {
-								currentNode.removeAttribute( attrs[i].name );
-							}
-						}
+					// Evaluate structural integrity rules
+					const isDataAttr = attrName.startsWith( 'data-' ) && attrName.length > 5;
+					const isAllowed = isDataAttr || validAttrs.includes( attrName );
+					const isMaliciousUri = ( 'href' === attrName || 'src' === attrName ) && attrValue.startsWith( 'javascript:' );
+
+					if ( ! isAllowed || isMaliciousUri ) {
+						currentNode.removeAttribute( attrs[i].name );
 					}
 				}
 			}
-			currentNode = walker.nextNode();
 		}
 
-		// 5. Safely execute destruction of forbidden DOM structures
-		nodesToRemove.forEach( node => node.remove() );
-
-		// 6. Purge container contents and inject the safe node fragment layout
-		this.innerHTML = '';
-		this.append( fragment );
+		// Purge container contents and inject the safe node fragment layout
+		this.replaceChildren( fragment );
 	};
 }

--- a/src/wp-includes/js/polyfill.js
+++ b/src/wp-includes/js/polyfill.js
@@ -1,0 +1,66 @@
+/**
+ * Element.prototype.setHTML Polyfill (Whitelist Architecture)
+ * Supports Safari and older browser variants natively.
+ * Includes dynamic custom data-* attribute routing.
+ */
+// Use only if the browser does not already have native setHTML
+if ( ! ( 'setHTML' in Element.prototype ) ) {
+
+	// 1. Establish strict safety baselines
+	const ALLOWED_TAGS = ['P', 'BR', 'SPAN', 'DIV', 'A', 'IMG', 'B', 'I', 'STRONG', 'EM', 'U', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'UL', 'OL', 'LI'];
+	const ALLOWED_ATTR = ['id', 'class', 'href', 'src', 'alt', 'title', 'target'];
+
+	Element.prototype.setHTML = function( input, options = {} ) {
+		// 2. Map and parse parameters to uppercase/lowercase for accurate matrix comparisons
+		const config = options.sanitizer || {};
+		const validTags = config.allowElements ? config.allowElements.map( t => t.toUpperCase() ) : ALLOWED_TAGS;
+		const validAttrs = config.allowAttributes ? config.allowAttributes.map( a => a.toLowerCase() ) : ALLOWED_ATTR;
+
+		// 3. Mount content safely within an inert browser memory fragment
+		const template = document.createElement( 'template' );
+		template.innerHTML = input;
+		const fragment = template.content;
+
+		// 4. Create an optimized flat tree iterator
+		const walker = document.createTreeWalker( fragment, NodeFilter.SHOW_ELEMENT );
+		let currentNode = walker.currentNode;
+		const nodesToRemove = [];
+
+		while ( currentNode ) {
+			if ( currentNode !== fragment ) {
+				const tagName = currentNode.tagName;
+
+				// Tag Filter: Flag for complete destruction if missing from the whitelist
+				if ( ! validTags.includes( tagName ) ) {
+					nodesToRemove.push( currentNode );
+				} else {
+					// Attribute Filter: Strip unapproved data points out of approved elements
+					const attrs = currentNode.attributes;
+					if ( attrs ) {
+						for ( let i = attrs.length - 1; i >= 0; i-- ) {
+							const attrName = attrs[i].name.toLowerCase();
+							const attrValue = attrs[i].value.trim().toLowerCase();
+
+							// Evaluate structural integrity rules
+							const isDataAttr = attrName.startsWith( 'data-' ) && attrName.length > 5;
+							const isAllowed = isDataAttr || validAttrs.includes( attrName );
+							const isMaliciousUri = ( 'href' === attrName || 'src' === attrName ) && attrValue.startsWith( 'javascript:' );
+
+							if ( ! isAllowed || isMaliciousUri ) {
+								currentNode.removeAttribute( attrs[i].name );
+							}
+						}
+					}
+				}
+			}
+			currentNode = walker.nextNode();
+		}
+
+		// 5. Safely execute destruction of forbidden DOM structures
+		nodesToRemove.forEach( node => node.remove() );
+
+		// 6. Purge container contents and inject the safe node fragment layout
+		this.innerHTML = '';
+		this.append( fragment );
+	};
+}

--- a/src/wp-includes/js/polyfill.js
+++ b/src/wp-includes/js/polyfill.js
@@ -3,6 +3,7 @@
  * Supports Safari and older browser variants natively.
  * Includes dynamic custom data-* attribute routing.
  */
+/* jshint scripturl: true */
 if ( ! ( 'setHTML' in Element.prototype ) ) {
 
 	// Establish strict safety baselines

--- a/src/wp-includes/js/polyfill.js
+++ b/src/wp-includes/js/polyfill.js
@@ -48,7 +48,8 @@ if ( ! ( 'setHTML' in Element.prototype ) ) {
 
 					// Evaluate structural integrity rules
 					const isDataAttr = attrName.startsWith( 'data-' ) && attrName.length > 5;
-					const isAllowed = isDataAttr || validAttrs.includes( attrName );
+					const isAriaAttr = attrName.startsWith( 'aria-' ) && attrName.length > 5;
+					const isAllowed = isDataAttr || isAriaAttr || validAttrs.includes( attrName );
 					const isMaliciousUri = ( 'href' === attrName || 'src' === attrName ) && attrValue.startsWith( 'javascript:' );
 
 					if ( ! isAllowed || isMaliciousUri ) {

--- a/src/wp-includes/js/polyfill.js
+++ b/src/wp-includes/js/polyfill.js
@@ -11,13 +11,8 @@ if ( ! ( 'setHTML' in Element.prototype ) ) {
 
 	Element.prototype.setHTML = function( input, options = {} ) {
 		const config = options.sanitizer || {};
-		
-		// If an elements/attributes array is passed, use it. Otherwise, use the defaults.
-		const validTags = config.elements ? config.elements.map( t => t.toUpperCase() ) : ALLOWED_TAGS;
-		const validAttrs = config.attributes ? config.attributes.map( a => a.toLowerCase() ) : ALLOWED_ATTR;
 
 		// Map and parse parameters to uppercase/lowercase for accurate matrix comparisons
-		const config = options.sanitizer || {};
 		const validTags = config.allowElements ? config.allowElements.map( t => t.toUpperCase() ) : ALLOWED_TAGS;
 		const validAttrs = config.allowAttributes ? config.allowAttributes.map( a => a.toLowerCase() ) : ALLOWED_ATTR;
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -843,6 +843,7 @@ function wp_default_scripts( $scripts ) {
 
 	$scripts->add( 'underscore', "/wp-includes/js/underscore$dev_suffix.js", array(), '1.13.4', 1 );
 	$scripts->add( 'backbone', "/wp-includes/js/backbone$dev_suffix.js", array( 'underscore', 'jquery' ), '1.4.1', 1 );
+	$scripts->add( 'cp-polyfill', "/wp-includes/js/polyfill$suffix.js", array(), false, 1 );
 
 	$scripts->add( 'wp-util', "/wp-includes/js/wp-util$suffix.js", array( 'underscore', 'jquery' ), false, 1 );
 	did_action( 'init' ) && $scripts->localize(

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1079,7 +1079,7 @@ function wp_default_scripts( $scripts ) {
 
 	$scripts->add( 'customize-preview', "/wp-includes/js/customize-preview$suffix.js", array( 'wp-a11y' ), false, 1 );
 	$scripts->add( 'customize-controls-proxy', "/wp-admin/js/customize-controls-proxy$suffix.js", array( 'underscore' ), false, 1 );
-	$scripts->add( 'customize-controls', "/wp-admin/js/customize-controls$suffix.js", array( 'coloris', 'cp-filepond', 'media-image-widget', 'cp-cropper', 'customize-controls-proxy' ), false, 1 );
+	$scripts->add( 'customize-controls', "/wp-admin/js/customize-controls$suffix.js", array( 'coloris', 'cp-filepond', 'media-image-widget', 'cp-cropper', 'customize-controls-proxy', 'cp-polyfill' ), false, 1 );
 	did_action( 'init' ) && $scripts->localize(
 		'customize-controls',
 		'_wpCustomizeControlsL10n',
@@ -1171,8 +1171,8 @@ function wp_default_scripts( $scripts ) {
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'wp-util', 'customize-preview' ), false, 1 );
-	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy' ), false, 1 );
-	$scripts->add( 'customize-nav-menus', "/wp-admin/js/customize-nav-menus$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'wp-sanitize' ), false, 1 );
+	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'cp-polyfill' ), false, 1 );
+	$scripts->add( 'customize-nav-menus', "/wp-admin/js/customize-nav-menus$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'wp-sanitize', 'cp-polyfill' ), false, 1 );
 	$scripts->add( 'wp-custom-header', "/wp-includes/js/wp-custom-header$suffix.js", array( 'wp-a11y' ), false, 1 );
 
 	$scripts->add( 'shortcode', "/wp-includes/js/shortcode$suffix.js", array( 'underscore' ), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1171,7 +1171,7 @@ function wp_default_scripts( $scripts ) {
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'wp-util', 'customize-preview' ), false, 1 );
-	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy' ), false, 1 );
+	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'cp-polyfill' ), false, 1 );
 	$scripts->add( 'customize-nav-menus', "/wp-admin/js/customize-nav-menus$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'wp-sanitize', 'cp-polyfill' ), false, 1 );
 	$scripts->add( 'wp-custom-header', "/wp-includes/js/wp-custom-header$suffix.js", array( 'wp-a11y' ), false, 1 );
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1171,7 +1171,7 @@ function wp_default_scripts( $scripts ) {
 		)
 	);
 	$scripts->add( 'customize-selective-refresh', "/wp-includes/js/customize-selective-refresh$suffix.js", array( 'wp-util', 'customize-preview' ), false, 1 );
-	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'cp-polyfill' ), false, 1 );
+	$scripts->add( 'customize-widgets', "/wp-admin/js/customize-widgets$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy' ), false, 1 );
 	$scripts->add( 'customize-nav-menus', "/wp-admin/js/customize-nav-menus$suffix.js", array( 'sortable-js', 'customize-controls', 'customize-controls-proxy', 'wp-sanitize', 'cp-polyfill' ), false, 1 );
 	$scripts->add( 'wp-custom-header', "/wp-includes/js/wp-custom-header$suffix.js", array( 'wp-a11y' ), false, 1 );
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -858,8 +858,8 @@ function wp_default_scripts( $scripts ) {
 
 	$scripts->add( 'wp-backbone', "/wp-includes/js/wp-backbone$suffix.js", array( 'backbone', 'wp-util' ), false, 1 );
 
-	$scripts->add( 'revisions', "/wp-admin/js/revisions$suffix.js", array(), false, 1 );
-	$scripts->add( 'revisions-list', "/wp-admin/js/revisions-list$suffix.js", array(), false, 1 );
+	$scripts->add( 'revisions', "/wp-admin/js/revisions$suffix.js", array( 'cp-polyfill' ), false, 1 );
+	$scripts->add( 'revisions-list', "/wp-admin/js/revisions-list$suffix.js", array( 'cp-polyfill' ), false, 1 );
 
 	$scripts->add( 'imgareaselect', "/wp-includes/js/imgareaselect/jquery.imgareaselect$suffix.js", array( 'jquery' ), false, 1 );
 
@@ -1239,7 +1239,7 @@ function wp_default_scripts( $scripts ) {
 
 		$scripts->add( 'admin-gallery', "/wp-admin/js/gallery$suffix.js", array( 'sortable-js' ) );
 
-		$scripts->add( 'admin-widgets', "/wp-admin/js/widgets$suffix.js", array( 'sortable-js', 'wp-a11y' ), false, 1 );
+		$scripts->add( 'admin-widgets', "/wp-admin/js/widgets$suffix.js", array( 'sortable-js', 'wp-a11y', 'cp-polyfill' ), false, 1 );
 		$scripts->set_translations( 'admin-widgets' );
 
 		$scripts->add( 'media-widgets', "/wp-admin/js/widgets/media-widgets$suffix.js", array( 'wp-api-request' ) );
@@ -1312,7 +1312,7 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'privacy-tools', "/wp-admin/js/privacy-tools$suffix.js", array( 'jquery', 'wp-a11y' ), false, 1 );
 		$scripts->set_translations( 'privacy-tools' );
 
-		$scripts->add( 'updates', "/wp-admin/js/updates$suffix.js", array( 'common', 'jquery', 'wp-util', 'wp-a11y', 'wp-sanitize', 'wp-i18n' ), false, 1 );
+		$scripts->add( 'updates', "/wp-admin/js/updates$suffix.js", array( 'common', 'jquery', 'wp-util', 'wp-a11y', 'wp-sanitize', 'wp-i18n', 'cp-polyfill' ), false, 1 );
 		$scripts->set_translations( 'updates' );
 		did_action( 'init' ) && $scripts->localize(
 			'updates',
@@ -1413,7 +1413,7 @@ function wp_default_scripts( $scripts ) {
 		 * Navigation Menus: Adding underscore as a dependency to utilize _.debounce
 		 * see https://core.trac.wordpress.org/ticket/42321
 		 */
-		$scripts->add( 'nav-menu', "/wp-admin/js/nav-menu$suffix.js", array( 'sortable-js', 'wp-lists', 'postbox', 'json2', 'underscore' ) );
+		$scripts->add( 'nav-menu', "/wp-admin/js/nav-menu$suffix.js", array( 'sortable-js', 'wp-lists', 'postbox', 'json2', 'underscore', 'cp-polyfill' ) );
 		$scripts->set_translations( 'nav-menu' );
 
 		$scripts->add( 'custom-header', '/wp-admin/js/custom-header.js', array( 'jquery-masonry' ), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1250,7 +1250,7 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'text-widgets', "/wp-admin/js/widgets/text-widgets$suffix.js", array( 'media-widgets', 'editor', 'image-edit', 'wp-util', 'wp-a11y', 'sortable-js' ) );
 		$scripts->add( 'custom-html-widgets', "/wp-admin/js/widgets/custom-html-widgets$suffix.js", array() );
 
-		$scripts->add( 'theme', "/wp-admin/js/theme$suffix.js", array( 'wp-a11y' ), false, 1 );
+		$scripts->add( 'theme', "/wp-admin/js/theme$suffix.js", array( 'wp-a11y', 'cp-polyfill' ), false, 1 );
 		did_action( 'init' ) && $scripts->localize(
 			'theme',
 			'_wpThemeSettings',


### PR DESCRIPTION
CP:Props to @George928 for a report that prompted me to review the JS addressed here.

There are a couple of problematic methods in JavaScript, `innerHTML` and `insertAdjacentHTML`, which can open the way to injection attacks and should, therefore, be used only with trusted content. Arbitrary user input is obviously not trustworthy, but sometimes it's a judgment call about whether the input should be considered trustworthy or not. For example, do we consider lists of themes and plugins at `wordpress.org` to be trustworthy?

Ideally, we should be able to avoid such questions by using a more modern method, `setHTML()`, which sanitizes input and renders it safe. Much of this PR makes use of this to replaces many instances of `innerHTML`. It also makes use of a more permissive configuration of this method to harden instances of `insertAdjacentHTML` like this:

```
container.setHTML( incoming.html, {
	sanitizer: {}
} );
```

Even with this more permissive configuration, the browser will still strip:

-     <script>, <frame>, <iframe>, <embed>, <object>, SVG <use>
-     Inline event handler attributes like onclick, onerror, etc.
-     javascript: URLs in href/src, and similar execution vectors.

Even so, there are two problems with using `setHTML()`. The first is that it sometimes mangles the HTML that it's setting. In such cases, there are really two options. One is instead to replace either `innerHTML` and `insertAdjacentHTML` with a process that builds the nodes from scratch and then appends them to the target element. This is always safe. I have done that in some cases in this PR. The second option is simply to leave the `innerHTML` and `insertAdjacentHTML` methods untouched where it is clear that the incoming HTML is safe. I have also adopted that approach in some cases.

The other problem is that `setHTML()` is not yet supported by Safari (those its developers have indicated that they do plan to support it). Accordingly, I have added a polyfill here, as `polyfill.js`. I chose that name in case we wish to add other polyfills. At the same time, we will be able to delete that file once Safari supports `setHTML()`.

Finally, I have replaced instances of `innerHTML = ''` with `replaceChildren()`. The original is perfectly safe, but (a) its use causes false positives when `grepping` for uses of `innerHTML`, and (b) it still invokes the parser, so that `replaceChildren()` is likely to be quicker.